### PR TITLE
Ensure defines are in place in fts.c and fts.h

### DIFF
--- a/misc/fts.c
+++ b/misc/fts.c
@@ -31,6 +31,11 @@
 static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #endif /* LIBC_SCCS and not lint */
 
+/* This file is expected to exist for any Linux libc */
+#if defined(linux)
+#include <features.h>
+#endif
+
 /* Conditional to set up proper fstat64 implementation */
 #if defined(__GLIBC__) && !defined(__UCLIBC__)
 #   define FTS_FSTAT64(_fd, _sbp)   __fxstat64(_STAT_VER, (_fd), (_sbp))

--- a/misc/fts.h
+++ b/misc/fts.h
@@ -34,7 +34,7 @@
 
 #include <rpm/rpmutil.h>
 
-#if defined(__GLIBC__)
+#if defined(linux)
 #include <features.h>
 #else
 

--- a/misc/fts.h
+++ b/misc/fts.h
@@ -44,7 +44,7 @@
 # define	_LARGEFILE64_SOURCE
 #endif
 
-#if !defined(_D_EXACT_NAMELEN)
+#if !defined(_D_EXACT_NAMLEN)
 # define _D_EXACT_NAMLEN(d) (strlen((d)->d_name))
 #endif
 


### PR DESCRIPTION
It's not clear that `features.h` is included when it is supposed to be, and in fact it wasn't. This should correct that.