### PR TITLE
Fix %setup logic in presence of '-[cbaT]' options.

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -362,14 +362,19 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 
     /* if necessary, create and cd into the proper dir */
     if (createDir) {
-	buf = rpmExpand("%{__mkdir_p} ", spec->buildSubdir, "\n",
-			"cd '", spec->buildSubdir, "'", NULL);
+	buf = rpmExpand("%{__mkdir_p} ", spec->buildSubdir, "\n", NULL);
+	appendLineStringBuf(spec->prep, buf);
+	free(buf);
+
+	appendStringBuf(spec->prep, getStringBuf(before));
+
+	rasprintf(&buf, "cd '%s'", spec->buildSubdir);
 	appendLineStringBuf(spec->prep, buf);
 	free(buf);
     }
 
     /* do the default action */
-   if (!createDir && !skipDefaultAction) {
+    else if (!skipDefaultAction) {
 	char *chptr = doUntar(spec, 0, quietly);
 	if (!chptr)
 	    goto exit;
@@ -377,15 +382,15 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 	free(chptr);
     }
 
-    appendStringBuf(spec->prep, getStringBuf(before));
-
     if (!createDir) {
+	appendStringBuf(spec->prep, getStringBuf(before));
+
 	rasprintf(&buf, "cd '%s'", spec->buildSubdir);
 	appendLineStringBuf(spec->prep, buf);
 	free(buf);
     }
 
-    if (createDir && !skipDefaultAction) {
+    else if (!skipDefaultAction) {
 	char *chptr = doUntar(spec, 0, quietly);
 	if (chptr == NULL)
 	    goto exit;

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -360,21 +360,18 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 	free(buf);
     }
 
+    appendStringBuf(spec->prep, getStringBuf(before));
+
     /* if necessary, create and cd into the proper dir */
     if (createDir) {
-	buf = rpmExpand("%{__mkdir_p} ", spec->buildSubdir, "\n", NULL);
-	appendLineStringBuf(spec->prep, buf);
-	free(buf);
-
-	appendStringBuf(spec->prep, getStringBuf(before));
-
-	rasprintf(&buf, "cd '%s'", spec->buildSubdir);
+	buf = rpmExpand("%{__mkdir_p} ", spec->buildSubdir, "\n",
+			"cd '", spec->buildSubdir, "'", NULL);
 	appendLineStringBuf(spec->prep, buf);
 	free(buf);
     }
 
     /* do the default action */
-    else if (!skipDefaultAction) {
+   if (!createDir && !skipDefaultAction) {
 	char *chptr = doUntar(spec, 0, quietly);
 	if (!chptr)
 	    goto exit;
@@ -383,14 +380,12 @@ static int doSetupMacro(rpmSpec spec, const char *line)
     }
 
     if (!createDir) {
-	appendStringBuf(spec->prep, getStringBuf(before));
-
 	rasprintf(&buf, "cd '%s'", spec->buildSubdir);
 	appendLineStringBuf(spec->prep, buf);
 	free(buf);
     }
 
-    else if (!skipDefaultAction) {
+    if (createDir && !skipDefaultAction) {
 	char *chptr = doUntar(spec, 0, quietly);
 	if (chptr == NULL)
 	    goto exit;


### PR DESCRIPTION
The processing of the `%setup` macro heavily depends on the presence/absence of the options

   `-c` – Create the project subdirectory (and step into it)
   `-b` – Unpack the given source drop _before_ stepping into the project subdirectory
   `-a` – Unpack the given source drop _after_ stepping into the project subdirectory
   `-T` – Suppress unpacking the ‘default’ source drop (‘0’)

Although not well-documented, it is permissible to use combinations of these options (and there can be multiple occurrences of `-b` and `-a`).

The present commit modifies/corrects at least one border case that was not quite right in the original flow: In case of `-c -b N`, the `N`th source drop was extracted _after_ the `cd` triggered by `-c`, so
`-b` (incorrectly) worked similar to `-a`. The updated logic fixes the above rules:

* Any source drop marked by `-b` will be unpacked _before_ the `cd` into the project subdirectory, irrelevant of the presence of the `-c` option. Hence, such source drops _must_ extract in the build directory and put their contents into the project subdirectory (somewhat redundantly in combination with `-c`).

* Any source drop marked by `-a` will be unpacked _after_ the `cd` into the project subdirectory. Hence, such source drops must cleanly extract _in_ the project subdirectory.

* Unless suppressed by `-T`, the ‘default’ source drop will be extracted _before_ the `cd` if `-c` is not flagged, and _after_ the `cd` if `-c` is present. Thus it is possible to extract the ‘default’ source drop correctly, depending on its contents w/o the project directory.

----
Admittedly, combining the `-c`, `-b`, and `-a` options in a single `%setup` line is quite esoteric, but it can make the specification a bit simpler. For example

    %setup -c -q -a 1    # Note that '-T' is not flagged

certainly is shorter than

    %setup -c -q
    %setup -D -T -q -a 1   # Here '-T' must be flagged to suppress the default action

Both create the project directory, step into it, extract the ‘default’ source drop, and “add” source ‘no. 1’. Moreover, the one-liner generates at least two `cd` commands less in the prepscript.