### PR TITLE
Remove size limit when expanding macros

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1631,11 +1631,13 @@ static rpmRC readFilesManifest(rpmSpec spec, Package pkg, const char *path)
     while (fgets(buf, sizeof(buf), fd)) {
 	if (handleComments(buf))
 	    continue;
-	if (expandMacros(spec, spec->macros, buf, sizeof(buf))) {
+	char *expanded = expandMacros(spec, spec->macros, buf);
+	if (expanded == NULL) {
 	    rpmlog(RPMLOG_ERR, _("line: %s\n"), buf);
 	    goto exit;
 	}
-	argvAdd(&(pkg->fileList), buf);
+	argvAdd(&(pkg->fileList), expanded);
+	free(expanded);
 	nlines++;
     }
 

--- a/build/pack.c
+++ b/build/pack.c
@@ -132,11 +132,13 @@ static rpmRC addFileToTag(rpmSpec spec, const char * file,
     }
 
     while (fgets(buf, sizeof(buf), f)) {
-	if (expandMacros(spec, spec->macros, buf, sizeof(buf))) {
+	char *expanded = expandMacros(spec, spec->macros, buf);
+	if (expanded == NULL) {
 	    rpmlog(RPMLOG_ERR, _("%s: line: %s\n"), fn, buf);
 	    goto exit;
 	}
-	appendStringBuf(sb, buf);
+	appendStringBuf(sb, expanded);
+	free(expanded);
     }
     headerPutString(h, tag, getStringBuf(sb));
     rc = RPMRC_OK;

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -180,13 +180,15 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
     if (lbuf[0] == '#')
 	isComment = 1;
 
-    lbuf = xstrdup(spec->lbuf);
+    lbuf = spec->lbuf;
 
-    rc = expandMacros(spec, spec->macros, spec->lbuf, spec->lbufSize);
-    if (rc) {
+    spec->lbuf = expandMacros(spec, spec->macros, lbuf);
+    if (spec->lbuf == NULL) {
 	rpmlog(RPMLOG_ERR, _("line %d: %s\n"),
-		spec->lineNum, spec->lbuf);
+		spec->lineNum, lbuf);
 	goto exit;
+    } else {
+	spec->lbufSize = strlen(spec->lbuf) + 1;
     }
 
     if (strip & STRIP_COMMENTS && isComment) {

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1457,7 +1457,7 @@ static void copyMacros(rpmMacroContext src, rpmMacroContext dst, int level)
 
 /* External interfaces */
 
-int expandMacros(void * spec, rpmMacroContext mc, char * sbuf, size_t slen)
+char *expandMacros(void * spec, rpmMacroContext mc, char * sbuf)
 {
     char *target = NULL;
     int rc;
@@ -1466,9 +1466,12 @@ int expandMacros(void * spec, rpmMacroContext mc, char * sbuf, size_t slen)
     rc = doExpandMacros(mc, sbuf, &target);
     rpmmctxRelease(mc);
 
-    rstrlcpy(sbuf, target, slen);
-    free(target);
-    return rc;
+    if (rc) {
+	free(target);
+	target = NULL;
+    }
+
+    return target;
 }
 
 void

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -57,13 +57,11 @@ void	rpmDumpMacroTable	(rpmMacroContext mc,
  * @todo Eliminate from API.
  * @param spec		cookie (unused)
  * @param mc		macro context (NULL uses global context).
- * @retval sbuf		input macro to expand, output expansion
- * @param slen		size of buffer
- * @return		0 on success
+ * @retval sbuf		input macro to expand
+ * @return		macro expansion (malloc'ed) or NULL on failure
  */
-int	expandMacros	(void * spec, rpmMacroContext mc,
-				char * sbuf,
-				size_t slen);
+char	*expandMacros	(void * spec, rpmMacroContext mc,
+				char * sbuf);
 
 /** \ingroup rpmmacro
  * Add macro to context.


### PR DESCRIPTION
There is a seemingly undocumented, and not even well defined, limit on the size of a macro expansion. If more text is generated then the result of the expansion is simply truncated.

This attempts to lift that limit. It is an API/ABI breaking change to librpmio as it changes the expandMacros prototype.

Since encountering this problem and starting to write this patch I have discovered http://rpm.org/ticket/814 which refers to this problem and was suggesting adding an extra function to librpmio instead. I'm happy to go that way if people prefer.