### PR TITLE
Put all Perl-related macros in a single file.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -968,33 +968,6 @@ done \
 %sources %{lua: for i, s in ipairs(sources) do print(s.." ") end}
 
 #------------------------------------------------------------------------------
-# Useful perl macros (from Artur Frysiak <wiget@t17.ds.pwr.wroc.pl>)
-#
-# For example, these can be used as (from ImageMagick.spec from PLD site)
-#	[...]
-#	BuildPrereq: perl
-#	[...]
-#	%package perl
-#	Summary: libraries and modules for access to ImageMagick from perl
-#	Group: Development/Languages/Perl
-#	Requires: %{name} = %{version}
-#	%requires_eq    perl
-#	[...]
-#	%install
-#	rm -fr $RPM_BUILD_ROOT
-#	install -d $RPM_BUILD_ROOT/%{perl_sitearch}
-#	[...]
-#	%files perl
-#	%defattr(644,root,root,755)
-#	%{perl_sitearch}/Image
-#	%dir %{perl_sitearch}/auto/Image
-#
-%requires_eq()	%(LC_ALL="C" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
-# To make use of the Perl-related macros insert the following line into your
-# spec file:
-# %include %{_rpmconfigdir}/macros.perl
-
-#------------------------------------------------------------------------------
 # Useful python macros for determining python version and paths
 #
 %python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")

--- a/macros.in
+++ b/macros.in
@@ -990,12 +990,9 @@ done \
 #	%dir %{perl_sitearch}/auto/Image
 #
 %requires_eq()	%(LC_ALL="C" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
-%perl_sitearch	%(eval "`%{__perl} -V:installsitearch`"; echo $installsitearch)
-%perl_sitelib	%(eval "`%{__perl} -V:installsitelib`"; echo $installsitelib)
-%perl_vendorarch %(eval "`%{__perl} -V:installvendorarch`"; echo $installvendorarch)
-%perl_vendorlib  %(eval "`%{__perl} -V:installvendorlib`"; echo $installvendorlib)
-%perl_archlib	%(eval "`%{__perl} -V:installarchlib`"; echo $installarchlib)
-%perl_privlib	%(eval "`%{__perl} -V:installprivlib`"; echo $installprivlib)
+# To make use of the Perl-related macros insert the following line into your
+# spec file:
+# %include %{_rpmconfigdir}/macros.perl
 
 #------------------------------------------------------------------------------
 # Useful python macros for determining python version and paths

--- a/scripts/macros.perl
+++ b/scripts/macros.perl
@@ -2,6 +2,29 @@
 # To make use of these macros insert the following line into your spec file:
 # %include %{_rpmconfigdir}/macros.perl
 
+#------------------------------------------------------------------------------
+# Useful perl macros (from Artur Frysiak <wiget@t17.ds.pwr.wroc.pl>)
+#
+# For example, these can be used as (from ImageMagick.spec from PLD site)
+#	[...]
+#	BuildPrereq: perl
+#	[...]
+#	%package perl
+#	Summary: libraries and modules for access to ImageMagick from perl
+#	Group: Development/Languages/Perl
+#	Requires: %{name} = %{version}
+#	%requires_eq    perl
+#	[...]
+#	%install
+#	rm -fr $RPM_BUILD_ROOT
+#	install -d $RPM_BUILD_ROOT/%{perl_sitearch}
+#	[...]
+#	%files perl
+#	%defattr(644,root,root,755)
+#	%{perl_sitearch}/Image
+#	%dir %{perl_sitearch}/auto/Image
+#
+%define		requires_eq()	%(LC_ALL="C" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
 %define		perl_sitearch	%(eval "`%{__perl} -V:installsitearch`"; echo $installsitearch)
 %define		perl_sitelib	%(eval "`%{__perl} -V:installsitelib`"; echo $installsitelib)
 %define		perl_vendorarch %(eval "`%{__perl} -V:installvendorarch`"; echo $installvendorarch)

--- a/scripts/macros.perl
+++ b/scripts/macros.perl
@@ -2,8 +2,9 @@
 # To make use of these macros insert the following line into your spec file:
 # %include %{_rpmconfigdir}/macros.perl
 
-%define		perl_sitelib	%(eval "`perl -V:installsitelib`"; echo $installsitelib)
-%define		perl_sitearch	%(eval "`perl -V:installsitearch`"; echo $installsitearch)
-%define		perl_archlib	%(eval "`perl -V:installarchlib`"; echo $installarchlib)
-%define		perl_privlib	%(eval "`perl -V:installprivlib`"; echo $installprivlib)
-
+%define		perl_sitearch	%(eval "`%{__perl} -V:installsitearch`"; echo $installsitearch)
+%define		perl_sitelib	%(eval "`%{__perl} -V:installsitelib`"; echo $installsitelib)
+%define		perl_vendorarch %(eval "`%{__perl} -V:installvendorarch`"; echo $installvendorarch)
+%define		perl_vendorlib  %(eval "`%{__perl} -V:installvendorlib`"; echo $installvendorlib)
+%define		perl_archlib	%(eval "`%{__perl} -V:installarchlib`"; echo $installarchlib)
+%define		perl_privlib	%(eval "`%{__perl} -V:installprivlib`"; echo $installprivlib)


### PR DESCRIPTION
If the `%perl_...` macros are `%define`d in `macros[.in]`, they are automatically loaded on startup, so `%include`ing the extra `macros.perl` in the spec file is redundant.

In case that the `%perl_...` macros are sufficiently important to be `%define`d automatically on startup, the separate file `macros.perl` can savely be removed from the distribution.