### PR TITLE
Redundant Python version macro replaced.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -998,13 +998,6 @@ done \
 %perl_privlib	%(eval "`%{__perl} -V:installprivlib`"; echo $installprivlib)
 
 #------------------------------------------------------------------------------
-# Useful python macros for determining python version and paths
-#
-%python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")
-%python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
-%python_version %(%{__python} -c "import sys; sys.stdout.write(sys.version[:3])")
-
-#------------------------------------------------------------------------------
 # arch macro for all Intel i?86 compatibile processors
 #  (Note: This macro (and it's analogues) will probably be obsoleted when
 #   rpm can use regular expressions against target platforms in macro

--- a/scripts/macros.python
+++ b/scripts/macros.python
@@ -3,7 +3,7 @@
 # %include %{_rpmconfigdir}/macros.python
 
 # python main version
-%define py_ver         %(echo `python -c "import sys; sys.stdout.write(sys.version[:3])"`)
+%define py_ver         %python_version
 
 # directories
 %define py_prefix      %(echo `python -c "import sys; sys.stdout.write(sys.prefix)"`)

--- a/scripts/macros.python
+++ b/scripts/macros.python
@@ -13,7 +13,7 @@
 %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")
 %define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
 
-%define py_prefix      %(python -c "import sys; sys.stdout.write(sys.prefix)")
+%define py_prefix      %(%{__python} -c "import sys; sys.stdout.write(sys.prefix)")
 %define py_libdir      %{py_prefix}/lib/python%{py_ver}
 %define py_incdir      /usr/include/python%{py_ver}
 %define py_sitedir     %{py_libdir}/site-packages

--- a/scripts/macros.python
+++ b/scripts/macros.python
@@ -2,11 +2,18 @@
 # To make use of these macros insert the following line into your spec file:
 # %include %{_rpmconfigdir}/macros.python
 
+#------------------------------------------------------------------------------
+# Useful python macros for determining python version and paths
+#
 # python main version
+%define python_version %(%{__python} -c "import sys; sys.stdout.write(sys.version[:3])")
 %define py_ver         %python_version
 
 # directories
-%define py_prefix      %(echo `python -c "import sys; sys.stdout.write(sys.prefix)"`)
+%define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib())")
+%define python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1))")
+
+%define py_prefix      %(python -c "import sys; sys.stdout.write(sys.prefix)")
 %define py_libdir      %{py_prefix}/lib/python%{py_ver}
 %define py_incdir      /usr/include/python%{py_ver}
 %define py_sitedir     %{py_libdir}/site-packages


### PR DESCRIPTION
The global `macros` file already provides a macro that determines the runtime version of the Python interpreter. The separate `macros.python` adds a convenient shortcut.