### PR TITLE
Fix broken -q on %setup.

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -228,7 +228,6 @@ exit:
 
 /**
  * Parse %setup macro.
- * @todo FIXME: Option -q broken when not immediately after %setup.
  * @param spec		build info
  * @param line		current line from spec file
  * @return		RPMRC_OK on success
@@ -260,6 +259,8 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 	    { NULL, 'q', 0, &quietly, 0,		NULL, NULL},
 	    { 0, 0, 0, 0, 0,	NULL, NULL}
     };
+
+    if (strstr(line+6, " -q")) quietly = 1;
 
     if ((xx = poptParseArgvString(line, &argc, &argv))) {
 	rpmlog(RPMLOG_ERR, _("Error parsing %%setup: %s\n"), poptStrerror(xx));


### PR DESCRIPTION
popt would set 'quietly' not until poptGetNextOpt would encounter '-q'.
Any extraction that occurred prior to this would be 'verbose'. By looking
for '-q' in the full '%setup' line beforehand, this is fixed.