### PR TITLE
Rename expandMacrosU to rpmExpandMacros

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1631,7 +1631,7 @@ static rpmRC readFilesManifest(rpmSpec spec, Package pkg, const char *path)
     while (fgets(buf, sizeof(buf), fd)) {
 	if (handleComments(buf))
 	    continue;
-	char *expanded = expandMacrosU(spec, spec->macros, buf);
+	char *expanded = rpmExpandMacros(spec->macros, buf, 0);
 	if (expanded == NULL) {
 	    rpmlog(RPMLOG_ERR, _("line: %s\n"), buf);
 	    goto exit;

--- a/build/pack.c
+++ b/build/pack.c
@@ -132,7 +132,7 @@ static rpmRC addFileToTag(rpmSpec spec, const char * file,
     }
 
     while (fgets(buf, sizeof(buf), f)) {
-	char *expanded = expandMacrosU(spec, spec->macros, buf);
+	char *expanded = rpmExpandMacros(spec->macros, buf, 0);
 	if (expanded == NULL) {
 	    rpmlog(RPMLOG_ERR, _("%s: line: %s\n"), fn, buf);
 	    goto exit;

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -182,7 +182,7 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
 
     lbuf = spec->lbuf;
 
-    spec->lbuf = expandMacrosU(spec, spec->macros, lbuf);
+    spec->lbuf = rpmExpandMacros(spec->macros, lbuf, 0);
     if (spec->lbuf == NULL) {
 	rpmlog(RPMLOG_ERR, _("line %d: %s\n"),
 		spec->lineNum, lbuf);

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1471,7 +1471,7 @@ int expandMacros(void * spec, rpmMacroContext mc, char * sbuf, size_t slen)
     return rc;
 }
 
-char *expandMacrosU(void * spec, rpmMacroContext mc, char * sbuf)
+char *rpmExpandMacros(rpmMacroContext mc, const char * sbuf, int flags)
 {
     char *target = NULL;
     int rc;

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -67,15 +67,13 @@ int	expandMacros	(void * spec, rpmMacroContext mc,
 
 /** \ingroup rpmmacro
  * Expand macro into buffer.
- * @deprecated Use rpmExpand().
- * @todo Eliminate from API.
- * @param spec		cookie (unused)
  * @param mc		macro context (NULL uses global context).
- * @retval sbuf		input macro to expand
+ * @param sbuf		input macro to expand
+ * @param flags		flags (currently unused)
  * @return		macro expansion (malloc'ed) or NULL on failure
  */
-char	*expandMacrosU	(void * spec, rpmMacroContext mc,
-				char * sbuf);
+char	*rpmExpandMacros	(rpmMacroContext mc, const char * sbuf,
+					int flags);
 
 /** \ingroup rpmmacro
  * Add macro to context.


### PR DESCRIPTION
Address review issues from #32 by renaming the function and cleaning up the comment and parameter list.