### PR TITLE
Various fixes and refactoring to new pythonegg Req/Prov generator

### DIFF
--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2010 Per Øyvind Karlsen <proyvind@moondrake.org>

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -101,11 +101,11 @@ for f in files:
                 py_deps[stdoutdata.strip()]= ""
 
     # XXX: hack to workaround RPM internal dependency generator not passing directories
-    dlower = dirname(lower)
-    if dlower.endswith('.egg') or \
-            dlower.endswith('.egg-info') or \
-            dlower.endswith('.egg-link'):
-        lower = dlower
+    lower_dir = dirname(lower)
+    if lower_dir.endswith('.egg') or \
+            lower_dir.endswith('.egg-info') or \
+            lower_dir.endswith('.egg-link'):
+        lower = lower_dir
         f = dirname(f)
     # Determine provide, requires, conflicts & recommends based on egg metadata
     if lower.endswith('.egg') or \

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 from getopt import getopt
 from os.path import basename, dirname, isdir, sep, splitext
 from sys import argv, stdin, version
-from pkg_resources import Distribution, FileMetadata, PathMetadata
 from distutils.sysconfig import get_python_lib
 from subprocess import Popen, PIPE, STDOUT
 import os
@@ -112,6 +111,8 @@ for f in files:
     if lower.endswith('.egg') or \
             lower.endswith('.egg-info') or \
             lower.endswith('.egg-link'):
+        # This import is very slow, so only do it if needed
+        from pkg_resources import Distribution, FileMetadata, PathMetadata
         dist_name = basename(f)
         if isdir(f):
             path_item = dirname(f)

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2010 Per Øyvind Karlsen <proyvind@moondrake.org>
+# Copyright 2015 Neal Gompa <ngompa13@gmail.com>
 #
 # This program is free software. It may be redistributed and/or modified under
 # the terms of the LGPL version 2.1 (or later).
@@ -9,6 +10,7 @@
 # RPM python (egg) dependency generator.
 #
 
+from __future__ import print_function
 from getopt import getopt
 from os.path import basename, dirname, isdir, sep, splitext
 from sys import argv, stdin, version
@@ -127,7 +129,7 @@ for f in files:
                 if not name in py_deps:
                     py_deps[name] = []
                 py_deps[name].append(('==', dist.py_version))
-            name = 'python%segg(%s)' % (pyver_major, dist.key)
+            name = 'python{}egg({})'.format(pyver_major, dist.key)
             if not name in py_deps:
                 py_deps[name] = []
             if dist.version:
@@ -157,7 +159,7 @@ for f in files:
                 deps = depsextras
             # add requires/recommends based on egg metadata
             for dep in deps:
-                name = 'python%segg(%s)' % (pyver_major, dep.key)
+                name = 'python{}egg({})'.format(pyver_major, dep.key)
                 for spec in dep.specs:
                     if spec[0] != '!=':
                         if not name in py_deps:
@@ -173,8 +175,8 @@ for f in files:
             extras = dist.extras
             print(extras)
             for extra in extras:
-                print('%%package\textras-%s' % extra)
-                print('Summary:\t%s extra for %s python egg' % (extra, dist.key))
+                print('%%package\textras-{}'.format(extra))
+                print('Summary:\t{} extra for {} python egg'.format(extra, dist.key))
                 print('Group:\t\tDevelopment/Python')
                 depsextras = dist.requires(extras=[extra])
                 for dep in reversed(depsextras):
@@ -184,12 +186,12 @@ for f in files:
                 for dep in deps:
                     for spec in dep.specs:
                         if spec[0] == '!=':
-                            print('Conflicts:\t%s %s %s' % (dep.key, '==', spec[1]))
+                            print('Conflicts:\t{} {} {}'.format(dep.key, '==', spec[1]))
                         else:
