### PR TITLE
Fix fstat64 implementation conditional and define typo

### DIFF
--- a/misc/fts.c
+++ b/misc/fts.c
@@ -32,12 +32,10 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #endif /* LIBC_SCCS and not lint */
 
 /* Conditional to set up proper fstat64 implementation */
-#if defined(__GLIBC__) && !defined(__UCLIBC__)
-#   define FTS_FSTAT64(_fd, _sbp)   __fxstat64(_STAT_VER, (_fd), (_sbp))
-#elif defined(__APPLE__)
-#   define FTS_FSTAT64(_fd, _sbp)   fstat64((_fd), (_sbp))
-#else
+#if defined(hpux) || defined(sun)
 #   define FTS_FSTAT64(_fd, _sbp)   fstat((_fd), (_sbp))
+#else
+#   define FTS_FSTAT64(_fd, _sbp)   fstat64((_fd), (_sbp))
 #endif
 
 #if defined(_LIBC)

--- a/misc/fts.h
+++ b/misc/fts.h
@@ -44,7 +44,7 @@
 # define	_LARGEFILE64_SOURCE
 #endif
 
-#if !defined(_D_EXACT_NAMELEN)
+#if !defined(_D_EXACT_NAMLEN)
 # define _D_EXACT_NAMLEN(d) (strlen((d)->d_name))
 #endif
 


### PR DESCRIPTION
So, as it turns out, pretty much all libc implementations except for legacy ones implement it as `fstat64()`, so we will use `fstat64()` unless otherwise necessary.

Also, fix typo in checking for `_D_EXACT_NAMLEN` definition.