### PR TITLE
Reset nice and ionice priorities when executing scripts.

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -4,6 +4,10 @@
 #include <sys/wait.h>
 #include <errno.h>
 #include <unistd.h>
+#include <sys/resource.h>
+#if defined(__linux__)
+#include <sys/syscall.h>        /* For ionice */
+#endif
 
 #include <rpm/rpmfileutil.h>
 #include <rpm/rpmmacro.h>
@@ -325,6 +329,32 @@ static rpmRC runExtScript(rpmPlugins plugins, ARGV_const_t prefixes,
 
 	fclose(in);
 	dup2(inpipe[0], STDIN_FILENO);
+
+        /* If RPM was invoked with nice and/or ionice, the scripts that we run
+         * will be also nice'd/ionice'd.  This is terrible if you restart any
+         * daemon (e.g. mysqld), so let's reset this to default values before
+         * taking any actions.
+         */
+
+        /* Call for resetting nice priority. */
+        int ret;
+        ret = setpriority(PRIO_PROCESS, 0, 0);
+        if (ret == -1) {
+            rpmlog(RPMLOG_WARNING, _("Unable to reset nice value: %s"),
+                strerror(errno));
+        }
+
+        /* Call for resetting IO priority. */
+        #if defined(__linux__)
+        /* Defined at include/linux/ioprio.h */
+        const int _IOPRIO_WHO_PROCESS = 1;
+        const int _IOPRIO_CLASS_NONE = 0;
+        ret = syscall(SYS_ioprio_set, _IOPRIO_WHO_PROCESS, 0, _IOPRIO_CLASS_NONE);
+        if (ret == -1) {
+            rpmlog(RPMLOG_WARNING, _("Unable to reset I/O priority: %s"),
+                strerror(errno));
+        }
+        #endif
 
 	/* Run scriptlet post fork hook for all plugins */
 	if (rpmpluginsCallScriptletForkPost(plugins, *argvp[0], RPMSCRIPTLET_FORK | RPMSCRIPTLET_EXEC) != RPMRC_FAIL) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -110,7 +110,7 @@ testing$(bindir)/rpmbuild: ../rpmbuild
 	for node in stdin stderr stdout null; do ln -s /dev/$${node} testing/dev/$${node}; done
 	for cf in hosts resolv.conf passwd shadow group gshadow mtab fstab; do [ -f /etc/$${cf} ] && ln -s /etc/$${cf} testing/etc/$${cf}; done
 	ln -s ../$(bindir) testing/usr/bin
-	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file mktemp cut sort diff touch; do p=`which $${prog}`; ln -s $${p} testing/$${p}; done
+	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch; do p=`which $${prog}`; ln -s $${p} testing/$${p}; done
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 

--- a/tests/data/SPECS/scripts-nice-ionice.spec
+++ b/tests/data/SPECS/scripts-nice-ionice.spec
@@ -1,0 +1,48 @@
+Name:           scripts-nice-ionice
+Version:        1.0
+Release:        %{rel}
+Summary:        Testing reset of nice/ionice levels on scripts
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%files
+%defattr(-,root,root,-)
+
+%pretrans
+echo %{name}-%{version}-%{release} PRETRANS $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)
+
+%pre
+echo %{name}-%{version}-%{release} PRE $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)
+
+%post
+echo %{name}-%{version}-%{release} POST $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)
+
+%preun
+echo %{name}-%{version}-%{release} PREUN $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)
+
+%postun
+echo %{name}-%{version}-%{release} POSTUN $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)
+
+%posttrans
+echo %{name}-%{version}-%{release} POSTTRANS $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)
+
+%verifyscript
+echo %{name}-%{version}-%{release} VERIFY $*
+echo Nice value is $(/bin/nice)
+echo IOnice value is $(/usr/bin/ionice)

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -201,3 +201,69 @@ transfiletriggerpostun(/foo*):
 ],
 [])
 AT_CLEANUP
+
+# 
+AT_SETUP([Proper reset of nice/ionice levels on scripts - only works as root!])
+AT_KEYWORDS([verify nice])
+AT_CHECK([
+RPMDB_CLEAR
+RPMDB_INIT
+rm -rf "${TOPDIR}"
+
+runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
+runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts-nice-ionice.spec
+runroot rpmbuild --quiet -bb --define "rel 2" /data/SPECS/scripts-nice-ionice.spec
+
+runroot rpm -U "${TOPDIR}"/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+runroot nice -n 10 ionice -c3 rpm -Vvp "${TOPDIR}"/RPMS/noarch/scripts-nice-ionice-1.0-1.noarch.rpm
+runroot nice -n 10 ionice -c3 rpm -U "${TOPDIR}"/RPMS/noarch/scripts-nice-ionice-1.0-1.noarch.rpm
+runroot nice -n 10 ionice -c3 rpm -U "${TOPDIR}"/RPMS/noarch/scripts-nice-ionice-1.0-2.noarch.rpm
+runroot nice -n 10 ionice -c3 rpm -Vv scripts-nice-ionice
+runroot nice -n 10 ionice -c3 rpm -e scripts-nice-ionice
+],
+[0],
+[scripts-nice-ionice-1.0-1 VERIFY 0
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-1 PRETRANS 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-1 PRE 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-1 POST 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-1 POSTTRANS 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 PRETRANS 2
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 PRE 2
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 POST 2
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-1 PREUN 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-1 POSTUN 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 POSTTRANS 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 VERIFY 1
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 PREUN 0
+Nice value is 0
+IOnice value is none: prio 4
+scripts-nice-ionice-1.0-2 POSTUN 0
+Nice value is 0
+IOnice value is none: prio 4
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
Sometimes you may consider running an entire yum upgrade wrapped on nice and
ionice to soften the effect of the upcoming I/O and CPU storm on the system.
The side effect of that is that restarted services and anything else executed
from the pre- and post- rm and installation scripts will be niced and ioniced as
well, defeating the whole idea.  If e.g. sshd is in such state, anything that you install and restart while connected through ssh will be also nice'd and ionice'd.

With this, you are safe to run it, because we will reset nice and ionice values
right after fork() to the default values.