### PR TITLE
More flexible build phases

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -248,6 +248,7 @@ static int doSetupMacro(rpmSpec spec, const char *line)
     uint32_t num;
     int leaveDirs = 0, skipDefaultAction = 0;
     int createDir = 0, quietly = 0;
+    int buildInPlace = 0;
     const char * dirName = NULL;
     struct poptOption optionsTable[] = {
 	    { NULL, 'a', POPT_ARG_STRING, NULL, 'a',	NULL, NULL},
@@ -301,7 +302,16 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 		  headerGetString(spec->packages->header, RPMTAG_NAME),
 		  headerGetString(spec->packages->header, RPMTAG_VERSION));
     }
+    /* Mer addition - support --build-in-place */
+    if (rpmExpandNumeric("%{_build_in_place}")) {
+	buildInPlace = 1;
+	spec->buildSubdir = NULL;
+    }
     addMacro(spec->macros, "buildsubdir", NULL, spec->buildSubdir, RMIL_SPEC);
+    if (buildInPlace) {
+	rc = RPMRC_OK;
+	goto exit;
+    }
     
     /* cd to the build dir */
     {	char * buildDir = rpmGenPath(spec->rootDir, "%{_builddir}", "");

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -566,6 +566,10 @@ static int build(rpmts ts, const char * arg, BTA_t ba, const char * rcfile)
 
 	/* Read in configuration for target. */
 	rpmFreeMacros(NULL);
+	if (buildInPlace) {
+		/* Need to redefine this after freeing all the macros */
+		rpmDefineMacro(NULL, "_build_in_place 1", 0);
+	}
 	rpmFreeRpmrc();
 	(void) rpmReadConfigFiles(rcfile, *target);
 	rc = buildForTarget(ts, arg, ba);

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -221,6 +221,8 @@ static struct poptOption rpmBuildPoptTable[] = {
 
  { "noclean", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_CLEAN,
 	N_("do not execute %clean stage of the build"), NULL },
+ { "noprep", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_PREP,
+	N_("do not execute %prep stage of the build"), NULL },
  { "nocheck", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_CHECK,
 	N_("do not execute %check stage of the build"), NULL },
 


### PR DESCRIPTION
Here is a set of patches that we use in the [Mer Project](http://merproject.org/) for speeding up building of RPMs during development (incremental in-tree builds and specifying the phases to run from e.g. Qt Creator).

I'm a bit unsure about adding `--skip-clean` and `--skip-prep`, as those phases might also be skipped by `--noclean` (which already exists) and `--noprep` (which is added by this patchset). @lbt might know.