-                            print('Requires:\t%s %s %s' % (dep.key, spec[0], spec[1]))
-                print('%%description\t%s' % extra)
-                print('%s extra for %s python egg' % (extra, dist.key))
-                print('%%files\t\textras-%s\n' % extra)
+                            print('Requires:\t{} {} {}'.format(dep.key, spec[0], spec[1]))
+                print('%%description\t{}'.format(extra))
+                print('{} extra for {} python egg'.format(extra, dist.key))
+                print('%%files\t\textras-{}\n'.format(extra))
         if Conflicts:
             # Should we really add conflicts for extras?
             # Creating a meta package per extra with recommends on, which has
@@ -209,7 +211,7 @@ for name in names:
     if py_deps[name]:
         # Print out versioned provides, requires, recommends, conflicts
         for spec in py_deps[name]:
-            print('%s %s %s' % (name, spec[0], spec[1]))
+            print('{} {} {}'.format(name, spec[0], spec[1]))
     else:
         # Print out unversioned provides, requires, recommends, conflicts
         print(name)

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -118,6 +118,8 @@ for f in files:
             path_item = f
             metadata = FileMetadata(f)
         dist = Distribution.from_location(path_item, dist_name, metadata)
+        # Get the Python major version
+        pyver_major = dist.py_version.split('.')[0]
         if Provides:
             # If egg metadata says package name is python, we provide python(abi)
             if dist.key == 'python':
@@ -125,10 +127,7 @@ for f in files:
                 if not name in py_deps:
                     py_deps[name] = []
                 py_deps[name].append(('==', dist.py_version))
-            if f.find('python2') > 0:
-                name = 'python2egg(%s)' % dist.key
-            elif f.find('python3') > 0:
-                name = 'python3egg(%s)' % dist.key
+            name = 'python%segg(%s)' % (pyver_major, dist.key)
             if not name in py_deps:
                 py_deps[name] = []
             if dist.version:
@@ -158,10 +157,7 @@ for f in files:
                 deps = depsextras
             # add requires/recommends based on egg metadata
             for dep in deps:
-                if f.find('python2') > 0:
-                    name = 'python2egg(%s)' % dep.key
-                elif f.find('python3') > 0:
-                    name = 'python3egg(%s)' % dep.key
+                name = 'python%segg(%s)' % (pyver_major, dep.key)
                 for spec in dep.specs:
                     if spec[0] != '!=':
                         if not name in py_deps:

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -125,10 +125,10 @@ for f in files:
                 if not name in py_deps:
                     py_deps[name] = []
                 py_deps[name].append(('==', dist.py_version))
-            if f.find('python3') > 0:
+            if f.find('python2') > 0:
+                name = 'python2egg(%s)' % dist.key
+            elif f.find('python3') > 0:
                 name = 'python3egg(%s)' % dist.key
-            else:
-                name = 'pythonegg(%s)' % dist.key
             if not name in py_deps:
                 py_deps[name] = []
             if dist.version:
@@ -160,8 +160,8 @@ for f in files:
             for dep in deps:
                 if f.find('python2') > 0:
                     name = 'python2egg(%s)' % dep.key
-                else:
-                    name = 'pythonegg(%s)' % dep.key
+                elif f.find('python3') > 0:
+                    name = 'python3egg(%s)' % dep.key
                 for spec in dep.specs:
                     if spec[0] != '!=':
                         if not name in py_deps:


### PR DESCRIPTION
The egg dependency generator was slightly inconsistent here.
While it would generate python2egg() for Py2 Requires/Recommends and pythonegg() for Py3 Requires/Recommends, it would generate python3egg() for Py3 Provides and pythonegg() for Py2 Provides. Rather than make a decision on which is the "proper" Python here, let's just handle them the same way: pythonXegg(), with "X" being the Python major version.

This way, it's absolutely clear which Python it is for, and as new major versions of Python become a reality, we should be able to handle that quite easily and (of course) sanely.

Additionally, I've made some fixes and refactorings to simplify the generation logic and make it clearer on how the string formatting is occurring, as well as prevent virtualenvs from messing with the execution of the script.