### PR TITLE
Make terminating build on empty %files manifest files configurable

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1642,8 +1642,14 @@ static rpmRC readFilesManifest(rpmSpec spec, Package pkg, const char *path)
 	nlines++;
     }
 
-    if (nlines == 0)
-	rpmlog(RPMLOG_WARNING, _("Empty %%files file %s\n"), fn);
+    if (nlines == 0) {
+	int terminate =
+		rpmExpandNumeric("%{?_empty_manifest_terminate_build}");
+	rpmlog(terminate ? RPMLOG_ERR : RPMLOG_WARNING,
+	       _("Empty %%files file %s\n"), fn);
+	if (terminate)
+		goto exit;
+    }
 
     if (ferror(fd))
 	rpmlog(RPMLOG_ERR, _("Error reading %%files file %s: %m\n"), fn);

--- a/macros.in
+++ b/macros.in
@@ -389,6 +389,12 @@ package or when debugging this package.\
 %_missing_doc_files_terminate_build	1
 
 #
+# Should empty %files manifest file terminate a build?
+#
+# Note: The default value should be 0 for legacy compatibility.
+%_empty_manifest_terminate_build	1
+
+#
 # Should binaries in noarch packages terminate a build?
 %_binaries_in_noarch_packages_terminate_build	1
 


### PR DESCRIPTION
Prior discussion and submission at http://rpm.org/ticket/870