### PR TITLE
Set up more portable definitions for alternative libc (μClibc and MUSL)

### DIFF
--- a/misc/fts.h
+++ b/misc/fts.h
@@ -40,18 +40,18 @@
 
 #   define __THROW
 
-#if defined(hpux)
-# define _D_EXACT_NAMLEN(d) ((d)->d_namlen)
-# define	_INCLUDE_POSIX_SOURCE
+#if !defined(_LARGEFILE64_SOURCE)
 # define	_LARGEFILE64_SOURCE
 #endif
 
-#if defined(sun)
-# define _D_EXACT_NAMLEN(d) ((d)->d_reclen)
+#if !defined(_D_EXACT_NAMELEN)
+# define _D_EXACT_NAMLEN(d) (strlen((d)->d_name))
 #endif
 
-#if defined(__APPLE__)
-# define _D_EXACT_NAMLEN(d) (strlen((d)->d_name))
+#if defined(hpux)
+# if !defined(_INCLUDE_POSIX_SOURCE)
+#  define	_INCLUDE_POSIX_SOURCE
+# endif
 #endif
 
 #endif


### PR DESCRIPTION
Distributions such as Unity Linux are working on developing RPM based Linux distributions using lightweight libc implementations. In particular, Unity Linux is using MUSL.

This pull request adjusts the definitions so that it works correctly with μClibc and MUSL, while simultaneously simplifying the definitions a bit for non-GNU platforms.