### PR TITLE
Add "-O" to %make_build

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -877,7 +877,7 @@ package or when debugging this package.\
 
 #------------------------------------------------------------------------------
 # The "make" analogue, hiding the _smp_mflags magic from specs
-%make_build %{__make} %{?_smp_mflags}
+%make_build %{__make} -O %{?_smp_mflags}
 
 #------------------------------------------------------------------------------
 # The make install analogue of %configure for modern autotools:


### PR DESCRIPTION
In order to preserve our sanity when reading logs of `%make_build` output, adding `-O` to `%make_build` keeps the output of each thread contiguous, making the resultant build log readable and useful. See the [GNU Make manual](http://www.gnu.org/software/make/manual/make.html#Options-Summary) for details on `-O`.