### PR TITLE
Rpm 4.13.x

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -275,7 +275,7 @@ static int haveRichDep(Package pkg)
 	if (tagN != RPMTAG_REQUIRENAME && tagN != RPMTAG_CONFLICTNAME)
 	    continue;
 	while (rpmdsNext(ds) >= 0) {
-	    if (rpmdsFlags(ds) & RPMSENSE_RICH)
+	    if (rpmdsIsRich(ds))
 		return 1;
 	}
     }

--- a/build/parseReqs.c
+++ b/build/parseReqs.c
@@ -214,7 +214,7 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 		freeStringBuf(data.sb);
 		goto exit;
 	    }
-	    if (addReqProv(pkg, nametag, getStringBuf(data.sb), NULL, Flags | RPMSENSE_RICH, index)) {
+	    if (addReqProv(pkg, nametag, getStringBuf(data.sb), NULL, Flags, index)) {
 		rasprintf(&emsg, _("invalid dependency"));
 		freeStringBuf(data.sb);
 		goto exit;

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.61)
-AC_INIT(rpm, 4.12.90, rpm-maint@lists.rpm.org)
+AC_INIT(rpm, 4.13.0-rc1, rpm-maint@lists.rpm.org)
 
 AC_CONFIG_SRCDIR([rpmqv.c])
 AC_CONFIG_HEADERS([config.h])

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -631,7 +631,7 @@ retry:
 	goto exit;
 
     /* Handle rich dependencies */
-    if (dsflags & RPMSENSE_RICH) {
+    if (rpmdsIsRich(dep)) {
 	rpmds ds1, ds2; 
 	rpmrichOp op;
 	char *emsg = 0; 
@@ -644,7 +644,7 @@ retry:
 	    goto exit;
 	}
 	if (op == RPMRICHOP_IF) {
-	    if (rpmdsFlags(ds2) & RPMSENSE_RICH) {
+	    if (rpmdsIsRich(ds2)) {
 		/* check if this is a IF...ELSE combination */
 		rpmds ds21 = NULL, ds22 = NULL;
 		rpmrichOp op2;

--- a/lib/order.c
+++ b/lib/order.c
@@ -153,7 +153,7 @@ static inline int addRelation(rpmts ts,
     if (dsflags & (RPMSENSE_RPMLIB|RPMSENSE_CONFIG|RPMSENSE_PRETRANS|RPMSENSE_POSTTRANS))
 	return 0;
 
-    if (dsflags & RPMSENSE_RICH) {
+    if (rpmdsIsRich(requires)) {
 	rpmds ds1, ds2;
 	rpmrichOp op;
 	if (rpmdsParseRichDep(requires, &ds1, &ds2, &op, NULL) == RPMRC_OK) {

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1312,10 +1312,10 @@ rpmsenseFlags rpmSanitizeDSFlags(rpmTagVal tagN, rpmsenseFlags Flags)
     case RPMTAG_SUPPLEMENTNAME:
     case RPMTAG_ENHANCENAME:
     case RPMTAG_REQUIRENAME:
-	extra = Flags & (_ALL_REQUIRES_MASK | RPMSENSE_RICH);
+	extra = Flags & (_ALL_REQUIRES_MASK);
 	break;
     case RPMTAG_CONFLICTNAME:
-	extra = Flags & RPMSENSE_RICH;
+	extra = Flags;
 	break;
     default:
 	break;
@@ -1543,7 +1543,7 @@ static rpmRC rpmdsParseRichDepCB(void *cbdata, rpmrichParseType type,
 	    strncpy(right + 1, data->rightstart, n + nl - data->rightstart);
 	    right[n + nl - data->rightstart + 1] = 0;
 	    data->rightds = rpmdsFree(data->rightds);
-	    ds = singleDS(data->dep->pool, data->dep->tagN, 0, 0, RPMSENSE_RICH | data->depflags, 0, 0, 0);
+	    ds = singleDS(data->dep->pool, data->dep->tagN, 0, 0, data->depflags, 0, 0, 0);
 	    ds->N[0] = rpmstrPoolId(ds->pool, right, 1);
 	    ds->EVR[0] = rpmstrPoolId(ds->pool, "", 1);
 	    data->rightds = ds;
@@ -1553,9 +1553,7 @@ static rpmRC rpmdsParseRichDepCB(void *cbdata, rpmrichParseType type,
     if (data->depth != 1)
 	return RPMRC_OK;	/* we're only interested in top-level parsing */
     if ((type == RPMRICH_PARSE_SIMPLE || type == RPMRICH_PARSE_LEAVE) && !data->dochain) {
-	if (type == RPMRICH_PARSE_LEAVE)
-	    sense = RPMSENSE_RICH;
-	else if (data->dep->tagN == RPMTAG_REQUIRENAME && nl > 7 &&
+	if (type == RPMRICH_PARSE_SIMPLE && data->dep->tagN == RPMTAG_REQUIRENAME && nl > 7 &&
 			 rstreqn(n, "rpmlib(", sizeof("rpmlib(")-1))
 	    sense |= RPMSENSE_RPMLIB;
 	ds = singleDS(data->dep->pool, data->dep->tagN, 0, 0, sense | data->depflags, 0, 0, 0);
@@ -1586,7 +1584,7 @@ rpmRC rpmdsParseRichDep(rpmds dep, rpmds *leftds, rpmds *rightds, rpmrichOp *op,
     memset(&data, 0, sizeof(data));
     data.dep = dep;
     data.op = RPMRICHOP_SINGLE;
-    data.depflags = rpmdsFlags(dep) & ~(RPMSENSE_SENSEMASK | RPMSENSE_RICH | RPMSENSE_MISSINGOK);
+    data.depflags = rpmdsFlags(dep) & ~(RPMSENSE_SENSEMASK | RPMSENSE_MISSINGOK);
     rc = rpmrichParse(&depstr, emsg, rpmdsParseRichDepCB, &data);
     if (rc == RPMRC_OK && *depstr) {
 	if (emsg)

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1354,14 +1354,10 @@ static struct RichOpComp {
     const char * token;
     rpmrichOp op;
 } const RichOps[] = { 
-    { "&",	RPMRICHOP_AND},
-    { "&&",	RPMRICHOP_AND},
-    { "AND",	RPMRICHOP_AND},
-    { "|",	RPMRICHOP_OR},
-    { "||",	RPMRICHOP_OR},
-    { "OR",	RPMRICHOP_OR},
-    { "IF",	RPMRICHOP_IF},
-    { "ELSE",	RPMRICHOP_ELSE},
+    { "and",	RPMRICHOP_AND},
+    { "or",	RPMRICHOP_OR},
+    { "if",	RPMRICHOP_IF},
+    { "else",	RPMRICHOP_ELSE},
     { NULL, 0 },
 };
 

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1365,6 +1365,12 @@ static struct RichOpComp {
     { NULL, 0 },
 };
 
+int rpmdsIsRich(rpmds dep)
+{
+    const char * n = rpmdsN(dep);
+    return (n && n[0] == '(');
+}
+
 static rpmRC parseRichDepOp(const char **dstrp, rpmrichOp *opp, char **emsg)
 {
     const char *p = *dstrp, *pe = p;

--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -493,6 +493,14 @@ typedef rpmRC (*rpmrichParseFunction) (void *cbdata, rpmrichParseType type,
  */
 rpmRC rpmrichParse(const char **dstrp, char **emsg, rpmrichParseFunction cb, void *cbdata);
 
+
+/**
+ * Return if current depenency is rich
+ * @param dep		the dependency
+ * @return		1 is dependency is a rich 0 otherwise
+ */
+int rpmdsIsRich(rpmds dep);
+
 /**
  * Return a string representation of the rich dependency op
  * @param op		the dependency op

--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -49,8 +49,7 @@ enum rpmsenseFlags_e {
     RPMSENSE_TRIGGERPREIN = (1 << 25),	/*!< %triggerprein dependency. */
     RPMSENSE_KEYRING	= (1 << 26),
     /* bit 27 unused */
-    RPMSENSE_CONFIG	= (1 << 28),
-    RPMSENSE_RICH	= (1 << 29)
+    RPMSENSE_CONFIG	= (1 << 28)
 };
 
 typedef rpmFlags rpmsenseFlags;

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -432,7 +432,7 @@ const unsigned char * rpmfilesFDigest(rpmfiles fi, int ix, int *algo, size_t *le
  * Return file (binary) digest of file info set.
  * @param fi            file info set
  * @param ix            file index
- * @retval siglen       signature length (pass NULL to ignore)
+ * @retval len       signature length (pass NULL to ignore)
  * @return              file signature, NULL on invalid
  */
 const unsigned char * rpmfilesFSignature(rpmfiles fi, int ix, size_t *len);

--- a/lib/tagexts.c
+++ b/lib/tagexts.c
@@ -199,6 +199,7 @@ typedef enum tMode_e {
 
 /**
  * Retrieve trigger info.
+ * @param mode		type of trigger (see tMode_e)
  * @param h		header
  * @retval td		tag data container
  * @param hgflags	header get flags
@@ -314,6 +315,7 @@ static int transfiletriggercondsTag(Header h, rpmtd td, headerGetFlags hgflags)
 
 /**
  * Retrieve trigger type info.
+ * @param mode		type of trigger (see tMode_e)
  * @param h		header
  * @retval td		tag data container
  * @param hgflags	header get flags

--- a/macros.in
+++ b/macros.in
@@ -877,7 +877,7 @@ package or when debugging this package.\
 
 #------------------------------------------------------------------------------
 # The "make" analogue, hiding the _smp_mflags magic from specs
-%make_build %{__make} %{?_smp_mflags}
+%make_build %{__make} -O %{?_smp_mflags}
 
 #------------------------------------------------------------------------------
 # The make install analogue of %configure for modern autotools:

--- a/plugins/ima.c
+++ b/plugins/ima.c
@@ -25,14 +25,7 @@ static rpmRC ima_psm_post(rpmPlugin plugin, rpmte te, int res)
 	    goto exit;
 	}
 
-	while (!rc) {
-	    rc = rpmfiNext(fi);
-	    if (rc < 0) {
-		if (rc == RPMERR_ITER_END)
-		    rc = 0;
-		break;
-	    }
-
+	while (rpmfiNext(fi) >= 0) {
 	    /* Don't install signatures for (mutable) config files */
 	    if (!(rpmfiFFlags(fi) & RPMFILE_CONFIG)) {
 		fpath = rpmfiFN(fi);

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,24 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Mosaab Alzoubi <moceap@hotmail.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Arabic (http://www.transifex.com/projects/p/rpm/language/"
-"ar/)\n"
-"Language: ar\n"
+"Language-Team: Arabic (http://www.transifex.com/rpm-team/rpm/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
-"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -39,8 +37,7 @@ msgstr "الحقوق محفوظة 1998-2002 - شركة ريدهات.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"يُمكن إعادة نشر هذا البرنامج بحريّة تحت بنود رخصة النّشر العمومية من غنّو\n"
+msgstr "يُمكن إعادة نشر هذا البرنامج بحريّة تحت بنود رخصة النّشر العمومية من غنّو\n"
 
 #: cliutils.c:53
 #, c-format
@@ -83,7 +80,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -104,7 +101,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -139,7 +136,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -204,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -224,243 +222,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, c-format
-msgid "verify %files section from <source package>"
-msgstr ""
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "أزِل المصادر عند الانتهاء"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "أزِل ملف المُحدّد عند الانتهاء"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr ""
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -509,7 +465,7 @@ msgstr "أظهر قائمة المفاتيح من حلقة مفاتيح RPM"
 msgid "Keyring options:"
 msgstr "خيارات حلقة المفاتيح:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -529,9 +485,28 @@ msgstr "احذف توقيعات الحُزم"
 msgid "Signature options:"
 msgstr "خيارات التّوقيع:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "تعذّر تنفيذ %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "أدخل عبّارة المرور:"
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "عبّارة المرور جيدة.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -550,7 +525,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -597,71 +572,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"أخطاء بناء الحزمة:\n"
+msgstr "\n\nأخطاء بناء الحزمة:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -671,46 +643,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -720,144 +692,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "السّطر: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -886,79 +863,79 @@ msgstr "%s: السّطر: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "تعذّر تحميل رأس التّوقيع.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "تعذّر فتح %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "تعذّرت كتابة الحزمة: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "بيانات CSA خاطئة\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "تعذّر تنفيذ %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "تعذّر إيجاد %s:\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "تمت كتابة: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "يجري تنفيذ \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1009,19 +986,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1128,94 +1105,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "السّطر %d: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: السّطر: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1225,193 +1198,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "مصدر خاطئ: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "السّطر %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1482,281 +1423,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "تعذّر تنفيذ %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "يجري إبجاد  %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "تعذّر إيجاد %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(ليس رقمًا)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(نوع غير سليم)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "عادية"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "مُستبدلة"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "غير مثبّتة"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "لون خاطئ"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "مفقودة"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(غير معروفة)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s حُفت كـ %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s أُنشئت كـ %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "دليل"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "ملف"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1885,13 +1835,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1970,7 +1921,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2090,178 +2041,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2336,116 +2271,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, c-format
-msgid "no package suggests %s\n"
-msgstr ""
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, c-format
-msgid "no package enhances %s\n"
-msgstr ""
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "الملف %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "غير موافق"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "موافق"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (مفاتيح مفقودة:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (مفاتيح غير موثوقة:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: فشل فتح: %s\n"
@@ -2470,191 +2385,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "لا"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "نعم"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-msgid "support for rich dependencies."
-msgstr ""
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " فشل - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2686,42 +2554,42 @@ msgstr "فشل في الاعتماديات:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "تعذّر فتح %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "يجري تثبيت %s\n"
@@ -2747,12 +2615,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2914,75 +2782,56 @@ msgstr "خيار خاطئ '%s' at %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "نظام غير معروف: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "اتّصل رجاءً %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "تعذّرت كتابة الحزمة: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "تعذّرت كتابة الحزمة: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: فشل فتح: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "صيغة غير معروفة"
 
@@ -2994,142 +2843,127 @@ msgstr "ثبّت"
 msgid "erase"
 msgstr "أزِل"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "مُبادلة"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "الترويسة"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "الترويسة"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "مُستثناة"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "مفقود   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3203,240 +3037,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "مُشتركة"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3456,31 +3290,31 @@ msgstr "الملف %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3489,19 +3323,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(بدون أخطاء)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "خطأ فادح: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "خطأ: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr ""
 
@@ -3510,121 +3344,99 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(لا شيء)"
 
-#: sign/rpmgensig.c:56
-#, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:64
-#, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "تعذّر تنفيذ %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: فشل فتح: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "تعذّر تنفيذ %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "تعذّر تنفيذ %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3637,12 +3449,3 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "أدخل عبّارة المرور:"
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "عبّارة المرور جيدة.\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "تعذّر فتح ملفٍ مؤقت.\n"

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,22 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Mosaab Alzoubi <moceap@hotmail.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/rpm-team/rpm/language/ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -37,7 +38,8 @@ msgstr "الحقوق محفوظة 1998-2002 - شركة ريدهات.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "يُمكن إعادة نشر هذا البرنامج بحريّة تحت بنود رخصة النّشر العمومية من غنّو\n"
+msgstr ""
+"يُمكن إعادة نشر هذا البرنامج بحريّة تحت بنود رخصة النّشر العمومية من غنّو\n"
 
 #: cliutils.c:53
 #, c-format
@@ -80,7 +82,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +103,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -136,8 +138,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -202,7 +203,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -222,201 +223,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
+#, c-format
+msgid "verify %files section from <source package>"
 msgstr ""
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr ""
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "أزِل المصادر عند الانتهاء"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "أزِل ملف المُحدّد عند الانتهاء"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr ""
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -465,48 +508,61 @@ msgstr "أظهر قائمة المفاتيح من حلقة مفاتيح RPM"
 msgid "Keyring options:"
 msgstr "خيارات حلقة المفاتيح:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "وقّع الحزم"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "احذف توقيعات الحُزم"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "وقّع الحزم"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "خيارات التّوقيع:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "تعذّر تنفيذ %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "أدخل عبّارة المرور:"
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "عبّارة المرور جيدة.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
+msgstr ""
+
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -525,7 +581,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -572,68 +628,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nأخطاء بناء الحزمة:\n"
+msgstr ""
+"\n"
+"\n"
+"أخطاء بناء الحزمة:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -643,46 +702,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -692,149 +751,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "السّطر: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -863,79 +922,76 @@ msgstr "%s: السّطر: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "تعذّر تحميل رأس التّوقيع.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "تعذّر فتح %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "تعذّرت كتابة الحزمة: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "بيانات CSA خاطئة\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "تمت كتابة: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "يجري تنفيذ \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -986,19 +1042,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1105,90 +1161,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "السّطر %d: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: السّطر: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1198,161 +1258,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "مصدر خاطئ: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "السّطر %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1423,290 +1515,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "تعذّر تنفيذ %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "يجري إبجاد  %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "تعذّر إيجاد %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(ليس رقمًا)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(نوع غير سليم)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "عادية"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "مُستبدلة"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "غير مثبّتة"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "لون خاطئ"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "مفقودة"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(غير معروفة)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s حُفت كـ %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s أُنشئت كـ %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "دليل"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "ملف"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1835,14 +1918,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1921,7 +2003,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2041,162 +2123,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2271,96 +2369,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, c-format
+msgid "no package suggests %s\n"
+msgstr ""
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, c-format
+msgid "no package enhances %s\n"
+msgstr ""
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "الملف %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "غير موافق"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "موافق"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (مفاتيح مفقودة:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (مفاتيح غير موثوقة:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: فشل فتح: %s\n"
@@ -2385,144 +2503,191 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "لا"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "نعم"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+msgid "support for rich dependencies."
+msgstr ""
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " فشل - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2554,42 +2719,42 @@ msgstr "فشل في الاعتماديات:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "تعذّر فتح %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "يجري تثبيت %s\n"
@@ -2615,12 +2780,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2778,60 +2943,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr "خيار خاطئ '%s' at %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "نظام غير معروف: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "اتّصل رجاءً %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "تعذّرت كتابة الحزمة: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "تعذّرت كتابة الحزمة: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: فشل فتح: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "صيغة غير معروفة"
 
@@ -2843,127 +3027,146 @@ msgstr "ثبّت"
 msgid "erase"
 msgstr "أزِل"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "مُبادلة"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr ""
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "تعذّر تحميل رأس التّوقيع.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "الترويسة"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "مُستثناة"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "مفقود   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3037,240 +3240,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "مُشتركة"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "مُشتركة"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3290,31 +3493,31 @@ msgstr "الملف %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3323,19 +3526,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(بدون أخطاء)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "خطأ فادح: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "خطأ: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr ""
 
@@ -3344,99 +3547,152 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(لا شيء)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:66
+#, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr ""
+msgid "Could not exec %s: %s\n"
+msgstr "تعذّر تنفيذ %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: فشل فتح: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "فشل التّنفيذ\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "فشل التّنفيذ\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "فشل التّنفيذ\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3449,3 +3705,9 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "أدخل عبّارة المرور:"
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "عبّارة المرور جيدة.\n"

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-04-07 13:17+0300\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Bengali (India) (http://www.transifex.com/projects/p/rpm/language/bn_IN/)\n"
+"Language-Team: Bengali (India) (http://www.transifex.com/rpm-team/rpm/language/bn_IN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:199
+#: rpmsign.c:93 sign/rpmgensig.c:232
 #, c-format
 msgid "Could not exec %s: %s\n"
 msgstr ""
@@ -862,92 +862,74 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:238
-#, c-format
-msgid "Unable to write payload to %s: %s\n"
+#: build/pack.c:350
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:246
-#, c-format
-msgid "Unable to read payload from %s: %s\n"
-msgstr ""
-
-#: build/pack.c:346
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:374
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:385
-msgid "Unable to open temp file.\n"
-msgstr ""
-
-#: build/pack.c:392
-msgid "Unable to write temp header\n"
-msgstr ""
-
-#: build/pack.c:400
-msgid "Bad CSA data\n"
-msgstr ""
-
-#: build/pack.c:464
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:472
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:484
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:500
-#, c-format
-msgid "Unable to open sigtarget %s: %s\n"
+#: build/pack.c:495
+msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:511
-#, c-format
-msgid "Unable to read header from %s: %s\n"
+#: build/pack.c:504
+msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:521
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
-msgid "Unable to write header to %s: %s\n"
+msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:554
+#: build/pack.c:526
+#, c-format
+msgid "Fread failed in file %s: %s\n"
+msgstr ""
+
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:573
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:576
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:580
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:627
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:644
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
@@ -1175,37 +1157,37 @@ msgstr ""
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:901
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:990
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1051
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1060
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1095
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1127
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1590,19 +1572,19 @@ msgstr ""
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:341
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:335
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:337
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:339
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
@@ -1754,79 +1736,83 @@ msgstr ""
 msgid "'EXPR'"
 msgstr ""
 
-#: lib/poptALL.c:187 lib/poptALL.c:201
+#: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
 msgstr ""
 
-#: lib/poptALL.c:188 lib/poptALL.c:202
+#: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
 msgstr ""
 
-#: lib/poptALL.c:191
+#: lib/poptALL.c:193
+msgid "don't enable any plugins"
+msgstr ""
+
+#: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
 msgstr ""
 
-#: lib/poptALL.c:193
+#: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
 msgstr ""
 
-#: lib/poptALL.c:195
+#: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
 msgstr ""
 
-#: lib/poptALL.c:198
+#: lib/poptALL.c:203
 msgid "send stdout to CMD"
 msgstr ""
 
-#: lib/poptALL.c:199
+#: lib/poptALL.c:204
 msgid "CMD"
 msgstr ""
 
-#: lib/poptALL.c:204
+#: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
 msgstr ""
 
-#: lib/poptALL.c:205
+#: lib/poptALL.c:210
 msgid "ROOT"
 msgstr ""
 
-#: lib/poptALL.c:207
+#: lib/poptALL.c:212
 msgid "use database in DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:208
+#: lib/poptALL.c:213
 msgid "DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:211
+#: lib/poptALL.c:216
 msgid "display known query tags"
 msgstr ""
 
-#: lib/poptALL.c:213
+#: lib/poptALL.c:218
 msgid "display final rpmrc and macro configuration"
 msgstr ""
 
-#: lib/poptALL.c:215
+#: lib/poptALL.c:220
 msgid "provide less detailed output"
 msgstr ""
 
-#: lib/poptALL.c:217
+#: lib/poptALL.c:222
 msgid "provide more detailed output"
 msgstr ""
 
-#: lib/poptALL.c:219
+#: lib/poptALL.c:224
 msgid "print the version of rpm being used"
 msgstr ""
 
-#: lib/poptALL.c:225
+#: lib/poptALL.c:230
 msgid "debug payload file state machine"
 msgstr ""
 
-#: lib/poptALL.c:231
+#: lib/poptALL.c:236
 msgid "debug rpmio I/O"
 msgstr ""
 
-#: lib/poptALL.c:298
+#: lib/poptALL.c:303
 #, c-format
 msgid "%s: option table misconfigured (%d)\n"
 msgstr ""
@@ -1898,7 +1884,7 @@ msgstr ""
 msgid "upgrade package(s) if already installed"
 msgstr ""
 
-#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:255 lib/poptI.c:259
+#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:251 lib/poptI.c:255
 msgid "<packagefile>+"
 msgstr ""
 
@@ -2009,52 +1995,48 @@ msgid "do not execute any %%triggerpostun scriptlet(s)"
 msgstr ""
 
 #: lib/poptI.c:229
-msgid "do not perform any collection actions"
-msgstr ""
-
-#: lib/poptI.c:233
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
 msgstr ""
 
-#: lib/poptI.c:237
+#: lib/poptI.c:233
 msgid "print percentages as package installs"
 msgstr ""
 
-#: lib/poptI.c:239
+#: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
 msgstr ""
 
-#: lib/poptI.c:240
+#: lib/poptI.c:236
 msgid "<dir>"
 msgstr ""
 
-#: lib/poptI.c:242
+#: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
 msgstr ""
 
-#: lib/poptI.c:243
+#: lib/poptI.c:239
 msgid "<old>=<new>"
 msgstr ""
 
-#: lib/poptI.c:246
+#: lib/poptI.c:242
 msgid "ignore file conflicts between packages"
 msgstr ""
 
-#: lib/poptI.c:249
+#: lib/poptI.c:245
 msgid "reinstall if the package is already present"
 msgstr ""
 
-#: lib/poptI.c:251
+#: lib/poptI.c:247
 msgid "don't install, but tell if it would work or not"
 msgstr ""
 
-#: lib/poptI.c:254
+#: lib/poptI.c:250
 msgid "upgrade package(s)"
 msgstr ""
 
-#: lib/poptI.c:258
+#: lib/poptI.c:254
 msgid "reinstall package(s)"
 msgstr ""
 
@@ -2338,7 +2320,7 @@ msgstr ""
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
@@ -2348,7 +2330,7 @@ msgstr ""
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:93
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
@@ -2377,7 +2359,7 @@ msgstr ""
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:53
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2402,79 +2384,79 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:964
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:967
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:971
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:976
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:979
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:983
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:986
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:989
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:992
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:995
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:998
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1002
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1006
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1010
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1014
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1017
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1020
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
@@ -2654,10 +2636,10 @@ msgstr ""
 
 #: lib/rpmplugins.c:154
 #, c-format
-msgid "Failed to expand %%__%s_%s macro\n"
+msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:198
+#: lib/rpmplugins.c:199
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -2852,11 +2834,11 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:792
+#: lib/rpmte.c:729
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:793
+#: lib/rpmte.c:730
 msgid "erase"
 msgstr ""
 
@@ -2889,96 +2871,98 @@ msgstr ""
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:87
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:92
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:98
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:104
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:119
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:136
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:159
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:175
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:251
-msgid "Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-
-#: lib/signature.c:261
-msgid "Cannot sign RPM v3 packages\n"
-msgstr ""
-
-#: lib/signature.c:348
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:387
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:429
+#: lib/signature.c:316
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:470
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:343
+#: lib/verify.c:251
+#, c-format
+msgid "Duplicate username or UID for user %s\n"
+msgstr ""
+
+#: lib/verify.c:272
+#, c-format
+msgid "Duplicate groupname or GID for group %s\n"
+msgstr ""
+
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:345
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:396
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:448
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3209,90 +3193,6 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: plugins/sepolicy.c:215
-#, c-format
-msgid "Failed to decode policy for %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:222
-#, c-format
-msgid "Failed to create temporary file for %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:228
-#, c-format
-msgid "Failed to write %s policy to file %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:293
-msgid "Failed to create semanage handle\n"
-msgstr ""
-
-#: plugins/sepolicy.c:299
-msgid "Failed to connect to policy handler\n"
-msgstr ""
-
-#: plugins/sepolicy.c:303
-#, c-format
-msgid "Failed to begin policy transaction: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:334
-#, c-format
-msgid "Failed to remove temporary policy file %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:383
-#, c-format
-msgid "Failed to install policy module: %s (%s)\n"
-msgstr ""
-
-#: plugins/sepolicy.c:413
-#, c-format
-msgid "Failed to remove policy module: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:437 plugins/sepolicy.c:489
-#, c-format
-msgid "Failed to fork process: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:447 plugins/sepolicy.c:499
-#, c-format
-msgid "Failed to execute %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:453 plugins/sepolicy.c:505
-#, c-format
-msgid "%s terminated abnormally\n"
-msgstr ""
-
-#: plugins/sepolicy.c:457 plugins/sepolicy.c:509
-#, c-format
-msgid "%s failed with exit code %i\n"
-msgstr ""
-
-#: plugins/sepolicy.c:464
-msgid "Failed to commit policy changes\n"
-msgstr ""
-
-#: plugins/sepolicy.c:481
-msgid "Failed to expand restorecon path"
-msgstr ""
-
-#: plugins/sepolicy.c:560
-msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:564
-msgid "Failed to reload file contexts. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:591
-#, c-format
-msgid "Failed to extract policy from %s\n"
-msgstr ""
-
 #: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
@@ -3303,19 +3203,19 @@ msgstr ""
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:500 rpmio/macro.c:538
+#: rpmio/macro.c:494
+#, c-format
+msgid "Macro %%%s has unterminated opts\n"
+msgstr ""
+
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:557
-#, c-format
-msgid "Macro %%%s has illegal name (%%define)\n"
-msgstr ""
-
 #: rpmio/macro.c:563
 #, c-format
-msgid "Macro %%%s has unterminated opts\n"
+msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
 #: rpmio/macro.c:568
@@ -3333,63 +3233,63 @@ msgstr ""
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:615
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:644
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:727
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:956
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1025 rpmio/macro.c:1042
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1083
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1101
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1482
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:257
+#: rpmio/rpmfileutil.c:258
 #, c-format
 msgid "error creating temporary file %s: %m\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:322 rpmio/rpmfileutil.c:328
+#: rpmio/rpmfileutil.c:323 rpmio/rpmfileutil.c:329
 #, c-format
 msgid "File %s: %s\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:331
+#: rpmio/rpmfileutil.c:332
 #, c-format
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:599
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
@@ -3452,73 +3352,90 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:87
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:97
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:125
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:131
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:174
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
 msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:216
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+msgid "Could not write to pipe\n"
+msgstr ""
+
+#: sign/rpmgensig.c:284
+#, c-format
+msgid "Could not read from file %s: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:246
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:263
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:432
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:440 sign/rpmgensig.c:509
-msgid "rpmMkTemp failed\n"
+#: sign/rpmgensig.c:514
+msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:492
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
-#, c-format
-msgid "%s: writeLead failed: %s\n"
-msgstr ""
-
-#: sign/rpmgensig.c:522
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:536
+#: sign/rpmgensig.c:614
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:621
+#, c-format
+msgid "%s: writeLead failed: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/br.po
+++ b/po/br.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Thierry Vignaud <thierry.vignaud@gmail.com>, 2012,2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-21 08:33+0000\n"
 "Last-Translator: Thierry Vignaud <thierry.vignaud@gmail.com>\n"
 "Language-Team: Breton (http://www.transifex.com/rpm-team/rpm/language/br/)\n"
+"Language: br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: br\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +101,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -136,8 +136,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -202,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -222,201 +221,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<restr_spec>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<pakad tarzh>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
+#, c-format
+msgid "verify %files section from <source package>"
 msgstr ""
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr ""
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Muioc'h evit ur restr war ul linenn : %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -465,48 +506,61 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "Staliañ pakad(où)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Dibaboù ar sinadur:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "N'hell ket bet sevenet %s : %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:127
-#, c-format
-msgid "Pass phrase is good.\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
 msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -525,7 +579,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -574,66 +628,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -643,46 +697,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -692,149 +746,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "N'eo ket bet kavet ar renkell : %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "N'eo ket bet kavet ar rstr : %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "linenn : %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Muioc'h evit ur restr war ul linenn : %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "N'eo ket ur restr mat : %s : %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -863,79 +917,76 @@ msgstr "%s : linenn : %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "N'hell ket bet digoret ar restr %s : %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "sac'het eo bet Fread er restr %s : %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "O seveniñ « %s » :\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Sac'het eo bet seveniñ « %s ».\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Sac'het eo bet ar gwiriekaat pakad « %s ».\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "n'hell ket bet krouet %s : %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -986,19 +1037,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linenn %d : re a anvioù : %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linenn %d : n'eus ket eus ar pakad-se : %s\n"
@@ -1105,90 +1156,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linenn %d : %s : %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s : linenn : %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1198,161 +1253,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s : %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Ret eo e vede ur stumm"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Ret eo e vede ur stumm"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "linenn %d : %s : %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linenn %d : %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "fazi en ur zigeriñ %s : %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1423,290 +1510,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "N'hell bet bet sevenet %s : %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "sac'het eo bet %s : %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "sac'het eo bet magic_open(0x%x) : %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "sac'het eo bet magic_load : %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "O klask  %s : %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Sac'het eo bet klask %s :\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "Un Delta RPM eo %s neuez ne c'hell ket bezañ staliet\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "Bet eo ouzhpennet ar pakad %s dija, o tremen e-biou %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "Bet eo ouzhpennet ar pakad %s dija, o erlec'hiañ gant %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(n'eo ket un niverenn)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "reizh"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "erlec'hiet"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "ket staliet"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "ket rannet"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "mankout a ra"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(dianav)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s : sac'het eo bet lemel : %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "renkell"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "restr"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "sac'het eo bet Fread : %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1835,14 +1913,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1921,7 +1998,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2041,162 +2118,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "o tremen e-biou ar restroù %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " war restr "
 
@@ -2271,96 +2364,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "n'eus pakad evet da lemel"
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "n'eus pakad evet da lemel"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s : sac'het eo bet headerRead : %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s : sac'het eo bet Fread : %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "KET MAT"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "MAT"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s : sac'het eo bet digeriñ : %s\n"
@@ -2385,144 +2498,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "KET"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "YA"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+msgid "support for rich dependencies."
+msgstr ""
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Ret eo e vede ur stumm"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " sac'het - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2554,42 +2715,42 @@ msgstr "Sujedigezh sac'het :\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "O tegas %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "fazi en ur lenn eus ar restr %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "N'hell ket bet digoret %s : %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "O staliañ %s\n"
@@ -2615,12 +2776,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "o c'hortoz evit krouiliñ %s war %s\n"
@@ -2778,60 +2939,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "N'hell ket bet digoret %s evit lenn : %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "fazi en ur zigeriñ %s : %s\n"
+
+#: lib/rpmscript.c:354
+#, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr ""
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s : sac'het eo bet Fwrite : %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Furmad dianav"
 
@@ -2843,127 +3023,146 @@ msgstr "staliañ"
 msgid "erase"
 msgstr "lemel"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "N'hell ket bet digoret stlennvon ar pakadoù e %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "gra"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "tremenet en e biou"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "sac'het"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "mankout a ra  %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3037,240 +3236,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader : o tremen e-biou"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s : sac'het eo bet regexec : %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s : sac'het eo bet regcomp : %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator : o tremen e-biou"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "n'hellan ket krouiliñ %s war %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "rannet"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "n'hellan ket krouiliñ %s war %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "rannet"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3290,31 +3489,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3323,19 +3522,19 @@ msgstr ""
 msgid "[none]"
 msgstr "[hini ebet]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(fazi ebet)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "Fazi sac'hus : "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "fazi :"
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "hoc'h evezh : "
 
@@ -3344,99 +3543,154 @@ msgstr "hoc'h evezh : "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID alc'hwez %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(hini ebet)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s : sac'het eo bet Fwrite : %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s : sac'het eo bet Fflush : %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr ""
+msgid "Could not exec %s: %s\n"
+msgstr "N'hell ket bet sevenet %s : %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s : sac'het eo bet digeriñ : %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "N'hell ket bet lennet ar restr %s : %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "Sac'het eo bet seveniñ gpg (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s : sac'het eo bet rpmWriteSignature : %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s : sac'het eo bet rpmReadSignature : %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s : sac'het eo bet headerRead : %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "sac'het eo rpmMkTemp\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "sac'het eo bet seveniñ\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s : sac'het eo bet headerRead : %s\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s : sac'het eo bet rpmReadSignature : %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s : sac'het eo bet rpmWriteSignature : %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "sac'het eo rpmMkTemp\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s : sac'het eo bet writeLead : %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "sach'et eo bet erlec'hiañ %s : %s\n"
@@ -3449,3 +3703,6 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "sac'het eo bet Fread : %s"

--- a/po/br.po
+++ b/po/br.po
@@ -1,22 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
-# Thierry Vignaud <thierry.vignaud@gmail.com>, 2012
+# Thierry Vignaud <thierry.vignaud@gmail.com>, 2012,2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
-"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Breton (http://www.transifex.com/projects/p/rpm/language/"
-"br/)\n"
-"Language: br\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-21 08:33+0000\n"
+"Last-Translator: Thierry Vignaud <thierry.vignaud@gmail.com>\n"
+"Language-Team: Breton (http://www.transifex.com/rpm-team/rpm/language/br/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: br\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +80,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -102,7 +101,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -137,7 +136,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -202,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -222,243 +222,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
-msgstr ""
+msgstr "<restr_spec>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<pakad tarzh>"
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, c-format
-msgid "verify %files section from <source package>"
-msgstr ""
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Muioc'h evit ur restr war ul linenn : %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -485,7 +443,7 @@ msgstr ""
 
 #: rpmdb.c:42
 msgid "Database options:"
-msgstr ""
+msgstr "Dibaboù ar stlennvon:"
 
 #: rpmkeys.c:24
 msgid "verify package signature(s)"
@@ -507,7 +465,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -525,11 +483,30 @@ msgstr ""
 
 #: rpmsign.c:35
 msgid "Signature options:"
-msgstr ""
+msgstr "Dibaboù ar sinadur:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "N'hell ket bet sevenet %s : %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr ""
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr ""
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -548,7 +525,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -597,66 +574,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -666,46 +643,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -715,144 +692,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "N'eo ket bet kavet ar renkell : %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "N'eo ket bet kavet ar rstr : %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "linenn : %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Muioc'h evit ur restr war ul linenn : %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "N'eo ket ur restr mat : %s : %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -881,79 +863,79 @@ msgstr "%s : linenn : %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "N'hell ket bet digoret ar restr %s : %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "N'hell ket bet digoret ar restr %s : %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s : sac'het eo bet Fread : %s\n"
+msgstr "sac'het eo bet Fread er restr %s : %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "O seveniñ « %s » :\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Sac'het eo bet seveniñ « %s ».\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Sac'het eo bet ar gwiriekaat pakad « %s ».\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "n'hell ket bet krouet %s : %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1004,19 +986,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linenn %d : re a anvioù : %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linenn %d : n'eus ket eus ar pakad-se : %s\n"
@@ -1123,94 +1105,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linenn %d : %s : %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s : linenn : %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1220,193 +1198,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s : %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Ret eo e vede ur stumm"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "linenn %d : %s : %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linenn %d : %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "fazi en ur zigeriñ %s : %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1477,281 +1423,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "N'hell bet bet sevenet %s : %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "sac'het eo bet %s : %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "sac'het eo bet magic_open(0x%x) : %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "sac'het eo bet magic_load : %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "O klask  %s : %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Sac'het eo bet klask %s :\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "Un Delta RPM eo %s neuez ne c'hell ket bezañ staliet\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "Bet eo ouzhpennet ar pakad %s dija, o tremen e-biou %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "Bet eo ouzhpennet ar pakad %s dija, o erlec'hiañ gant %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(n'eo ket un niverenn)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "reizh"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "erlec'hiet"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "ket staliet"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "ket rannet"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "mankout a ra"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(dianav)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s : sac'het eo bet lemel : %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "renkell"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "restr"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
 msgstr ""
 
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "sac'het eo bet Fread : %s"
+
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1812,7 +1767,7 @@ msgstr ""
 
 #: lib/poptALL.c:204
 msgid "CMD"
-msgstr ""
+msgstr "URZH"
 
 #: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
@@ -1828,7 +1783,7 @@ msgstr ""
 
 #: lib/poptALL.c:213
 msgid "DIRECTORY"
-msgstr ""
+msgstr "RENKEL"
 
 #: lib/poptALL.c:216
 msgid "display known query tags"
@@ -1880,13 +1835,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1965,7 +1921,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2085,178 +2041,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "o tremen e-biou ar restroù %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " war restr "
 
@@ -2331,116 +2271,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "n'eus pakad evet da lemel"
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "n'eus pakad evet da lemel"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s : sac'het eo bet headerRead : %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s : sac'het eo bet Fread : %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "KET MAT"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "MAT"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s : sac'het eo bet digeriñ : %s\n"
@@ -2465,192 +2385,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "KET"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "YA"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-msgid "support for rich dependencies."
-msgstr ""
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Ret eo e vede ur stumm"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " sac'het - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2682,42 +2554,42 @@ msgstr "Sujedigezh sac'het :\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "O tegas %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "fazi en ur lenn eus ar restr %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "N'hell ket bet digoret %s : %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "O staliañ %s\n"
@@ -2743,12 +2615,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "o c'hortoz evit krouiliñ %s war %s\n"
@@ -2910,75 +2782,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "N'hell ket bet digoret %s evit lenn : %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "fazi en ur zigeriñ %s : %s\n"
-
-#: lib/rpmscript.c:354
-#, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr ""
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s : sac'het eo bet Fwrite : %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Furmad dianav"
 
@@ -2990,142 +2843,127 @@ msgstr "staliañ"
 msgid "erase"
 msgstr "lemel"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "N'hell ket bet digoret stlennvon ar pakadoù e %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "gra"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "tremenet en e biou"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "sac'het"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "mankout a ra  %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3199,240 +3037,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader : o tremen e-biou"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s : sac'het eo bet regexec : %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s : sac'het eo bet regcomp : %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator : o tremen e-biou"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "n'hellan ket krouiliñ %s war %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "rannet"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3452,31 +3290,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3485,142 +3323,120 @@ msgstr ""
 msgid "[none]"
 msgstr "[hini ebet]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(fazi ebet)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "Fazi sac'hus : "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "fazi :"
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
-msgstr "ho evezh : "
+msgstr "hoc'h evezh : "
 
 #: rpmio/rpmmalloc.c:25
 #, c-format
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID alc'hwez %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(hini ebet)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s : sac'het eo bet Fwrite : %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s : sac'het eo bet Fflush : %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "N'hell ket bet sevenet %s : %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s : sac'het eo bet digeriñ : %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "N'hell ket bet digoret ar restr %s : %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "N'hell ket bet digoret ar restr %s : %s\n"
+msgstr "N'hell ket bet lennet ar restr %s : %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "Sac'het eo bet seveniñ gpg (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s : sac'het eo bet rpmReadSignature : %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s : sac'het eo bet rpmWriteSignature : %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "sac'het eo rpmMkTemp\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s : sac'het eo bet writeLead : %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "sach'et eo bet erlec'hiañ %s : %s\n"
@@ -3633,6 +3449,3 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Sac'het eo bet seveniñ %s : %s\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
+# Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
-"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Catalan (http://www.transifex.com/projects/p/rpm/language/"
-"ca/)\n"
-"Language: ca\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-26 13:57+0000\n"
+"Last-Translator: Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>\n"
+"Language-Team: Catalan (http://www.transifex.com/rpm-team/rpm/language/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -26,7 +26,7 @@ msgstr "%s: %s\n"
 #: cliutils.c:27 lib/poptALL.c:57
 #, c-format
 msgid "RPM version %s\n"
-msgstr "Versió de l'RPM %s\n"
+msgstr "Versió %s de RPM\n"
 
 #: cliutils.c:32
 #, c-format
@@ -37,9 +37,7 @@ msgstr "Copyright (c) 1998 - 2002 Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Aquest programari es pot distribuir lliurement d'acord amb els termes de la "
-"Llicència Pública General GNU\n"
+msgstr "Aquest programari es pot distribuir lliurement d'acord amb els termes de la Llicència Pública General GNU\n"
 
 #: cliutils.c:53
 #, c-format
@@ -68,7 +66,7 @@ msgstr "no s'ha pogut tornar a obrir les dades de càrrega: %s\n"
 
 #: rpmqv.c:41
 msgid "Query/Verify package selection options:"
-msgstr ""
+msgstr "Opcions de selecció de paquets de consulta o verificació:"
 
 #: rpmqv.c:46
 msgid "Query options (with -q or --query):"
@@ -80,16 +78,16 @@ msgstr "Opcions de verificació (amb -V o --verify):"
 
 #: rpmqv.c:57
 msgid "Install/Upgrade/Erase options:"
-msgstr "Opcions d'instal·lació/actualització/supressió:"
+msgstr "Opcions d'instal·lació, actualització o supressió:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
-msgstr "Opcions comunes per a tots els modes d'rpm i executables:"
+msgstr "Opcions comunes per a tots els modes rpm i executables:"
 
 #: rpmqv.c:121
 msgid "one type of query/verify may be performed at a time"
-msgstr "només es pot realitzar un tipus de consulta/verificació alhora"
+msgstr "només es pot realitzar un tipus consulta o verifica alhora"
 
 #: rpmqv.c:125
 msgid "unexpected query flags"
@@ -101,19 +99,19 @@ msgstr "format inesperat de la consulta"
 
 #: rpmqv.c:131
 msgid "unexpected query source"
-msgstr "font inesperada de la consulta"
+msgstr "origen inesperat de la consulta"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "només es pot especificar un mode principal"
 
 #: rpmqv.c:154
 msgid "only installation and upgrading may be forced"
-msgstr ""
+msgstr "només es pot forçar la instal·lació i l'actualització"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "només es poden reubicar els fitxers durant la instal·lació d'un paquet"
+msgstr "només es poden traslladar els fitxers durant la instal·lació del paquet"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -122,15 +120,11 @@ msgstr "no es pot utilitzar l'opció --prefix amb --relocate o --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"només es poden utilitzar les opcions --relocate i --excludepath quan "
-"s'estiguin instal·lant paquets nous"
+msgstr "només es poden utilitzar les opcions --relocate i --excludepath quan s'instal·lin paquets nous"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
-msgstr ""
-"només es pot utilitzar l'opció --prefix quan s'estiguin instal·lant paquets "
-"nous"
+msgstr "només es pot utilitzar l'opció --prefix quan s'instal·lin paquets nous"
 
 #: rpmqv.c:168
 msgid "arguments to --prefix must begin with a /"
@@ -142,26 +136,21 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --replacepkgs durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --replacepkgs durant la instal·lació del paquet"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --excludedocs durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --excludedocs durant la instal·lació del paquet"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --includedocs durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --includedocs durant la instal·lació del paquet"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -169,54 +158,39 @@ msgstr "només es pot especificar una opció entre --excludedocs i --includedocs
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --ignorearch durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --ignorearch durant la instal·lació del paquet"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --ignoreos durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --ignoreos durant la instal·lació del paquet"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --ignoresize durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --ignoresize durant la instal·lació del paquet"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr ""
-"només es pot especificar l'opció --allmatches durant la supressió d'un paquet"
+msgstr "només es pot especificar l'opció --allmatches durant la supressió del paquet"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr ""
-"només es pot especificar l'opció --allfiles durant la instal·lació d'un "
-"paquet"
+msgstr "només es pot especificar l'opció --allfiles durant la instal·lació del paquet"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"només es pot especificar l'opció --justdb durant la instal·lació i supressió "
-"d'un paquet"
+msgstr "només es pot especificar l'opció --justdb durant la instal·lació i la supressió del paquet"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"només es poden especificar les opcions d'inhabilitació d'scripts durant la "
-"instal·lació i supressió d'un paquet"
+msgstr "només es poden especificar les opcions d'inhabilitació d'scripts durant la instal·lació i la supressió del paquet"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"només es poden especificar les opcions d'inhabilitació de l'activador durant "
-"la instal·lació i supressió d'un paquet"
+msgstr "només es poden especificar les opcions d'inhabilitació de l'activador durant la instal·lació i la supressió del paquet"
 
 #: rpmqv.c:231
 msgid ""
@@ -228,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "els arguments a --root (-r) han de començar per /"
 
@@ -246,265 +220,206 @@ msgstr "no s'han donat arguments per a consultar"
 
 #: rpmqv.c:315
 msgid "no arguments given for verify"
-msgstr "no s'han donat arguments per a verificar"
+msgstr "no s'han proporcionat arguments per verificar"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
-msgstr "el buildroot ja s'ha especificat, s'està ignorant %s\n"
+msgstr "el buildroot ja s'ha especificat, s'ignora %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"munta amb %prep (desempaqueta els fonts i aplica els pedaços) des del "
-"<fitxer d'especificació>"
+msgstr "construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) des del <fitxer spec>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
-msgstr "<fitxer d'especificació>"
+msgstr "<fitxer spec>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"munta amb %build (%prep, després compila) des del <fitxer d'especificació>"
+msgstr "construeix mitjançant el %build (%prep, després compila) des del <fitxer spec>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"munta amb %install (%prep, %build i després instal·la) des del <fitxer "
-"d'especificació>"
+msgstr "construeix mitjançant el %install (%prep, %build i després instal·la) des del <fitxer spec>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
-msgstr "verifica la secció %files de <fitxer d'especificació>"
+msgstr "verifica la secció %files des del <fitxer spec>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
-msgstr "munta els paquets de codi font i binaris de <fitxer d'especificació>"
+msgstr "construeix els paquets del codi font i del binaris des del <fitxer spec>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
-msgstr "munta només el paquet binari de <fitxer d'especificació>"
+msgstr "construeix només el paquet dels binaris des del <fitxer spec>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
-msgstr "munta només el paquet font de <fitxer d'especificació>"
+msgstr "construeix només el paquet del codi font des del <fitxer spec>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"munta amb %prep (desempaqueta els fonts i aplica els pedaços) des del "
-"<fitxer d'especificació>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<paquet font>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"munta amb %build (%prep, després compila) des del <fitxer d'especificació>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "munta amb %install (%prep, %build i instal·la) des del <paquet font>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verifica la secció %files de <fitxer d'especificació>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "munta els paquets binaris des de <paquet font>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "munta els paquets binaris des de <paquet font>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "munta només el paquet font de <fitxer d'especificació>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"munta amb %prep (desempaqueta els fonts i aplica els pedaços) des de "
-"l'<arxiu tar>"
+msgstr "construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) des de l'<arxiu tar>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<arxiu tar>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "munta amb %build (%prep, després compila) des de l'<arxiu tar>"
+msgstr "construeix mitjançant el %build (%prep, després compila) des de l'<arxiu tar>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "munta amb %install (%prep, %build, instal·la) des de l'<arxiu tar>"
+msgstr "construeix mitjançant el %install (%prep, %build, instal·la) des de l'<arxiu tar>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verifica la secció %files des de l'<arxiu tar>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
-msgstr "munta els paquets font i binari des de l'<arxiu tar>"
+msgstr "construeix els paquets del codi font i dels binaris des de l'<arxiu tar>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
-msgstr "munta el paquet binari des de l'<arxiu tar> només"
+msgstr "construeix el paquet dels binari només des de l'<arxiu tar>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
-msgstr "munta els paquets font només des de l'<arxiu tar>"
+msgstr "construeix el paquet del codi font només des de l'<arxiu tar>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
-msgstr "munta els paquets binaris des de <paquet font>"
+msgstr "construeix el paquet dels binaris des del <paquet dels fonts>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<paquet dels fonts>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "construeix mitjançant el %install (%prep, %build i instal·la) des del <paquet dels fonts>"
+
+#: rpmbuild.c:171
 msgid "override build root"
-msgstr "omet l'arrel de compilació"
+msgstr "substitueix l'arrel de la construcció"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "no s'ha pogut crear el directori"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
-msgstr "suprimeix l'arbre del muntatge en acabar"
+msgstr "suprimeix l'arbre de la construcció en acabar"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignora ExcludeArch: directives del fitxer d'especificació"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "depura la màquina d'estat de fitxers"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
-msgstr "no executis cap fase del muntatge"
+msgstr "no executis cap de les etapes de la construcció"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
-msgstr "no verifiquis les dependències del muntatge"
+msgstr "no verifiquis les dependències de la construcció"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
+msgstr "genera capçaleres del paquet compatibles amb l'empaquetament rpm v3 (llegat)"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
-msgstr ""
+msgstr "no executis l'etapa %clean de la construcció"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "no executis cap fase del muntatge"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
-msgstr ""
+msgstr "no executis l'etapa %check de la construcció"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
-msgstr "no acceptis els msgstr d'i18N des d'un fitxer d'especificació"
+msgstr "no acceptis els msgstr d'i18N del fitxer spec"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "suprimeix els fonts en acabar"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
-msgstr "suprimeix el fitxer d'especificació en acabar"
+msgstr "suprimeix el fitxer spec en acabar"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "vés directament a l'etapa especificada (només per a c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
-msgstr "omet plataforma objectiu"
+msgstr "substitueix la plataforma"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Opcions de muntatge amb [ <fitxer d'especificacions> | <arxiu tar> | <paquet "
-"font> ]:"
+msgstr "Opcions de construcció amb [ <fitxer spec> | <arxiu tar> | <paquet dels fonts> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
-msgstr "Han fallat les dependències de muntatge:\n"
+msgstr "Han fallat les dependències de la construcció:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "No s'ha pogut obrir el fitxer d'especificacions %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
-msgstr "No s'ha pogut obrir un conducte per al tar: %m\n"
+msgstr "Ha fallat l'obertura de la canonada per al tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "No s'ha pogut obrir el fitxer d'especificacions %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
-msgstr "No s'ha pogut llegir el fitxer d'especificacions des de %s\n"
+msgstr "Ha fallat la lectura del fitxer spec de %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
-msgstr "No s'ha pogut canviar el nom de %s per %s: %m\n"
+msgstr "Ha fallat el canvi de nom de %s a %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
-msgstr "No s'ha pogut obtenir l'estat de %s: %m\n"
+msgstr "Ha fallat l'obtenció de l'estat de %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "El fitxer %s no és un fitxer regular.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "El fitxer %s no sembla un fitxer d'especificacions.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
-msgstr "S'estan muntant les plataformes destí: %s\n"
+msgstr "S'estan construint per a les plataformes: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
-msgstr "S'està muntant per al destí %s\n"
+msgstr "S'està construint per a %s\n"
 
 #: rpmdb.c:25
 msgid "initialize database"
@@ -512,9 +427,7 @@ msgstr "initialitza la base de dades"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"torna a muntar les llistes invertides de la base de dades des de les "
-"capçaleres de paquets instal·lades"
+msgstr "reconstrueix la base de dades de les llistes inverses des de les capçaleres dels paquets instal·lats"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -522,11 +435,11 @@ msgstr "verifica els fitxers de la base de dades"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr ""
+msgstr "exporta la base de dades al llistat de capçaleres de la sortida estàndard"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr ""
+msgstr "importa la base de dades des de la llista de capçaleres de l'entrada estàndard"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -542,27 +455,27 @@ msgstr "importa una clau pública armada"
 
 #: rpmkeys.c:28
 msgid "don't import, but tell if it would work or not"
-msgstr ""
+msgstr "no importis, però diguis si podria funcionar o no"
 
 #: rpmkeys.c:31 rpmkeys.c:33
 msgid "list keys from RPM keyring"
-msgstr ""
+msgstr "llista les claus des de l'anell de claus RPM"
 
 #: rpmkeys.c:40
 msgid "Keyring options:"
-msgstr ""
+msgstr "Opcions de l'anell de claus:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "no s'han donat arguments"
 
 #: rpmsign.c:25
 msgid "sign package(s)"
-msgstr ""
+msgstr "signa els paquets"
 
 #: rpmsign.c:27
 msgid "sign package(s) (identical to --addsign)"
-msgstr "signa els paquets (igual que --addsign)"
+msgstr "signa els paquets (idèntic a --addsign)"
 
 #: rpmsign.c:29
 msgid "delete package signatures"
@@ -572,53 +485,72 @@ msgstr "suprimeix les signatures dels paquets"
 msgid "Signature options:"
 msgstr "Opcions de la signatura:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "No es pot executar %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Heu d'establir «%%_gpg_name» al vostre fitxer de macros\n"
 
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Introduïu la contrasenya:"
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "La contrasenya és correcta.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
+
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
-msgstr ""
+msgstr "analitza sintàcticament els fitxers spec per la sortida estàndard"
 
 #: rpmspec.c:28
 msgid "query spec file(s)"
-msgstr ""
+msgstr "consulta els fitxers spec"
 
 #: rpmspec.c:30
 msgid "operate on binary rpms generated by spec (default)"
-msgstr ""
+msgstr "opera sobre els binaris dels rpm generats amb el spec (per defecte)"
 
 #: rpmspec.c:32
 msgid "operate on source rpm generated by spec"
-msgstr ""
+msgstr "opera sobre els fonts del rpm generat amb el spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
-msgstr "utilitza el format de consulta següent"
+msgstr "utilitza el següent format de consulta"
 
 #: rpmspec.c:45
 msgid "Spec options:"
-msgstr ""
+msgstr "Opcions de spec:"
 
 #: rpmspec.c:90
 msgid "no arguments given for parse"
-msgstr ""
+msgstr "no s'ha proporcionat arguments per analitzar sintàcticament"
 
 #: build/build.c:120
 #, c-format
 msgid "Unable to open temp file: %s\n"
-msgstr ""
+msgstr "No es pot obrir el fitxer temporal: %s\n"
 
 #: build/build.c:126
 #, c-format
 msgid "Unable to open stream: %s\n"
-msgstr ""
+msgstr "No es pot obrir el flux: %s\n"
 
 #: build/build.c:161
 #, c-format
 msgid "Executing(%s): %s\n"
-msgstr "Executant(%s): %s\n"
+msgstr "Execució(%s): %s\n"
 
 #: build/build.c:168
 #, c-format
@@ -633,78 +565,75 @@ msgstr ""
 #: build/build.c:184
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
-msgstr "L'estat de sortida de %s (%s) és erroni\n"
+msgstr "Estat incorrecte de sortida de %s (%s)\n"
 
 #: build/build.c:291
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Errors del muntatge de l'RPM:\n"
+msgstr "\n\nErrors de construcció del RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "error de sintaxi mentre s'analitzava ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "error de sintaxi mentre s'analitzava &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "error de sintaxi mentre s'analitzava ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "error d'anàlisi a l'expressió\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "no hi ha hagut coincidències (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- només als nombres\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! només als nombres\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "els tipus han de coincidir\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / no és disponible per a les cadenes\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- no és disponible per a les cadenes\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& i || no són disponibles per a les cadenes\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "error de sintaxi a l'expressió\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
-msgstr "Manca '(' a %s %s\n"
+msgstr "Falta '(' a %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
-msgstr "Manca ')' a %s(%s\n"
+msgstr "Falta ')' a %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "L'element %s no és vàlid: %s\n"
@@ -712,48 +641,48 @@ msgstr "L'element %s no és vàlid: %s\n"
 #: build/files.c:424
 #, c-format
 msgid "Missing %s in %s %s\n"
-msgstr "Manca %s a %s %s\n"
+msgstr "Falta %s a %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() va seguit d'un caràcter que no és un espai en blanc: %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxi incorrecta: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
-msgstr "Especificació de mode incorrecta: %s(%s)\n"
+msgstr "mode incorrecte del spec: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
-msgstr "Especificació de dirmode incorrecta: %s(%s)\n"
+msgstr "dirmode incorrecte del spec: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacitat invàlida: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
-msgstr "No s'ha muntat amb disponibilitat de fitxers\n"
+msgstr "No s'ha construït amb disponibilitat de fitxers\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "El fitxer ha de començar amb  \"/\": %s\n"
@@ -761,165 +690,168 @@ msgstr "El fitxer ha de començar amb  \"/\": %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr "L'algorisme %u de resum del fitxer és desconegut, s'està usant MD5\n"
+msgstr "Es desconeix l'algorisme de resum del fitxer %u, es torna al MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "El fitxer apareix dues vegades: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "L'enllaç simbòlic apunta al BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
-msgstr ""
+msgstr "No es va trobar el directori: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "No s'ha trobat el fitxer: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
-msgstr ""
+msgstr "No és un directori: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: no es pot carregar l'etiqueta incorrecta (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
-msgstr "%s: ha fallat la clau pública.\n"
+msgstr "%s: ha fallat la lectura de la clau pública.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: no és una clau pública armada.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "El fitxer ha de començar amb \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "El glob no ha trobat el fitxer: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
-msgstr ""
+msgstr "No s'ha pogut obrir el fitxer %s del %%files: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "línia: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
-msgstr ""
+msgstr "Més d'un fitxer en una línia: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
-msgstr "Fitxer no vàlid: %s: %s\n"
+msgstr "Fitxer incorrecte: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Propietari o grup incorrecte: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
-msgstr "S'està comprovant fitxers no empaquetats: %s\n"
+msgstr "S'està comprovant si hi ha fitxers no empaquetats: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Hi ha fitxers instal·lats però no empaquetats:\n"
-"%s"
+msgstr "Hi ha fitxers instal·lats però no empaquetats:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
-msgstr ""
+msgstr "S'estan processant els fitxers: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Els binaris dependents de l'arquitectura estan en el paquet noarch\n"
 
 #: build/pack.c:90
 #, c-format
 msgid "create archive failed on file %s: %s\n"
-msgstr ""
+msgstr "ha fallat la creació de l'arxiu al fitxer %s: %s\n"
 
 #: build/pack.c:93
 #, c-format
 msgid "create archive failed: %s\n"
-msgstr ""
+msgstr "ha fallat la creació de l'arxiu: %s\n"
 
 #: build/pack.c:120
 #, c-format
 msgid "Could not open %s file: %s\n"
-msgstr ""
+msgstr "No s'ha pogut obrir el fitxer %s: %s\n"
 
 #: build/pack.c:136
 #, c-format
@@ -931,79 +863,79 @@ msgstr "%s: línia: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "El nom de màquina no es pot fer canònic: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "No es pot tornar a carregar la capçalera de signatura.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compressió de dades desconeguda: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "No es pot crear la regió de capçalera no modificable.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "No es pot obrir %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "No es pot escriure el paquet: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "No s'ha pogut escriure la capçalera temporal\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
-msgstr "Dades CSA invàlides\n"
+msgstr "Dades CSA incorrectes\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "No es pot executar %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: El Fread ha fallat: %s\n"
+msgstr "Ha fallat el fread al fitxer%s: %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
-msgstr "S'ha escrit: %s\n"
+msgstr "Es va escriure: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "S'està executant: \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Ha fallat l'execució de \"%s\" .\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Ha fallat la verificació del paquet \"%s\".\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "No es pot generar el nom de fitxer de sortida per al paquet %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "no es pot crear %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "línia %d: segon %s\n"
@@ -1016,17 +948,17 @@ msgstr ""
 #: build/parseChangelog.c:146
 #, c-format
 msgid "%%changelog entries must start with *\n"
-msgstr "les entrades del %%changelog han de començar amb *\n"
+msgstr "les entrades %%changelog han de començar amb *\n"
 
 #: build/parseChangelog.c:154
 #, c-format
 msgid "incomplete %%changelog entry\n"
-msgstr "l'entrada de %%changelog no és completa\n"
+msgstr "Entrada incompleta del %%changelog\n"
 
 #: build/parseChangelog.c:169
 #, c-format
 msgid "bad date in %%changelog: %s\n"
-msgstr "la data de %%changelog no és correcta: %s\n"
+msgstr "data incorrecta al %%changelog: %s\n"
 
 #: build/parseChangelog.c:174
 #, c-format
@@ -1036,60 +968,60 @@ msgstr "el %%changelog no està en ordre cronològic descendent\n"
 #: build/parseChangelog.c:182 build/parseChangelog.c:193
 #, c-format
 msgid "missing name in %%changelog\n"
-msgstr "manca el nom a %%changelog\n"
+msgstr "falta el nom a %%changelog\n"
 
 #: build/parseChangelog.c:200
 #, c-format
 msgid "no description in %%changelog\n"
-msgstr "no hi ha descripció a %%changelog\n"
+msgstr "sense descripció al %%changelog\n"
 
 #: build/parseChangelog.c:237
 #, c-format
 msgid "line %d: second %%changelog\n"
-msgstr ""
+msgstr "línia %d: segon %%changelog\n"
 
 #: build/parseDescription.c:32
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
-msgstr "línia %d: s'ha produït un error en analitzar %%description: %s\n"
+msgstr "línia %d: S'ha produït un error en analitzar sintàcticament el %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
-msgstr "línia %d: opció incorrecta %s: %s\n"
+msgstr "línia %d: Opció %s incorrecta: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "línia %d: massa noms: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
-msgstr "línia %d: no existeix Package: %s\n"
+msgstr "línia %d: No existeix el paquet: %s\n"
 
 #: build/parseFiles.c:33
 #, c-format
 msgid "line %d: Error parsing %%files: %s\n"
-msgstr "línia %d: s'ha produït un error en analitzar %%files: %s\n"
+msgstr "línia %d: S'ha produït un error en analitzar sintàcticament el %%files: %s\n"
 
 #: build/parseFiles.c:76
 #, c-format
 msgid "line %d: second %%files\n"
-msgstr ""
+msgstr "línia %d: segon %%files\n"
 
 #: build/parsePolicies.c:32
 #, c-format
 msgid "line %d: Error parsing %%policies: %s\n"
-msgstr ""
+msgstr "línia %d: S'ha produït un error en analitzar sintàcticament el %%policies: %s\n"
 
 #: build/parsePreamble.c:71
 #, c-format
 msgid "Error parsing tag field: %s\n"
-msgstr ""
+msgstr "S'ha produït un error en analitzar sintàcticament el camp tag: %s\n"
 
 #: build/parsePreamble.c:164
 #, c-format
@@ -1099,27 +1031,27 @@ msgstr "línia %d: número incorrecte: %s\n"
 #: build/parsePreamble.c:170
 #, c-format
 msgid "line %d: Bad no%s number: %u\n"
-msgstr "línia %d: Numero dolent%s número: %u\n"
+msgstr "línia %d: Número incorrecte de no%s: %u\n"
 
 #: build/parsePreamble.c:233
 #, c-format
 msgid "line %d: Bad %s number: %s\n"
-msgstr "línia %d: número %s incorrecte: %s\n"
+msgstr "línia %d: número incorrecte %s: %s\n"
 
 #: build/parsePreamble.c:247
 #, c-format
 msgid "%s %d defined multiple times\n"
-msgstr "%s %d definit múltiples vegades\n"
+msgstr "%s %d es va definir diverses vegades\n"
 
 #: build/parsePreamble.c:292
 #, c-format
 msgid "Downloading %s to %s\n"
-msgstr ""
+msgstr "S'està baixant %s a %s\n"
 
 #: build/parsePreamble.c:295
 #, c-format
 msgid "Couldn't download %s\n"
-msgstr ""
+msgstr "No s'ha pogut baixar %s\n"
 
 #: build/parsePreamble.c:434
 #, c-format
@@ -1129,7 +1061,7 @@ msgstr "S'ha exclòs l'arquitectura: %s\n"
 #: build/parsePreamble.c:439
 #, c-format
 msgid "Architecture is not included: %s\n"
-msgstr "No s'inclou l'arquitectura: %s\n"
+msgstr "No s'ha inclòs l'arquitectura: %s\n"
 
 #: build/parsePreamble.c:444
 #, c-format
@@ -1144,12 +1076,12 @@ msgstr "No s'ha inclòs el SO: %s\n"
 #: build/parsePreamble.c:475
 #, c-format
 msgid "%s field must be present in package: %s\n"
-msgstr "El camp %s ha de ser present al paquet: %s\n"
+msgstr "El camp %s ha d'estar present al paquet: %s\n"
 
 #: build/parsePreamble.c:498
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
-msgstr "L'entrada %s és duplicada al paquet: %s\n"
+msgstr "L'entrada %s està duplicada al paquet: %s\n"
 
 #: build/parsePreamble.c:556
 #, c-format
@@ -1164,299 +1096,263 @@ msgstr "No s'ha pogut llegir la icona %s: %s\n"
 #: build/parsePreamble.c:582
 #, c-format
 msgid "Unknown icon type: %s\n"
-msgstr "El tipus d'icona és desconegut: %s\n"
+msgstr "Tipus desconegut d'icona: %s\n"
 
 #: build/parsePreamble.c:596
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
-msgstr "línia %d: l'etiqueta pren un únic testimoni: %s\n"
+msgstr "línia %d: L'etiqueta pren un únic testimoni: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
-msgstr ""
+msgid "line %d: Illegal char '%c' in: %s\n"
+msgstr "línia %d: El caràcter '%c' no està permès: %s\n"
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
-msgstr ""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "línia %d: Caràcter no permès: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "línia %d: segon %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "línia %d: La seqüència \"..\" no està permesa: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: línia: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "línia %d: l'etiqueta és malament formada: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "línia %d: l'etiqueta és buida: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "línia %d: els prefixos no poden acabar en «/»: %s \n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "línia %d: «Docdir» ha de començar per «/»: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "línia %d: el camp Epoch ha d'ésser un nombre sense signe: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
-msgstr "línia %d: %s és incorrecte: qualificadors: %s\n"
+msgstr "línia %d: %s incorrecte: qualificadors: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
-msgstr "línia %d: el format de «BuildArchitecture» és incorrecte: %s\n"
+msgstr "línia %d: Format incorrecte del BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linia %d: Només els subpaquets noarch estan suportats: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "S'ha produït un error intern: l'etiqueta %d és incorrecta\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
-msgstr ""
+msgstr "línia %d: %s està en desús: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
-msgstr "L'especificació del paquet és incorrecta: %s\n"
+msgstr "Especificació incorrecta del paquet: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "El paquet ja existeix: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
-msgstr "línia %d: l'etiqueta és desconeguda: %s\n"
+msgstr "línia %d: Etiqueta desconeguda: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} no pot estar buit\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
-msgstr "%%{buildroot} no pot ésser \"/\"\n"
+msgstr "%%{buildroot} no pot ser \"/\"\n"
 
 #: build/parsePrep.c:28
 #, c-format
 msgid "Bad source: %s: %s\n"
-msgstr "La font és incorrecta: %s: %s\n"
+msgstr "Fonts incorrectes: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "No existeix el pedaç número %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sense l'etiqueta \"Patch:\" corresponent\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "No existeix la font número %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
-msgstr "Falta l'etiqueta \"Source:\" en el fitxer d'especificacions\n"
+msgstr "Sense \"Source:\" etiqueta al fitxer spec\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
-msgstr "Hi ha hagut un error en analitzar %%setup: %s\n"
+msgstr "S'ha produït un error en analitzar sintàcticament el %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
-msgstr "línia %d: l'argument a %%setup és incorrecte: %s\n"
+msgstr "línia %d: Argument incorrecte al %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
-msgstr "línia %d: l'opció de %%setup %s és incorrecta: %s\n"
+msgstr "línia %d: Opció %s incorrecta del %%setup: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "El número de pedaç %s no és vàlid: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "línia %d: segon %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
-msgstr ""
+msgstr "Es requereix la versió"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "dependència no vàlida"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
-msgstr ""
+msgstr "línia %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "línia %d: els activadors han de tenir --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
-msgstr "línia %d: s'ha produït un error en analitzar %s: %s\n"
+msgstr "línia %d: S'ha produït un error en analitzar sintàcticament %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "línia %d: l'script intern ha d'acabar en «>»: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "línia %d: el programa d'script ha de començar per «/»: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "línia %d: Segon %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "línia %d: l'script intern no està disponible: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "línia %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "No es pot obrir %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
-msgstr ""
+msgstr "%s:%d: S'esperava l'argument per %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
-msgstr ""
+msgstr "línia %d: %%if sense tancar\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
-msgstr ""
+msgstr "%s:%d: condició incorrecta del %%if\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: s'ha obtingut un %%else sense %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: s'ha obtingut un %%endif sense %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
-msgstr "No s'ha trobat cap arquitectura compatible per al muntatge\n"
+msgstr "No s'ha trobat cap arquitectura compatible per a la construcció\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "El paquet no té %%description: %s\n"
@@ -1473,17 +1369,17 @@ msgstr ""
 
 #: build/policies.c:101
 msgid "Failed to get policies from header\n"
-msgstr ""
+msgstr "Ha fallat l'obtenció de les polítiques de les capçaleres\n"
 
 #: build/policies.c:154
 #, c-format
 msgid "%%semodule requires a file path\n"
-msgstr ""
+msgstr "%%semodule requereix el camí a un fitxer\n"
 
 #: build/policies.c:163
 #, c-format
 msgid "Failed to read  policy file: %s\n"
-msgstr ""
+msgstr "Ha fallat la lectura del pitxer de política: %s\n"
 
 #: build/policies.c:170
 #, c-format
@@ -1493,7 +1389,7 @@ msgstr ""
 #: build/policies.c:187
 #, c-format
 msgid "Failed to determine a policy name: %s\n"
-msgstr ""
+msgstr "Ha fallat la determinació d'un nom de política: %s\n"
 
 #: build/policies.c:199
 #, c-format
@@ -1505,304 +1401,312 @@ msgstr ""
 #: build/policies.c:246
 #, c-format
 msgid "Error parsing %s: %s\n"
-msgstr ""
+msgstr "S'ha produït un error en analitzar sintàcticament %s: %s\n"
 
 #: build/policies.c:252
 #, c-format
 msgid "Expecting %%semodule tag: %s\n"
-msgstr ""
+msgstr "S'esperava l'etiqueta %%semodule: %s\n"
 
 #: build/policies.c:262
 #, c-format
 msgid "Missing module path in line: %s\n"
-msgstr ""
+msgstr "Falta el camí al mòdul en la línia: %s\n"
 
 #: build/policies.c:268
 #, c-format
 msgid "Too many arguments in line: %s\n"
-msgstr ""
+msgstr "Hi ha massa arguments en la línia: %s\n"
 
 #: build/policies.c:307
 #, c-format
 msgid "Processing policies: %s\n"
-msgstr ""
+msgstr "S'estan processant les polítiques: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
-msgstr ""
+msgstr "S'ignora l'expressió regular incorrecta %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "No s'ha pogut crear la canonada per a %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "No s'ha pogut executar %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "No s'ha pogut crear el procés fill de «%s»: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
-msgstr ""
+msgstr "ha fallat %s: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
-msgstr ""
+msgstr "ha fallat l'escriptura de totes les dades a %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
-msgstr ""
+msgstr "operador incorrecte"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
-msgstr ""
+msgstr "format incorrecte"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
-msgstr ""
+msgstr "dependència no vàlida (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
-msgstr "Ha fallat la conversió de %s a enter gran.\n"
+msgstr "Ha fallat la conversió de %s a long integer.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
-msgstr ""
+msgstr "Classificador buit de fitxer\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
-msgstr ""
+msgstr "Sense atributs de fitxer configurats\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "Ha fallat magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "Ha fallat magic_load: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Ha fallat el reconeixement del fitxer \"%s\": mode %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "S'està cercant %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Ha fallat la cerca de %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr ""
-"ha fallat la consulta del fitxer d'especificació %s, no es pot analitzar\n"
+msgstr "ha fallat la consulta del fitxer spec %s, no es pot analitzar sintàcticament\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s és un Delta RPM i no es pot instal·lar directament\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Les dades (%s) no estan disponibles al paquet %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "el paquet %s ja s'ha afegit, s'està ignorant %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "el paquet %s ja es va afegir, s'està reemplaçant per %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
-msgstr "(no és una xifra)"
+msgstr "(no és un número)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(no és base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(tipus invàlid)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(no és un blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
-msgstr "(tipus d'XML invàlid)"
+msgstr "(tipus invàlid d'XML)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(no és una signatura d'OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
-msgstr ""
+msgstr "Data no vàlida %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
-msgstr ""
+msgstr "normal"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
-msgstr ""
+msgstr "substituït"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
-msgstr ""
+msgstr "no instal·lat"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
-msgstr ""
+msgstr "compartit per xarxa"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
-msgstr ""
+msgstr "color incorrecte"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
-msgstr ""
+msgstr "falta"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
-msgstr ""
+msgstr "(deconegut)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
-msgstr ""
+msgstr "(no és una cadena)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
-msgstr "%s desat com a %s\n"
+msgstr "%s s'ha desat com a %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
-msgstr "%s creat com a %s\n"
+msgstr "%s s'ha creat com a %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
-msgstr ""
+msgstr "%s %s: ha fallat la supressió: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
-msgstr ""
+msgstr "directori"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
-msgstr ""
+msgstr "fitxer"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "%s té una signatura que no es pot verificar"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
 msgstr ""
 
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "Ha fallat el fread: %s"
+
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1815,15 +1719,15 @@ msgstr "'MACRO EXPR'"
 
 #: lib/poptALL.c:178
 msgid "define MACRO with value EXPR"
-msgstr "defineix la MACRO amb el valor EXPR"
+msgstr "defineix la MACRO amb el valor de l'EXPR"
 
 #: lib/poptALL.c:181
 msgid "undefine MACRO"
-msgstr ""
+msgstr "des-defineix la MACRO"
 
 #: lib/poptALL.c:182
 msgid "MACRO"
-msgstr ""
+msgstr "MACRO"
 
 #: lib/poptALL.c:184
 msgid "print macro expansion of EXPR"
@@ -1835,7 +1739,7 @@ msgstr "'EXPR'"
 
 #: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
-msgstr "llegeix <FILE:...> en comptes dels fitxers per defecte"
+msgstr "llegeix <FITXER:...> en comptes dels fitxers per defecte"
 
 #: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
@@ -1843,15 +1747,15 @@ msgstr "<FITXER:...>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "no habilitis cap complement"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
-msgstr "no verifiquis els resums dels fitxers"
+msgstr "no verifiquis els resums dels paquets"
 
 #: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
-msgstr "no verifiquis les capçaleres de la base de dades en obtenir-les"
+msgstr "no verifiquis les capçaleres de la base de dades quan s'obtinguin"
 
 #: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
@@ -1867,27 +1771,27 @@ msgstr "CMD"
 
 #: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
-msgstr "utilitza ROOT com a directori d'alt nivell"
+msgstr "utilitza l'ARREL com el directori de nivell superior"
 
 #: lib/poptALL.c:210
 msgid "ROOT"
-msgstr "ROOT"
+msgstr "ARREL"
 
 #: lib/poptALL.c:212
 msgid "use database in DIRECTORY"
-msgstr ""
+msgstr "utilitza la base de dades en el DIRECTORI"
 
 #: lib/poptALL.c:213
 msgid "DIRECTORY"
-msgstr ""
+msgstr "DIRECTORI"
 
 #: lib/poptALL.c:216
 msgid "display known query tags"
-msgstr "mostra etiquetes de consulta conegudes"
+msgstr "mostra les etiquetes conegudes de consulta"
 
 #: lib/poptALL.c:218
 msgid "display final rpmrc and macro configuration"
-msgstr "mostra rpmrc final i la configuració de macros"
+msgstr "mostra el rpmrc final i la configuració de les macros"
 
 #: lib/poptALL.c:220
 msgid "provide less detailed output"
@@ -1899,7 +1803,7 @@ msgstr "proporciona sortides més detallades"
 
 #: lib/poptALL.c:224
 msgid "print the version of rpm being used"
-msgstr "escriu la versió d'RPM que s'està usant"
+msgstr "escriu la versió del RPM que s'està utilitzant"
 
 #: lib/poptALL.c:230
 msgid "debug payload file state machine"
@@ -1907,7 +1811,7 @@ msgstr "depura la màquina d'estats del fitxer de dades"
 
 #: lib/poptALL.c:236
 msgid "debug rpmio I/O"
-msgstr "depura l'E/S de l'rpmio"
+msgstr "depura l'E/S de rpmio"
 
 #: lib/poptALL.c:303
 #, c-format
@@ -1920,37 +1824,34 @@ msgstr "els camins exclosos han de començar per /"
 
 #: lib/poptI.c:64
 msgid "relocations must begin with a /"
-msgstr "les reubicacions han de començar per /"
+msgstr "els trasllats han de començar amb /"
 
 #: lib/poptI.c:67
 msgid "relocations must contain a ="
-msgstr "les reubicacions han de contenir ="
+msgstr "els trasllats han de contenir un ="
 
 #: lib/poptI.c:70
 msgid "relocations must have a / following the ="
-msgstr "les reubicacions han de tenir un / seguit de ="
+msgstr "els trasllats han de tenir un / a continuació del ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"instal·la tots els fitxers, fins i tot configuracions que podrien ser "
-"ignorades"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "instal·la tots els fitxers, fins i tot les configuracions que podrien ser ignorades"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"suprimeix tots els paquets que coincideixen amb <paquet> (normalment es "
-"genera un error si <paquet> especifica múltiples paquets)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "suprimeix tots els paquets que coincideixen amb <paquet> (normalment es genera un error si <paquet> especifica múltiples paquets)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
-msgstr "reubica els fitxers en un paquet no reubicable"
+msgstr "trasllada els fitxers al paquet sense translació"
 
 #: lib/poptI.c:127
 msgid "print dependency loops as warning"
-msgstr "escriu els bucles de dependències com a avís"
+msgstr "escriu els bucles de dependències com advertències"
 
 #: lib/poptI.c:131
 msgid "erase (uninstall) package"
@@ -1966,11 +1867,11 @@ msgstr "no instal·lis fitxers de configuració"
 
 #: lib/poptI.c:137 lib/poptI.c:176
 msgid "do not install documentation"
-msgstr "no instal·lis documentació"
+msgstr "no instal·lis la documentació"
 
 #: lib/poptI.c:139
 msgid "skip files with leading component <path> "
-msgstr "ignora fitxers amb un component inicial <camí> "
+msgstr "ignora els fitxers amb un component inicial <camí> "
 
 #: lib/poptI.c:140
 msgid "<path>"
@@ -1986,7 +1887,7 @@ msgstr "actualitza els paquets si ja estan instal·lats"
 
 #: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:251 lib/poptI.c:255
 msgid "<packagefile>+"
-msgstr "<fitxerPaquet>+"
+msgstr "<fitxer paquet>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
@@ -2010,7 +1911,7 @@ msgstr "instal·la documentació"
 
 #: lib/poptI.c:164
 msgid "install package(s)"
-msgstr "instal·la paquets"
+msgstr "instal·la els paquets"
 
 #: lib/poptI.c:167
 msgid "update the database, but do not modify the filesystem"
@@ -2020,13 +1921,13 @@ msgstr "actualitza la base de dades, però no modifiquis el sistema de fitxers"
 msgid "do not verify package dependencies"
 msgstr "no verifiquis les dependències dels paquets"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
-msgstr "no verificar els resums dels fitxers"
+msgstr "no verifiquis els resums dels fitxers"
 
 #: lib/poptI.c:181
 msgid "don't verify digest of files (obsolete)"
-msgstr "no verificar els resums dels fitxers (obsolet)"
+msgstr "no verifiquis els resums dels fitxers (obsolet)"
 
 #: lib/poptI.c:183
 msgid "don't install file security contexts"
@@ -2034,8 +1935,7 @@ msgstr "no instal·lis els contexts de seguretat dels fitxers"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"no reordenis la instal·lació dels paquets per a satisfer les dependències"
+msgstr "no reordenis la instal·lació dels paquets per a satisfer les dependències"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2044,32 +1944,32 @@ msgstr "no executis els scriptlets del paquet"
 #: lib/poptI.c:195
 #, c-format
 msgid "do not execute %%pre scriptlet (if any)"
-msgstr "no executis cap scriptlet %%pre"
+msgstr "no executis el scriptlet %%pre (si n'hi hagués)"
 
 #: lib/poptI.c:198
 #, c-format
 msgid "do not execute %%post scriptlet (if any)"
-msgstr "no executis cap scriptlet %%post"
+msgstr "no executis el scriptlet %%post (si n'hi hagués)"
 
 #: lib/poptI.c:201
 #, c-format
 msgid "do not execute %%preun scriptlet (if any)"
-msgstr "no executis cap scriptlet %%preun"
+msgstr "no executis el scriptlet %%preun (si n'hi hagués)"
 
 #: lib/poptI.c:204
 #, c-format
 msgid "do not execute %%postun scriptlet (if any)"
-msgstr "no executis cap scriptlet %%postun"
+msgstr "no executis el scriptlet %%postun (si n'hi hagués)"
 
 #: lib/poptI.c:207
 #, c-format
 msgid "do not execute %%pretrans scriptlet (if any)"
-msgstr ""
+msgstr "no executis el scriptlet %%pretrans (si n'hi hagués)"
 
 #: lib/poptI.c:210
 #, c-format
 msgid "do not execute %%posttrans scriptlet (if any)"
-msgstr ""
+msgstr "no executis el scriptlet %%posttrans (si n'hi hagués)"
 
 #: lib/poptI.c:213
 msgid "do not execute any scriptlet(s) triggered by this package"
@@ -2099,9 +1999,7 @@ msgstr "no executis cap scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"actualitza a una versió antiga del paquet (--force ho fa automàticament en "
-"les actualitzacions)"
+msgstr "actualitza a una versió antiga del paquet (--force ho fa automàticament en les actualitzacions)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2109,7 +2007,7 @@ msgstr "escriu els percentatges com a instal·lació de paquets"
 
 #: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
-msgstr "reubica el paquet a <dir>, si és reubicable"
+msgstr "trasllada el paquet al <dir>, si es pot traslladar"
 
 #: lib/poptI.c:236
 msgid "<dir>"
@@ -2117,7 +2015,7 @@ msgstr "<dir>"
 
 #: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
-msgstr "reubica els fitxers del camí <vell> al <nou>"
+msgstr "trasllada els fitxers del camí <antic> al <nou>"
 
 #: lib/poptI.c:239
 msgid "<old>=<new>"
@@ -2137,189 +2035,168 @@ msgstr "no instal·lis, però digues si funcionarà correctament o no"
 
 #: lib/poptI.c:250
 msgid "upgrade package(s)"
-msgstr "actualitza paquets"
+msgstr "actualitza els paquets"
 
 #: lib/poptI.c:254
 msgid "reinstall package(s)"
-msgstr ""
+msgstr "reinstal·la els paquets"
+
+#: lib/poptQV.c:67
+msgid "query/verify all packages"
+msgstr "consulta o verifica tots els paquets"
+
+#: lib/poptQV.c:69
+msgid "rpm checksig mode"
+msgstr "mode rpm de comprovació de signatura"
+
+#: lib/poptQV.c:71
+msgid "query/verify package(s) owning file"
+msgstr "consulta o verifica els paquets als que pertany aquest fitxer"
+
+#: lib/poptQV.c:73
+msgid "query/verify package(s) in group"
+msgstr "consulta o verifica els paquets al grup"
 
 #: lib/poptQV.c:75
-msgid "query/verify all packages"
-msgstr "comprova tots els paquets"
+msgid "query/verify a package file"
+msgstr "consulta o verifica un fitxer de paquet"
 
-#: lib/poptQV.c:77
-msgid "rpm checksig mode"
-msgstr "mode de comprovació de signatura"
+#: lib/poptQV.c:78
+msgid "query/verify package(s) with package identifier"
+msgstr "consulta o verifica els paquets amb l'identificador de paquet"
 
-#: lib/poptQV.c:79
-msgid "query/verify package(s) owning file"
-msgstr "comprova a quins paquets pertany aquest fitxer"
-
-#: lib/poptQV.c:81
-msgid "query/verify package(s) in group"
-msgstr "comprova paquets en el grup"
+#: lib/poptQV.c:80
+msgid "query/verify package(s) with header identifier"
+msgstr "consulta o verifica els paquets amb l'identificació de capçalera"
 
 #: lib/poptQV.c:83
-msgid "query/verify a package file"
-msgstr "comprova un paquet"
-
-#: lib/poptQV.c:86
-msgid "query/verify package(s) with package identifier"
-msgstr "comprova quins paquets tenen identificador"
-
-#: lib/poptQV.c:88
-msgid "query/verify package(s) with header identifier"
-msgstr "comprova paquets amb identificació de capçalera"
-
-#: lib/poptQV.c:91
 msgid "rpm query mode"
-msgstr "mode de consulta"
+msgstr "mode rpm de consulta"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
-msgstr "comprova una instància de capçalera"
+msgstr "consulta o verifica una instància de capçalera"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
-msgstr "comprova els paquets de la transacció d'instal·lació"
+msgstr "consulta o verifica els paquets des de la transacció d'instal·lació"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "consulta els paquets exigits pel paquet"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
-msgstr "mode de verificació"
+msgstr "mode rpm de verificació"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
-msgstr "comprova les relacions de dependència dels paquets"
+msgstr "consulta o verifica els paquets que requereixen una dependència"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
-msgstr "comprova els paquets que satisfan les relacions de dependència"
+msgstr "consulta o verifica els paquets que proporcionen un dependència"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "comprova les relacions de dependència dels paquets"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "comprova les relacions de dependència dels paquets"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "comprova les relacions de dependència dels paquets"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "comprova les relacions de dependència dels paquets"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
-msgstr "no passis els arguments"
+msgstr "no englobis els arguments"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
-msgstr ""
-"no processis els fitxers que no pertanyin al paquet com a fitxers manifest"
+msgstr "no processis els fitxers que no pertanyin al paquet com manifests"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "mostra tots els fitxers de configuració"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
-msgstr "mostra llista de fitxers de documentació"
+msgstr "mostra tots els fitxers de documentació"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
-msgstr ""
+msgstr "mostra tots els fitxers de llicència"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
-msgstr "mostra informació bàsica del fitxer"
+msgstr "mostra la informació bàsica del fitxer"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "mostra tots els fitxers del paquet"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "omet fitxers %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
-msgstr "mostra l'estat dels fitxers de la llista"
+msgstr "mostra els estats dels fitxers llistats"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
-msgstr "no comprovis la mida dels fitxers"
+msgstr "no verifiquis la mida dels fitxers"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
-msgstr "no comprovis l'enllaç simbòlic dels fitxers"
+msgstr "no verifiquis l'enllaç simbòlic dels fitxers"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
-msgstr "no comprovis qui és el propietari dels fitxers"
+msgstr "no verifiquis qui és el propietari dels fitxers"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
-msgstr "no comprovis a quin grup pertanyen els fitxers"
+msgstr "no verifiquis a quin grup pertanyen els fitxers"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
-msgstr "no comprovis la data de modificació dels fitxers"
+msgstr "no verifiquis la data de modificació dels fitxers"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
-msgstr "no comprovis el mode dels fitxers"
+msgstr "no verifiquis el mode dels fitxers"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "no verifiquis les capacitats dels fitxers"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
-msgstr "no comprovis els contextos de seguretat dels fitxers"
+msgstr "no verifiquis els contextos de seguretat dels fitxers"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
-msgstr "no comprovis els fitxers del paquet"
+msgstr "no verifiquis els fitxers del paquet"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
-msgstr "no comprovis les relacions de dependència del paquet"
+msgstr "no verifiquis les relacions de dependència del paquet"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "no executis els scripts de verificació"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "s'espera un paquet de codi font, però s'ha trobat un de binari\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "el paquet font no conté un fitxer .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "ha fallat el desempaquetat de l'arxiu%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " al fitxer "
 
@@ -2394,131 +2271,109 @@ msgstr "cap paquet concorda amb %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "cap paquet necessita %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "cap paquet necessita %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "cap paquet dispara %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "cap paquet necessita %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "cap paquet necessita %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "cap paquet proporciona %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fitxer %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "el fitxer %s no pertany a cap paquet\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de paquet invàlid: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
-msgstr ""
+msgstr "no s'ha pogut llegir el registre %u\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "no s'ha instal·lat el paquet %s\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconeguda: «%s»\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
-msgstr ""
+msgstr "%s: ha fallat la importació de la clau %d.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: ha fallat la lectura de la importació (%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
-msgstr ""
+msgstr "%s: ha fallat el headerRead: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: la regió de capçalera inmutable no s'ha pogut llegir. El paquet és "
-"corrupte?\n"
+msgstr "%s: la regió de capçalera inmutable no s'ha pogut llegir. El paquet és corrupte?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
-msgstr "%s: El Fread ha fallat: %s\n"
+msgstr "%s: Ha fallat el fread: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NO ÉS CORRECTE"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "D'ACORD"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
-msgstr " (CLAUS NO TROBADES:"
+msgstr " (FALTEN LES CLAUS:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CLAUS NO FIABLES:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
-msgstr "%s: ha fallat l'apertura: %s\n"
+msgstr "%s: ha fallat l'obertura: %s\n"
 
 #: lib/rpmchroot.c:43
 #, c-format
 msgid "Unable to open current directory: %m\n"
-msgstr ""
+msgstr "No es pot obrir el directori actual: %m\n"
 
 #: lib/rpmchroot.c:59 lib/rpmchroot.c:84
 #, c-format
 msgid "%s: chroot directory not set\n"
-msgstr ""
+msgstr "%s: directori chroot sense establir\n"
 
 #: lib/rpmchroot.c:70
 #, c-format
@@ -2528,202 +2383,146 @@ msgstr "No s'ha pogut canviar el directori root: %m\n"
 #: lib/rpmchroot.c:95
 #, c-format
 msgid "Unable to restore root directory: %m\n"
-msgstr ""
+msgstr "No es pot restaurar el directori arrel: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "SÍ"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr ""
-"Les dependències PreReq:, Provides:, i Obsoletes: disposen de versionatge."
+msgstr "Les dependències PreReq:, Provides: i Obsoletes: suporten versions."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"els noms de fitxer s'han emmagatzemat com una tupla (dirName,baseName,"
-"dirIndex), no com a camí"
+msgstr "els noms de fitxer s'han emmagatzemat com una tupla (dirName,baseName,dirIndex), no com a camí"
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "les dades del paquet es poden comprimir amb el bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "Les dades del paquet es poden comprimir amb xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "Les dades del paquet es poden comprimir amb bzip2."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "els fitxer de les dades del paquet tenen el prefix «./»."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
-msgstr ""
-"no s'ha proporcionat implícitament el nom-versió-alliberament del paquet."
+msgstr "no s'ha proporcionat implícitament el nom-versió-alliberament del paquet."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "les etiquetes de la capçalera sempre s'ordenen després de carregar-se."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "l'íntèrpret de l'scriptlet pot emprar arguments de la capçalera."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
-msgstr ""
-"es pot instal·lar un conjunt d'enllaços durs a fitxer sense que estiguin "
-"complets."
+msgstr "es pot instal·lar un conjunt d'enllaços durs a fitxer sense que estiguin complets."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"els scriptlets del paquet poden accedir la base de dades rpm durant la "
-"instal·lació"
+msgstr "els scriptlets del paquet poden accedir la base de dades rpm durant la instal·lació"
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "es poden emprar scripts en lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "l'algorisme de resum de fitxer és configurable per paquet"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "suport per a capacitats de fitxer POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
-msgstr ""
+msgstr "els scriptlets del paquet es poden expandir en el moment de la instal·lació."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
-msgstr ""
+msgstr "suporta els fitxers superior als 4 GB"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "no verifiquis les dependències dels paquets"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c sense terminar: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
-msgstr "l'usuari %s no existeix - usant el root\n"
+msgstr "no existeix l'usuari %s - s'utilitza root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
-msgstr "el grup %s no existeix - s'està usant el root\n"
+msgstr "no existeix el grup %s- s'utilitza root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
-msgstr "Valor màgic incorrecte"
+msgstr "Valor incorrecte del magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
-msgstr "Capçalera dolenta/il·legible"
+msgstr "Capçalera incorrecta o il·legible"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "La mida de la capçalera és massa gran"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
-msgstr ""
+msgstr "El fitxer és massa gran per a l'arxiu"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Tipus de fitxer desconegut"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
-msgstr ""
+msgstr "Falten fitxers"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "No hi ha coincidència de resums"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Error intern"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "El fitxer de l'arxiu no és a la capçalera"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " ha fallat - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
-msgstr ""
+msgstr "%s: (error 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
-msgstr "ha fallat l'apertura de %s: %s\n"
+msgstr "ha fallat l'obertura de %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: no és un paquet rpm (o un manifest de paquet)\n"
@@ -2731,12 +2530,12 @@ msgstr "%s: no és un paquet rpm (o un manifest de paquet)\n"
 #: lib/rpminstall.c:141
 #, c-format
 msgid "Updating / installing...\n"
-msgstr ""
+msgstr "S'esta actualitzant o instal·lant...\n"
 
 #: lib/rpminstall.c:143
 #, c-format
 msgid "Cleaning up / removing...\n"
-msgstr ""
+msgstr "S'està netejant o suprimint...\n"
 
 #: lib/rpminstall.c:192
 msgid "Preparing..."
@@ -2744,7 +2543,7 @@ msgstr "S'està preparant..."
 
 #: lib/rpminstall.c:194
 msgid "Preparing packages..."
-msgstr ""
+msgstr "S'estan preparant els paquets..."
 
 #: lib/rpminstall.c:270 tools/rpmgraph.c:168
 msgid "Failed dependencies:\n"
@@ -2755,42 +2554,42 @@ msgstr "Dependències fallides:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: no és un paquet rpm (o un manifest de paquet): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "no es pot instal·lar %s\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "S'està obtenint %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "S'està ometent %s - ha fallat la transferència\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
-msgstr "el paquet %s no és reubicable\n"
+msgstr "el paquet %s no és pot traslladar\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "s'ha produït un error en llegir del fitxer %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" especifica múltiples paquets:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "no es pot obrir %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "S'està instal·lant %s\n"
@@ -2814,14 +2613,14 @@ msgstr "ha fallat la lectura: %s (%d)\n"
 
 #: lib/rpmlead.c:126
 msgid "not an rpm package\n"
-msgstr ""
+msgstr "no és un paquet rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
-msgstr ""
+msgstr "no es pot crea el bloqueig %s a %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2839,12 +2638,12 @@ msgstr ""
 #: lib/rpmplugins.c:154
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr ""
+msgstr "Complement %%__%s_%s no configurat\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
 msgid "Plugin %s not loaded\n"
-msgstr ""
+msgstr "Complement %s no carregat\n"
 
 #: lib/rpmprob.c:109
 msgid "different"
@@ -2868,19 +2667,17 @@ msgstr "el paquet %s ja s'ha instal·lat"
 #: lib/rpmprob.c:125
 #, c-format
 msgid "path %s in package %s is not relocatable"
-msgstr "el camí %s del paquet %s no és reubicable"
+msgstr "el camí %s al paquet %s no és pot traslladar"
 
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr "el fitxer %s té un conflicte amb els intents d'instal·lació de %s i %s"
+msgstr "el fitxer %s entra amb conflicte entre els intents d'instal·lació de %s i %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"el fitxer %s de la instal·lació de %s té un conflicte amb un fitxer del "
-"paquet %s"
+msgstr "el fitxer %s de la instal·lació de %s entra amb conflicte amb el fitxer del paquet %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2890,34 +2687,31 @@ msgstr "ja s'ha instal·lat el paquet %s, que és més nou que %s"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"el paquet a instal·lar %s necessita %<PRIu64>%cB al sistema de fitxers %s"
+msgstr "el paquet a instal·lar %s necessita %<PRIu64>%cB al sistema de fitxers %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"el paquet a instal·lar %s necessita %<PRIu64> nodes-i al sistema de fitxers "
-"%s"
+msgstr "el paquet a instal·lar %s necessita %<PRIu64> nodes-i al sistema de fitxers %s"
 
 #: lib/rpmprob.c:159
 #, c-format
 msgid "%s is needed by %s%s"
-msgstr "el paquet %s és requerit per %s%s"
+msgstr "el paquet %s és requerit pel paquet %s%s"
 
 #: lib/rpmprob.c:160 lib/rpmprob.c:164 lib/rpmprob.c:168
 msgid "(installed) "
-msgstr "(instalat) "
+msgstr "(instal·lat) "
 
 #: lib/rpmprob.c:163
 #, c-format
 msgid "%s conflicts with %s%s"
-msgstr "%s té conflictes amb %s%s"
+msgstr "%s entra en conflicte amb %s%s"
 
 #: lib/rpmprob.c:167
 #, c-format
 msgid "%s is obsoleted by %s%s"
-msgstr ""
+msgstr "%s està devaluat amb %s%s"
 
 #: lib/rpmprob.c:172
 #, c-format
@@ -2927,7 +2721,7 @@ msgstr "error desconegut %d en manipular el paquet %s"
 #: lib/rpmrc.c:222
 #, c-format
 msgid "missing second ':' at %s:%d\n"
-msgstr "falten el segon ':' a %s:%d\n"
+msgstr "falta el segon ':' a %s:%d\n"
 
 #: lib/rpmrc.c:225
 #, c-format
@@ -2937,7 +2731,7 @@ msgstr "falta el nom d'arquitectura a %s:%d\n"
 #: lib/rpmrc.c:370
 #, c-format
 msgid "Incomplete data line at %s:%d\n"
-msgstr "Línia de dades incompleta a %s:%d\n"
+msgstr "Línia incompleta de dades a %s:%d\n"
 
 #: lib/rpmrc.c:375
 #, c-format
@@ -2947,12 +2741,12 @@ msgstr "Massa arguments a la línia de dades a %s:%d\n"
 #: lib/rpmrc.c:382
 #, c-format
 msgid "Bad arch/os number: %s (%s:%d)\n"
-msgstr "Número d'arquitectura/S.O. incorrecte: %s (%s:%d)\n"
+msgstr "Número incorrecte d'arch/os: %s (%s:%d)\n"
 
 #: lib/rpmrc.c:413
 #, c-format
 msgid "Incomplete default line at %s:%d\n"
-msgstr "Línia per defecte incorrecta a %s:%d\n"
+msgstr "Línia incompleta per defecte a %s:%d\n"
 
 #: lib/rpmrc.c:418
 #, c-format
@@ -2962,12 +2756,12 @@ msgstr "Massa arguments a la línia per defecte a %s:%d\n"
 #: lib/rpmrc.c:523
 #, c-format
 msgid "missing ':' (found 0x%02x) at %s:%d\n"
-msgstr "manca ':' (trobat a 0x%02x) a %s:%d\n"
+msgstr "falta ':' (trobat a 0x%02x) a %s:%d\n"
 
 #: lib/rpmrc.c:540 lib/rpmrc.c:572
 #, c-format
 msgid "missing argument for %s at %s:%d\n"
-msgstr "manca un argument per a %s a %s:%d\n"
+msgstr "falta l'argument per %s a %s:%d\n"
 
 #: lib/rpmrc.c:551
 #, c-format
@@ -2982,243 +2776,209 @@ msgstr "falta l'arquitecutra per a %s a %s:%d\n"
 #: lib/rpmrc.c:632
 #, c-format
 msgid "bad option '%s' at %s:%d\n"
-msgstr "opció incorrecte '%s' a %s:%d\n"
+msgstr "opció incorrecta '%s' a %s:%d\n"
 
 #: lib/rpmrc.c:959
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconegut: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "contacteu amb %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "No s'ha pogut obrir %s per a lectura: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
-msgstr ""
+msgstr "No s'ha pogut restaurar el directori actual: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
-msgstr "no s'ha muntat la disponibilitat per a emprar scriptlets <lua>\n"
+msgstr "no s'ha construït amb la compatibilitat cap als scriptlets <lua>\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "No s'ha pogut crear el fitxer temporal per a %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "S'ha produït un error en duplicar el descriptor de fitxer: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "No s'ha pogut llegir la icona %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "No s'ha pogut llegir la icona %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: ha fallat l'Fwrite: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "Ha fallat l'scriptlet %s, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s ha fallat l'scriplet, senyal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "Ha fallat l'scriptlet %s,  estat de sortida %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Format desconegut"
 
 #: lib/rpmte.c:729
 msgid "install"
-msgstr ""
+msgstr "instal·la"
 
 #: lib/rpmte.c:730
 msgid "erase"
-msgstr ""
+msgstr "esborra"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "no es pot obrir la base de dades Packages a %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "hi ha un '(' de més a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "falta '(' a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "falta ')' a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: ha fallat la lectura de la clau pública.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
-msgstr ""
+msgstr "transacció"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(no és una signatura d'OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Capçalera "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "Resum MD5:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Capçalera de resum SHA1:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Capçalera "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
-msgstr ""
+msgstr "s'ha omès"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
-msgstr ""
+msgstr "ha fallat"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
-msgstr ""
+msgstr "sense estat"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
-msgstr ""
+msgstr "estat desconegut"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
-msgstr "manca   %c %s"
+msgstr "falta   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dependències insatisfetes per a %s:\n"
 
 #: lib/headerfmt.c:336
 msgid "invalid field width"
-msgstr ""
+msgstr "l'amplada del camp no és vàlida"
 
 #: lib/headerfmt.c:342
 msgid "missing { after %"
-msgstr "manca { després de %"
+msgstr "falta { després de %"
 
 #: lib/headerfmt.c:364
 msgid "missing } after %{"
-msgstr "manca } després de %{"
+msgstr "falta } després de %{"
 
 #: lib/headerfmt.c:375
 msgid "empty tag format"
@@ -3277,243 +3037,240 @@ msgstr "iterador de matrius emprat amb matrius de mides diferents"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "no s'ha establert cap dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: s'està ignorant"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "s'ha produït un error (%d) en emmagatzemar el registre #%d a %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: ha fallat regexec: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: ha fallat regcomp: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: s'està ignorant"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
-msgstr "rpmdb: s'ha obtingut la capçalera #%u malmesa -- s'està ignorant.\n"
+msgstr "rpmdb: s'ha obtingut malmesa la capçalera #%u -- s'ignora.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: no s'ha pogut llegir la capçalera a 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "no s'ha establert el dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "ha fallat en crear el directori %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
-msgstr "la capçalera #%u de la base de dades és incorrecta -- s'ignorarà.\n"
+msgstr "la capçalera #%u en la base de dades és incorrecta -- s'ignora.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "no es pot afegir el registre originalment a %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"no s'ha pogut remuntar la base de dades: es continua fent servir la base de "
-"dades original\n"
+msgstr "no s'ha pogut reconstruir la base de dades: la base de dades original continua al seu lloc\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "no s'ha pogut reemplaçar la base de dades antiga amb la nova\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "reemplaçeu els fitxers a %s amb fitxers de %s per a recuperar-ho"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "no s'ha pogut suprimir el directori %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
-msgstr ""
+msgstr "%s error(%d) de %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
-msgstr ""
+msgstr "%s error(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "opció de la bd no reconeguda: s'ignora «%s».\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s té un valor numèric invàlid, s'ignorarà\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s té un valor de tipus «long» massa gran o massa petit, s'ignorarà\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-"%s té un valor de tipus «enter» massa llarg o massa petit, s'ignorarà\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "no es pot obtenir el blocatge %s a %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "compartit"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exclusiu"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "error(%d) en emmagatzemar el registre «%s» en %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "error(%d) en suprimir el registre «%s» de %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "error(%d) en assignar la instància de nou paquet\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "opció de la bd no reconeguda: s'ignora «%s».\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s té un valor numèric invàlid, s'ignorarà\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s té un valor de tipus «long» massa gran o massa petit, s'ignorarà\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s té un valor de tipus «enter» massa llarg o massa petit, s'ignorarà\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(buit)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(buit)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s té opcions inacabades\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s té un cos inacabat\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "La macro %%%s té un nom invàlid (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s té un cos buit\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
-msgstr ""
+msgstr "La macro %%%s necessita un espai en blanc abans del cos\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
-msgstr "No s'ha expandit la macro %%%s\n"
+msgstr "Ha fallat l'expansió de la macro %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "La macro %%%s té un nom invàlid (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opció desconeguda %c a %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c sense terminar: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% precedeix una macro que no es pot analitzar\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
-msgstr ""
+msgstr "ha fallat la càrrega del fitxer de les macros %s"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== actiu %d buit %d\n"
@@ -3531,180 +3288,158 @@ msgstr "Fitxer %s: %s\n"
 #: rpmio/rpmfileutil.c:332
 #, c-format
 msgid "File %s is smaller than %u bytes\n"
-msgstr "El fitxer %s fa menys de %u bytes\n"
+msgstr "El fitxer %s és inferior als %u bytes\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "no s'ha pogut crear el directori"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxi invàlida en l'scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxi invàlida en l'script lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "ha fallat l'script lua: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxi invàlida en el ftixer lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Ha fallat el hook lua: %s\n"
 
 #: rpmio/rpmio.c:280
 msgid "[none]"
-msgstr ""
+msgstr "[cap]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(cap error)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "error fatal: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "error: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
-msgstr "avís: "
+msgstr "advertència: "
 
 #: rpmio/rpmmalloc.c:25
 #, c-format
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "l'assignació de memòria (%u bytes) ha retornat NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
-msgstr ""
+msgstr "V%d %s/%s %s, id. de la clau %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
-msgstr ""
+msgstr "(cap)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "S'ha produït un error en crear el fitxer temporal %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "S'ha produït un error en crear el fitxer temporal %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "S'ha produït un error en crear el fitxer temporal %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "ha fallat en crear el directori %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: ha fallat l'Fwrite: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: ha fallat l'Fflush: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
-msgstr ""
+msgstr "Signatura PGP no suportada\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
-msgstr ""
+msgstr "Algoritme de dispersió PGP no suportat %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
-msgstr ""
+msgstr "Algoritme de clau pública PGP no suportat %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "No es pot executar %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "No s'ha pogut crear una canonada per a la signatura: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: ha fallat l'apertura: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "ha fallat el fdopen\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "No es pot executar %s: %s\n"
+msgstr "No s'ha pogut escriure a la canonada\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "No es pot executar %s: %s\n"
+msgstr "No s'ha pogut llegir des del fitxer %s: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "ha fallat l'execució del gpg (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "el gpg no ha escrit la signatura\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "no es pot llegir la signatura\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: El rpmReadSignature ha fallat: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
-msgstr ""
+msgstr "No es poden signar els paquets RPM v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
-msgstr ""
+msgstr "%s ja conté una signatura idèntica, s'omet\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
-msgstr "%s: ha fallat rpmWriteSignature: %s\n"
+msgstr "%s: ha fallat el rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
-msgstr "Ha fallat rpmMkTemp\n"
+msgstr "Ha fallat el rpmMkTemp\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
-msgstr "%s: ha fallat writeLead: %s\n"
+msgstr "%s: ha fallat el writeLead: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
-msgstr ""
+msgstr "ha fallat la substitució %s: %s\n"
 
 #: tools/rpmgraph.c:142
 #, c-format
@@ -3714,38 +3449,3 @@ msgstr "%s: ha fallat la lectura del manifest: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "no verifiquis la signatura de la capçalera i les dades"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Introduïu la contrasenya:"
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "La contrasenya és correcta.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Propietari/grup incorrecte: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "No s'ha pogut crear una canonada per a la signatura: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "No s'ha pogut escriure les dades de %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "No s'ha pogut llegir les dades de %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "No s'ha pogut obrir el fitxer temporal.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "No s'ha pogut obrir el sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "No es pot llegir la capçalera de %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "No es pot escriure la capçalera a %s: %s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "La regió inmutable de la capçalera no s'ha pogut llegir. És possible que "
-#~ "el paquet sigui corrupte\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-26 13:57+0000\n"
 "Last-Translator: Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/rpm-team/rpm/language/ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -37,7 +37,9 @@ msgstr "Copyright (c) 1998 - 2002 Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Aquest programari es pot distribuir lliurement d'acord amb els termes de la Llicència Pública General GNU\n"
+msgstr ""
+"Aquest programari es pot distribuir lliurement d'acord amb els termes de la "
+"Llicència Pública General GNU\n"
 
 #: cliutils.c:53
 #, c-format
@@ -80,7 +82,7 @@ msgstr "Opcions de verificació (amb -V o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opcions d'instal·lació, actualització o supressió:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opcions comunes per a tots els modes rpm i executables:"
@@ -101,7 +103,7 @@ msgstr "format inesperat de la consulta"
 msgid "unexpected query source"
 msgstr "origen inesperat de la consulta"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "només es pot especificar un mode principal"
 
@@ -111,7 +113,8 @@ msgstr "només es pot forçar la instal·lació i l'actualització"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "només es poden traslladar els fitxers durant la instal·lació del paquet"
+msgstr ""
+"només es poden traslladar els fitxers durant la instal·lació del paquet"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -120,7 +123,9 @@ msgstr "no es pot utilitzar l'opció --prefix amb --relocate o --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "només es poden utilitzar les opcions --relocate i --excludepath quan s'instal·lin paquets nous"
+msgstr ""
+"només es poden utilitzar les opcions --relocate i --excludepath quan "
+"s'instal·lin paquets nous"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -136,21 +141,26 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr "només es pot especificar l'opció --replacepkgs durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --replacepkgs durant la instal·lació del "
+"paquet"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr "només es pot especificar l'opció --excludedocs durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --excludedocs durant la instal·lació del "
+"paquet"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr "només es pot especificar l'opció --includedocs durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --includedocs durant la instal·lació del "
+"paquet"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -158,39 +168,52 @@ msgstr "només es pot especificar una opció entre --excludedocs i --includedocs
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr "només es pot especificar l'opció --ignorearch durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --ignorearch durant la instal·lació del "
+"paquet"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr "només es pot especificar l'opció --ignoreos durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --ignoreos durant la instal·lació del paquet"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr "només es pot especificar l'opció --ignoresize durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --ignoresize durant la instal·lació del "
+"paquet"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr "només es pot especificar l'opció --allmatches durant la supressió del paquet"
+msgstr ""
+"només es pot especificar l'opció --allmatches durant la supressió del paquet"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr "només es pot especificar l'opció --allfiles durant la instal·lació del paquet"
+msgstr ""
+"només es pot especificar l'opció --allfiles durant la instal·lació del paquet"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "només es pot especificar l'opció --justdb durant la instal·lació i la supressió del paquet"
+msgstr ""
+"només es pot especificar l'opció --justdb durant la instal·lació i la "
+"supressió del paquet"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "només es poden especificar les opcions d'inhabilitació d'scripts durant la instal·lació i la supressió del paquet"
+msgstr ""
+"només es poden especificar les opcions d'inhabilitació d'scripts durant la "
+"instal·lació i la supressió del paquet"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "només es poden especificar les opcions d'inhabilitació de l'activador durant la instal·lació i la supressió del paquet"
+msgstr ""
+"només es poden especificar les opcions d'inhabilitació de l'activador durant "
+"la instal·lació i la supressió del paquet"
 
 #: rpmqv.c:231
 msgid ""
@@ -202,7 +225,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "els arguments a --root (-r) han de començar per /"
 
@@ -222,201 +245,270 @@ msgstr "no s'han donat arguments per a consultar"
 msgid "no arguments given for verify"
 msgstr "no s'han proporcionat arguments per verificar"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "el buildroot ja s'ha especificat, s'ignora %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) des del <fitxer spec>"
+msgstr ""
+"construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) "
+"des del <fitxer spec>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<fitxer spec>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "construeix mitjançant el %build (%prep, després compila) des del <fitxer spec>"
+msgstr ""
+"construeix mitjançant el %build (%prep, després compila) des del <fitxer "
+"spec>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "construeix mitjançant el %install (%prep, %build i després instal·la) des del <fitxer spec>"
+msgstr ""
+"construeix mitjançant el %install (%prep, %build i després instal·la) des "
+"del <fitxer spec>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verifica la secció %files des del <fitxer spec>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
-msgstr "construeix els paquets del codi font i del binaris des del <fitxer spec>"
+msgstr ""
+"construeix els paquets del codi font i del binaris des del <fitxer spec>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "construeix només el paquet dels binaris des del <fitxer spec>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "construeix només el paquet del codi font des del <fitxer spec>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) "
+"des del <fitxer spec>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<paquet dels fonts>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"construeix mitjançant el %build (%prep, després compila) des del <fitxer "
+"spec>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"construeix mitjançant el %install (%prep, %build i instal·la) des del "
+"<paquet dels fonts>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verifica la secció %files des del <fitxer spec>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "construeix el paquet dels binaris des del <paquet dels fonts>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "construeix el paquet dels binaris des del <paquet dels fonts>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "construeix només el paquet del codi font des del <fitxer spec>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) des de l'<arxiu tar>"
+msgstr ""
+"construeix mitjançant el %prep (desempaqueta els fonts i aplica els pedaços) "
+"des de l'<arxiu tar>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<arxiu tar>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "construeix mitjançant el %build (%prep, després compila) des de l'<arxiu tar>"
+msgstr ""
+"construeix mitjançant el %build (%prep, després compila) des de l'<arxiu tar>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "construeix mitjançant el %install (%prep, %build, instal·la) des de l'<arxiu tar>"
+msgstr ""
+"construeix mitjançant el %install (%prep, %build, instal·la) des de l'<arxiu "
+"tar>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verifica la secció %files des de l'<arxiu tar>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
-msgstr "construeix els paquets del codi font i dels binaris des de l'<arxiu tar>"
+msgstr ""
+"construeix els paquets del codi font i dels binaris des de l'<arxiu tar>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "construeix el paquet dels binari només des de l'<arxiu tar>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "construeix el paquet del codi font només des de l'<arxiu tar>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "construeix el paquet dels binaris des del <paquet dels fonts>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<paquet dels fonts>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "construeix mitjançant el %install (%prep, %build i instal·la) des del <paquet dels fonts>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "substitueix l'arrel de la construcció"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "No es pot obrir el directori actual: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "suprimeix l'arbre de la construcció en acabar"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignora ExcludeArch: directives del fitxer d'especificació"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "depura la màquina d'estat de fitxers"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "no executis cap de les etapes de la construcció"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "no verifiquis les dependències de la construcció"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "genera capçaleres del paquet compatibles amb l'empaquetament rpm v3 (llegat)"
+msgstr ""
+"genera capçaleres del paquet compatibles amb l'empaquetament rpm v3 (llegat)"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "no executis l'etapa %clean de la construcció"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "no executis l'etapa %clean de la construcció"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "no executis l'etapa %check de la construcció"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "no acceptis els msgstr d'i18N del fitxer spec"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "suprimeix els fonts en acabar"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "suprimeix el fitxer spec en acabar"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "vés directament a l'etapa especificada (només per a c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "substitueix la plataforma"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Opcions de construcció amb [ <fitxer spec> | <arxiu tar> | <paquet dels fonts> ]:"
+msgstr ""
+"Opcions de construcció amb [ <fitxer spec> | <arxiu tar> | <paquet dels "
+"fonts> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Han fallat les dependències de la construcció:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "No s'ha pogut obrir el fitxer d'especificacions %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Ha fallat l'obertura de la canonada per al tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Més d'un fitxer en una línia: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Ha fallat la lectura del fitxer spec de %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Ha fallat el canvi de nom de %s a %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "Ha fallat l'obtenció de l'estat de %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "El fitxer %s no és un fitxer regular.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "El fitxer %s no sembla un fitxer d'especificacions.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "S'estan construint per a les plataformes: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "S'està construint per a %s\n"
@@ -427,7 +519,9 @@ msgstr "initialitza la base de dades"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "reconstrueix la base de dades de les llistes inverses des de les capçaleres dels paquets instal·lats"
+msgstr ""
+"reconstrueix la base de dades de les llistes inverses des de les capçaleres "
+"dels paquets instal·lats"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -435,11 +529,14 @@ msgstr "verifica els fitxers de la base de dades"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr "exporta la base de dades al llistat de capçaleres de la sortida estàndard"
+msgstr ""
+"exporta la base de dades al llistat de capçaleres de la sortida estàndard"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr "importa la base de dades des de la llista de capçaleres de l'entrada estàndard"
+msgstr ""
+"importa la base de dades des de la llista de capçaleres de l'entrada "
+"estàndard"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -465,49 +562,65 @@ msgstr "llista les claus des de l'anell de claus RPM"
 msgid "Keyring options:"
 msgstr "Opcions de l'anell de claus:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "no s'han donat arguments"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "signa els paquets"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "signa els paquets (idèntic a --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "suprimeix les signatures dels paquets"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "signa els paquets"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opcions de la signatura:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "No es pot executar %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Heu d'establir «%%_gpg_name» al vostre fitxer de macros\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Introduïu la contrasenya:"
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "La contrasenya és correcta.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "només es pot utilitzar l'opció --prefix quan s'instal·lin paquets nous"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr ""
+"només es pot especificar l'opció --allmatches durant la supressió del paquet"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -525,7 +638,7 @@ msgstr "opera sobre els binaris dels rpm generats amb el spec (per defecte)"
 msgid "operate on source rpm generated by spec"
 msgstr "opera sobre els fonts del rpm generat amb el spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "utilitza el següent format de consulta"
 
@@ -572,68 +685,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nErrors de construcció del RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Errors de construcció del RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "error de sintaxi mentre s'analitzava ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "error de sintaxi mentre s'analitzava &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "error de sintaxi mentre s'analitzava ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "error d'anàlisi a l'expressió\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "no hi ha hagut coincidències (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- només als nombres\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! només als nombres\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "els tipus han de coincidir\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / no és disponible per a les cadenes\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- no és disponible per a les cadenes\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& i || no són disponibles per a les cadenes\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "error de sintaxi a l'expressió\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Falta '(' a %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Falta ')' a %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "L'element %s no és vàlid: %s\n"
@@ -643,46 +759,46 @@ msgstr "L'element %s no és vàlid: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Falta %s a %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() va seguit d'un caràcter que no és un espai en blanc: %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxi incorrecta: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "mode incorrecte del spec: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "dirmode incorrecte del spec: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacitat invàlida: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "No s'ha construït amb disponibilitat de fitxers\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "El fitxer ha de començar amb  \"/\": %s\n"
@@ -692,149 +808,151 @@ msgstr "El fitxer ha de començar amb  \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Es desconeix l'algorisme de resum del fitxer %u, es torna al MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "El fitxer apareix dues vegades: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "L'enllaç simbòlic apunta al BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "No es va trobar el directori: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "No s'ha trobat el fitxer: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "No és un directori: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: no es pot carregar l'etiqueta incorrecta (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: ha fallat la lectura de la clau pública.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: no és una clau pública armada.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "El fitxer ha de començar amb \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "El glob no ha trobat el fitxer: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "No s'ha pogut obrir el fitxer %s del %%files: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "línia: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "El glob no ha trobat el fitxer: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Més d'un fitxer en una línia: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Fitxer incorrecte: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Propietari o grup incorrecte: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "S'està comprovant si hi ha fitxers no empaquetats: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Hi ha fitxers instal·lats però no empaquetats:\n%s"
+msgstr ""
+"Hi ha fitxers instal·lats però no empaquetats:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "S'estan processant els fitxers: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Els binaris dependents de l'arquitectura estan en el paquet noarch\n"
 
@@ -863,79 +981,76 @@ msgstr "%s: línia: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "El nom de màquina no es pot fer canònic: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "No es pot tornar a carregar la capçalera de signatura.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compressió de dades desconeguda: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "No es pot crear la regió de capçalera no modificable.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "No es pot obrir %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "No es pot escriure el paquet: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "No s'ha pogut escriure la capçalera temporal\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Dades CSA incorrectes\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "Ha fallat el fread al fitxer%s: %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Es va escriure: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "S'està executant: \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Ha fallat l'execució de \"%s\" .\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Ha fallat la verificació del paquet \"%s\".\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "No es pot generar el nom de fitxer de sortida per al paquet %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "no es pot crear %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "línia %d: segon %s\n"
@@ -983,22 +1098,24 @@ msgstr "línia %d: segon %%changelog\n"
 #: build/parseDescription.c:32
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
-msgstr "línia %d: S'ha produït un error en analitzar sintàcticament el %%description: %s\n"
+msgstr ""
+"línia %d: S'ha produït un error en analitzar sintàcticament el "
+"%%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "línia %d: Opció %s incorrecta: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "línia %d: massa noms: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "línia %d: No existeix el paquet: %s\n"
@@ -1006,7 +1123,8 @@ msgstr "línia %d: No existeix el paquet: %s\n"
 #: build/parseFiles.c:33
 #, c-format
 msgid "line %d: Error parsing %%files: %s\n"
-msgstr "línia %d: S'ha produït un error en analitzar sintàcticament el %%files: %s\n"
+msgstr ""
+"línia %d: S'ha produït un error en analitzar sintàcticament el %%files: %s\n"
 
 #: build/parseFiles.c:76
 #, c-format
@@ -1016,7 +1134,9 @@ msgstr "línia %d: segon %%files\n"
 #: build/parsePolicies.c:32
 #, c-format
 msgid "line %d: Error parsing %%policies: %s\n"
-msgstr "línia %d: S'ha produït un error en analitzar sintàcticament el %%policies: %s\n"
+msgstr ""
+"línia %d: S'ha produït un error en analitzar sintàcticament el %%policies: "
+"%s\n"
 
 #: build/parsePreamble.c:71
 #, c-format
@@ -1104,91 +1224,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "línia %d: L'etiqueta pren un únic testimoni: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "línia %d: El caràcter '%c' no està permès: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "línia %d: Caràcter no permès: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "línia %d: La seqüència \"..\" no està permesa: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "línia %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: línia: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "línia %d: l'etiqueta és malament formada: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "línia %d: l'etiqueta és buida: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "línia %d: els prefixos no poden acabar en «/»: %s \n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "línia %d: «Docdir» ha de començar per «/»: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "línia %d: el camp Epoch ha d'ésser un nombre sense signe: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "línia %d: %s incorrecte: qualificadors: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "línia %d: Format incorrecte del BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linia %d: Només els subpaquets noarch estan suportats: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "S'ha produït un error intern: l'etiqueta %d és incorrecta\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "línia %d: %s està en desús: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificació incorrecta del paquet: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "El paquet ja existeix: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "línia %d: Etiqueta desconeguda: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} no pot estar buit\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} no pot ser \"/\"\n"
@@ -1198,161 +1323,193 @@ msgstr "%%{buildroot} no pot ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fonts incorrectes: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "No existeix el pedaç número %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sense l'etiqueta \"Patch:\" corresponent\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "No existeix la font número %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Sense \"Source:\" etiqueta al fitxer spec\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "S'ha produït un error en analitzar sintàcticament el %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "línia %d: Argument incorrecte al %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "línia %d: Opció %s incorrecta del %%setup: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "El número de pedaç %s no és vàlid: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "línia %d: segon %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Es requereix la versió"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "dependència no vàlida"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Es requereix la versió"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "línia %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "línia %d: els activadors han de tenir --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "línia %d: S'ha produït un error en analitzar sintàcticament %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "línia %d: l'script intern ha d'acabar en «>»: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "línia %d: el programa d'script ha de començar per «/»: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "línia %d: Segon %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "línia %d: l'script intern no està disponible: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "línia %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "No es pot obrir %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: S'esperava l'argument per %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "línia %d: %%if sense tancar\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: condició incorrecta del %%if\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: s'ha obtingut un %%else sense %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: s'ha obtingut un %%endif sense %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "No s'ha trobat cap arquitectura compatible per a la construcció\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "El paquet no té %%description: %s\n"
@@ -1423,290 +1580,283 @@ msgstr "Hi ha massa arguments en la línia: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "S'estan processant les polítiques: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "S'ignora l'expressió regular incorrecta %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "No s'ha pogut crear la canonada per a %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "No s'ha pogut executar %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "No s'ha pogut crear el procés fill de «%s»: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "ha fallat %s: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "ha fallat l'escriptura de totes les dades a %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "operador incorrecte"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "format incorrecte"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "dependència no vàlida (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Ha fallat la conversió de %s a long integer.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Classificador buit de fitxer\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Sense atributs de fitxer configurats\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "Ha fallat magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "Ha fallat magic_load: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Ha fallat el reconeixement del fitxer \"%s\": mode %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "S'està cercant %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Ha fallat la cerca de %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "ha fallat la consulta del fitxer spec %s, no es pot analitzar sintàcticament\n"
+msgstr ""
+"ha fallat la consulta del fitxer spec %s, no es pot analitzar "
+"sintàcticament\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s és un Delta RPM i no es pot instal·lar directament\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Les dades (%s) no estan disponibles al paquet %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "el paquet %s ja s'ha afegit, s'està ignorant %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "el paquet %s ja es va afegir, s'està reemplaçant per %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(no és un número)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(no és base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(tipus invàlid)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(no és un blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(tipus invàlid d'XML)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(no és una signatura d'OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Data no vàlida %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "substituït"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "no instal·lat"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "compartit per xarxa"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "color incorrecte"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "falta"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(deconegut)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(no és una cadena)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s s'ha desat com a %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s s'ha creat com a %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: ha fallat la supressió: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "directori"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "fitxer"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "%s té una signatura que no es pot verificar"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "Ha fallat el fread: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1835,15 +1985,18 @@ msgid "relocations must have a / following the ="
 msgstr "els trasllats han de tenir un / a continuació del ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "instal·la tots els fitxers, fins i tot les configuracions que podrien ser ignorades"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"instal·la tots els fitxers, fins i tot les configuracions que podrien ser "
+"ignorades"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "suprimeix tots els paquets que coincideixen amb <paquet> (normalment es genera un error si <paquet> especifica múltiples paquets)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"suprimeix tots els paquets que coincideixen amb <paquet> (normalment es "
+"genera un error si <paquet> especifica múltiples paquets)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1921,7 +2074,7 @@ msgstr "actualitza la base de dades, però no modifiquis el sistema de fitxers"
 msgid "do not verify package dependencies"
 msgstr "no verifiquis les dependències dels paquets"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "no verifiquis els resums dels fitxers"
 
@@ -1935,7 +2088,8 @@ msgstr "no instal·lis els contexts de seguretat dels fitxers"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "no reordenis la instal·lació dels paquets per a satisfer les dependències"
+msgstr ""
+"no reordenis la instal·lació dels paquets per a satisfer les dependències"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1999,7 +2153,9 @@ msgstr "no executis cap scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "actualitza a una versió antiga del paquet (--force ho fa automàticament en les actualitzacions)"
+msgstr ""
+"actualitza a una versió antiga del paquet (--force ho fa automàticament en "
+"les actualitzacions)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2041,162 +2197,182 @@ msgstr "actualitza els paquets"
 msgid "reinstall package(s)"
 msgstr "reinstal·la els paquets"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "consulta o verifica tots els paquets"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "mode rpm de comprovació de signatura"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "consulta o verifica els paquets als que pertany aquest fitxer"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "consulta o verifica els paquets al grup"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "consulta o verifica un fitxer de paquet"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "consulta o verifica els paquets amb l'identificador de paquet"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "consulta o verifica els paquets amb l'identificació de capçalera"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "mode rpm de consulta"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "consulta o verifica una instància de capçalera"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "consulta o verifica els paquets des de la transacció d'instal·lació"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "consulta els paquets exigits pel paquet"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "mode rpm de verificació"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "consulta o verifica els paquets que requereixen una dependència"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "consulta o verifica els paquets que proporcionen un dependència"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "consulta o verifica els paquets que requereixen una dependència"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "consulta o verifica els paquets que requereixen una dependència"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "consulta o verifica els paquets que requereixen una dependència"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "consulta o verifica els paquets que requereixen una dependència"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "no englobis els arguments"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "no processis els fitxers que no pertanyin al paquet com manifests"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "mostra tots els fitxers de configuració"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "mostra tots els fitxers de documentació"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "mostra tots els fitxers de llicència"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "mostra la informació bàsica del fitxer"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "mostra tots els fitxers del paquet"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "omet fitxers %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "mostra els estats dels fitxers llistats"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "no verifiquis la mida dels fitxers"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "no verifiquis l'enllaç simbòlic dels fitxers"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "no verifiquis qui és el propietari dels fitxers"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "no verifiquis a quin grup pertanyen els fitxers"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "no verifiquis la data de modificació dels fitxers"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "no verifiquis el mode dels fitxers"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "no verifiquis les capacitats dels fitxers"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "no verifiquis els contextos de seguretat dels fitxers"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "no verifiquis els fitxers del paquet"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "no verifiquis les relacions de dependència del paquet"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "no executis els scripts de verificació"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "s'espera un paquet de codi font, però s'ha trobat un de binari\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "el paquet font no conté un fitxer .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "ha fallat el desempaquetat de l'arxiu%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " al fitxer "
 
@@ -2271,96 +2447,118 @@ msgstr "cap paquet concorda amb %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "cap paquet necessita %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "cap paquet necessita %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "cap paquet dispara %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "cap paquet necessita %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "cap paquet necessita %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "cap paquet proporciona %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fitxer %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "el fitxer %s no pertany a cap paquet\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de paquet invàlid: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "no s'ha pogut llegir el registre %u\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "no s'ha instal·lat el paquet %s\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconeguda: «%s»\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: ha fallat la importació de la clau %d.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: ha fallat la lectura de la importació (%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: ha fallat el headerRead: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: la regió de capçalera inmutable no s'ha pogut llegir. El paquet és corrupte?\n"
+msgstr ""
+"%s: la regió de capçalera inmutable no s'ha pogut llegir. El paquet és "
+"corrupte?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Ha fallat el fread: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NO ÉS CORRECTE"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "D'ACORD"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (FALTEN LES CLAUS:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CLAUS NO FIABLES:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: ha fallat l'obertura: %s\n"
@@ -2385,144 +2583,203 @@ msgstr "No s'ha pogut canviar el directori root: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "No es pot restaurar el directori arrel: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "SÍ"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Les dependències PreReq:, Provides: i Obsoletes: suporten versions."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "els noms de fitxer s'han emmagatzemat com una tupla (dirName,baseName,dirIndex), no com a camí"
+msgstr ""
+"els noms de fitxer s'han emmagatzemat com una tupla (dirName,baseName,"
+"dirIndex), no com a camí"
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "les dades del paquet es poden comprimir amb el bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "Les dades del paquet es poden comprimir amb xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "Les dades del paquet es poden comprimir amb bzip2."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "els fitxer de les dades del paquet tenen el prefix «./»."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
-msgstr "no s'ha proporcionat implícitament el nom-versió-alliberament del paquet."
+msgstr ""
+"no s'ha proporcionat implícitament el nom-versió-alliberament del paquet."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "les etiquetes de la capçalera sempre s'ordenen després de carregar-se."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "l'íntèrpret de l'scriptlet pot emprar arguments de la capçalera."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
-msgstr "es pot instal·lar un conjunt d'enllaços durs a fitxer sense que estiguin complets."
+msgstr ""
+"es pot instal·lar un conjunt d'enllaços durs a fitxer sense que estiguin "
+"complets."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "els scriptlets del paquet poden accedir la base de dades rpm durant la instal·lació"
+msgstr ""
+"els scriptlets del paquet poden accedir la base de dades rpm durant la "
+"instal·lació"
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "es poden emprar scripts en lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "l'algorisme de resum de fitxer és configurable per paquet"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "suport per a capacitats de fitxer POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
-msgstr "els scriptlets del paquet es poden expandir en el moment de la instal·lació."
+msgstr ""
+"els scriptlets del paquet es poden expandir en el moment de la instal·lació."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "suporta els fitxers superior als 4 GB"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "no verifiquis les dependències dels paquets"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Es requereix la versió"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "dependència no vàlida"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c sense terminar: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "dependència no vàlida"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "no existeix l'usuari %s - s'utilitza root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "no existeix el grup %s- s'utilitza root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Valor incorrecte del magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Capçalera incorrecta o il·legible"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "La mida de la capçalera és massa gran"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "El fitxer és massa gran per a l'arxiu"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Tipus de fitxer desconegut"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Falten fitxers"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "No hi ha coincidència de resums"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Error intern"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "El fitxer de l'arxiu no és a la capçalera"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " ha fallat - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (error 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "ha fallat l'obertura de %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: no és un paquet rpm (o un manifest de paquet)\n"
@@ -2554,42 +2811,42 @@ msgstr "Dependències fallides:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: no és un paquet rpm (o un manifest de paquet): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "no es pot instal·lar %s\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "S'està obtenint %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "S'està ometent %s - ha fallat la transferència\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "el paquet %s no és pot traslladar\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "s'ha produït un error en llegir del fitxer %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" especifica múltiples paquets:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "no es pot obrir %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "S'està instal·lant %s\n"
@@ -2615,12 +2872,12 @@ msgstr "ha fallat la lectura: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "no és un paquet rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "no es pot crea el bloqueig %s a %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2672,12 +2929,15 @@ msgstr "el camí %s al paquet %s no és pot traslladar"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr "el fitxer %s entra amb conflicte entre els intents d'instal·lació de %s i %s"
+msgstr ""
+"el fitxer %s entra amb conflicte entre els intents d'instal·lació de %s i %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "el fitxer %s de la instal·lació de %s entra amb conflicte amb el fitxer del paquet %s"
+msgstr ""
+"el fitxer %s de la instal·lació de %s entra amb conflicte amb el fitxer del "
+"paquet %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2687,12 +2947,15 @@ msgstr "ja s'ha instal·lat el paquet %s, que és més nou que %s"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "el paquet a instal·lar %s necessita %<PRIu64>%cB al sistema de fitxers %s"
+msgstr ""
+"el paquet a instal·lar %s necessita %<PRIu64>%cB al sistema de fitxers %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "el paquet a instal·lar %s necessita %<PRIu64> nodes-i al sistema de fitxers %s"
+msgstr ""
+"el paquet a instal·lar %s necessita %<PRIu64> nodes-i al sistema de fitxers "
+"%s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2778,60 +3041,79 @@ msgstr "falta l'arquitecutra per a %s a %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "opció incorrecta '%s' a %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconegut: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "contacteu amb %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "No s'ha pogut obrir %s per a lectura: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "No s'ha pogut restaurar el directori actual: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "no s'ha construït amb la compatibilitat cap als scriptlets <lua>\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "No s'ha pogut crear el fitxer temporal per a %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "S'ha produït un error en duplicar el descriptor de fitxer: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "No s'ha pogut llegir la icona %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "No es pot restaurar el directori arrel: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: ha fallat l'Fwrite: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "Ha fallat l'scriptlet %s, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s ha fallat l'scriplet, senyal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "Ha fallat l'scriptlet %s,  estat de sortida %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Format desconegut"
 
@@ -2843,127 +3125,146 @@ msgstr "instal·la"
 msgid "erase"
 msgstr "esborra"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "no es pot obrir la base de dades Packages a %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "hi ha un '(' de més a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "falta '(' a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "falta ')' a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: ha fallat la lectura de la clau pública.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transacció"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(no és una signatura d'OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "Resum MD5:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "No es pot tornar a carregar la capçalera de signatura.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Capçalera de resum SHA1:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Capçalera "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "Resum MD5:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Capçalera de resum SHA1:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "s'ha omès"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "ha fallat"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "sense estat"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "estat desconegut"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "falta   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dependències insatisfetes per a %s:\n"
@@ -3037,240 +3338,243 @@ msgstr "iterador de matrius emprat amb matrius de mides diferents"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "no s'ha establert cap dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: s'està ignorant"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "s'ha produït un error (%d) en emmagatzemar el registre #%d a %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: ha fallat regexec: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: ha fallat regcomp: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: s'està ignorant"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: s'ha obtingut malmesa la capçalera #%u -- s'ignora.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: no s'ha pogut llegir la capçalera a 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "no s'ha establert el dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "ha fallat en crear el directori %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "la capçalera #%u en la base de dades és incorrecta -- s'ignora.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "no es pot afegir el registre originalment a %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "no s'ha pogut reconstruir la base de dades: la base de dades original continua al seu lloc\n"
+msgstr ""
+"no s'ha pogut reconstruir la base de dades: la base de dades original "
+"continua al seu lloc\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "no s'ha pogut reemplaçar la base de dades antiga amb la nova\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "reemplaçeu els fitxers a %s amb fitxers de %s per a recuperar-ho"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "no s'ha pogut suprimir el directori %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s error(%d) de %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s error(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "no es pot obtenir el blocatge %s a %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "compartit"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exclusiu"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "error(%d) en emmagatzemar el registre «%s» en %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "error(%d) en suprimir el registre «%s» de %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "error(%d) en assignar la instància de nou paquet\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "opció de la bd no reconeguda: s'ignora «%s».\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s té un valor numèric invàlid, s'ignorarà\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s té un valor de tipus «long» massa gran o massa petit, s'ignorarà\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s té un valor de tipus «enter» massa llarg o massa petit, s'ignorarà\n"
+msgstr ""
+"%s té un valor de tipus «enter» massa llarg o massa petit, s'ignorarà\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "no es pot obtenir el blocatge %s a %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "compartit"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exclusiu"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "error(%d) en emmagatzemar el registre «%s» en %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "error(%d) en suprimir el registre «%s» de %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "error(%d) en assignar la instància de nou paquet\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(buit)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(buit)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s té opcions inacabades\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s té un cos inacabat\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "La macro %%%s té un nom invàlid (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s té un cos buit\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La macro %%%s necessita un espai en blanc abans del cos\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Ha fallat l'expansió de la macro %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "La macro %%%s té un nom invàlid (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opció desconeguda %c a %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c sense terminar: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% precedeix una macro que no es pot analitzar\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "ha fallat la càrrega del fitxer de les macros %s"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== actiu %d buit %d\n"
@@ -3290,31 +3594,31 @@ msgstr "Fitxer %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "El fitxer %s és inferior als %u bytes\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "no s'ha pogut crear el directori"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxi invàlida en l'scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxi invàlida en l'script lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "ha fallat l'script lua: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxi invàlida en el ftixer lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Ha fallat el hook lua: %s\n"
@@ -3323,19 +3627,19 @@ msgstr "Ha fallat el hook lua: %s\n"
 msgid "[none]"
 msgstr "[cap]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(cap error)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "error fatal: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "error: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "advertència: "
 
@@ -3344,99 +3648,154 @@ msgstr "advertència: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "l'assignació de memòria (%u bytes) ha retornat NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, id. de la clau %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(cap)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "S'ha produït un error en crear el fitxer temporal %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "S'ha produït un error en crear el fitxer temporal %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "S'ha produït un error en crear el fitxer temporal %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "ha fallat en crear el directori %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: ha fallat l'Fwrite: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: ha fallat l'Fflush: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Signatura PGP no suportada\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algoritme de dispersió PGP no suportat %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algoritme de clau pública PGP no suportat %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "No s'ha pogut crear una canonada per a la signatura: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "No es pot executar %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "ha fallat el fdopen\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "No s'ha pogut escriure a la canonada\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "No s'ha pogut llegir des del fitxer %s: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "ha fallat l'execució del gpg (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "el gpg no ha escrit la signatura\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "no es pot llegir la signatura\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: ha fallat el rpmWriteSignature: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: El rpmReadSignature ha fallat: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: ha fallat el headerRead: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "Ha fallat el rpmMkTemp\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "ha fallat el fdopen\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: ha fallat el headerRead: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s ja conté una signatura idèntica, s'omet\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: El rpmReadSignature ha fallat: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "No es poden signar els paquets RPM v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s ja conté una signatura idèntica, s'omet\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: ha fallat el rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "Ha fallat el rpmMkTemp\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: ha fallat el writeLead: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "ha fallat la substitució %s: %s\n"
@@ -3449,3 +3808,24 @@ msgstr "%s: ha fallat la lectura del manifest: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "no verifiquis la signatura de la capçalera i les dades"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Introduïu la contrasenya:"
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "La contrasenya és correcta.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Propietari o grup incorrecte: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "línia %d: Caràcter no permès: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "%s té una signatura que no es pot verificar"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "Ha fallat el fread: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "No s'ha pogut crear una canonada per a la signatura: %m"

--- a/po/cmn.po
+++ b/po/cmn.po
@@ -1,22 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
+# 趙惟倫 <bluebat@member.fsf.org>, 2013
 # 趙惟倫 <bluebat@member.fsf.org>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Chinese (Mandarin) (http://www.transifex.com/projects/p/rpm/"
-"language/cmn/)\n"
-"Language: cmn\n"
+"Language-Team: Chinese (Mandarin) (http://www.transifex.com/rpm-team/rpm/language/cmn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: cmn\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +81,7 @@ msgstr "驗證選項 (使用 -V 或 --verify)："
 msgid "Install/Upgrade/Erase options:"
 msgstr "安裝/升級/抹除選項："
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "用於所有 rpm 模式和可執行檔案的共同選項："
@@ -102,7 +102,7 @@ msgstr "不可預料的查詢格式"
 msgid "unexpected query source"
 msgstr "不可預料的查詢來源"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "只能指定一個主要工作模式"
 
@@ -137,7 +137,8 @@ msgid ""
 msgstr "--hash (-h) 只能在套件安裝與抹除時指定"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr "--percent 只能在套件安裝與抹除時指定"
 
 #: rpmqv.c:179
@@ -202,7 +203,7 @@ msgstr "--nodeps 只能在套件安裝、抹除與驗證時指定"
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test 只能在套件安裝與抹除時指定"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的引數必須以「/」開頭"
 
@@ -222,248 +223,201 @@ msgstr "沒有給定查詢引數"
 msgid "no arguments given for verify"
 msgstr "沒有給定驗證引數"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot 已被指定，忽略 %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "從 <specfile> 透過 %prep (解包原始碼並套用修補程式) 來建置"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "從 <specfile> 透過 %install (%prep，%build，然後安裝) 來建置"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "從 <specfile> 驗證 %files 區段"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "根據 <specfile> 建置原始碼套件與二進位套件"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "根據 <specfile> 只建置二進位套件"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "根據 <specfile> 只建置原始碼套件"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "從 <specfile> 透過 %prep (解包原始碼並套用修補程式) 來建置"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "從 <tarball> 透過 %prep (解包原始碼和套用修補檔) 來建置"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "從 <tarball> 驗證 %files 區段"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "從 <tarball> 中建置原始碼套件與二進位套件"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr "從 <tarball> 中只建置二進位套件"
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr "從 <tarball> 中只建置原始碼套件"
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "從 <source package> 透過 %install (%prep，%build，然後安裝) 來建置"
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "從 <specfile> 驗證 %files 區段"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "根據 <specfile> 只建置原始碼套件"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "從 <tarball> 透過 %prep (解包原始碼和套用修補檔) 來建置"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "從 <tarball> 驗證 %files 區段"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "從 <tarball> 中建置原始碼套件與二進位套件"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr "從 <tarball> 中只建置二進位套件"
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr "從 <tarball> 中只建置原始碼套件"
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "強制覆寫建置根目錄"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "無法開啟目前的目錄：%m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "完成後移除建置樹"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "忽略 ExcludeArch：根據規格檔的指示"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "除錯檔案狀態機器"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "不執行建置程序裡的任何步驟"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "不驗證建置相依關係"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "產生與(舊)rpm v3 封裝相容的套件標頭"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "不執行組建的 %clean 階段"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "不執行組建的 %clean 階段"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "不執行組建的 %check 階段"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "不接受來自規格檔的 i18N msgstr"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "完成後移除原始碼檔案"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "完成後移除規格檔"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "直接跳到指定的階段 (只有用於 c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "無視目標平臺"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "組建選項中使用 [ <specfile> | <tarball> | <source package> ]："
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "相依性建置失敗：\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "無法開啟 %s 規格檔：%s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "無法開啟 tar 管線：%m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "一列中超過一個檔案：%s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "無法從 %s 讀取規格檔\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "無法將 %s 重新命名為 %s：%m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "無法檢視 %s 的狀態：%m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s 不是通常的檔案。\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s 似乎不是規格檔。\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "建置目標平臺：%s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "建置目標 %s\n"
@@ -512,7 +466,7 @@ msgstr "列出 RPM 鑰匙圈的金鑰"
 msgid "Keyring options:"
 msgstr "鑰匙圈選項："
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "沒有給定引數"
 
@@ -532,10 +486,29 @@ msgstr "刪除套件簽名"
 msgid "Signature options:"
 msgstr "簽名選項："
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "無法執行 %s：%s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "您必須在您的巨集檔案中設定「%%_gpg_name」\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "輸入通關密語： "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "通關密語良好。\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "密語檢查失敗或是 GPG 金鑰過期\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -553,7 +526,7 @@ msgstr "操作透過規格所建立的二進位 rpm (預設)"
 msgid "operate on source rpm generated by spec"
 msgstr "操作透過規格所建立的原始碼 rpm"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "使用以下的查詢格式"
 
@@ -600,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM 建置錯誤：\n"
+msgstr "\n\nRPM 建置錯誤：\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "剖析 == 時有語法錯誤\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "剖析 && 時有語法錯誤\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "剖析 || 時有語法錯誤\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "表述式剖析錯誤\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "不符合的 (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- 只能用於數字\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! 只能用於數字\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "類型必須符合\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "字串不支援 *、/\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "字串不支援 -\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "字串不支援 && 和 ||\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "表述式中有語法錯誤\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "在 %s %s 中有遺漏的「(」\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "在 %s(%s 中有遺漏的「)」\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "無效的 %s 符記：%s\n"
@@ -674,46 +644,46 @@ msgstr "無效的 %s 符記：%s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "在 %2$s %3$s 中有缺失的 %1$s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 之後有非空白空格：%s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "不當語法：%s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "不當模式規格：%s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "不當目錄模式規格：%s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "不尋常的語區長度：「%s」於 %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "複製語區 %s 於 %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "無效的功能：%s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "檔案功能支援未內建於\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "檔案必須以「/」開頭：%s\n"
@@ -723,146 +693,149 @@ msgstr "檔案必須以「/」開頭：%s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "不明檔案摘要演算法 %u，權宜落回 MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "列出了兩次的檔案：%s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "讀取符號鏈結 %s 失敗：%s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "指向 BuildRoot 的符號鏈結：%s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "找不到目錄：%s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "找不到檔案：%s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：無法呼叫不明的標籤 (%d)。\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公鑰讀入失敗。\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s：不是一個受保護的公鑰。\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：編碼失敗\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "檔案需要以「/」開頭：%s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev 不允許透過 glob 解析：%s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "透過 glob 解析找不到目錄：%s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "透過 glob 解析找不到檔案：%s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "無法開啟 %%files 檔案 %s：%m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "列：%s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "讀取 %%files 檔案 %s 時發生錯誤：%m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "不合法的 _docdir_fmt %s：%s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "無法混合特殊 %s 與其他表單：%s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一列中超過一個檔案：%s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不當檔案：%s：%s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "不當擁有者/群組：%s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "正在檢查未打包的檔案：%s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"找到已安裝 (但未打包) 的檔案：\n"
-"%s"
+msgstr "找到已安裝 (但未打包) 的檔案：\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "正在處理檔案：%s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二進位架構 (%d) 無法匹配套件架構 (%d)。\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 套件中有依賴架構的二進位檔\n"
 
@@ -891,79 +864,79 @@ msgstr "%s: 列：%s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "無法標準化主機名稱：%s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "無法重新載入簽名標頭。\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "不明酬載壓縮：%s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "無法建立不可變的標頭區域。\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "無法寫入套件：%s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "無法寫入臨時標頭\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "不當 CSA 資料\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "無法開啟 %s 檔案：%s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "建立檔案 %s 封存時失敗：%s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已寫入：%s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在執行「%s」：\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」執行失敗。\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "套件檢查「%s」失敗。\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "無法產生套件 %s 的檔案名稱輸出：%s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "無法建立 %s：%s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "第 %d 列：第二個 %s\n"
@@ -1014,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "第 %d 列：剖析 %%description 時發生錯誤：%s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "第 %d 列：不當選項 %s：%s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "第 %d 列：過多名稱：%s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "第 %d 列：套件不存在：%s\n"
@@ -1132,96 +1105,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "第 %d 列：標籤只需單一符記：%s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "第 %d 列：不合法的字元 %c 於：%s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "第 %d 列：不合法的序列「..」於：%s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "第 %d 列：不合法的字元於：%s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "第 %d 列：%s：%s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "第 %d 列：不合法的序列「..」於：%s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: 列：%s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "第 %d 列：格式不當的標籤：%s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "第 %d 列：空的標籤：%s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "第 %d 列：前綴不能以「/」結尾：%s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "第 %d 列：Docdir 必須以「/」開頭：%s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "第 %d 列：Epoch 欄位必須是無正負號的數字：%s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "第 %d 列：不當 %s：修飾詞：%s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "第 %d 列：不當 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "第 %d 列：只有支援 noarch 子套裝模組：%s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "內部錯誤：假造的標籤 %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "第 %d 列：%s 已過時：%s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不當套件規格：%s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "套件已經存在：%s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "第 %d 列：不明標籤：%s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不可是空的\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不可為「/」\n"
@@ -1231,193 +1199,161 @@ msgstr "%%{buildroot} 不可為「/」\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不當原始碼：%s：%s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "沒有修補編號 %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch 卻無相應的「Patch:」標籤\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "沒有原始碼編號 %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "規格檔內無「Source:」標籤\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "剖析 %%setup 時發生錯誤：%s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "第 %d 列：%%setup 中出現不當引數：%s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "第 %d 列：不當 %%setup 選項 %s：%s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無效的修補編號 %s：%s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "第 %d 列：第二個 %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "依存字組必須以英數字、_ 或 / 開頭"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "不允許標上版本的檔案名稱"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "無效的依存性"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "所需版本"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "無效的依存性"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "第 %d 列：%s：%s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "第 %d 列：觸發器必須包含 --：%s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "第 %d 列：剖析 %s 時發生錯誤：%s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "第 %d 列：內部指令稿必須以「>」結尾：%s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "第 %d 列：指令稿程式必須以「/」開頭：%s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr "第 %d 列：解譯器引數不允許存在觸發器中：%s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "第 %d 列：第二個 %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "第 %d 列：不支援的內部指令稿：%s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "第 %d 列：解譯器引數不允許存在觸發器中：%s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "第 %d 列：%s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d：預期用於 %s 的引數\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "第 %d 列：未關閉的 %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "第 %d 列：未關閉的巨集或不當的列延續\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d：不當的 %%if 條件\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d：有個 %%else 沒有對應 %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d：有個 %%endif 沒有對應 %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d：異常的 %%include 敘述\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "找不到可供建置的相容架構\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "套件沒有 %%description：%s\n"
@@ -1488,281 +1424,290 @@ msgstr "太多引數於列號：%s\n"
 msgid "Processing policies: %s\n"
 msgstr "處理策略：%s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略無效的正規表示式 %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "無法為 %s 建立管線：%m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "無法執行 %s：%s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "無法分支 %s：%s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失敗：%x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "無法寫入所有資料至 %s：%s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s 轉換至長整數時失敗。\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "空的檔案分類器\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "無設定檔案特性\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失敗：%s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失敗：%s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "檔案「%s」辨識失敗：模式 %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在尋找 %s：%s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "找不到 %s：\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s 規格檔查詢失敗，無法剖析\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 是個差異 RPM 而無法直接安裝\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "未支援的酬載 (%s) 於套件 %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "套件 %s 已被加入，跳過 %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "套件 %s 已被加入，以 %s 替換\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(不是一個數字)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%Y %b %d %a"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(不是 base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(無效型態)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(不是 blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(無效 xml 類型)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(不是個 OpenPGP 簽名)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "無效的日期 %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "一般"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "已替換"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "未安裝"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "已網路分享"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "錯誤色彩"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "遺失"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(不明)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(不是字串)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已被另存為 %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立為 %s \n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s：移除失敗：%s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "目錄"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "檔案"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1891,16 +1836,15 @@ msgid "relocations must have a / following the ="
 msgstr "重新分配位置必須有個 / 跟在 = 之後"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr "安裝所有檔案，即使組態可能被略過"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤"
-"出現)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤出現)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1978,7 +1922,7 @@ msgstr "更新資料庫，但不修改檔案系統"
 msgid "do not verify package dependencies"
 msgstr "不驗證套件相依性"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "不要驗證檔案的摘要"
 
@@ -2098,182 +2042,162 @@ msgstr "升級套件"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "查詢/驗證所有套件"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm 檢查簽名模式"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "查詢/驗證套件擁有的檔案"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "查詢/驗證套件所屬的群組"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "查詢/驗證一個套件檔案"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "以套件的識別符查詢/驗證套件"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "以標頭識別符查詢/驗證套件"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm 查詢模式"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "查詢/驗證標頭實體"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "從安裝異動作業查詢/驗證套件"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "查詢套件所觸發的套件"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm 驗證模式"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "查詢/驗證需要某些相依套件的套件"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "查詢/驗證提供某些相依套件的套件"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "查詢/驗證需要某些相依套件的套件"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "查詢/驗證需要某些相依套件的套件"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "查詢/驗證需要某些相依套件的套件"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "查詢/驗證需要某些相依套件的套件"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "不以 glob 解析引數"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "不以清單形式處理非套件檔案"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "列出所有組態檔案"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "列出所有文件檔案"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "傾印基本檔案資訊"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "列出套件內的檔案"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "略過 %%ghost 檔案"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "顯示列出的檔案的狀態"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "不驗證檔案大小"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "不驗證檔案的符號鏈結路徑"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "不驗證檔案的擁有者"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "不驗證檔案的群組"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "不驗證檔案的修改時間"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "不驗證檔案的模式"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "不驗證檔案的能力"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "不驗證檔案的安全情境"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "不驗證套件內的檔案"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "不驗證套件的相依關係"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "不執行驗證指令稿"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "缺少 rpmlib 的特色用於 %s：\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "預期是原始碼套件，但卻找到二進位套件\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "原始碼套件內未包含 .spec 檔案\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解包封存檔失敗 %s%s：%s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr "  於檔案 "
 
@@ -2348,116 +2272,96 @@ msgstr "沒有套件符合 %s：%s\n"
 msgid "no package requires %s\n"
 msgstr "沒有套件需要 %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "沒有套件需要 %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "沒有套件會觸發 %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "沒有套件需要 %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "沒有套件需要 %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "沒有套件提供 %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "檔案 %s：%s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "檔案 %s 不被任何套件擁有\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無效的套件編號：%s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "記錄 %u 無法讀取\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "套件 %s 尚未安裝\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "不明的標籤：「%s」\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s：金鑰 %d 匯入失敗。\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：金鑰 %d 不是受保護的公鑰。\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：匯入時讀取失敗(%d)。\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s：headerRead 失敗：%s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s：不可變的標頭區域無法讀取。套件已損壞？\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s：Fread 失敗：%s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "不正確"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "正確"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (遺失的金鑰："
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (未受信任的金鑰："
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s：開啟失敗：%s\n"
@@ -2482,195 +2386,144 @@ msgstr "無法變更根目錄：%m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "無法還原根目錄：%m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "否 "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "是"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:、Provides:、以及 Obsoletes: 相依性支援版本。"
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "檔案名稱儲存為 (dirName、baseName、dirIndex) 字組，而非路徑。"
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "套件酬載可以使用 bzip2 壓縮。"
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "套件酬載可以使用 xz 壓縮。"
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "套件酬載可以使用 lzma 壓縮。"
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "套件酬載檔案有「./」前綴。"
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "套件的「名稱-版本-釋出編號」沒有隱含性地提供。"
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "標頭標籤總在載入之後排序。"
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "指令稿片段解譯器可以使用來自標頭的引數。"
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "硬鏈結檔案組也許沒有被完整安裝。"
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "套件指令稿片段在安裝過程中可以存取 rpm 資料庫。"
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "lua 指令稿的內部支援。"
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "檔案摘要演算法可依各套件組配"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "支援 POSIX.1e 檔案的能力"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "套件指令片段可以於安裝期間展開。"
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "依存性的比較支援附有波折號的版本。"
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "不驗證套件相依性"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "所需版本"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "無效的依存性"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "未終結的 %c：%s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "無效的依存性"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "使用者 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "群組 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "不當魔法數字"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "不當或無法讀取的標頭"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "標頭尺寸過大"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "檔案太大而無法封存"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "不明檔案類型"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "摘要不符"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "內部錯誤"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "在標頭中沒有封存檔"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " 失敗 - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "開啟 %s 失敗：%s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s：不是一個 rpm 套件 (或套件清單)\n"
@@ -2702,42 +2555,42 @@ msgstr "相依關係失敗：\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s：不是一個 rpm 套件 (或套件清單)：%s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s 無法安裝\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "擷取 %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "跳過 %s - 轉移失敗\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "套件 %s 不能重新分配位置\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "讀取檔案 %s 時發生錯誤\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "「%s」指定多個套件：\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "正在安裝 %s\n"
@@ -2763,12 +2616,12 @@ msgstr "讀取失敗：%s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "並非 rpm 套件\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "無法建立 %s 鎖定於 %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "等待 %s 鎖定於 %s\n"
@@ -2784,9 +2637,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "解析符號 %s 時失敗：%s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "%s 插件未載入\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2930,75 +2783,56 @@ msgstr "不當選項「%s」位於 %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "讀取輔助向量時失敗，/proc 未掛載？\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "不明系統：%s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "請聯絡 %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "無法開啟 %s 以供讀取：%m。\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "無法還原目前的目錄：%m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 指令稿片段支援未內建\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "無法建立暫存檔用於 %s：%s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "無法複製檔案描述符號：%s：%s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "無法讀取圖示 %s：%s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "無法還原根目錄：%m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite 失敗：%s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s 指令稿片段失敗，waitpid(%d) rc %d：%s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s 指令稿片段失敗，信號 %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s 指令稿片段失敗，離開狀態 %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "不明格式"
 
@@ -3010,142 +2844,127 @@ msgstr "安裝"
 msgid "erase"
 msgstr "抹除"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "無法開啟套件資料庫 %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的「(」存在於套件標貼中：%s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "套件標貼遺漏「(」：%s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "套件標貼遺漏「)」：%s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s：讀取公鑰時失敗。\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "異動作業"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(不是個 OpenPGP 簽名)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "標頭 "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 摘要："
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "標頭 SHA1 摘要："
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "標頭 "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "已跳過"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "已失敗"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "遺漏      %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "未滿足 %s 的依存性：\n"
@@ -3219,240 +3038,240 @@ msgstr "用於不同大小陣列的陣列迭代器"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "正在產生 %d 個缺少的索引，請稍待…\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "尚未設定 dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳過"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "儲存記錄 #%2$d 到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s：regexec 失敗：%s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s：regcomp 失敗：%s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳過"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：已擷取損壞的標頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：無法讀取位於 0x%x 的標頭\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "尚未設定 dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "建立目錄 %s 時失敗：%s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "在資料庫中有不當的標頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "無法加入原本位於 %u 的記錄\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建資料庫時失敗：原來的資料庫保持原狀\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "以新的資料庫取代舊的資料庫時失敗！\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "以 %2$s 的檔案取代 %1$s 的檔案來復原"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "移除目錄時失敗 %s：%s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "無法辨識的資料庫選項：「%s」 已忽略。\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s 有無效的數值，略過\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s 有過大或過小的 long 數值，略過\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s 有過大或過小的整數值，略過\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "已共享"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "無效的索引類型 %x 於 %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "錯誤(%d) 發生於取得「%s」記錄自 %s 索引：%s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "錯誤(%d) 發生於加入標頭 #%d 記錄\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "錯誤(%d) 發生於移除標頭 #%d 記錄\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "分配新套件實體時發生錯誤(%d)\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "無法辨識的資料庫選項：「%s」 已忽略。\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s 有無效的數值，略過\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s 有過大或過小的 long 數值，略過\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s 有過大或過小的整數值，略過\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "巨集 %%%s 具有未終結的主體\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "巨集 %%%s 具有空的主體\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "巨集 %%%s 展開時失敗\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中有不明的選項 %1$c\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "在巨集展開中有太多層的遞迴。它似乎是遞迴的巨集宣告所造成的。\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未終結的 %c：%s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在無法剖析的巨集之後跟著一個 %%\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3472,31 +3291,31 @@ msgstr "檔案 %s：%s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "檔案 %s 小於 %u 位元組\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "無法建立目錄"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "無效的語法於 lua 指令稿片段：%s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "無效的語法於 lua 指令稿：%s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 指令稿失敗：%s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua 檔案內有無效語法：%s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua 攔截指令失敗：%s\n"
@@ -3505,19 +3324,19 @@ msgstr "lua 攔截指令失敗：%s\n"
 msgid "[none]"
 msgstr "[無]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(無錯誤)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "嚴重錯誤："
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "錯誤："
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "警告："
 
@@ -3526,121 +3345,99 @@ msgstr "警告："
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "記憶體配置 (%u 位元組) 回傳 NULL。\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s，金鑰識別號 %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(無)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "建立暫存檔 %s 時發生錯誤：%m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "建立暫存檔 %s 時發生錯誤：%m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "建立暫存檔 %s 時發生錯誤：%m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "建立目錄 %s 時失敗：%s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite 失敗：%s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s：Fflush 失敗：%s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "未支援的 PGP 簽名\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "未支援的 PGP 雜湊演算法 %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "未支援的 PGP 公鑰演算法 %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "無法執行 %s：%s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "無法建立簽署用的管線：%m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s：開啟失敗：%s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "無法開啟 %s 檔案：%s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "無法開啟 %%files 檔案 %s：%m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg 執行失敗 (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "寫入簽名時 gpg 失敗\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "無法讀取簽名\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 失敗：%s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "無法簽署 RPM v3 套件\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已經含有相同的簽名，跳過\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失敗：%s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp 失敗\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失敗：%s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "置換 %s 時失敗：%s\n"
@@ -3653,99 +3450,3 @@ msgstr "%s：讀取清單失敗：%s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "不驗證標頭+酬載簽名"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "輸入通關密語： "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "通關密語良好。\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "密語檢查失敗或是 GPG 金鑰過期\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "不當擁有者/群組：%s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "第 %d 列：不合法的字元於：%s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "無法建立簽署用的管線：%m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "無法寫入酬載到 %s：%s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "無法從 %s 讀取酬載：%s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "無法開啟暫時檔案。\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "無法開啟簽名目標 %s：%s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "無法讀取 %s 的標頭：%s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "無法寫入 %s 的標頭：%s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "不實行任何收集動作"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "不可變的標頭區域無法讀取。套件已損壞？\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "無法解碼 %s 的策略\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "無法為 %s 建立暫存檔：%s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "無法寫入 %s 策略至檔案 %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "建立 semanage 控柄時失敗\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "無法連接至策略控柄\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "無法開始策略異動作業：%s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "無法移除暫存策略檔 %s：%s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "無法安裝策略模組：%s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "無法移除策略模組：%s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "無法分支程序：%s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "無法執行 %s：%s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s 已異常終止\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s 已失敗並伴隨代碼 %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "無法提交策略變更\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "無法擴展 restorecon 路徑"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr "無法將檔案系統重新貼標。檔案可能標貼有誤\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr "無法重新載入檔案語境。檔案可能標貼有誤\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "無法從 %s 抽出策略\n"

--- a/po/cmn.po
+++ b/po/cmn.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # 趙惟倫 <bluebat@member.fsf.org>, 2013
 # 趙惟倫 <bluebat@member.fsf.org>, 2013
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Chinese (Mandarin) (http://www.transifex.com/rpm-team/rpm/language/cmn/)\n"
+"Language-Team: Chinese (Mandarin) (http://www.transifex.com/rpm-team/rpm/"
+"language/cmn/)\n"
+"Language: cmn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cmn\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +82,7 @@ msgstr "驗證選項 (使用 -V 或 --verify)："
 msgid "Install/Upgrade/Erase options:"
 msgstr "安裝/升級/抹除選項："
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "用於所有 rpm 模式和可執行檔案的共同選項："
@@ -102,7 +103,7 @@ msgstr "不可預料的查詢格式"
 msgid "unexpected query source"
 msgstr "不可預料的查詢來源"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "只能指定一個主要工作模式"
 
@@ -137,8 +138,7 @@ msgid ""
 msgstr "--hash (-h) 只能在套件安裝與抹除時指定"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr "--percent 只能在套件安裝與抹除時指定"
 
 #: rpmqv.c:179
@@ -203,7 +203,7 @@ msgstr "--nodeps 只能在套件安裝、抹除與驗證時指定"
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test 只能在套件安裝與抹除時指定"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的引數必須以「/」開頭"
 
@@ -223,201 +223,248 @@ msgstr "沒有給定查詢引數"
 msgid "no arguments given for verify"
 msgstr "沒有給定驗證引數"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot 已被指定，忽略 %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "從 <specfile> 透過 %prep (解包原始碼並套用修補程式) 來建置"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "從 <specfile> 透過 %install (%prep，%build，然後安裝) 來建置"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "從 <specfile> 驗證 %files 區段"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "根據 <specfile> 建置原始碼套件與二進位套件"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "根據 <specfile> 只建置二進位套件"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "根據 <specfile> 只建置原始碼套件"
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "從 <tarball> 透過 %prep (解包原始碼和套用修補檔) 來建置"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "從 <specfile> 透過 %prep (解包原始碼並套用修補程式) 來建置"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "從 <tarball> 驗證 %files 區段"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "從 <tarball> 中建置原始碼套件與二進位套件"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr "從 <tarball> 中只建置二進位套件"
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr "從 <tarball> 中只建置原始碼套件"
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "從 <source package> 透過 %install (%prep，%build，然後安裝) 來建置"
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "從 <specfile> 驗證 %files 區段"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "根據 <specfile> 只建置原始碼套件"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "從 <tarball> 透過 %prep (解包原始碼和套用修補檔) 來建置"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "從 <tarball> 驗證 %files 區段"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "從 <tarball> 中建置原始碼套件與二進位套件"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr "從 <tarball> 中只建置二進位套件"
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr "從 <tarball> 中只建置原始碼套件"
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "強制覆寫建置根目錄"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "無法開啟目前的目錄：%m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "完成後移除建置樹"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "忽略 ExcludeArch：根據規格檔的指示"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "除錯檔案狀態機器"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "不執行建置程序裡的任何步驟"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "不驗證建置相依關係"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "產生與(舊)rpm v3 封裝相容的套件標頭"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "不執行組建的 %clean 階段"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "不執行組建的 %clean 階段"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "不執行組建的 %check 階段"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "不接受來自規格檔的 i18N msgstr"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "完成後移除原始碼檔案"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "完成後移除規格檔"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "直接跳到指定的階段 (只有用於 c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "無視目標平臺"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "組建選項中使用 [ <specfile> | <tarball> | <source package> ]："
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "相依性建置失敗：\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "無法開啟 %s 規格檔：%s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "無法開啟 tar 管線：%m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "一列中超過一個檔案：%s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "無法從 %s 讀取規格檔\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "無法將 %s 重新命名為 %s：%m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "無法檢視 %s 的狀態：%m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s 不是通常的檔案。\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s 似乎不是規格檔。\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "建置目標平臺：%s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "建置目標 %s\n"
@@ -466,49 +513,64 @@ msgstr "列出 RPM 鑰匙圈的金鑰"
 msgid "Keyring options:"
 msgstr "鑰匙圈選項："
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "沒有給定引數"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "簽署套件"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "簽署套件 (與 --addsign 含義相同)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "刪除套件簽名"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "簽署套件"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "簽名選項："
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "無法執行 %s：%s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "您必須在您的巨集檔案中設定「%%_gpg_name」\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "輸入通關密語： "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "通關密語良好。\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "密語檢查失敗或是 GPG 金鑰過期\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix 只能在安裝新套件時使用"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches 只能在套件抹除時指定"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -526,7 +588,7 @@ msgstr "操作透過規格所建立的二進位 rpm (預設)"
 msgid "operate on source rpm generated by spec"
 msgstr "操作透過規格所建立的原始碼 rpm"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "使用以下的查詢格式"
 
@@ -573,68 +635,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM 建置錯誤：\n"
+msgstr ""
+"\n"
+"\n"
+"RPM 建置錯誤：\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "剖析 == 時有語法錯誤\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "剖析 && 時有語法錯誤\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "剖析 || 時有語法錯誤\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "表述式剖析錯誤\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "不符合的 (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- 只能用於數字\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! 只能用於數字\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "類型必須符合\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "字串不支援 *、/\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "字串不支援 -\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "字串不支援 && 和 ||\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "表述式中有語法錯誤\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "在 %s %s 中有遺漏的「(」\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "在 %s(%s 中有遺漏的「)」\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "無效的 %s 符記：%s\n"
@@ -644,46 +709,46 @@ msgstr "無效的 %s 符記：%s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "在 %2$s %3$s 中有缺失的 %1$s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 之後有非空白空格：%s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "不當語法：%s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "不當模式規格：%s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "不當目錄模式規格：%s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "不尋常的語區長度：「%s」於 %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "複製語區 %s 於 %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "無效的功能：%s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "檔案功能支援未內建於\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "檔案必須以「/」開頭：%s\n"
@@ -693,149 +758,151 @@ msgstr "檔案必須以「/」開頭：%s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "不明檔案摘要演算法 %u，權宜落回 MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "列出了兩次的檔案：%s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "讀取符號鏈結 %s 失敗：%s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "指向 BuildRoot 的符號鏈結：%s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "找不到目錄：%s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "找不到檔案：%s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：無法呼叫不明的標籤 (%d)。\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公鑰讀入失敗。\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s：不是一個受保護的公鑰。\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：編碼失敗\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "檔案需要以「/」開頭：%s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev 不允許透過 glob 解析：%s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "透過 glob 解析找不到目錄：%s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "透過 glob 解析找不到檔案：%s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "無法開啟 %%files 檔案 %s：%m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "列：%s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "讀取 %%files 檔案 %s 時發生錯誤：%m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "不合法的 _docdir_fmt %s：%s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "透過 glob 解析找不到檔案：%s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "無法混合特殊 %s 與其他表單：%s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一列中超過一個檔案：%s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不當檔案：%s：%s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "不當擁有者/群組：%s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "正在檢查未打包的檔案：%s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "找到已安裝 (但未打包) 的檔案：\n%s"
+msgstr ""
+"找到已安裝 (但未打包) 的檔案：\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "正在處理檔案：%s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二進位架構 (%d) 無法匹配套件架構 (%d)。\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 套件中有依賴架構的二進位檔\n"
 
@@ -864,79 +931,76 @@ msgstr "%s: 列：%s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "無法標準化主機名稱：%s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "無法重新載入簽名標頭。\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "不明酬載壓縮：%s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "無法建立不可變的標頭區域。\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "無法寫入套件：%s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "無法寫入臨時標頭\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "不當 CSA 資料\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已寫入：%s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在執行「%s」：\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」執行失敗。\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "套件檢查「%s」失敗。\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "無法產生套件 %s 的檔案名稱輸出：%s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "無法建立 %s：%s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "第 %d 列：第二個 %s\n"
@@ -987,19 +1051,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "第 %d 列：剖析 %%description 時發生錯誤：%s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "第 %d 列：不當選項 %s：%s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "第 %d 列：過多名稱：%s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "第 %d 列：套件不存在：%s\n"
@@ -1105,91 +1169,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "第 %d 列：標籤只需單一符記：%s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "第 %d 列：不合法的字元 %c 於：%s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "第 %d 列：不合法的字元於：%s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "第 %d 列：不合法的序列「..」於：%s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "第 %d 列：%s：%s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: 列：%s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "第 %d 列：格式不當的標籤：%s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "第 %d 列：空的標籤：%s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "第 %d 列：前綴不能以「/」結尾：%s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "第 %d 列：Docdir 必須以「/」開頭：%s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "第 %d 列：Epoch 欄位必須是無正負號的數字：%s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "第 %d 列：不當 %s：修飾詞：%s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "第 %d 列：不當 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "第 %d 列：只有支援 noarch 子套裝模組：%s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "內部錯誤：假造的標籤 %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "第 %d 列：%s 已過時：%s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不當套件規格：%s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "套件已經存在：%s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "第 %d 列：不明標籤：%s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不可是空的\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不可為「/」\n"
@@ -1199,161 +1268,193 @@ msgstr "%%{buildroot} 不可為「/」\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不當原始碼：%s：%s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "沒有修補編號 %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch 卻無相應的「Patch:」標籤\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "沒有原始碼編號 %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "規格檔內無「Source:」標籤\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "剖析 %%setup 時發生錯誤：%s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "第 %d 列：%%setup 中出現不當引數：%s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "第 %d 列：不當 %%setup 選項 %s：%s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無效的修補編號 %s：%s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "第 %d 列：第二個 %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "依存字組必須以英數字、_ 或 / 開頭"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "不允許標上版本的檔案名稱"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "所需版本"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "無效的依存性"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "所需版本"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "第 %d 列：%s：%s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "第 %d 列：觸發器必須包含 --：%s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "第 %d 列：剖析 %s 時發生錯誤：%s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "第 %d 列：內部指令稿必須以「>」結尾：%s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "第 %d 列：指令稿程式必須以「/」開頭：%s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "第 %d 列：解譯器引數不允許存在觸發器中：%s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "第 %d 列：第二個 %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "第 %d 列：不支援的內部指令稿：%s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "第 %d 列：解譯器引數不允許存在觸發器中：%s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "第 %d 列：%s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d：預期用於 %s 的引數\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "第 %d 列：未關閉的 %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "第 %d 列：未關閉的巨集或不當的列延續\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d：不當的 %%if 條件\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d：有個 %%else 沒有對應 %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d：有個 %%endif 沒有對應 %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d：異常的 %%include 敘述\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "找不到可供建置的相容架構\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "套件沒有 %%description：%s\n"
@@ -1424,290 +1525,281 @@ msgstr "太多引數於列號：%s\n"
 msgid "Processing policies: %s\n"
 msgstr "處理策略：%s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略無效的正規表示式 %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "無法為 %s 建立管線：%m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "無法執行 %s：%s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "無法分支 %s：%s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失敗：%x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "無法寫入所有資料至 %s：%s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s 轉換至長整數時失敗。\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "空的檔案分類器\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "無設定檔案特性\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失敗：%s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失敗：%s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "檔案「%s」辨識失敗：模式 %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在尋找 %s：%s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "找不到 %s：\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s 規格檔查詢失敗，無法剖析\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 是個差異 RPM 而無法直接安裝\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "未支援的酬載 (%s) 於套件 %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "套件 %s 已被加入，跳過 %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "套件 %s 已被加入，以 %s 替換\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(不是一個數字)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%Y %b %d %a"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(不是 base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(無效型態)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(不是 blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(無效 xml 類型)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(不是個 OpenPGP 簽名)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "無效的日期 %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "一般"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "已替換"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "未安裝"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "已網路分享"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "錯誤色彩"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "遺失"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(不明)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(不是字串)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已被另存為 %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立為 %s \n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s：移除失敗：%s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "目錄"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "檔案"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1836,15 +1928,16 @@ msgid "relocations must have a / following the ="
 msgstr "重新分配位置必須有個 / 跟在 = 之後"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr "安裝所有檔案，即使組態可能被略過"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤出現)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤"
+"出現)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1922,7 +2015,7 @@ msgstr "更新資料庫，但不修改檔案系統"
 msgid "do not verify package dependencies"
 msgstr "不驗證套件相依性"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "不要驗證檔案的摘要"
 
@@ -2042,162 +2135,182 @@ msgstr "升級套件"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "查詢/驗證所有套件"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm 檢查簽名模式"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "查詢/驗證套件擁有的檔案"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "查詢/驗證套件所屬的群組"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "查詢/驗證一個套件檔案"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "以套件的識別符查詢/驗證套件"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "以標頭識別符查詢/驗證套件"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm 查詢模式"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "查詢/驗證標頭實體"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "從安裝異動作業查詢/驗證套件"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "查詢套件所觸發的套件"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm 驗證模式"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "查詢/驗證需要某些相依套件的套件"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "查詢/驗證提供某些相依套件的套件"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "查詢/驗證需要某些相依套件的套件"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "查詢/驗證需要某些相依套件的套件"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "查詢/驗證需要某些相依套件的套件"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "查詢/驗證需要某些相依套件的套件"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "不以 glob 解析引數"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "不以清單形式處理非套件檔案"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "列出所有組態檔案"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "列出所有文件檔案"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "傾印基本檔案資訊"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "列出套件內的檔案"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "略過 %%ghost 檔案"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "顯示列出的檔案的狀態"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "不驗證檔案大小"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "不驗證檔案的符號鏈結路徑"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "不驗證檔案的擁有者"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "不驗證檔案的群組"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "不驗證檔案的修改時間"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "不驗證檔案的模式"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "不驗證檔案的能力"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "不驗證檔案的安全情境"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "不驗證套件內的檔案"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "不驗證套件的相依關係"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "不執行驗證指令稿"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "缺少 rpmlib 的特色用於 %s：\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "預期是原始碼套件，但卻找到二進位套件\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "原始碼套件內未包含 .spec 檔案\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解包封存檔失敗 %s%s：%s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr "  於檔案 "
 
@@ -2272,96 +2385,116 @@ msgstr "沒有套件符合 %s：%s\n"
 msgid "no package requires %s\n"
 msgstr "沒有套件需要 %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "沒有套件需要 %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "沒有套件會觸發 %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "沒有套件需要 %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "沒有套件需要 %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "沒有套件提供 %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "檔案 %s：%s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "檔案 %s 不被任何套件擁有\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無效的套件編號：%s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "記錄 %u 無法讀取\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "套件 %s 尚未安裝\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "不明的標籤：「%s」\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s：金鑰 %d 匯入失敗。\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：金鑰 %d 不是受保護的公鑰。\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：匯入時讀取失敗(%d)。\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s：headerRead 失敗：%s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s：不可變的標頭區域無法讀取。套件已損壞？\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s：Fread 失敗：%s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "不正確"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "正確"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (遺失的金鑰："
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (未受信任的金鑰："
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s：開啟失敗：%s\n"
@@ -2386,144 +2519,195 @@ msgstr "無法變更根目錄：%m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "無法還原根目錄：%m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "否 "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "是"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:、Provides:、以及 Obsoletes: 相依性支援版本。"
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "檔案名稱儲存為 (dirName、baseName、dirIndex) 字組，而非路徑。"
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "套件酬載可以使用 bzip2 壓縮。"
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "套件酬載可以使用 xz 壓縮。"
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "套件酬載可以使用 lzma 壓縮。"
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "套件酬載檔案有「./」前綴。"
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "套件的「名稱-版本-釋出編號」沒有隱含性地提供。"
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "標頭標籤總在載入之後排序。"
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "指令稿片段解譯器可以使用來自標頭的引數。"
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "硬鏈結檔案組也許沒有被完整安裝。"
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "套件指令稿片段在安裝過程中可以存取 rpm 資料庫。"
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "lua 指令稿的內部支援。"
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "檔案摘要演算法可依各套件組配"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "支援 POSIX.1e 檔案的能力"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "套件指令片段可以於安裝期間展開。"
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "依存性的比較支援附有波折號的版本。"
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "不驗證套件相依性"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "所需版本"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "無效的依存性"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "未終結的 %c：%s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "無效的依存性"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "使用者 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "群組 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "不當魔法數字"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "不當或無法讀取的標頭"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "標頭尺寸過大"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "檔案太大而無法封存"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "不明檔案類型"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "摘要不符"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "內部錯誤"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "在標頭中沒有封存檔"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " 失敗 - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "開啟 %s 失敗：%s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s：不是一個 rpm 套件 (或套件清單)\n"
@@ -2555,42 +2739,42 @@ msgstr "相依關係失敗：\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s：不是一個 rpm 套件 (或套件清單)：%s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s 無法安裝\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "擷取 %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "跳過 %s - 轉移失敗\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "套件 %s 不能重新分配位置\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "讀取檔案 %s 時發生錯誤\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "「%s」指定多個套件：\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "正在安裝 %s\n"
@@ -2616,12 +2800,12 @@ msgstr "讀取失敗：%s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "並非 rpm 套件\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "無法建立 %s 鎖定於 %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "等待 %s 鎖定於 %s\n"
@@ -2779,60 +2963,79 @@ msgstr "%s 遺漏架構位於 %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "不當選項「%s」位於 %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "讀取輔助向量時失敗，/proc 未掛載？\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "不明系統：%s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "請聯絡 %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "無法開啟 %s 以供讀取：%m。\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "無法還原目前的目錄：%m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 指令稿片段支援未內建\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "無法建立暫存檔用於 %s：%s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "無法複製檔案描述符號：%s：%s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "無法讀取圖示 %s：%s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "無法還原根目錄：%m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite 失敗：%s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s 指令稿片段失敗，waitpid(%d) rc %d：%s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s 指令稿片段失敗，信號 %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s 指令稿片段失敗，離開狀態 %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "不明格式"
 
@@ -2844,127 +3047,146 @@ msgstr "安裝"
 msgid "erase"
 msgstr "抹除"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "無法開啟套件資料庫 %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的「(」存在於套件標貼中：%s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "套件標貼遺漏「(」：%s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "套件標貼遺漏「)」：%s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s：讀取公鑰時失敗。\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "異動作業"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(不是個 OpenPGP 簽名)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 摘要："
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "無法重新載入簽名標頭。\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "標頭 SHA1 摘要："
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "標頭 "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 摘要："
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "標頭 SHA1 摘要："
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "已跳過"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "已失敗"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "遺漏      %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "未滿足 %s 的依存性：\n"
@@ -3038,240 +3260,240 @@ msgstr "用於不同大小陣列的陣列迭代器"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "正在產生 %d 個缺少的索引，請稍待…\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "尚未設定 dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳過"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "儲存記錄 #%2$d 到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s：regexec 失敗：%s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s：regcomp 失敗：%s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳過"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：已擷取損壞的標頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：無法讀取位於 0x%x 的標頭\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "尚未設定 dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "建立目錄 %s 時失敗：%s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "在資料庫中有不當的標頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "無法加入原本位於 %u 的記錄\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建資料庫時失敗：原來的資料庫保持原狀\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "以新的資料庫取代舊的資料庫時失敗！\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "以 %2$s 的檔案取代 %1$s 的檔案來復原"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "移除目錄時失敗 %s：%s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "已共享"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "排他"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "無效的索引類型 %x 於 %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "錯誤(%d) 發生於取得「%s」記錄自 %s 索引：%s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "錯誤(%d) 發生於加入標頭 #%d 記錄\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "錯誤(%d) 發生於移除標頭 #%d 記錄\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "分配新套件實體時發生錯誤(%d)\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "無法辨識的資料庫選項：「%s」 已忽略。\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s 有無效的數值，略過\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s 有過大或過小的 long 數值，略過\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s 有過大或過小的整數值，略過\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "已共享"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "排他"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "無效的索引類型 %x 於 %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "錯誤(%d) 發生於取得「%s」記錄自 %s 索引：%s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "錯誤(%d) 發生於加入標頭 #%d 記錄\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "錯誤(%d) 發生於移除標頭 #%d 記錄\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "分配新套件實體時發生錯誤(%d)\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "巨集 %%%s 具有未終結的主體\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "巨集 %%%s 具有空的主體\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "巨集 %%%s 展開時失敗\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中有不明的選項 %1$c\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "在巨集展開中有太多層的遞迴。它似乎是遞迴的巨集宣告所造成的。\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未終結的 %c：%s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在無法剖析的巨集之後跟著一個 %%\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3291,31 +3513,31 @@ msgstr "檔案 %s：%s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "檔案 %s 小於 %u 位元組\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "無法建立目錄"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "無效的語法於 lua 指令稿片段：%s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "無效的語法於 lua 指令稿：%s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 指令稿失敗：%s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua 檔案內有無效語法：%s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua 攔截指令失敗：%s\n"
@@ -3324,19 +3546,19 @@ msgstr "lua 攔截指令失敗：%s\n"
 msgid "[none]"
 msgstr "[無]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(無錯誤)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "嚴重錯誤："
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "錯誤："
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "警告："
 
@@ -3345,99 +3567,154 @@ msgstr "警告："
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "記憶體配置 (%u 位元組) 回傳 NULL。\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s，金鑰識別號 %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(無)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "建立暫存檔 %s 時發生錯誤：%m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "建立暫存檔 %s 時發生錯誤：%m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "建立暫存檔 %s 時發生錯誤：%m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "建立目錄 %s 時失敗：%s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite 失敗：%s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s：Fflush 失敗：%s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "未支援的 PGP 簽名\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "未支援的 PGP 雜湊演算法 %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "未支援的 PGP 公鑰演算法 %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "無法建立簽署用的管線：%m"
+msgid "Could not exec %s: %s\n"
+msgstr "無法執行 %s：%s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s：開啟失敗：%s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg 執行失敗 (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "寫入簽名時 gpg 失敗\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "無法讀取簽名\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s：rpmWriteSignature 失敗：%s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s：rpmReadSignature 失敗：%s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s：headerRead 失敗：%s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp 失敗\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "執行失敗\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s：headerRead 失敗：%s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s 已經含有相同的簽名，跳過\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 失敗：%s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "無法簽署 RPM v3 套件\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已經含有相同的簽名，跳過\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失敗：%s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp 失敗\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失敗：%s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "置換 %s 時失敗：%s\n"
@@ -3450,3 +3727,21 @@ msgstr "%s：讀取清單失敗：%s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "不驗證標頭+酬載簽名"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "輸入通關密語： "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "通關密語良好。\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "密語檢查失敗或是 GPG 金鑰過期\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "不當擁有者/群組：%s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "第 %d 列：不合法的字元於：%s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "無法建立簽署用的管線：%m"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Czech (http://www.transifex.com/rpm-team/rpm/language/cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr "Vollby kontroly (s -V nebo --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Volby pro Instalaci/Aktualizaci/Mazání:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Společné volby pro všechny rpm režimy a spustitelné soubory:"
@@ -100,7 +100,7 @@ msgstr "neočekávaný formát dotazu"
 msgid "unexpected query source"
 msgstr "neočekávaný zdroj dotazu"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "specifikovat lze jen jeden hlavní režim"
 
@@ -119,7 +119,8 @@ msgstr "nemohu použít --prefix s --relocate nebo --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate a --excludepath je možno použít jen při instalaci nových balíčků"
+msgstr ""
+"--relocate a --excludepath je možno použít jen při instalaci nových balíčků"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +136,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -183,13 +183,17 @@ msgstr "--justdb může být použit jen při instalaci a odstraňování balí�
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "volba pro potlačení skriptů může být použita jen při instalaci nebo při odstraňování balíčků"
+msgstr ""
+"volba pro potlačení skriptů může být použita jen při instalaci nebo při "
+"odstraňování balíčků"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "volba pro potlačení triggerů může být použita jen při instalaci nebo odstraňování balíčků"
+msgstr ""
+"volba pro potlačení triggerů může být použita jen při instalaci nebo "
+"odstraňování balíčků"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +205,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametry pro --root (-r) musejí začínat znakem /"
 
@@ -221,201 +225,255 @@ msgstr "k dotazu nezadány žádné parametry"
 msgid "no arguments given for verify"
 msgstr "pro kontrolu nezadány žádné balíčky"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot byl již nastaven, ignoruji %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "sestavení podle %prep (rozbalení zdrojových kódů a aplikace patchů) podle <spec_soubor>"
+msgstr ""
+"sestavení podle %prep (rozbalení zdrojových kódů a aplikace patchů) podle "
+"<spec_soubor>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<spec_soubor>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "sestavení podle %build (%prep, pak kompilace) podle <spec_soubor>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "sestavení podle %install (%prep, %build, pak install) podle <spec_soubor>"
+msgstr ""
+"sestavení podle %install (%prep, %build, pak install) podle <spec_soubor>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "kontrola části %files ve <spec_soubor>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "vytvoření zdrojového a binárního balíčku podle <spec_soubor>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "vytvoření pouze binárního balíčku podle <spec_soubor>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "sestavení podle %prep (rozbalení zdrojových kódů, aplikace patchů) z <tar_soubor>"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"sestavení podle %prep (rozbalení zdrojových kódů a aplikace patchů) podle "
+"<spec_soubor>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tar_soubor>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "sestavení podle %build (%prep, pak kompilace) z <tar_soubor>"
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "sestavení podle %%install (%prep, %build, pak install) z <tar_soubor>"
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "kontrola části %files z <tar_soubor>"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "vytvoření zdrojového a binárního balíčku z <tar_soubor>"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr "vytvoření pouze binárního balíčku z <tar_soubor>"
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr "vytvoření pouze zdrojového balíčku z <tar_soubor>"
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<zdrojový balíček>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "sestavení podle %build (%prep, pak kompilace) podle <spec_soubor>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "sestavení podle %%install (včetně %prep, %build) ze <zdrojový balíček>"
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "kontrola části %files ve <spec_soubor>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr ""
+"sestavení podle %prep (rozbalení zdrojových kódů, aplikace patchů) z "
+"<tar_soubor>"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tar_soubor>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "sestavení podle %build (%prep, pak kompilace) z <tar_soubor>"
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "sestavení podle %%install (%prep, %build, pak install) z <tar_soubor>"
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "kontrola části %files z <tar_soubor>"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "vytvoření zdrojového a binárního balíčku z <tar_soubor>"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr "vytvoření pouze binárního balíčku z <tar_soubor>"
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr "vytvoření pouze zdrojového balíčku z <tar_soubor>"
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "build root předefinován"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "po dokončení odstranit sestavovací strom"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorovat ExcludeArch: direktivy ve spec souboru"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "ladit nástroj stavu souborů"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "nespouštět žádné etapy vytváření balíčku"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "nekontrolovat závislosti balíčků"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "nespouštět žádné etapy vytváření balíčku"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "neakceptovat i18N popisky ze spec souboru"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "po dokončení odstranit zdrojové kódy"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "po dokončení odstranit spec soubor"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "přeskočit přímo na určenou etapu (pouze pro c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "cílová platforma předefinována"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Sestavovací volby s [ <spec_soubor> | <tar_soubor> | <zdrojový_balíček> ]:"
+msgstr ""
+"Sestavovací volby s [ <spec_soubor> | <tar_soubor> | <zdrojový_balíček> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Chybné závislosti při sestavování:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Nelze otevřít spec soubor %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Nelze otevřít rouru pro tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Nelze otevřít spec soubor %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Nelze číst spec soubor z %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Nelze přejmenovat %s na %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "nemohu zjistit stav %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Soubor %s není obyčejný soubor.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Nezdá se, že by %s byl spec soubor.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Sestavuji cílové platformy: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Sestavuji pro cíl %s\n"
@@ -464,49 +522,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "nezadány žádné parametry"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "podepsat balíček (identické s --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "vymazat podpisy balíčku"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "nainstalovat balíčky"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Volby signatury:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Nemohu spustit %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Je nutné nastavit \"%%_gpg_name\" ve vašem souboru maker\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Vložte heslovou frázi: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Heslová fráze je v pořádku.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix je možno použít jen při instalaci nových balíčků"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches může být použit jen při instalaci balíčků"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +597,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "použij následující formát dotazů"
 
@@ -571,68 +644,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nchyby sestavení RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"chyby sestavení RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "chyba syntaxe při zpracování ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "chyba syntaxe při zpracování &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "chyba syntaxe při zpracování ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "chyba při parsování ve výrazu\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "nedoplněná (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- jen na číslech\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! jen na číslech\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "typy musí souhlasit\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / nejsou podporovány pro řetězce\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- není podporováno pro řetězce\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& a || není podporováno pro řetězce\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "chyba syntaxe ve výrazu\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Chybí '(' v %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Chybí ')' v %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Neplatný %s token: %s\n"
@@ -642,46 +718,46 @@ msgstr "Neplatný %s token: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Chybějící %s v %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Následuje neprázdný znak %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Špatná syntaxe: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Špatná práva spec: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Špatná práva adresáře: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Soubor musí začínat na \"/\": %s\n"
@@ -691,149 +767,151 @@ msgstr "Soubor musí začínat na \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Soubor uveden dvakrát: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolická linka ukazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Soubor nenalezen: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nemohu nahrát neznámou značku (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: čtení veřejného klíče selhalo.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: není obrněný veřejný klíč.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Soubor potřebuje úvodní \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Soubor nenalezen globem: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Nemohu otevřít %%files soubor %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "řádek: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Soubor nenalezen globem: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Špatný soubor: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Špatný vlastník/skupina: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontroluji nezabalené soubory: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Nalezeny instalované, ale nezabalené soubory:\n%s"
+msgstr ""
+"Nalezeny instalované, ale nezabalené soubory:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +940,76 @@ msgstr "%s: řádek: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nemohu získat jméno počítače: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Nemohu znovu přečíst hlavičku podpisu.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Neznámá komprese payloadu: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Nemohu vytvořit nezměnitelný region hlavičky.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nemohu otevřít %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nemohu zapsat balíček: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Nemohu zapsat dočasnou hlavičku\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Špatná CSA data\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapsáno: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nemohu vygenerovat jméno souboru pro balíček %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nemohu vytvořit %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "řádek: %d: druhý %s\n"
@@ -985,19 +1060,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "řádek %d: Chyba při parsování %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "řádek %d: špatná volba %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "řádek %d: Příliš mnoho jmen: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "řádek %d: Balíček neexistuje: %s\n"
@@ -1104,90 +1179,94 @@ msgstr "řádek %d: Značka má jen jeden token: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "řádek: %d: druhý %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: řádek: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "řádek %d: Počkozená značka: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "řádek %d: Prázdná značka: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "řádek %d: Prefixy nesmí končit znakem \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "řádek %d: Docdir musí začínat na '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "řádek %d: Špatné určení %s: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "řádek %d: Špatný formát BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interní chyba: Špatná značka: %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Špatná specifikace balíčku: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Balíček již existuje: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "řádek %d: Neznámá značka: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1276,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Špatný zdrojový soubor: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Chyba při parsování %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "řádek %d: Špatný parametr v %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "řádek %d: Špatná volba v %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neplatné číslo záplaty %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "řádek %d: druhý %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "řádek %d: spouště (triggery) musí mít --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "řádek %d: Chyba při parsování %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "řádek %d: vnitřní skript musí končit na '>': %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "řádek %d: jméno skriptu musí začínat na '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "řádek %d: Druhý %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "řádek %d: nepodporovaný interní skript: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "řádek %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nemohu otevřít %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else bez počítečního %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif bez počátečního %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Nenalezeny žádné kompatibilní architektury pro sestavení\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Balíček nemá žádné %%description: %s\n"
@@ -1422,290 +1533,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nemohu vytvořit rouru pro %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Nemohu spustit %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nemohu provést fork %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) selhalo: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load selhal: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Hledám   %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Selhalo vyhledání %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "dotaz na spec soubor %s selhal, nemohu parsovat\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s is a Delta RPM a nemůže být přímo instalován\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodporovaný payload (%s) in balíčku %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "balíček %s byl již přidán, přeskakuji %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "balíček %s byl již přidán, nahrazuji ho s %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(není číslo)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(není base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(neplatný typ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(není blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(neplatný typ xml)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(není OpenPGP podpis)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s uloženo jako %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s vytvořen jako %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1936,17 @@ msgid "relocations must have a / following the ="
 msgstr "přemístění musejí mít za znakem = znak /"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "nainstalovat všechny soubory i konfigurace, které by se jinak mohly vynechat"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"nainstalovat všechny soubory i konfigurace, které by se jinak mohly vynechat"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "odstranit všechny balíčky odpovídající <balíčku> (obvykle se generuje chyba, specifikuje-li <balíček> více balíčků)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"odstranit všechny balíčky odpovídající <balíčku> (obvykle se generuje chyba, "
+"specifikuje-li <balíček> více balíčků)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2024,7 @@ msgstr "upravit databázi, ale neupravovat systém souborovů"
 msgid "do not verify package dependencies"
 msgstr "nekontrolovat závislosti balíčků"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1998,7 +2102,9 @@ msgstr "nespouštět žádné instalační skripty"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "aktualizovat na starou verzi balíčku (--force to dělá při aktualizacích automaticky)"
+msgstr ""
+"aktualizovat na starou verzi balíčku (--force to dělá při aktualizacích "
+"automaticky)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2146,182 @@ msgstr "aktualizace balíčku"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "dotázat/ověřit všechny balíčky"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "režim rpm checksig"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "dotaz/ověření balíčků vlastnícího soubor"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "dotaz/ověření balíčků ve skupině"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "dotázat/ověřit soubor balíčku"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "dotaz/ověření balíčků s identifikátorem balíčku"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "dotaz/ověření balíčků s hlavičkovým identifikátorem"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "režim dotazů"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "dotaz/ověření hlavičkové instance"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "dotaz/ověření balíčků z instalační transakce"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "dotaz na balíčky aktivované balíčkem"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "režim kontroly"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "dotaz/ověření balíčků vyžadujících závislost"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "dotaz/ověření balíčků poskytujících závislost"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "dotaz/ověření balíčků vyžadujících závislost"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "dotaz/ověření balíčků vyžadujících závislost"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "dotaz/ověření balíčků vyžadujících závislost"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "dotaz/ověření balíčků vyžadujících závislost"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "neseparuj argumenty"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "nezpracovávej nebalíčkové soubory jako seznamy"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "vypsat všechny konfigurační soubory"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "vypsat všechny soubory s dokumentací"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "zobrazit základní informace o souborech"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "vypsat soubory v balíčku"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "vynechat %%ghost soubory"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "zobrazit stav vypsaných souborů"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "nekontrolovat velikost souborů"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "nekontrolovat cesty symbolických linek"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "nekontrolovat vlastníka souborů"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "nekontrolovat skupinu souborů"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "nekontrolovat čas změny souboru"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "nekontrolovat mód souborů"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "nekontrolovat bezpečnostní kontexty souboru"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "nekontrolovat soubory v balíčku"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "nekontrolovat závislosti balíčků"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "nespouštět kontrolní skripty"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "očekávám balíček se zdrojovými kódy, nalezen však binární\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "zdrojový balíček neobsahuje .spec soubor\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozbalování archívu selhalo %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " na souboru "
 
@@ -2270,96 +2396,117 @@ msgstr "žádný balíček se neshoduje s %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "žádný balíček nevyžaduje %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "žádný balíček nevyžaduje %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "žádný balíček neaktivuje %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "žádný balíček nevyžaduje %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "žádný balíček nevyžaduje %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "žádný balíček neposkytuje %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "soubor %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "soubor %s nevlastní žádný balíček\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neplatné číslo balíčku: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "balíček %s není nainstalován\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "neznámá značka: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importní čtení selhalo(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: Nezměnitelná oblast hlavičky nemůže být čtena. Poškozený balíček?\n"
+msgstr ""
+"%s: Nezměnitelná oblast hlavičky nemůže být čtena. Poškozený balíček?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread selhalo: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NENÍ OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr "(CHYBĚJÍCÍ KLÍČE:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr "(NEDŮVĚRYHODNÉ KLÍČE:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otevření selhalo: %s\n"
@@ -2384,144 +2531,192 @@ msgstr "Není možné změnit kořenový adresář: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NE "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "ANO"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, a Obsoletes: verze pro podporu závislostí."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "jména souborů uložená jako diName,baseName,dirIndex, ne jako cesta."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "payload balíčku může být komprimován pomocí bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "payload balíčku může být komprimován pomocí lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "soubory payloadu balíčku mají předponu \"./\"."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "NVR balíčku není implicitně zprostředkována."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "značky hlavičky jsou vždy setřízeny po nahrátí."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "interpret skriptletů může použít argumenty z hlavičky."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "hardlinkovaný soubor může být instalován bez toho, aby byl kompletní."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "skriptlety balíčku mohou přistupovat k rpm databázi při instalaci."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "interní podpora pro lua skripty."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "nekontrolovat závislosti balíčků"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Neukončené %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "uživatel %s neexistuje - použit uživatel root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "skupina %s neexistuje - použita skupina root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Špatné magické číslo"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Špatná nebo nečitelná hlavička"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Velikost hlavičky je přiliš velká"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Neznámý typ souboru"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Interní chyba"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Soubor z archivu není v hlavičce"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr "selhal - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otevření %s selhalo: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2748,42 @@ msgstr "Selhalé závislosti:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: není rpm balíčkem (nebo seznamem balíčků): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s nemůže být nainstalován\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Získávám %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "balíček %s není přemístitelný\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "chyba při vytváření dočasného souboru %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "nemohu otevřít %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instaluji: %s\n"
@@ -2614,12 +2809,12 @@ msgstr "čtení selhalo: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2777,60 +2972,79 @@ msgstr "chybí arcitektura pro %s na %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "špatný parametr'%s' na %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Neznámý systém: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Prosím kontaktujte %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Nemohu otevřít %s pro čtení: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Nemohu přečíst ikonu %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Nemohu přečíst ikonu %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite selhalo: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s scriptlet selhal, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skriplet selhal, signál %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "provedení %s skripletu selhalo, návratový kód: %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3056,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "nemohu otevřít Packages databázi v %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "nadbytečná '(' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "chybějící '(' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "chybějící ')' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(není OpenPGP podpis)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Nemohu znovu přečíst hlavičku podpisu.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "SHA1 digest v hlavičce:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Hlavička "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 digest:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "SHA1 digest v hlavičce:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "chybí     %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Nesplněné závislosti pro %s:\n"
@@ -3036,240 +3269,240 @@ msgstr "iterátor pole použitý s poli jiné délky"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "nebyla nastavena dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: přeskakuji"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "chyba(%d) ukládání záznamu #%d do %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec selhal: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp selhal: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: přeskakuji"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: poškozená hlavička #%u získáno -- přeskakuji.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nemohu číst hlavičku na 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "žádný dbpath nebyl nastaven"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "selhání při vytváření adresáře %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "hlavička #%u v databázi je špatná -- přeskakuji.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nemohu přidat záznam původně na %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "selhalo znovusestavení databáze: původní databáze zůstává na místě\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "selhalo nahrazení staré databáze novou databází!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "nahraď soubory v %s soubory z %s k obnovení"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "selhalo odstranění adresáře %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "nemohu získat zámek %s na %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "sdílen"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exkluzivní"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "chyba(%d) při ukládání záznamu \"%s\" do %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "chyba(%d) v odstraňování \"%s\" z %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "chyba(%d) při alokaci nové instance balíčku\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "nerozpoznaný db parametr: \"%s\" ignorován.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s má neplatnou číselnou hodnotu, přeskakuji\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s má příliš velkou nebo příliš malou long hodnotu, přeskakuji\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s má příliš velkou nebo příliš malou int hodnotu, přeskakuji\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "nemohu získat zámek %s na %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "sdílen"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exkluzivní"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "chyba(%d) při ukládání záznamu \"%s\" do %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "chyba(%d) v odstraňování \"%s\" z %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "chyba(%d) při alokaci nové instance balíčku\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prázdné)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prázdné)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s má neukončené parametry\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s má neukončené tělo\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s má nepřípustné jméno (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s má prázdné tělo\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Selhalo vyhodnocení makra %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s má nedovolené jméno (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Neznámý parametr %c v %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neukončené %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Po %% následuje nezpracovatelné makro\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivní %d prázdné %d\n"
@@ -3289,31 +3522,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "neplatná syntax v lua skriptletu: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "neplatná syntax v lua skriptu: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skript selhal: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "neplatné syntax v lua souboru: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua obsloužení selhalo: %s\n"
@@ -3322,19 +3555,19 @@ msgstr "lua obsloužení selhalo: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(žádná chyba)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "fatální chyba:"
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "chyba: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "varování: "
 
@@ -3343,99 +3576,154 @@ msgstr "varování: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokace paměti (%u bajtů) vrátila NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "selhání při vytváření adresáře %s: %s\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "chyba při vytváření dočasného souboru %s\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "selhání při vytváření adresáře %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite selhalo: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush selhal: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Nemohu vytvořit rouru pro podepsání: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Nemohu spustit %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: otevření selhalo: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "spuštění gpg selhalo (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg selhal při zápisu podpisu\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "nemohu přečíst podpis\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: Fwrite selhalo: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature selhalo: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "spuštění selhalo\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp selhal\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "spuštění selhalo\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "spuštění selhalo\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature selhalo: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: Fwrite selhalo: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp selhal\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead selhalo: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3736,15 @@ msgstr "%s: čtení seznamu selhalo: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "neověřuj podpis hlavičky a payloadu"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Vložte heslovou frázi: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Heslová fráze je v pořádku.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Špatný vlastník/skupina: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Nemohu vytvořit rouru pro podepsání: %m"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Czech (http://www.transifex.com/projects/p/rpm/language/cs/)\n"
-"Language: cs\n"
+"Language-Team: Czech (http://www.transifex.com/rpm-team/rpm/language/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr "Vollby kontroly (s -V nebo --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Volby pro Instalaci/Aktualizaci/Mazání:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Společné volby pro všechny rpm režimy a spustitelné soubory:"
@@ -100,7 +100,7 @@ msgstr "neočekávaný formát dotazu"
 msgid "unexpected query source"
 msgstr "neočekávaný zdroj dotazu"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "specifikovat lze jen jeden hlavní režim"
 
@@ -119,8 +119,7 @@ msgstr "nemohu použít --prefix s --relocate nebo --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate a --excludepath je možno použít jen při instalaci nových balíčků"
+msgstr "--relocate a --excludepath je možno použít jen při instalaci nových balíčků"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -136,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -183,17 +183,13 @@ msgstr "--justdb může být použit jen při instalaci a odstraňování balí�
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"volba pro potlačení skriptů může být použita jen při instalaci nebo při "
-"odstraňování balíčků"
+msgstr "volba pro potlačení skriptů může být použita jen při instalaci nebo při odstraňování balíčků"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"volba pro potlačení triggerů může být použita jen při instalaci nebo "
-"odstraňování balíčků"
+msgstr "volba pro potlačení triggerů může být použita jen při instalaci nebo odstraňování balíčků"
 
 #: rpmqv.c:231
 msgid ""
@@ -205,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametry pro --root (-r) musejí začínat znakem /"
 
@@ -225,255 +221,201 @@ msgstr "k dotazu nezadány žádné parametry"
 msgid "no arguments given for verify"
 msgstr "pro kontrolu nezadány žádné balíčky"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot byl již nastaven, ignoruji %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"sestavení podle %prep (rozbalení zdrojových kódů a aplikace patchů) podle "
-"<spec_soubor>"
+msgstr "sestavení podle %prep (rozbalení zdrojových kódů a aplikace patchů) podle <spec_soubor>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<spec_soubor>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "sestavení podle %build (%prep, pak kompilace) podle <spec_soubor>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"sestavení podle %install (%prep, %build, pak install) podle <spec_soubor>"
+msgstr "sestavení podle %install (%prep, %build, pak install) podle <spec_soubor>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "kontrola části %files ve <spec_soubor>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "vytvoření zdrojového a binárního balíčku podle <spec_soubor>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "vytvoření pouze binárního balíčku podle <spec_soubor>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"sestavení podle %prep (rozbalení zdrojových kódů a aplikace patchů) podle "
-"<spec_soubor>"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "sestavení podle %prep (rozbalení zdrojových kódů, aplikace patchů) z <tar_soubor>"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tar_soubor>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "sestavení podle %build (%prep, pak kompilace) z <tar_soubor>"
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "sestavení podle %%install (%prep, %build, pak install) z <tar_soubor>"
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "kontrola části %files z <tar_soubor>"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "vytvoření zdrojového a binárního balíčku z <tar_soubor>"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr "vytvoření pouze binárního balíčku z <tar_soubor>"
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr "vytvoření pouze zdrojového balíčku z <tar_soubor>"
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<zdrojový balíček>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "sestavení podle %build (%prep, pak kompilace) podle <spec_soubor>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "sestavení podle %%install (včetně %prep, %build) ze <zdrojový balíček>"
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "kontrola části %files ve <spec_soubor>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"sestavení podle %prep (rozbalení zdrojových kódů, aplikace patchů) z "
-"<tar_soubor>"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tar_soubor>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "sestavení podle %build (%prep, pak kompilace) z <tar_soubor>"
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "sestavení podle %%install (%prep, %build, pak install) z <tar_soubor>"
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "kontrola části %files z <tar_soubor>"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "vytvoření zdrojového a binárního balíčku z <tar_soubor>"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr "vytvoření pouze binárního balíčku z <tar_soubor>"
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr "vytvoření pouze zdrojového balíčku z <tar_soubor>"
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "vytvoření binárního balíčku ze <zdrojový balíček>"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "build root předefinován"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "po dokončení odstranit sestavovací strom"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorovat ExcludeArch: direktivy ve spec souboru"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "ladit nástroj stavu souborů"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "nespouštět žádné etapy vytváření balíčku"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "nekontrolovat závislosti balíčků"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "nespouštět žádné etapy vytváření balíčku"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "neakceptovat i18N popisky ze spec souboru"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "po dokončení odstranit zdrojové kódy"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "po dokončení odstranit spec soubor"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "přeskočit přímo na určenou etapu (pouze pro c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "cílová platforma předefinována"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Sestavovací volby s [ <spec_soubor> | <tar_soubor> | <zdrojový_balíček> ]:"
+msgstr "Sestavovací volby s [ <spec_soubor> | <tar_soubor> | <zdrojový_balíček> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Chybné závislosti při sestavování:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Nelze otevřít spec soubor %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Nelze otevřít rouru pro tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Nelze otevřít spec soubor %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Nelze číst spec soubor z %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Nelze přejmenovat %s na %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "nemohu zjistit stav %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Soubor %s není obyčejný soubor.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Nezdá se, že by %s byl spec soubor.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Sestavuji cílové platformy: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Sestavuji pro cíl %s\n"
@@ -522,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "nezadány žádné parametry"
 
@@ -542,10 +484,29 @@ msgstr "vymazat podpisy balíčku"
 msgid "Signature options:"
 msgstr "Volby signatury:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Nemohu spustit %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Je nutné nastavit \"%%_gpg_name\" ve vašem souboru maker\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Vložte heslovou frázi: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Heslová fráze je v pořádku.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -563,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "použij následující formát dotazů"
 
@@ -610,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"chyby sestavení RPM:\n"
+msgstr "\n\nchyby sestavení RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "chyba syntaxe při zpracování ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "chyba syntaxe při zpracování &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "chyba syntaxe při zpracování ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "chyba při parsování ve výrazu\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "nedoplněná (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- jen na číslech\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! jen na číslech\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "typy musí souhlasit\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / nejsou podporovány pro řetězce\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- není podporováno pro řetězce\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& a || není podporováno pro řetězce\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "chyba syntaxe ve výrazu\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Chybí '(' v %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Chybí ')' v %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Neplatný %s token: %s\n"
@@ -684,46 +642,46 @@ msgstr "Neplatný %s token: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Chybějící %s v %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Následuje neprázdný znak %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Špatná syntaxe: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Špatná práva spec: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Špatná práva adresáře: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Soubor musí začínat na \"/\": %s\n"
@@ -733,146 +691,149 @@ msgstr "Soubor musí začínat na \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Soubor uveden dvakrát: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolická linka ukazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Soubor nenalezen: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nemohu nahrát neznámou značku (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: čtení veřejného klíče selhalo.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: není obrněný veřejný klíč.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Soubor potřebuje úvodní \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Soubor nenalezen globem: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Nemohu otevřít %%files soubor %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "řádek: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Špatný soubor: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Špatný vlastník/skupina: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontroluji nezabalené soubory: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Nalezeny instalované, ale nezabalené soubory:\n"
-"%s"
+msgstr "Nalezeny instalované, ale nezabalené soubory:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -901,79 +862,79 @@ msgstr "%s: řádek: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nemohu získat jméno počítače: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Nemohu znovu přečíst hlavičku podpisu.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Neznámá komprese payloadu: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Nemohu vytvořit nezměnitelný region hlavičky.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nemohu otevřít %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nemohu zapsat balíček: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Nemohu zapsat dočasnou hlavičku\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Špatná CSA data\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Nemohu otevřít %%files soubor %s: %m\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread selhalo: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapsáno: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nemohu vygenerovat jméno souboru pro balíček %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nemohu vytvořit %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "řádek: %d: druhý %s\n"
@@ -1024,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "řádek %d: Chyba při parsování %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "řádek %d: špatná volba %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "řádek %d: Příliš mnoho jmen: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "řádek %d: Balíček neexistuje: %s\n"
@@ -1143,94 +1104,90 @@ msgstr "řádek %d: Značka má jen jeden token: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "řádek: %d: druhý %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: řádek: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "řádek %d: Počkozená značka: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "řádek %d: Prázdná značka: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "řádek %d: Prefixy nesmí končit znakem \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "řádek %d: Docdir musí začínat na '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "řádek %d: Špatné určení %s: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "řádek %d: Špatný formát BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interní chyba: Špatná značka: %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Špatná specifikace balíčku: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Balíček již existuje: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "řádek %d: Neznámá značka: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1240,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Špatný zdrojový soubor: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Chyba při parsování %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "řádek %d: Špatný parametr v %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "řádek %d: Špatná volba v %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neplatné číslo záplaty %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "řádek %d: druhý %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "řádek %d: spouště (triggery) musí mít --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "řádek %d: Chyba při parsování %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "řádek %d: vnitřní skript musí končit na '>': %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "řádek %d: jméno skriptu musí začínat na '/': %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "řádek %d: Druhý %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "řádek %d: nepodporovaný interní skript: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "řádek %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nemohu otevřít %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else bez počítečního %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif bez počátečního %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Nenalezeny žádné kompatibilní architektury pro sestavení\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Balíček nemá žádné %%description: %s\n"
@@ -1497,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nemohu vytvořit rouru pro %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Nemohu spustit %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nemohu provést fork %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) selhalo: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load selhal: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Hledám   %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Selhalo vyhledání %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "dotaz na spec soubor %s selhal, nemohu parsovat\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s is a Delta RPM a nemůže být přímo instalován\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodporovaný payload (%s) in balíčku %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "balíček %s byl již přidán, přeskakuji %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "balíček %s byl již přidán, nahrazuji ho s %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(není číslo)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(není base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(neplatný typ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(není blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(neplatný typ xml)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(není OpenPGP podpis)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s uloženo jako %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s vytvořen jako %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1900,17 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "přemístění musejí mít za znakem = znak /"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"nainstalovat všechny soubory i konfigurace, které by se jinak mohly vynechat"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "nainstalovat všechny soubory i konfigurace, které by se jinak mohly vynechat"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"odstranit všechny balíčky odpovídající <balíčku> (obvykle se generuje chyba, "
-"specifikuje-li <balíček> více balíčků)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "odstranit všechny balíčky odpovídající <balíčku> (obvykle se generuje chyba, specifikuje-li <balíček> více balíčků)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1988,7 +1920,7 @@ msgstr "upravit databázi, ale neupravovat systém souborovů"
 msgid "do not verify package dependencies"
 msgstr "nekontrolovat závislosti balíčků"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2066,9 +1998,7 @@ msgstr "nespouštět žádné instalační skripty"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"aktualizovat na starou verzi balíčku (--force to dělá při aktualizacích "
-"automaticky)"
+msgstr "aktualizovat na starou verzi balíčku (--force to dělá při aktualizacích automaticky)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2110,182 +2040,162 @@ msgstr "aktualizace balíčku"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "dotázat/ověřit všechny balíčky"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "režim rpm checksig"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "dotaz/ověření balíčků vlastnícího soubor"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "dotaz/ověření balíčků ve skupině"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "dotázat/ověřit soubor balíčku"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "dotaz/ověření balíčků s identifikátorem balíčku"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "dotaz/ověření balíčků s hlavičkovým identifikátorem"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "režim dotazů"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "dotaz/ověření hlavičkové instance"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "dotaz/ověření balíčků z instalační transakce"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "dotaz na balíčky aktivované balíčkem"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "režim kontroly"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "dotaz/ověření balíčků vyžadujících závislost"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "dotaz/ověření balíčků poskytujících závislost"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "dotaz/ověření balíčků vyžadujících závislost"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "dotaz/ověření balíčků vyžadujících závislost"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "dotaz/ověření balíčků vyžadujících závislost"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "dotaz/ověření balíčků vyžadujících závislost"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "neseparuj argumenty"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "nezpracovávej nebalíčkové soubory jako seznamy"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "vypsat všechny konfigurační soubory"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "vypsat všechny soubory s dokumentací"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "zobrazit základní informace o souborech"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "vypsat soubory v balíčku"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "vynechat %%ghost soubory"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "zobrazit stav vypsaných souborů"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "nekontrolovat velikost souborů"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "nekontrolovat cesty symbolických linek"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "nekontrolovat vlastníka souborů"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "nekontrolovat skupinu souborů"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "nekontrolovat čas změny souboru"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "nekontrolovat mód souborů"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "nekontrolovat bezpečnostní kontexty souboru"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "nekontrolovat soubory v balíčku"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "nekontrolovat závislosti balíčků"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "nespouštět kontrolní skripty"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "očekávám balíček se zdrojovými kódy, nalezen však binární\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "zdrojový balíček neobsahuje .spec soubor\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozbalování archívu selhalo %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " na souboru "
 
@@ -2360,117 +2270,96 @@ msgstr "žádný balíček se neshoduje s %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "žádný balíček nevyžaduje %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "žádný balíček nevyžaduje %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "žádný balíček neaktivuje %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "žádný balíček nevyžaduje %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "žádný balíček nevyžaduje %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "žádný balíček neposkytuje %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "soubor %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "soubor %s nevlastní žádný balíček\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neplatné číslo balíčku: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "balíček %s není nainstalován\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "neznámá značka: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importní čtení selhalo(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: Nezměnitelná oblast hlavičky nemůže být čtena. Poškozený balíček?\n"
+msgstr "%s: Nezměnitelná oblast hlavičky nemůže být čtena. Poškozený balíček?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread selhalo: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NENÍ OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr "(CHYBĚJÍCÍ KLÍČE:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr "(NEDŮVĚRYHODNÉ KLÍČE:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otevření selhalo: %s\n"
@@ -2495,192 +2384,144 @@ msgstr "Není možné změnit kořenový adresář: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NE "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "ANO"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, a Obsoletes: verze pro podporu závislostí."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "jména souborů uložená jako diName,baseName,dirIndex, ne jako cesta."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "payload balíčku může být komprimován pomocí bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "payload balíčku může být komprimován pomocí lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "soubory payloadu balíčku mají předponu \"./\"."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "NVR balíčku není implicitně zprostředkována."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "značky hlavičky jsou vždy setřízeny po nahrátí."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "interpret skriptletů může použít argumenty z hlavičky."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "hardlinkovaný soubor může být instalován bez toho, aby byl kompletní."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "skriptlety balíčku mohou přistupovat k rpm databázi při instalaci."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "interní podpora pro lua skripty."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "nekontrolovat závislosti balíčků"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Neukončené %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "uživatel %s neexistuje - použit uživatel root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "skupina %s neexistuje - použita skupina root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Špatné magické číslo"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Špatná nebo nečitelná hlavička"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Velikost hlavičky je přiliš velká"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Neznámý typ souboru"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Interní chyba"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Soubor z archivu není v hlavičce"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr "selhal - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otevření %s selhalo: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2712,42 +2553,42 @@ msgstr "Selhalé závislosti:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: není rpm balíčkem (nebo seznamem balíčků): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s nemůže být nainstalován\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Získávám %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "balíček %s není přemístitelný\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "chyba při vytváření dočasného souboru %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "nemohu otevřít %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instaluji: %s\n"
@@ -2773,12 +2614,12 @@ msgstr "čtení selhalo: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2940,75 +2781,56 @@ msgstr "špatný parametr'%s' na %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Neznámý systém: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Prosím kontaktujte %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Nemohu otevřít %s pro čtení: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Nemohu přečíst ikonu %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Nemohu přečíst ikonu %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite selhalo: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s scriptlet selhal, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skriplet selhal, signál %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "provedení %s skripletu selhalo, návratový kód: %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -3020,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "nemohu otevřít Packages databázi v %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "nadbytečná '(' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "chybějící '(' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "chybějící ')' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(není OpenPGP podpis)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Hlavička "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 digest:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "SHA1 digest v hlavičce:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Hlavička "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "chybí     %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Nesplněné závislosti pro %s:\n"
@@ -3229,240 +3036,240 @@ msgstr "iterátor pole použitý s poli jiné délky"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "nebyla nastavena dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: přeskakuji"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "chyba(%d) ukládání záznamu #%d do %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec selhal: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp selhal: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: přeskakuji"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: poškozená hlavička #%u získáno -- přeskakuji.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nemohu číst hlavičku na 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "žádný dbpath nebyl nastaven"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "selhání při vytváření adresáře %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "hlavička #%u v databázi je špatná -- přeskakuji.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nemohu přidat záznam původně na %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "selhalo znovusestavení databáze: původní databáze zůstává na místě\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "selhalo nahrazení staré databáze novou databází!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "nahraď soubory v %s soubory z %s k obnovení"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "selhalo odstranění adresáře %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "nerozpoznaný db parametr: \"%s\" ignorován.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s má neplatnou číselnou hodnotu, přeskakuji\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s má příliš velkou nebo příliš malou long hodnotu, přeskakuji\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s má příliš velkou nebo příliš malou int hodnotu, přeskakuji\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "nemohu získat zámek %s na %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "sdílen"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exkluzivní"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "chyba(%d) při ukládání záznamu \"%s\" do %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "chyba(%d) v odstraňování \"%s\" z %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "chyba(%d) při alokaci nové instance balíčku\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "nerozpoznaný db parametr: \"%s\" ignorován.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s má neplatnou číselnou hodnotu, přeskakuji\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s má příliš velkou nebo příliš malou long hodnotu, přeskakuji\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s má příliš velkou nebo příliš malou int hodnotu, přeskakuji\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prázdné)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prázdné)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s má neukončené parametry\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s má neukončené tělo\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s má nepřípustné jméno (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s má prázdné tělo\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Selhalo vyhodnocení makra %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s má nedovolené jméno (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Neznámý parametr %c v %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neukončené %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Po %% následuje nezpracovatelné makro\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivní %d prázdné %d\n"
@@ -3482,31 +3289,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "neplatná syntax v lua skriptletu: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "neplatná syntax v lua skriptu: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skript selhal: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "neplatné syntax v lua souboru: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua obsloužení selhalo: %s\n"
@@ -3515,19 +3322,19 @@ msgstr "lua obsloužení selhalo: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(žádná chyba)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "fatální chyba:"
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "chyba: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "varování: "
 
@@ -3536,121 +3343,99 @@ msgstr "varování: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokace paměti (%u bajtů) vrátila NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "selhání při vytváření adresáře %s: %s\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "chyba při vytváření dočasného souboru %s\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "selhání při vytváření adresáře %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite selhalo: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush selhal: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Nemohu spustit %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Nemohu vytvořit rouru pro podepsání: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: otevření selhalo: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Nemohu spustit %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Nemohu otevřít %%files soubor %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "spuštění gpg selhalo (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg selhal při zápisu podpisu\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "nemohu přečíst podpis\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature selhalo: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: Fwrite selhalo: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp selhal\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead selhalo: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3663,36 +3448,3 @@ msgstr "%s: čtení seznamu selhalo: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "neověřuj podpis hlavičky a payloadu"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Vložte heslovou frázi: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Heslová fráze je v pořádku.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Špatný vlastník/skupina: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Nemohu vytvořit rouru pro podepsání: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Nemohu zapsat payload do %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Nemohu přečíst payload z %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Nelze otevřít dočasný soubor.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Nemohu otevřít cíl pro podepsání %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Nemohu přečíst hlavičku z %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Nemohu zapsat hlavičku do %s: %s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "Nezměnitelná oblast hlavičky nemůže být čtena. Poškozený balíček?\n"

--- a/po/cs_CZ.po
+++ b/po/cs_CZ.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-04-07 13:17+0300\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Czech (Czech Republic) (http://www.transifex.com/projects/p/rpm/language/cs_CZ/)\n"
+"Language-Team: Czech (Czech Republic) (http://www.transifex.com/rpm-team/rpm/language/cs_CZ/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:199
+#: rpmsign.c:93 sign/rpmgensig.c:232
 #, c-format
 msgid "Could not exec %s: %s\n"
 msgstr ""
@@ -862,92 +862,74 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:238
-#, c-format
-msgid "Unable to write payload to %s: %s\n"
+#: build/pack.c:350
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:246
-#, c-format
-msgid "Unable to read payload from %s: %s\n"
-msgstr ""
-
-#: build/pack.c:346
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:374
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:385
-msgid "Unable to open temp file.\n"
-msgstr ""
-
-#: build/pack.c:392
-msgid "Unable to write temp header\n"
-msgstr ""
-
-#: build/pack.c:400
-msgid "Bad CSA data\n"
-msgstr ""
-
-#: build/pack.c:464
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:472
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:484
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:500
-#, c-format
-msgid "Unable to open sigtarget %s: %s\n"
+#: build/pack.c:495
+msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:511
-#, c-format
-msgid "Unable to read header from %s: %s\n"
+#: build/pack.c:504
+msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:521
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
-msgid "Unable to write header to %s: %s\n"
+msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:554
+#: build/pack.c:526
+#, c-format
+msgid "Fread failed in file %s: %s\n"
+msgstr ""
+
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:573
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:576
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:580
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:627
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:644
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
@@ -1175,37 +1157,37 @@ msgstr ""
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:901
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:990
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1051
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1060
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1095
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1127
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1590,19 +1572,19 @@ msgstr ""
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:341
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:335
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:337
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:339
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
@@ -1754,79 +1736,83 @@ msgstr ""
 msgid "'EXPR'"
 msgstr ""
 
-#: lib/poptALL.c:187 lib/poptALL.c:201
+#: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
 msgstr ""
 
-#: lib/poptALL.c:188 lib/poptALL.c:202
+#: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
 msgstr ""
 
-#: lib/poptALL.c:191
+#: lib/poptALL.c:193
+msgid "don't enable any plugins"
+msgstr ""
+
+#: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
 msgstr ""
 
-#: lib/poptALL.c:193
+#: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
 msgstr ""
 
-#: lib/poptALL.c:195
+#: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
 msgstr ""
 
-#: lib/poptALL.c:198
+#: lib/poptALL.c:203
 msgid "send stdout to CMD"
 msgstr ""
 
-#: lib/poptALL.c:199
+#: lib/poptALL.c:204
 msgid "CMD"
 msgstr ""
 
-#: lib/poptALL.c:204
+#: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
 msgstr ""
 
-#: lib/poptALL.c:205
+#: lib/poptALL.c:210
 msgid "ROOT"
 msgstr ""
 
-#: lib/poptALL.c:207
+#: lib/poptALL.c:212
 msgid "use database in DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:208
+#: lib/poptALL.c:213
 msgid "DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:211
+#: lib/poptALL.c:216
 msgid "display known query tags"
 msgstr ""
 
-#: lib/poptALL.c:213
+#: lib/poptALL.c:218
 msgid "display final rpmrc and macro configuration"
 msgstr ""
 
-#: lib/poptALL.c:215
+#: lib/poptALL.c:220
 msgid "provide less detailed output"
 msgstr ""
 
-#: lib/poptALL.c:217
+#: lib/poptALL.c:222
 msgid "provide more detailed output"
 msgstr ""
 
-#: lib/poptALL.c:219
+#: lib/poptALL.c:224
 msgid "print the version of rpm being used"
 msgstr ""
 
-#: lib/poptALL.c:225
+#: lib/poptALL.c:230
 msgid "debug payload file state machine"
 msgstr ""
 
-#: lib/poptALL.c:231
+#: lib/poptALL.c:236
 msgid "debug rpmio I/O"
 msgstr ""
 
-#: lib/poptALL.c:298
+#: lib/poptALL.c:303
 #, c-format
 msgid "%s: option table misconfigured (%d)\n"
 msgstr ""
@@ -1898,7 +1884,7 @@ msgstr ""
 msgid "upgrade package(s) if already installed"
 msgstr ""
 
-#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:255 lib/poptI.c:259
+#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:251 lib/poptI.c:255
 msgid "<packagefile>+"
 msgstr ""
 
@@ -2009,52 +1995,48 @@ msgid "do not execute any %%triggerpostun scriptlet(s)"
 msgstr ""
 
 #: lib/poptI.c:229
-msgid "do not perform any collection actions"
-msgstr ""
-
-#: lib/poptI.c:233
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
 msgstr ""
 
-#: lib/poptI.c:237
+#: lib/poptI.c:233
 msgid "print percentages as package installs"
 msgstr ""
 
-#: lib/poptI.c:239
+#: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
 msgstr ""
 
-#: lib/poptI.c:240
+#: lib/poptI.c:236
 msgid "<dir>"
 msgstr ""
 
-#: lib/poptI.c:242
+#: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
 msgstr ""
 
-#: lib/poptI.c:243
+#: lib/poptI.c:239
 msgid "<old>=<new>"
 msgstr ""
 
-#: lib/poptI.c:246
+#: lib/poptI.c:242
 msgid "ignore file conflicts between packages"
 msgstr ""
 
-#: lib/poptI.c:249
+#: lib/poptI.c:245
 msgid "reinstall if the package is already present"
 msgstr ""
 
-#: lib/poptI.c:251
+#: lib/poptI.c:247
 msgid "don't install, but tell if it would work or not"
 msgstr ""
 
-#: lib/poptI.c:254
+#: lib/poptI.c:250
 msgid "upgrade package(s)"
 msgstr ""
 
-#: lib/poptI.c:258
+#: lib/poptI.c:254
 msgid "reinstall package(s)"
 msgstr ""
 
@@ -2338,7 +2320,7 @@ msgstr ""
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
@@ -2348,7 +2330,7 @@ msgstr ""
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:93
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
@@ -2377,7 +2359,7 @@ msgstr ""
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:53
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2402,79 +2384,79 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:964
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:967
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:971
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:976
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:979
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:983
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:986
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:989
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:992
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:995
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:998
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1002
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1006
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1010
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1014
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1017
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1020
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
@@ -2654,10 +2636,10 @@ msgstr ""
 
 #: lib/rpmplugins.c:154
 #, c-format
-msgid "Failed to expand %%__%s_%s macro\n"
+msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:198
+#: lib/rpmplugins.c:199
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -2852,11 +2834,11 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:792
+#: lib/rpmte.c:729
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:793
+#: lib/rpmte.c:730
 msgid "erase"
 msgstr ""
 
@@ -2889,96 +2871,98 @@ msgstr ""
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:87
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:92
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:98
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:104
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:119
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:136
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:159
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:175
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:251
-msgid "Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-
-#: lib/signature.c:261
-msgid "Cannot sign RPM v3 packages\n"
-msgstr ""
-
-#: lib/signature.c:348
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:387
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:429
+#: lib/signature.c:316
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:470
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:343
+#: lib/verify.c:251
+#, c-format
+msgid "Duplicate username or UID for user %s\n"
+msgstr ""
+
+#: lib/verify.c:272
+#, c-format
+msgid "Duplicate groupname or GID for group %s\n"
+msgstr ""
+
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:345
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:396
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:448
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3209,90 +3193,6 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: plugins/sepolicy.c:215
-#, c-format
-msgid "Failed to decode policy for %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:222
-#, c-format
-msgid "Failed to create temporary file for %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:228
-#, c-format
-msgid "Failed to write %s policy to file %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:293
-msgid "Failed to create semanage handle\n"
-msgstr ""
-
-#: plugins/sepolicy.c:299
-msgid "Failed to connect to policy handler\n"
-msgstr ""
-
-#: plugins/sepolicy.c:303
-#, c-format
-msgid "Failed to begin policy transaction: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:334
-#, c-format
-msgid "Failed to remove temporary policy file %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:383
-#, c-format
-msgid "Failed to install policy module: %s (%s)\n"
-msgstr ""
-
-#: plugins/sepolicy.c:413
-#, c-format
-msgid "Failed to remove policy module: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:437 plugins/sepolicy.c:489
-#, c-format
-msgid "Failed to fork process: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:447 plugins/sepolicy.c:499
-#, c-format
-msgid "Failed to execute %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:453 plugins/sepolicy.c:505
-#, c-format
-msgid "%s terminated abnormally\n"
-msgstr ""
-
-#: plugins/sepolicy.c:457 plugins/sepolicy.c:509
-#, c-format
-msgid "%s failed with exit code %i\n"
-msgstr ""
-
-#: plugins/sepolicy.c:464
-msgid "Failed to commit policy changes\n"
-msgstr ""
-
-#: plugins/sepolicy.c:481
-msgid "Failed to expand restorecon path"
-msgstr ""
-
-#: plugins/sepolicy.c:560
-msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:564
-msgid "Failed to reload file contexts. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:591
-#, c-format
-msgid "Failed to extract policy from %s\n"
-msgstr ""
-
 #: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
@@ -3303,19 +3203,19 @@ msgstr ""
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:500 rpmio/macro.c:538
+#: rpmio/macro.c:494
+#, c-format
+msgid "Macro %%%s has unterminated opts\n"
+msgstr ""
+
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:557
-#, c-format
-msgid "Macro %%%s has illegal name (%%define)\n"
-msgstr ""
-
 #: rpmio/macro.c:563
 #, c-format
-msgid "Macro %%%s has unterminated opts\n"
+msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
 #: rpmio/macro.c:568
@@ -3333,63 +3233,63 @@ msgstr ""
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:615
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:644
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:727
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:956
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1025 rpmio/macro.c:1042
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1083
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1101
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1482
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:257
+#: rpmio/rpmfileutil.c:258
 #, c-format
 msgid "error creating temporary file %s: %m\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:322 rpmio/rpmfileutil.c:328
+#: rpmio/rpmfileutil.c:323 rpmio/rpmfileutil.c:329
 #, c-format
 msgid "File %s: %s\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:331
+#: rpmio/rpmfileutil.c:332
 #, c-format
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:599
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
@@ -3452,73 +3352,90 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:87
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:97
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:125
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:131
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:174
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
 msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:216
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+msgid "Could not write to pipe\n"
+msgstr ""
+
+#: sign/rpmgensig.c:284
+#, c-format
+msgid "Could not read from file %s: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:246
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:263
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:432
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:440 sign/rpmgensig.c:509
-msgid "rpmMkTemp failed\n"
+#: sign/rpmgensig.c:514
+msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:492
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
-#, c-format
-msgid "%s: writeLead failed: %s\n"
-msgstr ""
-
-#: sign/rpmgensig.c:522
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:536
+#: sign/rpmgensig.c:614
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:621
+#, c-format
+msgid "%s: writeLead failed: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Danish (http://www.transifex.com/rpm-team/rpm/language/da/)\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr "Verifikationstilvalg (med -V eller --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr "uventet forespørgselsformat"
 msgid "unexpected query source"
 msgstr "uventet forespørgselskilde"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "kun ét hovedtilvalg kan angives"
 
@@ -135,8 +135,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +200,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parameteren til --root (-r) skal starte med et /"
 
@@ -221,201 +220,250 @@ msgstr "ingen parametre angivet ved forespørgsel"
 msgid "no arguments given for verify"
 msgstr "ingen parametre angivet ved verifikation"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
-msgstr "buildroot allerede angivet, ignorerer %s\n\n"
+msgstr ""
+"buildroot allerede angivet, ignorerer %s\n"
+"\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "opbyg gennem %prep (udpak kilder og påfør lapper) ud fra <spec-fil>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<spec-fil>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "opbyg gennem %build (%prep, så oversæt) ud fra <spec-fil>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "opbyg gennem %install (%prep, %build, så installér) ud fra <spec-fil>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificér afsnittet %files ud fra <spec-fil>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "opbyg kilde- og binærpakke ud fra <spec-fil>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "opbyg kun binærpakke ud fra <spec-fil>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "opbyg kun kildepakke ud fra <spec-fil>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "opbyg gennem %prep (udpak kilder og påfør lapper) ud fra <spec-fil>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<kildepakke>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "opbyg gennem %build (%prep, så oversæt) ud fra <spec-fil>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"opbyg gennem %install (%prep, %build, så installér) ud fra <kildepakke>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verificér afsnittet %files ud fra <spec-fil>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "opbyg binærpakke ud fra <kildepakke>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "opbyg binærpakke ud fra <kildepakke>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "opbyg kun kildepakke ud fra <spec-fil>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr "opbyg gennem %prep (udpak kilder og påfør lapper) ud fra <tararkiv>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tararkiv>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "opbyg gennem %build (%prep, så oversæt) ud fra <tararkiv>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "opbyg gennem %install (%prep, %build, så installér) ud fra <tararkiv>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificér afsnittet %files fra <tararkiv>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "opbyg kilde- og binærpakker ud fra <tararkiv>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "opbyg kun binærpakke ud fra <tararkiv>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "opbyg kun kildepakke ud fra <tararkiv>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "opbyg binærpakke ud fra <kildepakke>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<kildepakke>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "opbyg gennem %install (%prep, %build, så installér) ud fra <kildepakke>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "gennemtving opbygningsrod"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "fjern bygge-træ ved afslutning"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorér 'ExcludeArch':-angivelser fra spec-fil"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "udfør ingen stadier af opbygningen"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "udfør ingen stadier af opbygningen"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "acceptér ikke i18N msgstr'er fra spec-fil"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "fjern kilder ved afslutning"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "fjern spec-fil ved afslutning"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "spring direkte til angivet stadium (kun for c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "gennemtving målplatform"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opbygningstilvalg med [ <spec-fil> | <tararkiv> | <kildepakke> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Kan ikke åbne spec-fil %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Kunne ikke åbne tar-videreførsel: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Kan ikke åbne spec-fil %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Kunne ikke læse spec-fil fra %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Kunne ikke omdøbe %s til %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "kunne ikke finde %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Filen %s er ikke en regulær fil.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Filen %s synes ikke at være en spec-fil.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Opbygger mål-platforme: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Opbygger for mål %s\n"
@@ -464,49 +512,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "<pakkefil>+"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Signaturtilvalg"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Du skal angive \"%%_gpg_name\" i din makrofil\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Indtast adgangskode: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Adgangskode godkendt.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix kan kun bruges, når nye pakker installeres"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches kan kun angives ved installation"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +587,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "brug følgende forespørgselsformat"
 
@@ -571,68 +634,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM opbygningsfejl:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM opbygningsfejl:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "syntaksfejl under tolkning af ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "syntaksfejl under tolkning af &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "syntaksfejl under tolkning af ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "tolkningsfejl i udtryk\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "uparret (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- kun for tal\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! kun for tal\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "typer skal passe sammen\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / understøttes ikke for strenge\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- understøttes ikke for strenge\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& og || understøttes ikke for strenge\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "syntaksfejl i udtryk\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Manglende '(' i %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Manglende ')' i %s %s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ugyldigt %s-symbol: %s\n"
@@ -642,46 +708,46 @@ msgstr "Ugyldigt %s-symbol: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Ikke-mellemrum efterfølger %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Ugyldig syntaks: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Ugyldig tilstandsangivelse: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Ugyldig dirmode-spec: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Fil skal begynde med \"/\": %s\n"
@@ -691,149 +757,149 @@ msgstr "Fil skal begynde med \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Fil angivet to gange: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolsk lænke peger på BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fil ikke fundet: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Fil kræver foranstillet \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Fil ikke fundet med glob: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "linie: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Fil ikke fundet med glob: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ugyldig fil: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Ugyldig ejer/gruppe: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +928,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Kunne ikke kanonisere værtsnavn: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunne ikke åbne %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunne ikke skrive pakke: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Ugyldige CSA-data\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Kunne ikke generere filnavn til oprettelse af pakke %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "kan ikke oprette %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linie %d: anden %s\n"
@@ -985,19 +1048,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linie %d: Fejl ved tolkning af %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linie %d: Ugyldigt tilvalg %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "line %d: For mange navne: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "line %d: Pakken eksisterer ikke: %s\n"
@@ -1104,90 +1167,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linie %d: anden %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "linie: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linie %d: Forkert udformet mærke: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linie %d: Tomt mærke: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linie %d: Præfikser kan ikke ende på \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linie %d: Docdir skal starte med '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linie %d: Ugyldig %s: angivere: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linie %d: Ugyldigt 'BuildArchitecture'-format: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Intern fejl: Falsk mærke %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ugyldig pakkeangivelse: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pakken eksisterer allerede: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linie %d: Ukendt mærke: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1264,195 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Ugyldig kilde: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fejl ved tolking af %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linie %d: Ugyldigt '%%setup'-tilvalg %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linie %d: anden %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linie %d: udløsere skal have --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linie %d: Fejl under tolkning af %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linie %d: skriptprogram skal starte med '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linie %d: Anden %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linie %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
-msgstr "Kunne ikke åbne %s: %s\n\n"
+msgstr ""
+"Kunne ikke åbne %s: %s\n"
+"\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Fik et %%else uden et %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Fik et %%endif uden et %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakke har ingen %%description: %s\n"
@@ -1422,290 +1523,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Kunne ikke udføre %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Kunne ikke fraspalte ny proces til %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Kunne ikke finde %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "forespørgsel af spec-fil %s mislykkedes, kunne ikke tolkes\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(ikke et tal)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s gemt som %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s oprettet som %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1926,18 @@ msgid "relocations must have a / following the ="
 msgstr "i omrokeringer skal = efterfølges af /"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "installér alle filer -- også konfigurationsfiler, der ellers skulle overspringes"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"installér alle filer -- også konfigurationsfiler, der ellers skulle "
+"overspringes"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "fjern alle pakker, som passer med <pakke> (normalt ville det medføre en fejl, hvis <pakke> angav flere pakker)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"fjern alle pakker, som passer med <pakke> (normalt ville det medføre en "
+"fejl, hvis <pakke> angav flere pakker)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2015,7 @@ msgstr "opdatér databasen, men rør ikke filsystemet"
 msgid "do not verify package dependencies"
 msgstr "undlad at tjekke pakkers afhængighedskrav"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1934,7 +2029,8 @@ msgstr ""
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "ændr ikke pakkernes installationsrækkefølge for at opfylde afhængigheder"
+msgstr ""
+"ændr ikke pakkernes installationsrækkefølge for at opfylde afhængigheder"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1998,7 +2094,9 @@ msgstr ""
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "opgradér til en ældre version af pakken (--force gør ikke dette automatisk ved opgraderinger)"
+msgstr ""
+"opgradér til en ældre version af pakken (--force gør ikke dette automatisk "
+"ved opgraderinger)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2138,182 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "forespørg/verificér alle pakker"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "forespørg/verificér pakke(r), der ejer filen"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "forespørg/verificér pakke(r) i gruppen"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm forespørgselstilstand"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "forespørg pakke(r), der udløses af pakken"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm verifikationstilstand"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "forespørg/verificér pakke(r), der stiller et krav"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "forespørg/verificér pakke(r), der tilfredsstiller et krav"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "forespørg/verificér pakke(r), der stiller et krav"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "forespørg/verificér pakke(r), der stiller et krav"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "forespørg/verificér pakke(r), der stiller et krav"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "forespørg/verificér pakke(r), der stiller et krav"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "vis alle konfigurationsfiler"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "vis alle dokumentationsfiler"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "vis grundlæggende filinformation"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "vis liste over filerne i pakken"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "vis filernes status"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "verificér ikke filerne i pakke"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "kildepakke forventet, binær fundet\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "kildepakke indeholder ingen .spec-fil\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "udpakning af arkiv mislykkedes%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " for fil "
 
@@ -2270,96 +2388,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "ingen pakker kræver %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "ingen pakker kræver %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "ingen pakker udløser %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "ingen pakker kræver %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "ingen pakker kræver %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ingen pakker tilfører %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s tilhører ingen pakke\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "ugyldigt pakkenummer: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakken %s er ikke installeret\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread mislykkedes: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "IKKE O.K."
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "O.K."
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (MANGLENDE NØGLER:    "
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (IKKE-BETROEDE NØGLER:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: åbning mislykkedes: %s\n"
@@ -2384,144 +2522,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "undlad at tjekke pakkers afhængighedskrav"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Uafsluttet %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "bruger %s eksisterer ikke - bruger root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "gruppe %s eksisterer ikke - bruger root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Ugyldigt magisk tal"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Ugyldigt/ulæseligt hoved"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Hovedstørrelse er for stor"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Ukendt filtype"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Intern fejl"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " mislykkedes - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "åbning af %s mislykkedes %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2739,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s kunne ikke installeres\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Modtager %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "fejl ved læsning fra filen %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "kunne ikke åbne %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installerer %s\n"
@@ -2614,12 +2800,12 @@ msgstr "læsning mislykkedes: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2676,7 +2862,8 @@ msgstr "filen %s skaber konflikt mellem den forsøgte installation af %s og %s"
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "filen %s fra installationen af %s skaber konflikt med fil fra pakken %s"
+msgstr ""
+"filen %s fra installationen af %s skaber konflikt med fil fra pakken %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2777,60 +2964,81 @@ msgstr "manglende arkitektur for %s ved %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "ugyldig tilvalg '%s' ved %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
-msgstr "Ukendt system: %s\n\n"
+msgstr ""
+"Ukendt system: %s\n"
+"\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Kunne ikke læse ikon %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Kunne ikke læse ikon %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite mislykkedes: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3050,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "kunne ikke åbne Packages-database i %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3263,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "der er ikke sat nogen dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: kan ikke læse hoved ved 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "der ikke sat nogen dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "kunne ikke genopbygge database: original-databasen beholdes\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "kunne ikke erstatte gammel database med ny database!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "erstat filer i %s med filer fra %s for at genoprette"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "kunne ikke fjerne katalog %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "kan ikke opnå %s lås på %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "delt"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "eksklusiv"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "fejl(%d) under allokering af ny pakkeinstans\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s har ugyldig talværdi, overspringes\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s har for stor eller lille 'long'-værdi, overspringes\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s har for stor eller lille heltalsværdi, overspringes\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "kan ikke opnå %s lås på %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "delt"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "eksklusiv"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "fejl(%d) under allokering af ny pakkeinstans\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tom)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tom)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makroen %%%s har uafsluttede parametre\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makroen %%%s har et uafsluttet indhold (body)\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makroen %%%s har et ugyldig navn (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makroen %%%s har intet indhold\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makroen %%%s kunne ikke udfoldes\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makroen %%%s har ugyldigt navn (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Ukendt tilvalg %c i %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Uafsluttet %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Et %% efterfølges af en makro, der ikke kan tolkes\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiv %d tom %d\n"
@@ -3289,31 +3516,31 @@ msgstr "Fil %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Filen %s er mindre end %u byte\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3549,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(ingen fejl)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "fatal fejl: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "fejl: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "advarsel: "
 
@@ -3343,99 +3570,154 @@ msgstr "advarsel: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "hukommelsesallokering (%u byte) returnerede NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "fejl ved læsning fra filen %s\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "fejl ved læsning fra filen %s\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "kunne ikke fjerne katalog %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: åbning mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg kunne ikke skrive signaturen\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "kunne ikke læse signaturen\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature mislykkedes: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmWriteSignature mislykkedes: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "eksekvering mislykkedes\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "eksekvering mislykkedes\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "eksekvering mislykkedes\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3730,12 @@ msgstr "%s: læs manifest mislykkedes: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Indtast adgangskode: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Adgangskode godkendt.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Ugyldig ejer/gruppe: %s\n"

--- a/po/da.po
+++ b/po/da.po
@@ -1,21 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Danish (http://www.transifex.com/projects/p/rpm/language/"
-"da/)\n"
-"Language: da\n"
+"Language-Team: Danish (http://www.transifex.com/rpm-team/rpm/language/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,7 +79,7 @@ msgstr "Verifikationstilvalg (med -V eller --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +100,7 @@ msgstr "uventet forespørgselsformat"
 msgid "unexpected query source"
 msgstr "uventet forespørgselskilde"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "kun ét hovedtilvalg kan angives"
 
@@ -136,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parameteren til --root (-r) skal starte med et /"
 
@@ -221,250 +221,201 @@ msgstr "ingen parametre angivet ved forespørgsel"
 msgid "no arguments given for verify"
 msgstr "ingen parametre angivet ved verifikation"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
-msgstr ""
-"buildroot allerede angivet, ignorerer %s\n"
-"\n"
+msgstr "buildroot allerede angivet, ignorerer %s\n\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "opbyg gennem %prep (udpak kilder og påfør lapper) ud fra <spec-fil>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<spec-fil>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "opbyg gennem %build (%prep, så oversæt) ud fra <spec-fil>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "opbyg gennem %install (%prep, %build, så installér) ud fra <spec-fil>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificér afsnittet %files ud fra <spec-fil>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "opbyg kilde- og binærpakke ud fra <spec-fil>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "opbyg kun binærpakke ud fra <spec-fil>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "opbyg kun kildepakke ud fra <spec-fil>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "opbyg gennem %prep (udpak kilder og påfør lapper) ud fra <spec-fil>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<kildepakke>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "opbyg gennem %build (%prep, så oversæt) ud fra <spec-fil>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"opbyg gennem %install (%prep, %build, så installér) ud fra <kildepakke>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verificér afsnittet %files ud fra <spec-fil>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "opbyg binærpakke ud fra <kildepakke>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "opbyg binærpakke ud fra <kildepakke>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "opbyg kun kildepakke ud fra <spec-fil>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr "opbyg gennem %prep (udpak kilder og påfør lapper) ud fra <tararkiv>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tararkiv>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "opbyg gennem %build (%prep, så oversæt) ud fra <tararkiv>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "opbyg gennem %install (%prep, %build, så installér) ud fra <tararkiv>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificér afsnittet %files fra <tararkiv>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "opbyg kilde- og binærpakker ud fra <tararkiv>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "opbyg kun binærpakke ud fra <tararkiv>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "opbyg kun kildepakke ud fra <tararkiv>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "opbyg binærpakke ud fra <kildepakke>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<kildepakke>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "opbyg gennem %install (%prep, %build, så installér) ud fra <kildepakke>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "gennemtving opbygningsrod"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "fjern bygge-træ ved afslutning"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorér 'ExcludeArch':-angivelser fra spec-fil"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "udfør ingen stadier af opbygningen"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "udfør ingen stadier af opbygningen"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "acceptér ikke i18N msgstr'er fra spec-fil"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "fjern kilder ved afslutning"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "fjern spec-fil ved afslutning"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "spring direkte til angivet stadium (kun for c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "gennemtving målplatform"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opbygningstilvalg med [ <spec-fil> | <tararkiv> | <kildepakke> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Kan ikke åbne spec-fil %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Kunne ikke åbne tar-videreførsel: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Kan ikke åbne spec-fil %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Kunne ikke læse spec-fil fra %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Kunne ikke omdøbe %s til %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "kunne ikke finde %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Filen %s er ikke en regulær fil.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Filen %s synes ikke at være en spec-fil.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Opbygger mål-platforme: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Opbygger for mål %s\n"
@@ -513,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -533,10 +484,29 @@ msgstr ""
 msgid "Signature options:"
 msgstr "Signaturtilvalg"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Du skal angive \"%%_gpg_name\" i din makrofil\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Indtast adgangskode: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Adgangskode godkendt.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -554,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "brug følgende forespørgselsformat"
 
@@ -601,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM opbygningsfejl:\n"
+msgstr "\n\nRPM opbygningsfejl:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "syntaksfejl under tolkning af ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "syntaksfejl under tolkning af &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "syntaksfejl under tolkning af ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "tolkningsfejl i udtryk\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "uparret (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- kun for tal\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! kun for tal\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "typer skal passe sammen\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / understøttes ikke for strenge\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- understøttes ikke for strenge\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& og || understøttes ikke for strenge\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "syntaksfejl i udtryk\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Manglende '(' i %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Manglende ')' i %s %s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ugyldigt %s-symbol: %s\n"
@@ -675,46 +642,46 @@ msgstr "Ugyldigt %s-symbol: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Ikke-mellemrum efterfølger %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Ugyldig syntaks: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Ugyldig tilstandsangivelse: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Ugyldig dirmode-spec: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Fil skal begynde med \"/\": %s\n"
@@ -724,144 +691,149 @@ msgstr "Fil skal begynde med \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Fil angivet to gange: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolsk lænke peger på BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fil ikke fundet: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Fil kræver foranstillet \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Fil ikke fundet med glob: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "linie: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ugyldig fil: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Ugyldig ejer/gruppe: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -890,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Kunne ikke kanonisere værtsnavn: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunne ikke åbne %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunne ikke skrive pakke: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Ugyldige CSA-data\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Kunne ikke åbne %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread mislykkedes: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Kunne ikke generere filnavn til oprettelse af pakke %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "kan ikke oprette %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linie %d: anden %s\n"
@@ -1013,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linie %d: Fejl ved tolkning af %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linie %d: Ugyldigt tilvalg %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "line %d: For mange navne: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "line %d: Pakken eksisterer ikke: %s\n"
@@ -1132,94 +1104,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linie %d: anden %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "linie: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linie %d: Forkert udformet mærke: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linie %d: Tomt mærke: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linie %d: Præfikser kan ikke ende på \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linie %d: Docdir skal starte med '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linie %d: Ugyldig %s: angivere: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linie %d: Ugyldigt 'BuildArchitecture'-format: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Intern fejl: Falsk mærke %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ugyldig pakkeangivelse: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pakken eksisterer allerede: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linie %d: Ukendt mærke: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1229,195 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Ugyldig kilde: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fejl ved tolking af %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linie %d: Ugyldigt '%%setup'-tilvalg %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linie %d: anden %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linie %d: udløsere skal have --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linie %d: Fejl under tolkning af %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linie %d: skriptprogram skal starte med '/': %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linie %d: Anden %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linie %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
-msgstr ""
-"Kunne ikke åbne %s: %s\n"
-"\n"
+msgstr "Kunne ikke åbne %s: %s\n\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Fik et %%else uden et %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Fik et %%endif uden et %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakke har ingen %%description: %s\n"
@@ -1488,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Kunne ikke udføre %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Kunne ikke fraspalte ny proces til %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Kunne ikke finde %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "forespørgsel af spec-fil %s mislykkedes, kunne ikke tolkes\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(ikke et tal)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s gemt som %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s oprettet som %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1891,18 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "i omrokeringer skal = efterfølges af /"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"installér alle filer -- også konfigurationsfiler, der ellers skulle "
-"overspringes"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "installér alle filer -- også konfigurationsfiler, der ellers skulle overspringes"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"fjern alle pakker, som passer med <pakke> (normalt ville det medføre en "
-"fejl, hvis <pakke> angav flere pakker)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "fjern alle pakker, som passer med <pakke> (normalt ville det medføre en fejl, hvis <pakke> angav flere pakker)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1980,7 +1920,7 @@ msgstr "opdatér databasen, men rør ikke filsystemet"
 msgid "do not verify package dependencies"
 msgstr "undlad at tjekke pakkers afhængighedskrav"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1994,8 +1934,7 @@ msgstr ""
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"ændr ikke pakkernes installationsrækkefølge for at opfylde afhængigheder"
+msgstr "ændr ikke pakkernes installationsrækkefølge for at opfylde afhængigheder"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2059,9 +1998,7 @@ msgstr ""
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"opgradér til en ældre version af pakken (--force gør ikke dette automatisk "
-"ved opgraderinger)"
+msgstr "opgradér til en ældre version af pakken (--force gør ikke dette automatisk ved opgraderinger)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2103,182 +2040,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "forespørg/verificér alle pakker"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "forespørg/verificér pakke(r), der ejer filen"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "forespørg/verificér pakke(r) i gruppen"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm forespørgselstilstand"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "forespørg pakke(r), der udløses af pakken"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm verifikationstilstand"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "forespørg/verificér pakke(r), der stiller et krav"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "forespørg/verificér pakke(r), der tilfredsstiller et krav"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "forespørg/verificér pakke(r), der stiller et krav"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "forespørg/verificér pakke(r), der stiller et krav"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "forespørg/verificér pakke(r), der stiller et krav"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "forespørg/verificér pakke(r), der stiller et krav"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "vis alle konfigurationsfiler"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "vis alle dokumentationsfiler"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "vis grundlæggende filinformation"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "vis liste over filerne i pakken"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "vis filernes status"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "verificér ikke filerne i pakke"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "kildepakke forventet, binær fundet\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "kildepakke indeholder ingen .spec-fil\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "udpakning af arkiv mislykkedes%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " for fil "
 
@@ -2353,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "ingen pakker kræver %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "ingen pakker kræver %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "ingen pakker udløser %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "ingen pakker kræver %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "ingen pakker kræver %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ingen pakker tilfører %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s tilhører ingen pakke\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "ugyldigt pakkenummer: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakken %s er ikke installeret\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread mislykkedes: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "IKKE O.K."
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "O.K."
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (MANGLENDE NØGLER:    "
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (IKKE-BETROEDE NØGLER:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: åbning mislykkedes: %s\n"
@@ -2487,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "undlad at tjekke pakkers afhængighedskrav"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Uafsluttet %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "bruger %s eksisterer ikke - bruger root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "gruppe %s eksisterer ikke - bruger root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Ugyldigt magisk tal"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Ugyldigt/ulæseligt hoved"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Hovedstørrelse er for stor"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Ukendt filtype"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Intern fejl"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " mislykkedes - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "åbning af %s mislykkedes %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2704,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s kunne ikke installeres\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Modtager %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "fejl ved læsning fra filen %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "kunne ikke åbne %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installerer %s\n"
@@ -2765,12 +2614,12 @@ msgstr "læsning mislykkedes: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2827,8 +2676,7 @@ msgstr "filen %s skaber konflikt mellem den forsøgte installation af %s og %s"
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"filen %s fra installationen af %s skaber konflikt med fil fra pakken %s"
+msgstr "filen %s fra installationen af %s skaber konflikt med fil fra pakken %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2933,77 +2781,56 @@ msgstr "ugyldig tilvalg '%s' ved %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
-msgstr ""
-"Ukendt system: %s\n"
-"\n"
+msgstr "Ukendt system: %s\n\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Kunne ikke læse ikon %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Kunne ikke læse ikon %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite mislykkedes: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -3015,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "kunne ikke åbne Packages-database i %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3224,240 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "der er ikke sat nogen dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: kan ikke læse hoved ved 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "der ikke sat nogen dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "kunne ikke genopbygge database: original-databasen beholdes\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "kunne ikke erstatte gammel database med ny database!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "erstat filer i %s med filer fra %s for at genoprette"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "kunne ikke fjerne katalog %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s har ugyldig talværdi, overspringes\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s har for stor eller lille 'long'-værdi, overspringes\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s har for stor eller lille heltalsværdi, overspringes\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "kan ikke opnå %s lås på %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "delt"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "eksklusiv"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "fejl(%d) under allokering af ny pakkeinstans\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s har ugyldig talværdi, overspringes\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s har for stor eller lille 'long'-værdi, overspringes\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s har for stor eller lille heltalsværdi, overspringes\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tom)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tom)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makroen %%%s har uafsluttede parametre\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makroen %%%s har et uafsluttet indhold (body)\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makroen %%%s har et ugyldig navn (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makroen %%%s har intet indhold\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makroen %%%s kunne ikke udfoldes\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makroen %%%s har ugyldigt navn (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Ukendt tilvalg %c i %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Uafsluttet %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Et %% efterfølges af en makro, der ikke kan tolkes\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiv %d tom %d\n"
@@ -3477,31 +3289,31 @@ msgstr "Fil %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Filen %s er mindre end %u byte\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3510,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(ingen fejl)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "fatal fejl: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "fejl: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "advarsel: "
 
@@ -3531,121 +3343,99 @@ msgstr "advarsel: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "hukommelsesallokering (%u byte) returnerede NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "fejl ved læsning fra filen %s\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "fejl ved læsning fra filen %s\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "kunne ikke fjerne katalog %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: åbning mislykkedes: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Kunne ikke åbne %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Kunne ikke åbne %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg kunne ikke skrive signaturen\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "kunne ikke læse signaturen\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3658,30 +3448,3 @@ msgstr "%s: læs manifest mislykkedes: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Indtast adgangskode: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Adgangskode godkendt.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Ugyldig ejer/gruppe: %s\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Kunne ikke skrive pakkeindhold til %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Kunne ikke læse pakkeindhold fra %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Kunne ikke åbne midlertidig fil.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Kunne ikke åbne sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Kunne ikke læse hoved fra %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Kunne ikke skrive hoved til %s: %s\n"

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Roman Spirgi <bigant@fedoraproject.org>, 2012
 # Roman Spirgi <rspirgi@gmail.com>, 2011
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-13 10:35+0000\n"
 "Last-Translator: Lubos Kardos <kardos.lubos@gmail.com>\n"
 "Language-Team: German (http://www.transifex.com/rpm-team/rpm/language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -38,7 +38,9 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Dieses Programm darf unter den Bedingungen der GNU GPL frei weiterverbreitet werden\n"
+msgstr ""
+"Dieses Programm darf unter den Bedingungen der GNU GPL frei weiterverbreitet "
+"werden\n"
 
 #: cliutils.c:53
 #, c-format
@@ -81,14 +83,15 @@ msgstr "Überprüfungsoptionen (mit -V oder --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Installations-/Aktualisierungs-/Deinstallationsoptionen:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Gemeinsame Optionen für alle RPM-Modi und Ausführungen:"
 
 #: rpmqv.c:121
 msgid "one type of query/verify may be performed at a time"
-msgstr "Nur eine Art von Abfragen/Überprüfungen kann jeweils durchgeführt werden"
+msgstr ""
+"Nur eine Art von Abfragen/Überprüfungen kann jeweils durchgeführt werden"
 
 #: rpmqv.c:125
 msgid "unexpected query flags"
@@ -102,7 +105,7 @@ msgstr "Unerwartetes Abfrage-Format"
 msgid "unexpected query source"
 msgstr "Unerwartete Abfrage-Quelle"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "Nur ein Hauptmodus kann angegeben werden"
 
@@ -116,12 +119,16 @@ msgstr "Dateien können nur bei der Paket-Installation verschoben werden"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
-msgstr "--prefix kann nicht zusammen mit --relocate oder --excludepath verwendet werden"
+msgstr ""
+"--prefix kann nicht zusammen mit --relocate oder --excludepath verwendet "
+"werden"
 
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate und --excludepath dürfen nur bei der Installation neuer Pakete benutzt werden"
+msgstr ""
+"--relocate und --excludepath dürfen nur bei der Installation neuer Pakete "
+"benutzt werden"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -134,12 +141,15 @@ msgstr "Argumente für --prefix müssen mit einem / beginnen"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr "--hash (-h) kann nur während der Paket-Installation oder -Deinstallation angegeben werden"
+msgstr ""
+"--hash (-h) kann nur während der Paket-Installation oder -Deinstallation "
+"angegeben werden"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
-msgstr "--percent kann nur während der Paket-Installation oder -Deinstallation angegeben werden"
+msgid "--percent may only be specified during package installation and erasure"
+msgstr ""
+"--percent kann nur während der Paket-Installation oder -Deinstallation "
+"angegeben werden"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
@@ -171,7 +181,8 @@ msgstr "--ignoresize darf nur während der Paket-Installation angegeben werden"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr "--allmatches darf nur während der Paket-Deinstallation angegeben werden"
+msgstr ""
+"--allmatches darf nur während der Paket-Deinstallation angegeben werden"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
@@ -179,31 +190,41 @@ msgstr "--allfiles darf nur während der Paket-Installation angegeben werden"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb darf nur während der Paket-Installation oder -Deinstallation angegeben werden"
+msgstr ""
+"--justdb darf nur während der Paket-Installation oder -Deinstallation "
+"angegeben werden"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "Optionen zum Deaktivieren von Skripten können nur während der Paket-Installation oder -Deinstallation angegeben werden"
+msgstr ""
+"Optionen zum Deaktivieren von Skripten können nur während der Paket-"
+"Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "Optionen zum Deaktivieren von Trigger können nur während der Paket-Installation oder -Deinstallation angegeben werden"
+msgstr ""
+"Optionen zum Deaktivieren von Trigger können nur während der Paket-"
+"Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps kann nur während der Paket-Installation, -Deinstallation und -Überprüfung angegeben werden"
+msgstr ""
+"--nodeps kann nur während der Paket-Installation, -Deinstallation und -"
+"Überprüfung angegeben werden"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "--test kann nur während der Paket-Installation oder -Deinstallation angegeben werden"
+msgstr ""
+"--test kann nur während der Paket-Installation oder -Deinstallation "
+"angegeben werden"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "Argumente für --root (-r) müssen mit einem / beginnen"
 
@@ -223,201 +244,262 @@ msgstr "Es wurden keine Argumente für die Abfrage angegeben"
 msgid "no arguments given for verify"
 msgstr "Es wurden keine Argumente für die Überprüfung angegeben"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "BuildRoot wurde bereits angegeben, %s wird ignoriert\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "%prep (Quellen entpacken, Patches übernehmen) der <Spec-Datei> durchlaufen"
+msgstr ""
+"%prep (Quellen entpacken, Patches übernehmen) der <Spec-Datei> durchlaufen"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<Spec-Datei>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "%build (%prep, anschließendes Kompilieren) der <Spec-Datei> durchlaufen"
+msgstr ""
+"%build (%prep, anschließendes Kompilieren) der <Spec-Datei> durchlaufen"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "%install (%prep, %build, anschließendes Installieren) der <Spec-Datei> durchlaufen"
+msgstr ""
+"%install (%prep, %build, anschließendes Installieren) der <Spec-Datei> "
+"durchlaufen"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "%files-Abschnitt der <Spec-Datei> überprüfen"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "Quell- und Binär-Paket von <Spec-Datei> bauen"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "Nur ein Binär-Paket von <Spec-Datei> bauen"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "Nur ein Quell-Paket von <Spec-Datei> bauen"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"%prep (Quellen entpacken, Patches übernehmen) der <Spec-Datei> durchlaufen"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<Quell-Paket>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"%build (%prep, anschließendes Kompilieren) der <Spec-Datei> durchlaufen"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"%install (%prep, %build, anschließendes Installieren) des <Quell-Pakets> "
+"durchlaufen"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "%files-Abschnitt der <Spec-Datei> überprüfen"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "Ein Quell-Paket vom <Source-Paket> bauen"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "Ein Quell-Paket vom <Source-Paket> bauen"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "Nur ein Quell-Paket von <Spec-Datei> bauen"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "%prep (Quellen entpacken, Patches übernehmen) des <Tar-Archivs> durchlaufen"
+msgstr ""
+"%prep (Quellen entpacken, Patches übernehmen) des <Tar-Archivs> durchlaufen"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<Tar-Archiv>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "%build (%prep, anschließendes Kompilieren) des <Tar-Archivs> durchlaufen"
+msgstr ""
+"%build (%prep, anschließendes Kompilieren) des <Tar-Archivs> durchlaufen"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "%install (%prep, %build, anschließendes Installieren) des <Tar-Archivs> durchlaufen"
+msgstr ""
+"%install (%prep, %build, anschließendes Installieren) des <Tar-Archivs> "
+"durchlaufen"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "%files-Abschnitt des <Tar-Archivs> überprüfen"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "Quell- und Binär-Paket vom <Tar-Archiv> bauen"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "Nur ein Binär-Paket vom <Tar-Archiv> bauen"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "Nur ein Quell-Paket vom <Tar-Archiv> bauen"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "Ein Quell-Paket vom <Source-Paket> bauen"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<Quell-Paket>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "%install (%prep, %build, anschließendes Installieren) des <Quell-Pakets> durchlaufen"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "BuildRoot überschreiben"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Das aktuelle Verzeichnis kann nicht geöffnet werden: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "Erstellungsdateibaum nach Beendigung löschen"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ExcludeArch ignorieren: Anweisungen der Spec-Datei"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "Datei-Status debuggen"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "Keine der Phasen des Erstellungsvorganges ausführen"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "Paket-Header generieren, die mit veralteten RPM-Paketen (v3) kompatibel sind"
+msgstr ""
+"Paket-Header generieren, die mit veralteten RPM-Paketen (v3) kompatibel sind"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "%clean-Abschnitt des Bauvorgangs nicht ausführen"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "%clean-Abschnitt des Bauvorgangs nicht ausführen"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "%check-Abschnitt des Bauvorgangs nicht ausführen"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "Keine i18n-Übersetzungen der Spec-Datei zulassen"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "Quelldateien nach Beendigung löschen"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "Spec-Datei nach Beendigung löschen"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "Direkt zur angegeben Phase springen (nur für c, i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "Zielplattform überschreiben"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Erstellungsoptionen mit [ <Spec-Datei> | <Tar-Archiv> | <Quell-Paket> ]:"
+msgstr ""
+"Erstellungsoptionen mit [ <Spec-Datei> | <Tar-Archiv> | <Quell-Paket> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Fehlgeschlagene Paket-Abhängigkeiten:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Die Spec-Datei %s kann nicht geöffnet werden: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Die Tar-Pipe konnte nicht geöffnet werden: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Mehr als eine Datei in einer Zeile: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Spec-Datei konnte nicht von %s gelesen werden\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s konnte nicht in %s umbenannt werden: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "Aufruf von stat für %s nicht möglich: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Die Datei %s ist keine reguläre Datei.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Die Datei %s scheint keine Spec-Datei zu sein.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Für folgende Zielplattform(en) wird gebaut: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Für das Ziel %s wird gebaut\n"
@@ -428,7 +510,8 @@ msgstr "Datenbank initialisieren"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "Invertierte Datenbank-Liste anhand der installierten Paket-Header erstellen"
+msgstr ""
+"Invertierte Datenbank-Liste anhand der installierten Paket-Header erstellen"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -456,7 +539,8 @@ msgstr "Einen gepanzerten öffentlichen Schlüssel importieren"
 
 #: rpmkeys.c:28
 msgid "don't import, but tell if it would work or not"
-msgstr "Nicht importieren, aber ermitteln, ob es funktionieren würde oder nicht"
+msgstr ""
+"Nicht importieren, aber ermitteln, ob es funktionieren würde oder nicht"
 
 #: rpmkeys.c:31 rpmkeys.c:33
 msgid "list keys from RPM keyring"
@@ -466,49 +550,65 @@ msgstr "Schlüssel des RPM-Schlüsselbundes auflisten"
 msgid "Keyring options:"
 msgstr "Signatur-Optionen:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "Es wurden keine Argumente angegeben"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "Paket(e) signieren"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "Paket(e) signieren (identisch mit --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "Paket-Signatur(en) löschen"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "Paket(e) signieren"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Signatur-Optionen:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s konnte nicht ausgeführt werden: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "»%%_gpg_name« muss in der Makro-Datei gesetzt sein\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Bitte das Passwort eingeben: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Das Passwort ist richtig.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Überprüfung des Passworts fehlgeschlagen oder GPG-Schlüssel abgelaufen\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix darf nur bei der Installation neuer Pakete benutzt werden"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr ""
+"--allmatches darf nur während der Paket-Deinstallation angegeben werden"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -520,13 +620,15 @@ msgstr "Spec-Datei(en) abfragen"
 
 #: rpmspec.c:30
 msgid "operate on binary rpms generated by spec (default)"
-msgstr "Mit den binären RPMs arbeiten, die aus der Spezifikation erstellt wurden (Standard)"
+msgstr ""
+"Mit den binären RPMs arbeiten, die aus der Spezifikation erstellt wurden "
+"(Standard)"
 
 #: rpmspec.c:32
 msgid "operate on source rpm generated by spec"
 msgstr "Mit Quell-RPM arbeiten, das aus der Spezifikation erstellt wurde"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "Folgendes Abfrage-Format benutzen"
 
@@ -573,68 +675,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nFehler beim Bauen des RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Fehler beim Bauen des RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "Syntax-Fehler beim Auswerten von ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "Syntax-Fehler beim Auswerten von &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "Syntax-Fehler beim Auswerten von ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "Fehler beim Auswerten des Ausdrucks\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "Unerwartete (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- nur bei Zahlen\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! nur bei Zahlen\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "Typen müssen übereinstimmen\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / nicht unterstützt für Zeichenketten\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- nicht unterstützt für Zeichenketten\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& und || nicht unterstützt für Zeichenketten\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "Syntax-Fehler im Ausdruck\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Fehlende »(« bei %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Fehlende »)« bei %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ungültiges %s-Zeichen: %s\n"
@@ -644,46 +749,46 @@ msgstr "Ungültiges %s-Zeichen: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Fehlendes %s bei %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Darstellbarem Zeichen folgt %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Ungültiger Syntax: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Ungültige Dateiberechtigungen: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Ungültige Verzeichnisberechtigungen: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Ungültige Länge der Locale: »%s« in %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Doppelte Locale %s in %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Ungültige Fähigkeit: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Dateifähigkeits-Unterstützung nicht eingebaut\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Datei muss mit »/« beginnen: %s\n"
@@ -693,149 +798,153 @@ msgstr "Datei muss mit »/« beginnen: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Unbekannter Prüfsummen-Algorithmus %u, es wird auf MD5 ausgewichen\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Datei doppelt aufgelistet: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "Lesen des symbolischen Links %s fehlgeschlagen: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolischer Link zeigt auf den BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Pfad ist außerhalb von BuildRoot: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Verzeichnis nicht gefunden: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Datei nicht gefunden: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Kein Verzeichnis: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: Unbekannter Tag (%d) kann nicht geladen werden.\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: Lesen des öffentlichen Schlüssels fehlgeschlagen.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: Ist kein gepanzerter öffentlicher Schlüssel.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: Verschlüsselung fehlgeschlagen\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Datei benötigt führenden »/«: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev-glob ist unzulässig: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Verzeichnis von »glob« nicht gefunden: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Datei von »glob« nicht gefunden: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Datei %s aus %%files konnte nicht geöffnet werden: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "Zeile: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Leere Datei %s in %%files\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Fehler beim Lesen der Datei %s in %%files: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "Ungültiges _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Datei von »glob« nicht gefunden: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Spezielles %s kann nicht mit anderen Formen gemischt werden: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Mehr als eine Datei in einer Zeile: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ungültige Datei: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Ungültiger Eigentümer/Gruppe: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Auf nicht gepackte Datei(en) wird geprüft: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Installierte (aber nicht gepackte) Datei(en) gefunden:\n%s"
+msgstr ""
+"Installierte (aber nicht gepackte) Datei(en) gefunden:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Dateien werden verarbeitet: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "Architektur der Binärdateien (%d) entspricht nicht der Paketarchitektur (%d).\n"
+msgstr ""
+"Architektur der Binärdateien (%d) entspricht nicht der Paketarchitektur "
+"(%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Architekturabhängige Binärdateien in »noarch«-Paket\n"
 
@@ -864,79 +973,76 @@ msgstr "%s: Zeile: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Rechnername konnte nicht erkannt werden: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Header der Signatur kann nicht erneut geladen werden.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Unbekannte Nutzdaten-Kompression: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Unveränderliche Header-Region konnte nicht erstellt werden.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s konnte nicht geöffnet werden: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Paket konnte nicht geschrieben werden: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Temporärer Header konnte nicht geschrieben werden\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Ungültige CSA-Daten\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Datei %s kann nicht durchsucht werden: %s\n"
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "»fread« fehlgeschlagen in Datei %s: %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Erstellt: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "»%s« wird ausgeführt:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Ausführung von »%s« ist fehlgeschlagen.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paket-Prüfung »%s« fehlgeschlagen.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Dateiname für das Paket %s konnte nicht generiert werden: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s konnte nicht erstellt werden: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "Zeile %d: Zweites %s\n"
@@ -987,19 +1093,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "Zeile %d: Fehler beim Auswerten von %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "Zeile %d: Ungültige Option %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "Zeile %d: Zu viele Namen: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "Zeile: %d: Paket existiert nicht: %s\n"
@@ -1052,7 +1158,9 @@ msgstr "%s wird nach %s heruntergeladen\n"
 #: build/parsePreamble.c:295
 #, c-format
 msgid "Couldn't download %s\n"
-msgstr "%s konnte nicht heruntergeladen werden\n\n"
+msgstr ""
+"%s konnte nicht heruntergeladen werden\n"
+"\n"
 
 #: build/parsePreamble.c:434
 #, c-format
@@ -1105,91 +1213,97 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "Zeile %d: Tag benötigt nur ein Zeichen: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "Zeile %d: Ungültiges Zeichen »%c« in: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "Zeile %d: Ungültiges Zeichen in: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "Zeile %d: Ungültige Sequenz »..« in: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "Zeile %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: Zeile: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "Zeile %d: Missgebildeter Tag: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "Zeile %d: Leerer Tag: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "Zeile %d: Präfixe dürfen nicht mit einem »/« enden: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
-msgstr "Zeile %d: Das Dokumentationsverzeichnis muss mit einem »/« beginnen: %s\n"
+msgstr ""
+"Zeile %d: Das Dokumentationsverzeichnis muss mit einem »/« beginnen: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "Zeile %d: Das Epoch-Feld muss eine vorzeichenlose Zahl sein: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "Zeile %d: Ungültig %s: Kennzeichner: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "Zeile %d: Ungültiges BuildArchitecture-Format: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "Zeile %d: Nur »noarch«-Unterpakete werden unterstützt: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interner Fehler: Falscher Tag %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "Zeile %d: %s ist veraltet: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ungültige Paket-Spezifikation: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paket ist bereits vorhanden: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "Zeile %d: Unbekannter Tag: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} kann nicht leer sein\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} kann nicht »/« sein\n"
@@ -1199,161 +1313,195 @@ msgstr "%%{buildroot} kann nicht »/« sein\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Ungültige Quelle: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Kein Patch mit der Nummer %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch ohne korrespondierenden »Patch:«-Tag\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Keine Quelle mit der Nummer %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Kein »Source«-Tag in Spec-Datei\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fehler beim Auswerten von %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "Zeile %d: Ungültiges Argument für %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "Zeile %d: Ungültige %%setup-Option %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Ungültige Patch-Nummer %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "Zeile %d: Zweites %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr "Token mit Abhängigkeiten müssen mit alphanumerischem Zeichen, »_« oder »/« beginnen"
+msgstr ""
+"Token mit Abhängigkeiten müssen mit alphanumerischem Zeichen, »_« oder »/« "
+"beginnen"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Versionierter Dateiname ist nicht erlaubt"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Version wird benötigt"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "Ungültige Abhängigkeit"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Version wird benötigt"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "Zeile %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "Zeile %d: Trigger benötigen --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "Zeile %d: Fehler beim Auswerten von %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "Zeile %d: Internes Skript muss mit »>« enden: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "Zeile %d: Skript/Programm muss mit »/« beginnen: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "Zeile %d: Interpreter-Argumente sind in Triggern nicht erlaubt: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "Zeile %d: Zweites %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "Zeile %d: Nicht unterstütztes internes Skript: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "Zeile %d: Interpreter-Argumente sind in Triggern nicht erlaubt: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "Zeile %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Öffnen von %s fehlgeschlagen: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argument wurde für %s erwartet\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "Zeile %d: Nicht geschlossenes %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "Zeile %d: Nicht geschlossenes Makro oder ungültige Zeilenfortsetzung\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: Ungültige %%if-Bedingung\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else ohne %%if erhalten\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif ohne %%if erhalten\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: missgebildete %%include-Anweisung\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Keine für das Bauen kompatiblen Architekturen gefunden\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket hat keine %%description: %s\n"
@@ -1366,7 +1514,9 @@ msgstr "Richtlinienmodul »%s« dupliziert mit überlappenden Typen\n"
 #: build/policies.c:93
 #, c-format
 msgid "Base modules '%s' and '%s' have overlapping types\n"
-msgstr "Basismodule »%s« und »%s« beinhalten überlappende Typen\n\n"
+msgstr ""
+"Basismodule »%s« und »%s« beinhalten überlappende Typen\n"
+"\n"
 
 #: build/policies.c:101
 msgid "Failed to get policies from header\n"
@@ -1375,7 +1525,9 @@ msgstr "Richtlinien konnten nicht aus Header gelesen werden\n"
 #: build/policies.c:154
 #, c-format
 msgid "%%semodule requires a file path\n"
-msgstr "%%semodule benötigt einen Dateipfad\n\n"
+msgstr ""
+"%%semodule benötigt einen Dateipfad\n"
+"\n"
 
 #: build/policies.c:163
 #, c-format
@@ -1397,7 +1549,9 @@ msgstr "Bestimmung des Richtlinien-Namens fehlgeschlagen: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "»%s«-Type zusammen mit anderen Typen in %%semodule %s angegeben. Typen werden zu »%s« zusammengefasst.\n"
+msgstr ""
+"»%s«-Type zusammen mit anderen Typen in %%semodule %s angegeben. Typen "
+"werden zu »%s« zusammengefasst.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1407,7 +1561,9 @@ msgstr "Fehler beim Auswerten von %s: %s\n"
 #: build/policies.c:252
 #, c-format
 msgid "Expecting %%semodule tag: %s\n"
-msgstr "%%semodule-Tag wird erwartet: %s\n\n"
+msgstr ""
+"%%semodule-Tag wird erwartet: %s\n"
+"\n"
 
 #: build/policies.c:262
 #, c-format
@@ -1424,291 +1580,284 @@ msgstr "Zu viele Argumente in der Zeile: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Richtlinien werden verarbeitet: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ungültiger regulärer Ausdruck %s wird ignoriert\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Pipe für %s konnte nicht erzeugt werden: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s konnte nicht ausgeführt werden: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "fork %s konnte nicht ausgeführt werden: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s fehlgeschlagen: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "Nicht alle Daten konnten nach %s geschrieben werden: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "Falscher Operator"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "Falsches Format"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "Ungültige Abhängigkeit (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Umwandlung von %s in einen langen Integer fehlgeschlagen.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Leerer Dateiklassifizierer\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Keine Dateiattribute konfiguriert\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) fehlgeschlagen: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load fehlgeschlagen: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Erkennung der Datei »%s« fehlgeschlagen: Modus %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "%s wird gesucht: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s konnte nicht gefunden werden:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "Abfragen der Spec-Datei %s fehlgeschlagen, kann nicht ausgewertet werden\n"
+msgstr ""
+"Abfragen der Spec-Datei %s fehlgeschlagen, kann nicht ausgewertet werden\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s ist ein Delta-RPM und kann nicht direkt installiert werden\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nicht unterstütze Nutzdaten (%s) in Paket %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "Paket %s wurde bereits hinzugefügt, %s wird übersprungen\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "Paket %s wurde bereits hinzugefügt, wird durch %s ersetzt\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(keine Nummer)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(nicht Base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(ungültiger Typ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(kein Blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(ungültiger XML-Typ)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(keine OpenPGP-Signatur)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ungültiges Datum %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "ersetzt"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "nicht installiert"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "Netzwerk-Mitbenutzung"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "Falsche Farbe"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "fehlt"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(keine Zeichenkette)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s als %s gesichert\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s erstellt als %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: Entfernen fehlgeschlagen: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "Verzeichnis"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "Datei"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "%s hat eine nicht überprüfbare Signatur"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "»fread« fehlgeschlagen: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr "%s: Fehler: --pipe wurde mehrmals angegeben (inkompatible »popt«-Aliase?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr ""
+"%s: Fehler: --pipe wurde mehrmals angegeben (inkompatible »popt«-Aliase?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1836,15 +1985,18 @@ msgid "relocations must have a / following the ="
 msgstr "Verschiebungen müssen einen / nach dem = enthalten"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "Alle Dateien installieren, sogar Konfigurationsdateien, die sonst möglicherweise übersprungen werden"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"Alle Dateien installieren, sogar Konfigurationsdateien, die sonst "
+"möglicherweise übersprungen werden"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "Alle Pakete entfernen, die mit <Paket> übereinstimmen (normalerweise wird eine Fehlermeldung angezeigt, wenn <Paket> auf mehrere Pakete zutrifft)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"Alle Pakete entfernen, die mit <Paket> übereinstimmen (normalerweise wird "
+"eine Fehlermeldung angezeigt, wenn <Paket> auf mehrere Pakete zutrifft)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1922,7 +2074,7 @@ msgstr "Die Datenbank aktualisieren, aber nichts im Dateisystem verändern"
 msgid "do not verify package dependencies"
 msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "Keine Überprüfung der Prüfsumme der Dateien"
 
@@ -1936,7 +2088,8 @@ msgstr "Keine Sicherheitskontext-Dateien installieren"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "Paket-Installation nicht neu sortieren, um die Abhängigkeiten zu erfüllen"
+msgstr ""
+"Paket-Installation nicht neu sortieren, um die Abhängigkeiten zu erfüllen"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2000,7 +2153,9 @@ msgstr "%%triggerpostun-Scriptlets nicht ausführen"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "Aktualisierung auf eine alte Version des Pakets (--force macht das bei Aktualisierungen automatisch)"
+msgstr ""
+"Aktualisierung auf eine alte Version des Pakets (--force macht das bei "
+"Aktualisierungen automatisch)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2008,7 +2163,9 @@ msgstr "Prozentangabe bei der Paket-Installation anzeigen"
 
 #: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
-msgstr "Das Paket, wenn es verschiebbar ist, in das Verzeichnis <Verzeichnis> verschieben"
+msgstr ""
+"Das Paket, wenn es verschiebbar ist, in das Verzeichnis <Verzeichnis> "
+"verschieben"
 
 #: lib/poptI.c:236
 msgid "<dir>"
@@ -2042,162 +2199,182 @@ msgstr "Paket(e) aktualisieren"
 msgid "reinstall package(s)"
 msgstr "Paket(e) erneut installieren"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "Abfrage aller Pakete"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "Abfrage-Modus der Signatur"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "Abfragen/überprüfen eines Pakets, das die Datei besitzt"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "Abfragen/überprüfen eines Pakets einer Gruppe"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "Abfragen/überprüfen einer Paket-Datei"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "Abfragen/überprüfen von Paketen mit der Paket-Kennung"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "Abfragen/überprüfen von Paketen mit Header-Kennung"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "Abfrage-Modus"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "Abfragen/überprüfen einer Header-Instanz"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "Abfragen/überprüfen von Paketen einer Installation"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "Abfragen eines Pakets gesteuert vom Paket"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "Überprüfungsmodus"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "Abfrage nach Paketen, die die Fähigkeit bereitstellen"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "»Globe« nicht nach Argumenten"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "Dateien nicht als Paket-Liste verarbeiten"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "Alle Konfigurationsdateien anzeigen"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "Alle Dokumentationsdateien anzeigen"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "Alle Lizenzdateien anzeigen"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "Grundlegende Datei-Informationen auflisten"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "Alle Dateien im Paket auflisten"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost-Dateien überspringen"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "Anzeigen der Zustände der aufgelisteten Dateien"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "Keine Größenüberprüfung der Dateien"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "Keine Überprüfung der symbolischen Links der Dateien"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "Keine Überprüfung der Eigentümer der Dateien"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "Keine Überprüfung der Gruppen der Dateien"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "Keine Überprüfung der letzten Bearbeitungszeit der Dateien"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "Keine Überprüfung der Berechtigungen der Dateien"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "Keine Fähigkeitsprüfung der Dateien"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "Keine Überprüfung des Sicherheitskontexts"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "Keine Überprüfung der Dateien im Paket"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "Kein(e) Überprüfungsskript(e) ausführen"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Fehlende rpmlib-Features für %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "Quell-Paket erwartet, Binär-Paket entdeckt\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "Quell-Paket enthält keine Spec-Datei\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "Entpacken des Archivs fehlgeschlagen%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " bei Datei "
 
@@ -2272,96 +2449,120 @@ msgstr "Kein Paket stimmt mit %s überein: %s\n"
 msgid "no package requires %s\n"
 msgstr "Kein Paket benötigt %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "Kein Paket benötigt %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "Keine Paket-Trigger %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "Kein Paket benötigt %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "Kein Paket benötigt %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "Kein Paket stellt %s bereit\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "Datei %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "Die Datei %s gehört zu keinem Paket\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "Ungültige Paket-Nummer: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "Datensatz %u konnte nicht gelesen werden\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "Das Paket %s ist nicht installiert\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "Unbekannter Tag: »%s«\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
-msgstr "%s: Import des Schlüssels %d fehlgeschlagen.\n\n"
+msgstr ""
+"%s: Import des Schlüssels %d fehlgeschlagen.\n"
+"\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: Schlüssel %d ist kein gesicherter öffentlicher Schlüssel.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: Importieren fehlgeschlagen (%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead fehlgeschlagen: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: Unveränderlicher Header-Bereich konnte nicht gelesen werden. Beschädigtes Paket?\n"
+msgstr ""
+"%s: Unveränderlicher Header-Bereich konnte nicht gelesen werden. "
+"Beschädigtes Paket?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: »fread« fehlgeschlagen: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NICHT OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (FEHLENDE SCHLÜSSEL:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (UNBESTÄTIGTE SCHLÜSSEL:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: Öffnen fehlgeschlagen: %s\n"
@@ -2386,144 +2587,201 @@ msgstr "Wechseln des Wurzelverzeichnisses fehlgeschlagen: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Wurzelverzeichnis kann nicht wiederhergestellt werden: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NEIN "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "»PreReq:«-, »Provides:«- und »Obsoletes:«-Abhängigkeiten unterstützen Versionen."
+msgstr ""
+"»PreReq:«-, »Provides:«- und »Obsoletes:«-Abhängigkeiten unterstützen "
+"Versionen."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "Dateiname(n) als (dirName,baseName,dirIndex)-Tupel gespeichert, nicht als Pfad."
+msgstr ""
+"Dateiname(n) als (dirName,baseName,dirIndex)-Tupel gespeichert, nicht als "
+"Pfad."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "Paket-Nutzdaten können mit bzip2 komprimiert werden."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "Paket-Nutzdaten können mit xz komprimiert werden."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "Paket-Nutzdaten können mit lzma komprimiert werden."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "Dateien der Paket-Nutzdaten haben »./« als Präfix"
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "Paket Name-Version-Release wird nicht unbedingt bereitgestellt."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "Header-Tags werden immer nach dem Laden sortiert."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "Der Scriptlet-Interpreter kann Argumente aus dem Header benutzen."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "Eine harte Dateiverknüpfung ohne Ziel ist installierbar."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "Paket-Scriptlets können während der Installation auf die RPM-Datenbank zugreifen."
+msgstr ""
+"Paket-Scriptlets können während der Installation auf die RPM-Datenbank "
+"zugreifen."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "Interne Unterstützung für LUA-Scripte"
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "Datei-Prüfsummen-Algorithmus ist pro Paket konfigurierbar"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "Unterstützung für POSIX.1e-Dateifähigkeiten"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "Paket-Scriptlets können während der Installation entpackt werden."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "Abhängigkeitsvergleich unterstützt Versionen mit Tilde."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "Dateien größer als 4 GB werden unterstützt"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Version wird benötigt"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "Ungültige Abhängigkeit"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Nicht terminiertes %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "Ungültige Abhängigkeit"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "Benutzer %s existiert nicht - Root wird benutzt\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "Gruppe %s existiert nicht - Root wird benutzt\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Ungültige Magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Ungültiger oder unlesbarer Header"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Header zu groß"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Datei ist zu groß für das Archiv"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Unbekannter Datei-Typ"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Fehlende Datei(en)"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Prüfsummen stimmen nicht überein"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Interner Fehler"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Archiv-Datei nicht im Header"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " fehlgeschlagen - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (Fehler 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "Öffnen von %s fehlgeschlagen: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: Kein RPM-Paket (oder Paket-Liste)\n"
@@ -2555,42 +2813,42 @@ msgstr "Fehlgeschlagene Abhängigkeiten:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: Kein RPM-Paket (oder Paket-Liste): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s kann nicht installiert werden\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s wird geholt\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s wird übersprungen - Übertragung fehlgeschlagen\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "Paket %s ist nicht verschiebbar\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "Fehler beim Lesen von Datei %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "»%s« bezeichnet mehrere Pakete:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s kann nicht geöffnet werden: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s wird installiert\n"
@@ -2616,12 +2874,12 @@ msgstr "Lesen fehlgeschlagen: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "kein RPM-Paket\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "%s-Sperre auf %s kann nicht erstellt werden (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "Auf %s-Sperre auf %s wird gewartet\n"
@@ -2673,12 +2931,15 @@ msgstr "Der Pfad %s im Paket %s ist nicht verschiebbar"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr "Datei %s kollidiert zwischen den versuchten Installationen von %s und %s"
+msgstr ""
+"Datei %s kollidiert zwischen den versuchten Installationen von %s und %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "Datei %s aus der Installation von %s kollidiert mit der Datei aus dem Paket %s"
+msgstr ""
+"Datei %s aus der Installation von %s kollidiert mit der Datei aus dem Paket "
+"%s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2688,12 +2949,14 @@ msgstr "Paket %s (welches neuer als %s ist) ist bereits installiert"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "Installation des Pakets %s benötigt %<PRIu64>%cB auf dem %s-Dateisystem"
+msgstr ""
+"Installation des Pakets %s benötigt %<PRIu64>%cB auf dem %s-Dateisystem"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "Installation des Pakets %s benötigt %<PRIu64>-Inodes auf dem %s-Dateisystem"
+msgstr ""
+"Installation des Pakets %s benötigt %<PRIu64>-Inodes auf dem %s-Dateisystem"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2779,60 +3042,80 @@ msgstr "Fehlende Architektur für %s bei %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "Ungültige Option »%s« bei %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
-msgstr "»Auxiliary vector« kann nicht gelesen werden, ist /proc nicht eingehängt?\n"
+msgstr ""
+"»Auxiliary vector« kann nicht gelesen werden, ist /proc nicht eingehängt?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Unbekanntes System: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Bitte (in Englisch) %s kontaktieren\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "%s kann nicht zum Lesen geöffnet werden: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Aktuelles Verzeichnis kann nicht wiederhergestellt werden: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua>-Scriptlet-Unterstützung nicht eingebaut\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Temporäre Datei für %s konnte nicht angelegt werden: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Datei-Deskriptor konnte nicht dupliziert werden: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Symbol %s kann nicht gelesen werden: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Wurzelverzeichnis kann nicht wiederhergestellt werden: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite fehlgeschlagen: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s Scriptlet fehlgeschlagen, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s Scriptlet fehlgeschlagen, Signal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s Scriptlet fehlgeschlagen, Beenden-Status %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Unbekanntes Format"
 
@@ -2844,127 +3127,146 @@ msgstr "installieren"
 msgid "erase"
 msgstr "löschen"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "Paket-Datenbank in %s kann nicht geöffnet werden\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "Zusätzliche »(« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "Fehlende »(« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "Fehlende »)« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: Lesen des öffentlichen Schlüssels fehlgeschlagen.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "Transaktion"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(keine OpenPGP-Signatur)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5-Prüfsumme: "
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Header der Signatur kann nicht erneut geladen werden.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "SHA1-Prüfsumme des Headers: "
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Header "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5-Prüfsumme: "
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "SHA1-Prüfsumme des Headers: "
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Signaturüberprüfung: FALSCHE PARAMETER (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "übersprungen"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "fehlgeschlagen"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr "Doppelter Benutzername oder Benutzer-ID für Benutzer %s\n"
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr "Doppelter Gruppenname oder Gruppen-ID für Gruppe %s\n"
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "kein Status"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "unbekannter Status"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "fehlend   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Unerfüllte Abhängigkeiten für %s:\n"
@@ -3038,240 +3340,245 @@ msgstr "Zählvariable wird mit ungleich großem Array benutzt"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "%d fehlende(r) Index(e), bitte warten...\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "%s-Index kann nicht mittels %s geöffnet werden - %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "Datenbank-Pfad wurde nicht gesetzt\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: wird übersprungen"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "Fehler(%d) beim Speichern des Datensatzes #%d in %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: wird übersprungen"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: Beschädigten Header #%u erhalten -- wird übersprungen.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: Header bei 0x%x kann nicht gelesen werden\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "Datenbank-Pfad wurde nicht gesetzt"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "Anlegen des Verzeichnisses %s fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "Header #%u in der Datenbank ist ungültig -- wird übersprungen.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "Ursprünglicher Datensatz %u kann nicht hinzugefügt werden\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "Neu bauen der Datenbank fehlgeschlagen: Datenbank verbleibt entsprechend\n"
+msgstr ""
+"Neu bauen der Datenbank fehlgeschlagen: Datenbank verbleibt entsprechend\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "Konnte die alte Datenbank nicht durch die neue ersetzen!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "Für eine Wiederherstellung Dateien in %s durch Dateien aus %s ersetzen"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "Entfernen des Verzeichnisses %s fehlgeschlagen: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s Fehler(%d) von %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s Fehler(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "Keine %s-Sperre auf %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "gemeinsam"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exklusiv"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "Ungültiger Indextyp %x auf %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "Fehler(%d) beim Holen der Datensätze »%s« aus dem %s-Index: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "Fehler(%d) beim Speichern des Datensatzes »%s« in %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "Fehler(%d) beim Entfernen des Datensatzes »%s« aus %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "Fehler(%d) beim Hinzufügen des Datensatzes für Header #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "Fehler(%d) beim Entfernen des Datensatzes für Header #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "Fehler(%d) beim Reservieren einer neuen Paket-Instanz\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "Unbekannte Datenbank-Option: »%s« wird ignoriert.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s hat einen ungültigen numerischen Wert, wird übersprungen\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s hat einen zu großen oder zu kleinen Wert, wird übersprungen\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s hat einen zu großen oder zu kleinen Integer-Wert, wird übersprungen\n"
+msgstr ""
+"%s hat einen zu großen oder zu kleinen Integer-Wert, wird übersprungen\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "Keine %s-Sperre auf %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "gemeinsam"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exklusiv"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "Ungültiger Indextyp %x auf %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "Fehler(%d) beim Holen der Datensätze »%s« aus dem %s-Index: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "Fehler(%d) beim Speichern des Datensatzes »%s« in %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "Fehler(%d) beim Entfernen des Datensatzes »%s« aus %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "Fehler(%d) beim Hinzufügen des Datensatzes für Header #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "Fehler(%d) beim Entfernen des Datensatzes für Header #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "Fehler(%d) beim Reservieren einer neuen Paket-Instanz\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(leer)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(leer)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s hat nicht terminierte Optionen\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s hat einen nicht terminierten Hauptteil\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s hat einen ungültigen Namen (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s hat einen leeren Hauptteil\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makro %%%s benötigt Leerzeichen vor dem Hauptteil\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s konnte nicht erweitert werden\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s hat einen ungültigen Namen (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
-msgstr "Makro %%%s ist definiert, wird aber nicht innerhalb des Bereichs verwendet\n"
+msgstr ""
+"Makro %%%s ist definiert, wird aber nicht innerhalb des Bereichs verwendet\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Unbekannte Option %c in %s (%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Zu viele Rekursionsebenen bei der Expansion des Makros. Dies wird wahrscheinlich durch eine rekursive Makro-Deklaration verursacht.\n"
+msgstr ""
+"Zu viele Rekursionsebenen bei der Expansion des Makros. Dies wird "
+"wahrscheinlich durch eine rekursive Makro-Deklaration verursacht.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Nicht terminiertes %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Auf %% folgt ein nicht auswertbares Makro\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "Laden der Makro-Datei %s ist fehlgeschlagen"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiv %d  leer %d\n"
@@ -3291,31 +3598,31 @@ msgstr "Datei %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Datei %s ist kleiner als %u Byte\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "Erzeugen des Verzeichnisses fehlgeschlagen"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "Ungültige Syntax in Lua-Scriptlet: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "Ungültige Syntax in Lua-Script: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "Lua-Script fehlgeschlagen: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "Ungültige Syntax in Lua-Datei: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Lua-Hook fehlgeschlagen: %s\n"
@@ -3324,19 +3631,19 @@ msgstr "Lua-Hook fehlgeschlagen: %s\n"
 msgid "[none]"
 msgstr "[kein]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(kein Fehler)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "Schwerwiegender Fehler: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "Fehler: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "Warnung: "
 
@@ -3345,99 +3652,154 @@ msgstr "Warnung: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "Speicherbelegung (%u Byte) lieferte NULL zurück.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, Schlüssel-ID %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(keine)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "Fehler beim Erstellen der temporären Datei %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "Fehler beim Erstellen der temporären Datei %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "Fehler beim Erstellen der temporären Datei %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "Anlegen des Verzeichnisses %s fehlgeschlagen: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Nicht unterstützte PGP-Signatur\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Nicht unterstützter PGP-Prüfsummenalgorithmus %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Nicht unterstützter PGP-Algorithmus %u für öffentlichen Schlüssel\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Pipe zum Signieren konnte nicht erzeugt werden: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "%s konnte nicht ausgeführt werden: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "fdopen fehlgeschlagen\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "In die Pipe konnte nicht geschrieben werden\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "Aus Datei %s konnte nicht gelesen werden: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "Ausführung von GPG fehlgeschlagen (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "GPG konnte die Signatur nicht schreiben\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "Signatur konnte nicht gelesen werden\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature fehlgeschlagen: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature fehlgeschlagen: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: headerRead fehlgeschlagen: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMk Temp fehlgeschlagen\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "fdopen fehlgeschlagen\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: headerRead fehlgeschlagen: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s enthält bereits eine identische Signatur, wird übersprungen\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature fehlgeschlagen: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM-Pakete der Version 3 können nicht signiert werden\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s enthält bereits eine identische Signatur, wird übersprungen\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMk Temp fehlgeschlagen\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "Ersetzen von %s fehlgeschlagen: %s\n"
@@ -3450,3 +3812,28 @@ msgstr "%s: Lesen der Paket-Liste fehlgeschlagen: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "Keine Überprüfung der Header- und Nutzdaten-Signatur"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Bitte das Passwort eingeben: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Das Passwort ist richtig.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr ""
+#~ "Überprüfung des Passworts fehlgeschlagen oder GPG-Schlüssel abgelaufen\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Ungültiger Eigentümer/Gruppe: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "Zeile %d: Ungültiges Zeichen in: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "%s hat eine nicht überprüfbare Signatur"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "»fread« fehlgeschlagen: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Pipe zum Signieren konnte nicht erzeugt werden: %m"

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Roman Spirgi <bigant@fedoraproject.org>, 2012
 # Roman Spirgi <rspirgi@gmail.com>, 2011
@@ -9,15 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
-"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: German (http://www.transifex.com/projects/p/rpm/language/"
-"de/)\n"
-"Language: de\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-13 10:35+0000\n"
+"Last-Translator: Lubos Kardos <kardos.lubos@gmail.com>\n"
+"Language-Team: German (http://www.transifex.com/rpm-team/rpm/language/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -39,14 +38,12 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Dieses Programm darf unter den Bedingungen der GNU GPL frei weiterverbreitet "
-"werden\n"
+msgstr "Dieses Programm darf unter den Bedingungen der GNU GPL frei weiterverbreitet werden\n"
 
 #: cliutils.c:53
 #, c-format
 msgid "creating a pipe for --pipe failed: %m\n"
-msgstr "erzeugen einer Pipe für --pipe fehlgeschlagen: %m\n"
+msgstr "Erzeugen einer Pipe für --pipe fehlgeschlagen: %m\n"
 
 #: cliutils.c:63
 #, c-format
@@ -66,7 +63,7 @@ msgstr "Fehler beim Lesen des Paket-Headers\n"
 #: rpm2archive.c:111 rpm2cpio.c:83
 #, c-format
 msgid "cannot re-open payload: %s\n"
-msgstr "Kann Nutzdaten nicht erneut öffnen: %s\n"
+msgstr "Nutzdaten können nicht erneut geöffnet werden: %s\n"
 
 #: rpmqv.c:41
 msgid "Query/Verify package selection options:"
@@ -84,15 +81,14 @@ msgstr "Überprüfungsoptionen (mit -V oder --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Installations-/Aktualisierungs-/Deinstallationsoptionen:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Gemeinsame Optionen für alle RPM-Modi und Ausführungen:"
 
 #: rpmqv.c:121
 msgid "one type of query/verify may be performed at a time"
-msgstr ""
-"Nur eine Art von Abfragen/Überprüfungen kann jeweils durchgeführt werden"
+msgstr "Nur eine Art von Abfragen/Überprüfungen kann jeweils durchgeführt werden"
 
 #: rpmqv.c:125
 msgid "unexpected query flags"
@@ -106,13 +102,13 @@ msgstr "Unerwartetes Abfrage-Format"
 msgid "unexpected query source"
 msgstr "Unerwartete Abfrage-Quelle"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
-msgstr "Nur ein wichtiger Modus kann angegeben werden"
+msgstr "Nur ein Hauptmodus kann angegeben werden"
 
 #: rpmqv.c:154
 msgid "only installation and upgrading may be forced"
-msgstr "Nur Installation und Upgrade kann erzwungen werden"
+msgstr "Nur Installation und Aktualisierung kann erzwungen werden"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
@@ -120,16 +116,12 @@ msgstr "Dateien können nur bei der Paket-Installation verschoben werden"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
-msgstr ""
-"--prefix kann nicht zusammen mit --relocate oder --excludepath verwendet "
-"werden"
+msgstr "--prefix kann nicht zusammen mit --relocate oder --excludepath verwendet werden"
 
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate und --excludepath dürfen nur bei der Installation neuer Pakete "
-"benutzt werden"
+msgstr "--relocate und --excludepath dürfen nur bei der Installation neuer Pakete benutzt werden"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -142,15 +134,12 @@ msgstr "Argumente für --prefix müssen mit einem / beginnen"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr ""
-"--hash (-h) kann nur während der Paket-Installation oder -Deinstallation "
-"angegeben werden"
+msgstr "--hash (-h) kann nur während der Paket-Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
-msgstr ""
-"--percent kann nur während der Paket-Installation oder -Deinstallation "
-"angegeben werden"
+msgid ""
+"--percent may only be specified during package installation and erasure"
+msgstr "--percent kann nur während der Paket-Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
@@ -182,8 +171,7 @@ msgstr "--ignoresize darf nur während der Paket-Installation angegeben werden"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr ""
-"--allmatches darf nur während der Paket-Deinstallation angegeben werden"
+msgstr "--allmatches darf nur während der Paket-Deinstallation angegeben werden"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
@@ -191,41 +179,31 @@ msgstr "--allfiles darf nur während der Paket-Installation angegeben werden"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb darf nur während der Paket-Installation oder -Deinstallation "
-"angegeben werden"
+msgstr "--justdb darf nur während der Paket-Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"Optionen zum Deaktivieren von Skripten können nur während der Paket-"
-"Installation oder -Deinstallation angegeben werden"
+msgstr "Optionen zum Deaktivieren von Skripten können nur während der Paket-Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"Optionen zum Deaktivieren von Trigger können nur während der Paket-"
-"Installation oder -Deinstallation angegeben werden"
+msgstr "Optionen zum Deaktivieren von Trigger können nur während der Paket-Installation oder -Deinstallation angegeben werden"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps kann nur während der Paket-Installation, -Deinstallation und -"
-"Überprüfung angegeben werden"
+msgstr "--nodeps kann nur während der Paket-Installation, -Deinstallation und -Überprüfung angegeben werden"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"--test kann nur während der Paket-Installation oder -Deinstallation "
-"angegeben werden"
+msgstr "--test kann nur während der Paket-Installation oder -Deinstallation angegeben werden"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "Argumente für --root (-r) müssen mit einem / beginnen"
 
@@ -245,286 +223,224 @@ msgstr "Es wurden keine Argumente für die Abfrage angegeben"
 msgid "no arguments given for verify"
 msgstr "Es wurden keine Argumente für die Überprüfung angegeben"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
-msgstr "BuildRoot wurde bereits angegeben, ignoriere %s\n"
+msgstr "BuildRoot wurde bereits angegeben, %s wird ignoriert\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"%prep (Quellen entpacken, Patches übernehmen) der <Spec-Datei> durchlaufen"
+msgstr "%prep (Quellen entpacken, Patches übernehmen) der <Spec-Datei> durchlaufen"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<Spec-Datei>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"%build (%prep, anschliessendes Kompilieren) der <Spec-Datei> durchlaufen"
+msgstr "%build (%prep, anschließendes Kompilieren) der <Spec-Datei> durchlaufen"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"%install (%prep, %build, anschliessendes Installieren) der <Spec-Datei> "
-"durchlaufen"
+msgstr "%install (%prep, %build, anschließendes Installieren) der <Spec-Datei> durchlaufen"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
-msgstr "Überprüfe %files-Abschnitt der <Spec-Datei>"
+msgstr "%files-Abschnitt der <Spec-Datei> überprüfen"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
-msgstr "Baue Source- und Binär-Paket von <Spec-Datei>"
+msgstr "Quell- und Binär-Paket von <Spec-Datei> bauen"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
-msgstr "Baue nur ein Binär-Paket von <Spec-Datei>"
+msgstr "Nur ein Binär-Paket von <Spec-Datei> bauen"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
-msgstr "Baue nur ein Source-Paket von <Spec-Datei>"
+msgstr "Nur ein Quell-Paket von <Spec-Datei> bauen"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"%prep (Quellen entpacken, Patches übernehmen) der <Spec-Datei> durchlaufen"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<Source-Paket>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"%build (%prep, anschliessendes Kompilieren) der <Spec-Datei> durchlaufen"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"%install (%prep, %build, anschliessendes Installieren) des <Source-Pakets> "
-"durchlaufen"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "Überprüfe %files-Abschnitt der <Spec-Datei>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "Baue ein Binär-Paket vom <Source-Paket>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "Baue ein Binär-Paket vom <Source-Paket>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "Baue nur ein Source-Paket von <Spec-Datei>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"%prep (Quellen entpacken, Patches übernehmen) des <Tar-Archivs> durchlaufen"
+msgstr "%prep (Quellen entpacken, Patches übernehmen) des <Tar-Archivs> durchlaufen"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<Tar-Archiv>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-"%build (%prep, anschliessendes Kompilieren) des <Tar-Archivs> durchlaufen"
+msgstr "%build (%prep, anschließendes Kompilieren) des <Tar-Archivs> durchlaufen"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"%install (%prep, %build, anschliessendes Installieren) des <Tar-Archivs> "
-"durchlaufen"
+msgstr "%install (%prep, %build, anschließendes Installieren) des <Tar-Archivs> durchlaufen"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
-msgstr "Überprüfe %files-Abschnitt des <Tar-Archivs>"
+msgstr "%files-Abschnitt des <Tar-Archivs> überprüfen"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
-msgstr "Baue Source- und Binär-Paket vom <Tar-Archiv>"
+msgstr "Quell- und Binär-Paket vom <Tar-Archiv> bauen"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
-msgstr "Baue nur ein Binär-Paket vom <Tar-Archiv>"
+msgstr "Nur ein Binär-Paket vom <Tar-Archiv> bauen"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
-msgstr "Baue nur ein Source-Paket vom <Tar-Archiv>"
+msgstr "Nur ein Quell-Paket vom <Tar-Archiv> bauen"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
-msgstr "Baue ein Binär-Paket vom <Source-Paket>"
+msgstr "Ein Quell-Paket vom <Source-Paket> bauen"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<Quell-Paket>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "%install (%prep, %build, anschließendes Installieren) des <Quell-Pakets> durchlaufen"
+
+#: rpmbuild.c:171
 msgid "override build root"
-msgstr "Überschreibe BuildRoot"
+msgstr "BuildRoot überschreiben"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Das aktuelle Verzeichnis kann nicht geöffnet werden: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "Erstellungsdateibaum nach Beendigung löschen"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ExcludeArch ignorieren: Anweisungen der Spec-Datei"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
-msgstr "Debugge Datei-Status"
+msgstr "Datei-Status debuggen"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "Keine der Phasen des Erstellungsvorganges ausführen"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
-"Generiere Paket-Header, die mit veralteten RPM-Paketen (v3) kompatibel sind"
+msgstr "Paket-Header generieren, die mit veralteten RPM-Paketen (v3) kompatibel sind"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
-msgstr ""
+msgstr "%clean-Abschnitt des Bauvorgangs nicht ausführen"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "Keine der Phasen des Erstellungsvorganges ausführen"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
-msgstr ""
+msgstr "%check-Abschnitt des Bauvorgangs nicht ausführen"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "Keine i18n-Übersetzungen der Spec-Datei zulassen"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "Quelldateien nach Beendigung löschen"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "Spec-Datei nach Beendigung löschen"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
-msgstr "Springe direkt zur angegeben Phase (nur für c, i)"
+msgstr "Direkt zur angegeben Phase springen (nur für c, i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
-msgstr "Überschreibe Zielplattform"
+msgstr "Zielplattform überschreiben"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Erstellungsoptionen mit [ <Spec-Datei> | <Tar-Archiv> | <Source-Paket> ]:"
+msgstr "Erstellungsoptionen mit [ <Spec-Datei> | <Tar-Archiv> | <Quell-Paket> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Fehlgeschlagene Paket-Abhängigkeiten:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Die Spec-Datei %s kann nicht geöffnet werden: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Die Tar-Pipe konnte nicht geöffnet werden: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Die Spec-Datei %s kann nicht geöffnet werden: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
-msgstr "Konnte Spec-Datei von %s nicht lesen\n"
+msgstr "Spec-Datei konnte nicht von %s gelesen werden\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
-msgstr "Konnte %s nicht in %s umbenennen: %m\n"
+msgstr "%s konnte nicht in %s umbenannt werden: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "Aufruf von stat für %s nicht möglich: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
-msgstr "Die Datei %s ist keine normale Datei.\n"
+msgstr "Die Datei %s ist keine reguläre Datei.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Die Datei %s scheint keine Spec-Datei zu sein.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
-msgstr "Baue für die Zielplattform(en): %s\n"
+msgstr "Für folgende Zielplattform(en) wird gebaut: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
-msgstr "Baue für das Ziel %s\n"
+msgstr "Für das Ziel %s wird gebaut\n"
 
 #: rpmdb.c:25
 msgid "initialize database"
-msgstr "Initialisiere Datenbank"
+msgstr "Datenbank initialisieren"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"Erstelle invertierte Datenbank-Liste anhand der installierten Paket-Header"
+msgstr "Invertierte Datenbank-Liste anhand der installierten Paket-Header erstellen"
 
 #: rpmdb.c:30
 msgid "verify database files"
-msgstr "Überprüfe Datenbank-Dateien"
+msgstr "Datenbank-Dateien überprüfen"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr ""
+msgstr "Datenbank in die Header-Liste in der Standardeingabe exportieren"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr ""
+msgstr "Datenbank aus der Header-Liste in der Standardeingabe importieren"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -532,15 +448,15 @@ msgstr "Datenbank-Optionen:"
 
 #: rpmkeys.c:24
 msgid "verify package signature(s)"
-msgstr "Überprüfe Paket-Signatur(en)"
+msgstr "Paket-Signatur(en) überprüfen"
 
 #: rpmkeys.c:26
 msgid "import an armored public key"
-msgstr "Importiere einen gepanzerten öffentlichen Schlüssel"
+msgstr "Einen gepanzerten öffentlichen Schlüssel importieren"
 
 #: rpmkeys.c:28
 msgid "don't import, but tell if it would work or not"
-msgstr ""
+msgstr "Nicht importieren, aber ermitteln, ob es funktionieren würde oder nicht"
 
 #: rpmkeys.c:31 rpmkeys.c:33
 msgid "list keys from RPM keyring"
@@ -550,7 +466,7 @@ msgstr "Schlüssel des RPM-Schlüsselbundes auflisten"
 msgid "Keyring options:"
 msgstr "Signatur-Optionen:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "Es wurden keine Argumente angegeben"
 
@@ -560,24 +476,43 @@ msgstr "Paket(e) signieren"
 
 #: rpmsign.c:27
 msgid "sign package(s) (identical to --addsign)"
-msgstr "Signiere Paket(e) (identisch mit --addsign)"
+msgstr "Paket(e) signieren (identisch mit --addsign)"
 
 #: rpmsign.c:29
 msgid "delete package signatures"
-msgstr "Lösche Paket-Signatur(en)"
+msgstr "Paket-Signatur(en) löschen"
 
 #: rpmsign.c:35
 msgid "Signature options:"
 msgstr "Signatur-Optionen:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "%s konnte nicht ausgeführt werden: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
-msgstr "\"%%_gpg_name\" muss in der Makro-Datei gesetzt sein\n"
+msgstr "»%%_gpg_name« muss in der Makro-Datei gesetzt sein\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Bitte das Passwort eingeben: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Das Passwort ist richtig.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Überprüfung des Passworts fehlgeschlagen oder GPG-Schlüssel abgelaufen\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
-msgstr ""
+msgstr "Auswertung der Spec-Datei(en) in die Standardausgabe leiten"
 
 #: rpmspec.c:28
 msgid "query spec file(s)"
@@ -585,15 +520,13 @@ msgstr "Spec-Datei(en) abfragen"
 
 #: rpmspec.c:30
 msgid "operate on binary rpms generated by spec (default)"
-msgstr ""
-"Arbeite mit dem binären RPMS, das aus der Spezifikation erstellt wurde "
-"(Standard)"
+msgstr "Mit den binären RPMs arbeiten, die aus der Spezifikation erstellt wurden (Standard)"
 
 #: rpmspec.c:32
 msgid "operate on source rpm generated by spec"
-msgstr "Arbeite mit Quell-RPM, das aus der Spezifikation erstellt wurde"
+msgstr "Mit Quell-RPM arbeiten, das aus der Spezifikation erstellt wurde"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "Folgendes Abfrage-Format benutzen"
 
@@ -603,7 +536,7 @@ msgstr "Spec-Optionen:"
 
 #: rpmspec.c:90
 msgid "no arguments given for parse"
-msgstr ""
+msgstr "Keine Argumente zur Auswertung angegeben"
 
 #: build/build.c:120
 #, c-format
@@ -613,7 +546,7 @@ msgstr "Temp-Datei konnte nicht geöffnet werden: %s\n"
 #: build/build.c:126
 #, c-format
 msgid "Unable to open stream: %s\n"
-msgstr "Stream konnte nicht geöffnet werden: %s\n"
+msgstr "Datenstrom konnte nicht geöffnet werden: %s\n"
 
 #: build/build.c:161
 #, c-format
@@ -628,7 +561,7 @@ msgstr "Ausführung von %s fehlgeschlagen (%s): %s\n"
 #: build/build.c:177
 #, c-format
 msgid "Error executing scriptlet %s (%s)\n"
-msgstr ""
+msgstr "Fehler bei der Ausführung des Skriptlets %s (%s)\n"
 
 #: build/build.c:184
 #, c-format
@@ -640,288 +573,286 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Fehler beim Bauen des RPM:\n"
+msgstr "\n\nFehler beim Bauen des RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
-msgstr "Syntax-Fehler beim Parsen von ==\n"
+msgstr "Syntax-Fehler beim Auswerten von ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
-msgstr "Syntax-Fehler beim Parsen von &&\n"
+msgstr "Syntax-Fehler beim Auswerten von &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
-msgstr "Syntax-Fehler beim Parsen von ||\n"
+msgstr "Syntax-Fehler beim Auswerten von ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
-msgstr "Fehler beim Parsen des Ausdrucks\n"
+msgstr "Fehler beim Auswerten des Ausdrucks\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "Unerwartete (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- nur bei Zahlen\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! nur bei Zahlen\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "Typen müssen übereinstimmen\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
-msgstr "* / nicht unterstützt für Strings\n"
+msgstr "* / nicht unterstützt für Zeichenketten\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
-msgstr "- nicht unterstützt für Strings\n"
+msgstr "- nicht unterstützt für Zeichenketten\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
-msgstr "&& und || nicht unterstützt für Strings\n"
+msgstr "&& und || nicht unterstützt für Zeichenketten\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "Syntax-Fehler im Ausdruck\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
-msgstr "Fehlende '(' bei %s %s\n"
+msgstr "Fehlende »(« bei %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
-msgstr "Fehlende ')' bei %s(%s\n"
+msgstr "Fehlende »)« bei %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
-msgstr "Ungültiges %s Zeichen: %s\n"
+msgstr "Ungültiges %s-Zeichen: %s\n"
 
 #: build/files.c:424
 #, c-format
 msgid "Missing %s in %s %s\n"
 msgstr "Fehlendes %s bei %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
-msgstr "Druckbarem Zeichen folgt %s(): %s\n"
+msgstr "Darstellbarem Zeichen folgt %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Ungültiger Syntax: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Ungültige Dateiberechtigungen: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Ungültige Verzeichnisberechtigungen: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
-msgstr ""
+msgstr "Ungültige Länge der Locale: »%s« in %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
-msgstr ""
+msgstr "Doppelte Locale %s in %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Ungültige Fähigkeit: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Dateifähigkeits-Unterstützung nicht eingebaut\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
-msgstr "Datei muss mit \"/\" beginnen: %s\n"
+msgstr "Datei muss mit »/« beginnen: %s\n"
 
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr "Unbekannter Datei--Auszug-Algorithmus %u, gehe zurück zu MD5\n"
+msgstr "Unbekannter Prüfsummen-Algorithmus %u, es wird auf MD5 ausgewichen\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Datei doppelt aufgelistet: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
-msgstr ""
+msgstr "Lesen des symbolischen Links %s fehlgeschlagen: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolischer Link zeigt auf den BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
-msgstr ""
+msgstr "Pfad ist außerhalb von BuildRoot: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Verzeichnis nicht gefunden: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Datei nicht gefunden: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
-msgstr ""
+msgstr "Kein Verzeichnis: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
-msgstr "%s: Kann den unbekannten Tag (%d) nicht laden.\n"
+msgstr "%s: Unbekannter Tag (%d) kann nicht geladen werden.\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: Lesen des öffentlichen Schlüssels fehlgeschlagen.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: Ist kein gepanzerter öffentlicher Schlüssel.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: Verschlüsselung fehlgeschlagen\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
-msgstr "Datei benötigt führenden \"/\": %s\n"
+msgstr "Datei benötigt führenden »/«: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
-msgstr ""
+msgstr "%%dev-glob ist unzulässig: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
-msgstr "Verzeichnis von Glob nicht gefunden: %s\n"
+msgstr "Verzeichnis von »glob« nicht gefunden: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
-msgstr "Datei von \"glob\" nicht gefunden: %s\n"
+msgstr "Datei von »glob« nicht gefunden: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
-msgstr "Datei %s aus %%files konnte nicht geöffnet: %m\n"
+msgstr "Datei %s aus %%files konnte nicht geöffnet werden: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "Zeile: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
-msgstr ""
+msgstr "Leere Datei %s in %%files\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+msgstr "Fehler beim Lesen der Datei %s in %%files: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
-msgstr ""
+msgstr "Ungültiges _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
-msgstr ""
+msgstr "Spezielles %s kann nicht mit anderen Formen gemischt werden: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
-msgstr ""
+msgstr "Mehr als eine Datei in einer Zeile: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ungültige Datei: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Ungültiger Eigentümer/Gruppe: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
-msgstr "Prüfe auf nicht gepackte Datei(en): %s\n"
+msgstr "Auf nicht gepackte Datei(en) wird geprüft: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Installierte (aber nicht gepackte) Datei(en) gefunden:\n"
-"%s"
+msgstr "Installierte (aber nicht gepackte) Datei(en) gefunden:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
-msgstr "Verarbeite Daten: %s\n"
+msgstr "Dateien werden verarbeitet: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
+msgstr "Architektur der Binärdateien (%d) entspricht nicht der Paketarchitektur (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
-msgstr "Architekturabhängige Binärdateien in noarch-Paket\n"
+msgstr "Architekturabhängige Binärdateien in »noarch«-Paket\n"
 
 #: build/pack.c:90
 #, c-format
 msgid "create archive failed on file %s: %s\n"
-msgstr ""
+msgstr "Erstellen der Archivdatei fehlgeschlagen bei Datei %s: %s\n"
 
 #: build/pack.c:93
 #, c-format
 msgid "create archive failed: %s\n"
-msgstr ""
+msgstr "Erstellen der Archivdatei fehlgeschlagen: %s\n"
 
 #: build/pack.c:120
 #, c-format
 msgid "Could not open %s file: %s\n"
-msgstr ""
-"Konnte %s-Datei nicht öffnen: %s\n"
-"\n"
+msgstr "%s-Datei konnte nicht geöffnet werden: %s\n"
 
 #: build/pack.c:136
 #, c-format
@@ -933,81 +864,79 @@ msgstr "%s: Zeile: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Rechnername konnte nicht erkannt werden: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
-msgstr "Kann den Header der Signatur nicht erneut laden.\n"
+msgstr "Header der Signatur kann nicht erneut geladen werden.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
-msgstr "Unbekannte Nutzdaten.Kompression: %s\n"
+msgstr "Unbekannte Nutzdaten-Kompression: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
-msgstr "Konnte keine unveränderliche Header-Region erstellen.\n"
+msgstr "Unveränderliche Header-Region konnte nicht erstellt werden.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
-msgstr "Konnte %s nicht öffnen: %s\n"
+msgstr "%s konnte nicht geöffnet werden: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
-msgstr "Kann das Paket nicht schreiben: %s\n"
+msgstr "Paket konnte nicht geschrieben werden: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
-msgstr "Kann den temporären Header nicht schreiben\n"
+msgstr "Temporärer Header konnte nicht geschrieben werden\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Ungültige CSA-Daten\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr ""
-"Konnte %s-Datei nicht öffnen: %s\n"
-"\n"
+msgstr "Datei %s kann nicht durchsucht werden: %s\n"
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread fehlgeschlagen: %s\n"
+msgstr "»fread« fehlgeschlagen in Datei %s: %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Erstellt: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
-msgstr "Ausschluss \"%s\":\n"
+msgstr "»%s« wird ausgeführt:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
-msgstr "Ausschluss von \"%s\" fehlgeschlagen.\n"
+msgstr "Ausführung von »%s« ist fehlgeschlagen.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
-msgstr "Paket-Prüfung \"%s\" fehlgeschlagen.\n"
+msgstr "Paket-Prüfung »%s« fehlgeschlagen.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
-msgstr "Konnte den Dateinamen für das Paket %s nicht generieren: %s\n"
+msgstr "Dateiname für das Paket %s konnte nicht generiert werden: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
-msgstr "Kann Datei %s nicht erstellen: %s\n"
+msgstr "%s konnte nicht erstellt werden: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "Zeile %d: Zweites %s\n"
@@ -1015,7 +944,7 @@ msgstr "Zeile %d: Zweites %s\n"
 #: build/parseChangelog.c:114
 #, c-format
 msgid "bogus date in %%changelog: %s\n"
-msgstr ""
+msgstr "Ungültiges Datum in %%changelog: %s\n"
 
 #: build/parseChangelog.c:146
 #, c-format
@@ -1040,7 +969,7 @@ msgstr "%%changelog ist nicht in absteigender Reihenfolge\n"
 #: build/parseChangelog.c:182 build/parseChangelog.c:193
 #, c-format
 msgid "missing name in %%changelog\n"
-msgstr "Fehlender Name im %%changelog\n"
+msgstr "Name im %%changelog fehlt\n"
 
 #: build/parseChangelog.c:200
 #, c-format
@@ -1050,27 +979,27 @@ msgstr "Keine Beschreibung im %%changelog\n"
 #: build/parseChangelog.c:237
 #, c-format
 msgid "line %d: second %%changelog\n"
-msgstr ""
+msgstr "Zeile %d: zweites %%changelog\n"
 
 #: build/parseDescription.c:32
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
-msgstr "Zeile %d: Fehler beim Parsen von %%description: %s\n"
+msgstr "Zeile %d: Fehler beim Auswerten von %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "Zeile %d: Ungültige Option %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "Zeile %d: Zu viele Namen: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "Zeile: %d: Paket existiert nicht: %s\n"
@@ -1078,22 +1007,22 @@ msgstr "Zeile: %d: Paket existiert nicht: %s\n"
 #: build/parseFiles.c:33
 #, c-format
 msgid "line %d: Error parsing %%files: %s\n"
-msgstr "Zeile %d: Fehler beim Parsen von %%files: %s\n"
+msgstr "Zeile %d: Fehler beim Auswerten von %%files: %s\n"
 
 #: build/parseFiles.c:76
 #, c-format
 msgid "line %d: second %%files\n"
-msgstr ""
+msgstr "Zeile %d: zweiter %%files-Abschnitt\n"
 
 #: build/parsePolicies.c:32
 #, c-format
 msgid "line %d: Error parsing %%policies: %s\n"
-msgstr "Zeile %d: Fehler beim Parsen von %%policies: %s\n"
+msgstr "Zeile %d: Fehler beim Auswerten von %%policies: %s\n"
 
 #: build/parsePreamble.c:71
 #, c-format
 msgid "Error parsing tag field: %s\n"
-msgstr ""
+msgstr "Fehler beim Auswerten des Tag-Feldes: %s\n"
 
 #: build/parsePreamble.c:164
 #, c-format
@@ -1108,7 +1037,7 @@ msgstr "Zeile %d: Ungültige no%s-Nummer: %u\n"
 #: build/parsePreamble.c:233
 #, c-format
 msgid "line %d: Bad %s number: %s\n"
-msgstr "Zeile %d: Ungültige %s Nummer: %s\n"
+msgstr "Zeile %d: Ungültige %s-Nummer: %s\n"
 
 #: build/parsePreamble.c:247
 #, c-format
@@ -1118,14 +1047,12 @@ msgstr "%s %d ist mehrfach definiert\n"
 #: build/parsePreamble.c:292
 #, c-format
 msgid "Downloading %s to %s\n"
-msgstr "%s herunterladen nach %s\n"
+msgstr "%s wird nach %s heruntergeladen\n"
 
 #: build/parsePreamble.c:295
 #, c-format
 msgid "Couldn't download %s\n"
-msgstr ""
-"%s konnte nicht heruntergeladen werden\n"
-"\n"
+msgstr "%s konnte nicht heruntergeladen werden\n\n"
 
 #: build/parsePreamble.c:434
 #, c-format
@@ -1160,17 +1087,17 @@ msgstr "Doppelte %s-Einträge im Paket: %s\n"
 #: build/parsePreamble.c:556
 #, c-format
 msgid "Unable to open icon %s: %s\n"
-msgstr "Kann Icon %s nicht öffnen: %s\n"
+msgstr "Symbol %s kann nicht geöffnet werden: %s\n"
 
 #: build/parsePreamble.c:572
 #, c-format
 msgid "Unable to read icon %s: %s\n"
-msgstr "Kann Icon %s nicht lesen: %s\n"
+msgstr "Symbol %s kann nicht gelesen werden: %s\n"
 
 #: build/parsePreamble.c:582
 #, c-format
 msgid "Unknown icon type: %s\n"
-msgstr "Unbekannter Icon-Typ: %s\n"
+msgstr "Unbekannter Symbol-Typ: %s\n"
 
 #: build/parsePreamble.c:596
 #, c-format
@@ -1178,294 +1105,255 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "Zeile %d: Tag benötigt nur ein Zeichen: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
-msgstr "Zeile %d: Ungültiges Zeichen '%c' in: %s\n"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
+msgstr "Zeile %d: Ungültiges Zeichen »%c« in: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "Zeile %d: Ungültiges Zeichen \"..\" in: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "Zeile %d: Ungültiges Zeichen in: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "Zeile %d: Zweites %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "Zeile %d: Ungültige Sequenz »..« in: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: Zeile: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "Zeile %d: Missgebildeter Tag: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "Zeile %d: Leerer Tag: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
-msgstr "Zeile %d: Präfixe dürfen nicht mit einem \"/\" enden: %s\n"
+msgstr "Zeile %d: Präfixe dürfen nicht mit einem »/« enden: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
-msgstr ""
-"Zeile %d: Das Dokumentationsverzeichnis muss mit einem \"/\" beginnen: %s\n"
+msgstr "Zeile %d: Das Dokumentationsverzeichnis muss mit einem »/« beginnen: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "Zeile %d: Das Epoch-Feld muss eine vorzeichenlose Zahl sein: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "Zeile %d: Ungültig %s: Kennzeichner: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "Zeile %d: Ungültiges BuildArchitecture-Format: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
-msgstr "Zeile %d: Nur noarch-Unterpakete werden unterstützt: %s\n"
+msgstr "Zeile %d: Nur »noarch«-Unterpakete werden unterstützt: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interner Fehler: Falscher Tag %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "Zeile %d: %s ist veraltet: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ungültige Paket-Spezifikation: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paket ist bereits vorhanden: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "Zeile %d: Unbekannter Tag: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} kann nicht leer sein\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
-msgstr "%%{buildroot} kann nicht \"/\" sein\n"
+msgstr "%%{buildroot} kann nicht »/« sein\n"
 
 #: build/parsePrep.c:28
 #, c-format
 msgid "Bad source: %s: %s\n"
 msgstr "Ungültige Quelle: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
-msgstr "Keine Patch-Nummer %u\n"
+msgstr "Kein Patch mit der Nummer %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
-msgstr "%%patch ohne korrespondierenden \"Patch:\"-Tag\n"
+msgstr "%%patch ohne korrespondierenden »Patch:«-Tag\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
-msgstr "Keine Source-Nummer %u\n"
+msgstr "Keine Quelle mit der Nummer %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
-msgstr "Kein \"Source\"-Tag in Spec-Datei\n"
+msgstr "Kein »Source«-Tag in Spec-Datei\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
-msgstr "Fehler beim Parsen von %%setup: %s\n"
+msgstr "Fehler beim Auswerten von %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "Zeile %d: Ungültiges Argument für %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "Zeile %d: Ungültige %%setup-Option %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Ungültige Patch-Nummer %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "Zeile %d: Zweites %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr ""
-"Token mit Abhängigkeiten müssen alphanumerisch, mit '_' oder '/' beginnen"
+msgstr "Token mit Abhängigkeiten müssen mit alphanumerischem Zeichen, »_« oder »/« beginnen"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
-msgstr ""
+msgstr "Versionierter Dateiname ist nicht erlaubt"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
+#: build/parseReqs.c:173
+msgid "Version required"
+msgstr "Version wird benötigt"
 
-#: build/parseReqs.c:218 build/parseReqs.c:293
+#: build/parseReqs.c:189
 msgid "invalid dependency"
 msgstr "Ungültige Abhängigkeit"
 
-#: build/parseReqs.c:253 lib/rpmds.c:1441
-msgid "Version required"
-msgstr "Version benötigt"
-
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
-
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
-msgstr ""
+msgstr "Zeile %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "Zeile %d: Trigger benötigen --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
-msgstr "Zeile %d: Fehler beim Parsen von %s: %s\n"
+msgstr "Zeile %d: Fehler beim Auswerten von %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
-msgstr "Zeile %d: Internes Skript muss mit '>' enden: %s\n"
+msgstr "Zeile %d: Internes Skript muss mit »>« enden: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
-msgstr "Zeile %d: Skript/Programm muss mit '/' beginnen: %s\n"
+msgstr "Zeile %d: Skript/Programm muss mit »/« beginnen: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "Zeile %d: Zweites %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "Zeile %d: Nicht unterstütztes internes Skript: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr ""
+msgstr "Zeile %d: Interpreter-Argumente sind in Triggern nicht erlaubt: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "Zeile %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Öffnen von %s fehlgeschlagen: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
-msgstr ""
+msgstr "%s:%d: Argument wurde für %s erwartet\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
-msgstr ""
+msgstr "Zeile %d: Nicht geschlossenes %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
-msgstr ""
+msgstr "Zeile %d: Nicht geschlossenes Makro oder ungültige Zeilenfortsetzung\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
-msgstr ""
+msgstr "%s:%d: Ungültige %%if-Bedingung\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else ohne %%if erhalten\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif ohne %%if erhalten\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
-msgstr ""
+msgstr "%s:%d: missgebildete %%include-Anweisung\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
-msgstr "Keine für das Bauen kompatible Architektur gefunden\n"
+msgstr "Keine für das Bauen kompatiblen Architekturen gefunden\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket hat keine %%description: %s\n"
@@ -1478,9 +1366,7 @@ msgstr "Richtlinienmodul »%s« dupliziert mit überlappenden Typen\n"
 #: build/policies.c:93
 #, c-format
 msgid "Base modules '%s' and '%s' have overlapping types\n"
-msgstr ""
-"Basismodule »%s« und »%s« beinhalten überlappende Typen\n"
-"\n"
+msgstr "Basismodule »%s« und »%s« beinhalten überlappende Typen\n\n"
 
 #: build/policies.c:101
 msgid "Failed to get policies from header\n"
@@ -1489,14 +1375,12 @@ msgstr "Richtlinien konnten nicht aus Header gelesen werden\n"
 #: build/policies.c:154
 #, c-format
 msgid "%%semodule requires a file path\n"
-msgstr ""
-"%%semodule benötigt einen Dateipfad\n"
-"\n"
+msgstr "%%semodule benötigt einen Dateipfad\n\n"
 
 #: build/policies.c:163
 #, c-format
 msgid "Failed to read  policy file: %s\n"
-msgstr "Lesevorgang fehlgeschlagen  Richtlinien-Datei: %s\n"
+msgstr "Lesen der Richtlinien-Datei fehlgeschlagen: %s\n"
 
 #: build/policies.c:170
 #, c-format
@@ -1513,311 +1397,318 @@ msgstr "Bestimmung des Richtlinien-Namens fehlgeschlagen: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
+msgstr "»%s«-Type zusammen mit anderen Typen in %%semodule %s angegeben. Typen werden zu »%s« zusammengefasst.\n"
 
 #: build/policies.c:246
 #, c-format
 msgid "Error parsing %s: %s\n"
-msgstr "Fehler beim Parsen von %s: %s\n"
+msgstr "Fehler beim Auswerten von %s: %s\n"
 
 #: build/policies.c:252
 #, c-format
 msgid "Expecting %%semodule tag: %s\n"
-msgstr ""
-"Erwarte %%semodule Kennzeichen: %s\n"
-"\n"
+msgstr "%%semodule-Tag wird erwartet: %s\n\n"
 
 #: build/policies.c:262
 #, c-format
 msgid "Missing module path in line: %s\n"
-msgstr "Fehlender Modul-Pfad bei Zeile %s\n"
+msgstr "Fehlender Modul-Pfad in Zeile: %s\n"
 
 #: build/policies.c:268
 #, c-format
 msgid "Too many arguments in line: %s\n"
-msgstr "Zu viele Argumente in der Datenzeile bei %s\n"
+msgstr "Zu viele Argumente in der Zeile: %s\n"
 
 #: build/policies.c:307
 #, c-format
 msgid "Processing policies: %s\n"
-msgstr "Verarbeite Richtlinien: %s\n"
+msgstr "Richtlinien werden verarbeitet: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
-msgstr "Ungültiger Regex-Ausdruck %s wird ignoriert\n"
+msgstr "Ungültiger regulärer Ausdruck %s wird ignoriert\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
-msgstr "Konnte keine Pipe für %s erzeugen: %m\n"
+msgstr "Pipe für %s konnte nicht erzeugt werden: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
-msgstr "Konnte %s nicht ausführen: %s\n"
+msgstr "%s konnte nicht ausgeführt werden: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
-msgstr "Konnte fork %s nicht ausführen: %s\n"
+msgstr "fork %s konnte nicht ausgeführt werden: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s fehlgeschlagen: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
-msgstr "Konnte nicht all Daten nach %s: %s schreiben\n"
+msgstr "Nicht alle Daten konnten nach %s geschrieben werden: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
-msgstr ""
+msgstr "Falscher Operator"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
-msgstr ""
+msgstr "Falsches Format"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
-msgstr ""
+msgstr "Ungültige Abhängigkeit (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Umwandlung von %s in einen langen Integer fehlgeschlagen.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
-msgstr ""
+msgstr "Leerer Dateiklassifizierer\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Keine Dateiattribute konfiguriert\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) fehlgeschlagen: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load fehlgeschlagen: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
-msgstr "Erkennung der Datei \"%s\" fehlgeschlagen: Modus %06o %s\n"
+msgstr "Erkennung der Datei »%s« fehlgeschlagen: Modus %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
-msgstr "Finde %s: %s\n"
+msgstr "%s wird gesucht: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
-msgstr "Fehlgeschlagenes zu finden %s:\n"
+msgstr "%s konnte nicht gefunden werden:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "Abfragen der Spec-Datei %s fehlgeschlagen, kann nicht geparst werden\n"
+msgstr "Abfragen der Spec-Datei %s fehlgeschlagen, kann nicht ausgewertet werden\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
-msgstr "%s ist ein Delta RPM und kann nicht direkt installiert werden\n"
+msgstr "%s ist ein Delta-RPM und kann nicht direkt installiert werden\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
-msgstr "Nicht unterstütze Nutzlast (%s) in Paket %s\n"
+msgstr "Nicht unterstütze Nutzdaten (%s) in Paket %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
-msgstr "Paket %s wurde bereits hinzugefügt, überspringe %s\n"
+msgstr "Paket %s wurde bereits hinzugefügt, %s wird übersprungen\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
-msgstr "Paket %s wurde bereits hinzugefügt, ersetze es durch %s\n"
+msgstr "Paket %s wurde bereits hinzugefügt, wird durch %s ersetzt\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(keine Nummer)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(nicht Base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(ungültiger Typ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(kein Blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(ungültiger XML-Typ)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(keine OpenPGP-Signatur)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ungültiges Datum %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "ersetzt"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "nicht installiert"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "Netzwerk-Mitbenutzung"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "Falsche Farbe"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "fehlt"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
-msgstr "(kein String)"
+msgstr "(keine Zeichenkette)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s als %s gesichert\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s erstellt als %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
-msgstr ""
+msgstr "%s %s: Entfernen fehlgeschlagen: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
-msgstr ""
+msgstr "Verzeichnis"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
-msgstr ""
+msgstr "Datei"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "%s hat eine nicht überprüfbare Signatur"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
 msgstr ""
 
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "»fread« fehlgeschlagen: %s"
+
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr ""
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr "%s: Fehler: --pipe wurde mehrmals angegeben (inkompatible »popt«-Aliase?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1825,7 +1716,7 @@ msgstr "MAKRO mit Wert AUSDRUCK vordefinieren"
 
 #: lib/poptALL.c:176 lib/poptALL.c:179
 msgid "'MACRO EXPR'"
-msgstr "'MAKRO AUSDRUCK'"
+msgstr "»MAKRO AUSDRUCK«"
 
 #: lib/poptALL.c:178
 msgid "define MACRO with value EXPR"
@@ -1833,11 +1724,11 @@ msgstr "MAKRO mit Wert AUSDRUCK definieren"
 
 #: lib/poptALL.c:181
 msgid "undefine MACRO"
-msgstr ""
+msgstr "Definition von MAKRO zurücksetzen"
 
 #: lib/poptALL.c:182
 msgid "MACRO"
-msgstr ""
+msgstr "MAKRO"
 
 #: lib/poptALL.c:184
 msgid "print macro expansion of EXPR"
@@ -1845,11 +1736,11 @@ msgstr "Makro-Ausdehnung des AUSDRUCKS anzeigen"
 
 #: lib/poptALL.c:185
 msgid "'EXPR'"
-msgstr "'AUSDRUCK'"
+msgstr "»AUSDRUCK«"
 
 #: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
-msgstr "lese <DATEI:...> anstatt der Standard-Datei(en)"
+msgstr "<DATEI:...> anstatt der Standard-Datei(en) lesen"
 
 #: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
@@ -1857,11 +1748,11 @@ msgstr "<DATEI:...>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "Keinerlei Plugins aktivieren"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
-msgstr "Paket-Kurzfassung nicht überprüfen"
+msgstr "Paket-Prüfsummen nicht verifizieren"
 
 #: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
@@ -1873,7 +1764,7 @@ msgstr "Paket-Signatur(en) nicht überprüfen"
 
 #: lib/poptALL.c:203
 msgid "send stdout to CMD"
-msgstr "Sende Standardausgabe an CMD"
+msgstr "Standardausgabe an CMD senden"
 
 #: lib/poptALL.c:204
 msgid "CMD"
@@ -1881,7 +1772,7 @@ msgstr "CMD"
 
 #: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
-msgstr "benutze WURZELVERZEICHNIS als oberstes Verzeichnis"
+msgstr "WURZELVERZEICHNIS als oberstes Verzeichnis verwenden"
 
 #: lib/poptALL.c:210
 msgid "ROOT"
@@ -1897,31 +1788,31 @@ msgstr "VERZEICHNIS"
 
 #: lib/poptALL.c:216
 msgid "display known query tags"
-msgstr "Zeige bekannte Abfrage-Tags"
+msgstr "Bekannte Abfrage-Tags anzeigen"
 
 #: lib/poptALL.c:218
 msgid "display final rpmrc and macro configuration"
-msgstr "Zeige endgültige rpmrc- und Makro-Konfiguration"
+msgstr "Endgültige rpmrc- und Makro-Konfiguration anzeigen"
 
 #: lib/poptALL.c:220
 msgid "provide less detailed output"
-msgstr "Zeige weniger informative Ausgabe"
+msgstr "Weniger informative Ausgabe anzeigen"
 
 #: lib/poptALL.c:222
 msgid "provide more detailed output"
-msgstr "Zeige detailliertere Ausgabe"
+msgstr "Detailliertere Ausgabe anzeigen"
 
 #: lib/poptALL.c:224
 msgid "print the version of rpm being used"
-msgstr "Zeige benutzte RPM-Version"
+msgstr "Benutzte RPM-Version anzeigen"
 
 #: lib/poptALL.c:230
 msgid "debug payload file state machine"
-msgstr "Debugge Nutzdaten-Dateistatus"
+msgstr "Nutzdaten-Dateistatus debuggen"
 
 #: lib/poptALL.c:236
 msgid "debug rpmio I/O"
-msgstr "Debugge rpmio Ein-/Ausgabe"
+msgstr "rpmio-Ein-/Ausgabe debuggen"
 
 #: lib/poptALL.c:303
 #, c-format
@@ -1945,30 +1836,27 @@ msgid "relocations must have a / following the ="
 msgstr "Verschiebungen müssen einen / nach dem = enthalten"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"Installiere alle Dateien, sogar Konfigurationsdateien, die sonst "
-"möglicherweise übersprungen werden"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "Alle Dateien installieren, sogar Konfigurationsdateien, die sonst möglicherweise übersprungen werden"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"Entferne alle Pakete, die mit <Paket> übereinstimmen (normalerweise wird "
-"eine Fehlermeldung angezeigt, wenn <Paket> auf mehrere Pakete zutrifft)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "Alle Pakete entfernen, die mit <Paket> übereinstimmen (normalerweise wird eine Fehlermeldung angezeigt, wenn <Paket> auf mehrere Pakete zutrifft)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
-msgstr "Verschiebe Dateien eines nicht verschiebbaren Pakets"
+msgstr "Dateien eines nicht verschiebbaren Pakets verschieben"
 
 #: lib/poptI.c:127
 msgid "print dependency loops as warning"
-msgstr "Zeige Abhängigkeitsschleifen als Warnung"
+msgstr "Abhängigkeitsschleifen als Warnung anzeigen"
 
 #: lib/poptI.c:131
 msgid "erase (uninstall) package"
-msgstr "Lösche (deinstalliere) Paket"
+msgstr "Paket löschen (deinstallieren)"
 
 #: lib/poptI.c:131
 msgid "<package>+"
@@ -1976,15 +1864,15 @@ msgstr "<Paket>+"
 
 #: lib/poptI.c:134 lib/poptI.c:171
 msgid "do not install configuration files"
-msgstr "Installiere keine Konfigurationsdateien"
+msgstr "Keine Konfigurationsdateien installieren"
 
 #: lib/poptI.c:137 lib/poptI.c:176
 msgid "do not install documentation"
-msgstr "Installiere keine Dokumentation"
+msgstr "Keine Dokumentation installieren"
 
 #: lib/poptI.c:139
 msgid "skip files with leading component <path> "
-msgstr "Überspringe Dateien mit beginnendem <Pfad> "
+msgstr "Dateien überspringen, die mit <Pfad> beginnen"
 
 #: lib/poptI.c:140
 msgid "<path>"
@@ -1996,7 +1884,7 @@ msgstr "Abkürzung für --replacepkgs --replacefiles"
 
 #: lib/poptI.c:147
 msgid "upgrade package(s) if already installed"
-msgstr "Aktualisiere Paket(e), wenn bereits installiert"
+msgstr "Paket(e) aktualisieren, wenn bereits installiert"
 
 #: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:251 lib/poptI.c:255
 msgid "<packagefile>+"
@@ -2004,7 +1892,7 @@ msgstr "<Paket-Datei>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "Zeige Rautezeichen während der Installation (empfehlenswert mit -v)"
+msgstr "Rautezeichen während der Installation (empfehlenswert mit -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -2020,21 +1908,21 @@ msgstr "Keine Überprüfung des Festplattenspeichers vor der Installation"
 
 #: lib/poptI.c:161
 msgid "install documentation"
-msgstr "Installiere Dokumentation"
+msgstr "Dokumentation installieren"
 
 #: lib/poptI.c:164
 msgid "install package(s)"
-msgstr "Installiere Paket(e)"
+msgstr "Paket(e) installieren"
 
 #: lib/poptI.c:167
 msgid "update the database, but do not modify the filesystem"
-msgstr "Aktualisiere die Datenbank, aber verändere nichts im Dateisystem"
+msgstr "Die Datenbank aktualisieren, aber nichts im Dateisystem verändern"
 
 #: lib/poptI.c:173
 msgid "do not verify package dependencies"
 msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "Keine Überprüfung der Prüfsumme der Dateien"
 
@@ -2044,12 +1932,11 @@ msgstr "Keine Überprüfung der Prüfsumme der Dateien (veraltet)"
 
 #: lib/poptI.c:183
 msgid "don't install file security contexts"
-msgstr "Installiere keine Sicherheitskontext-Dateien"
+msgstr "Keine Sicherheitskontext-Dateien installieren"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"Paket-Installation nicht neu sortieren, um die Abhängigkeiten zu erfüllen"
+msgstr "Paket-Installation nicht neu sortieren, um die Abhängigkeiten zu erfüllen"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2078,12 +1965,12 @@ msgstr "%%postun-Scriptlet nicht ausführen (wenn vorhanden)"
 #: lib/poptI.c:207
 #, c-format
 msgid "do not execute %%pretrans scriptlet (if any)"
-msgstr ""
+msgstr "%%pretrans-Scriptlet nicht ausführen (wenn vorhanden)"
 
 #: lib/poptI.c:210
 #, c-format
 msgid "do not execute %%posttrans scriptlet (if any)"
-msgstr ""
+msgstr "%%posttrans-Scriptlet nicht ausführen (wenn vorhanden)"
 
 #: lib/poptI.c:213
 msgid "do not execute any scriptlet(s) triggered by this package"
@@ -2113,19 +2000,15 @@ msgstr "%%triggerpostun-Scriptlets nicht ausführen"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"Aktualisierung auf eine alte Version des Pakets (--force macht das bei "
-"Aktualisierungen automatisch)"
+msgstr "Aktualisierung auf eine alte Version des Pakets (--force macht das bei Aktualisierungen automatisch)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
-msgstr "Zeige Prozentangabe bei der Paket-Installation"
+msgstr "Prozentangabe bei der Paket-Installation anzeigen"
 
 #: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
-msgstr ""
-"Verschiebe das Paket, wenn es verschiebbar ist, in das Verzeichnis "
-"<Verzeichnis>"
+msgstr "Das Paket, wenn es verschiebbar ist, in das Verzeichnis <Verzeichnis> verschieben"
 
 #: lib/poptI.c:236
 msgid "<dir>"
@@ -2133,7 +2016,7 @@ msgstr "<Verzeichnis>"
 
 #: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
-msgstr "verschiebe Dateien von <alter Pfad> nach <neuer Pfad>"
+msgstr "Dateien von <alter Pfad> nach <neuer Pfad> verschieben"
 
 #: lib/poptI.c:239
 msgid "<old>=<new>"
@@ -2141,11 +2024,11 @@ msgstr "<alter Pfad>=<neuer Pfad>"
 
 #: lib/poptI.c:242
 msgid "ignore file conflicts between packages"
-msgstr "Ignoriere Datei-Konflikte zwischen Paketen"
+msgstr "Datei-Konflikte zwischen Paketen ignorieren"
 
 #: lib/poptI.c:245
 msgid "reinstall if the package is already present"
-msgstr "Installiere erneut, wenn das Paket bereits vorhanden ist"
+msgstr "Erneut installieren, wenn das Paket bereits vorhanden ist"
 
 #: lib/poptI.c:247
 msgid "don't install, but tell if it would work or not"
@@ -2157,184 +2040,164 @@ msgstr "Paket(e) aktualisieren"
 
 #: lib/poptI.c:254
 msgid "reinstall package(s)"
-msgstr ""
+msgstr "Paket(e) erneut installieren"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "Abfrage aller Pakete"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "Abfrage-Modus der Signatur"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "Abfragen/überprüfen eines Pakets, das die Datei besitzt"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "Abfragen/überprüfen eines Pakets einer Gruppe"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "Abfragen/überprüfen einer Paket-Datei"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "Abfragen/überprüfen von Paketen mit der Paket-Kennung"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "Abfragen/überprüfen von Paketen mit Header-Kennung"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "Abfrage-Modus"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "Abfragen/überprüfen einer Header-Instanz"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "Abfragen/überprüfen von Paketen einer Installation"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "Abfragen eines Pakets gesteuert vom Paket"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "Überprüfungsmodus"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "Abfrage nach Paketen, die die Fähigkeit bereitstellen"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "Abfrage nach Paketen, die die Fähigkeit benötigen"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
-msgstr "\"Globe\" nicht nach Argumenten"
+msgstr "»Globe« nicht nach Argumenten"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "Dateien nicht als Paket-Liste verarbeiten"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "Alle Konfigurationsdateien anzeigen"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "Alle Dokumentationsdateien anzeigen"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
-msgstr ""
+msgstr "Alle Lizenzdateien anzeigen"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "Grundlegende Datei-Informationen auflisten"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "Alle Dateien im Paket auflisten"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
-msgstr "Überspringe %%ghost-Dateien"
+msgstr "%%ghost-Dateien überspringen"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "Anzeigen der Zustände der aufgelisteten Dateien"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
-msgstr "Keine Grössenüberprüfung der Dateien"
+msgstr "Keine Größenüberprüfung der Dateien"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "Keine Überprüfung der symbolischen Links der Dateien"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "Keine Überprüfung der Eigentümer der Dateien"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "Keine Überprüfung der Gruppen der Dateien"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "Keine Überprüfung der letzten Bearbeitungszeit der Dateien"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "Keine Überprüfung der Berechtigungen der Dateien"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "Keine Fähigkeitsprüfung der Dateien"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "Keine Überprüfung des Sicherheitskontexts"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "Keine Überprüfung der Dateien im Paket"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "Kein(e) Überprüfungsskript(e) ausführen"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Fehlende rpmlib-Features für %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
-msgstr "Source-Paket erwartet, Binär-Paket entdeckt\n"
+msgstr "Quell-Paket erwartet, Binär-Paket entdeckt\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
-msgstr "Source-Paket enthält keine Spec-Datei\n"
+msgstr "Quell-Paket enthält keine Spec-Datei\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "Entpacken des Archivs fehlgeschlagen%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " bei Datei "
 
@@ -2361,7 +2224,7 @@ msgstr "nicht installiert"
 
 #: lib/query.c:165
 msgid "net shared    "
-msgstr "geshared      "
+msgstr "im Netz freigegeben"
 
 #: lib/query.c:168
 msgid "wrong color   "
@@ -2409,119 +2272,96 @@ msgstr "Kein Paket stimmt mit %s überein: %s\n"
 msgid "no package requires %s\n"
 msgstr "Kein Paket benötigt %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "Kein Paket benötigt %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "Keine Paket-Trigger %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "Kein Paket benötigt %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "Kein Paket benötigt %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
-msgstr "Kein Paket bietet %s\n"
+msgstr "Kein Paket stellt %s bereit\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "Datei %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "Die Datei %s gehört zu keinem Paket\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "Ungültige Paket-Nummer: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
-msgstr "Eintrag %u konnte nicht gelesen werden\n"
+msgstr "Datensatz %u konnte nicht gelesen werden\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "Das Paket %s ist nicht installiert\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
-msgstr "Unbekannter Tag: \"%s\"\n"
+msgstr "Unbekannter Tag: »%s«\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
-msgstr ""
-"%s: Import des Schlüssels %d fehlgeschlagen.\n"
-"\n"
+msgstr "%s: Import des Schlüssels %d fehlgeschlagen.\n\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
-msgstr "%s: Schlüssel %d nicht gesicherter öffentlicher Schlüssel.\n"
+msgstr "%s: Schlüssel %d ist kein gesicherter öffentlicher Schlüssel.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: Importieren fehlgeschlagen (%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
-msgstr ""
+msgstr "%s: headerRead fehlgeschlagen: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: Immuner Header-Bereich konnte nicht gelesen werden. Korruptes Paket?\n"
+msgstr "%s: Unveränderlicher Header-Bereich konnte nicht gelesen werden. Beschädigtes Paket?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
-msgstr "%s: Fread fehlgeschlagen: %s\n"
+msgstr "%s: »fread« fehlgeschlagen: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NICHT OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (FEHLENDE SCHLÜSSEL:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (UNBESTÄTIGTE SCHLÜSSEL:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: Öffnen fehlgeschlagen: %s\n"
@@ -2539,208 +2379,151 @@ msgstr "%s: chroot-Verzeichnis nicht gesetzt\n"
 #: lib/rpmchroot.c:70
 #, c-format
 msgid "Unable to change root directory: %m\n"
-msgstr "Wechseln des Wurzel.Verzeichnis fehlgeschlagen: %m\n"
+msgstr "Wechseln des Wurzelverzeichnisses fehlgeschlagen: %m\n"
 
 #: lib/rpmchroot.c:95
 #, c-format
 msgid "Unable to restore root directory: %m\n"
-msgstr "Root-Verzeichnis kann nicht wiederhergestellt werden: %m\n"
+msgstr "Wurzelverzeichnis kann nicht wiederhergestellt werden: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NEIN "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "PreReq:, Provides:, und Obsoletes: unterstützen Versionen."
+msgstr "»PreReq:«-, »Provides:«- und »Obsoletes:«-Abhängigkeiten unterstützen Versionen."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"Dateiname(n) als (dirName,baseName,dirIndex)-Tupel gespeichert, nicht als "
-"Pfad."
+msgstr "Dateiname(n) als (dirName,baseName,dirIndex)-Tupel gespeichert, nicht als Pfad."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "Paket-Nutzdaten können mit bzip2 komprimiert werden."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "Paket-Nutzdaten können mit xz komprimiert werden."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "Paket-Nutzdaten können mit lzma komprimiert werden."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
-msgstr "Dateien der Paket-Nutzdaten haben \"./\" als Präfix"
+msgstr "Dateien der Paket-Nutzdaten haben »./« als Präfix"
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "Paket Name-Version-Release wird nicht unbedingt bereitgestellt."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "Header-Tags werden immer nach dem Laden sortiert."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "Der Scriptlet-Interpreter kann Argumente aus dem Header benutzen."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
-msgstr ""
-"Eine harte Verlinkung kann auch ohne eine komplette Installation angelegt "
-"werden."
+msgstr "Eine harte Dateiverknüpfung ohne Ziel ist installierbar."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"Paket-Scriptlets können während der Installation auf die RPM-Datenbank "
-"zugreifen."
+msgstr "Paket-Scriptlets können während der Installation auf die RPM-Datenbank zugreifen."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "Interne Unterstützung für LUA-Scripte"
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "Datei-Prüfsummen-Algorithmus ist pro Paket konfigurierbar"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "Unterstützung für POSIX.1e-Dateifähigkeiten"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "Paket-Scriptlets können während der Installation entpackt werden."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
-msgstr ""
+msgstr "Abhängigkeitsvergleich unterstützt Versionen mit Tilde."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
-msgstr ""
+msgstr "Dateien größer als 4 GB werden unterstützt"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Version benötigt"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "Ungültige Abhängigkeit"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Nicht terminiertes %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "Ungültige Abhängigkeit"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
-msgstr "Benutzer %s existiert nicht - benutze Root\n"
+msgstr "Benutzer %s existiert nicht - Root wird benutzt\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
-msgstr "Gruppe %s existiert nicht - benutze Root\n"
+msgstr "Gruppe %s existiert nicht - Root wird benutzt\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Ungültige Magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
-msgstr "Ungültiger Header"
+msgstr "Ungültiger oder unlesbarer Header"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
-msgstr "Header zu gross"
+msgstr "Header zu groß"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
-msgstr ""
+msgstr "Datei ist zu groß für das Archiv"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Unbekannter Datei-Typ"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
-msgstr ""
+msgstr "Fehlende Datei(en)"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
-msgstr "Prüfsumme stimmt nicht überein"
+msgstr "Prüfsummen stimmen nicht überein"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Interner Fehler"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Archiv-Datei nicht im Header"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " fehlgeschlagen - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
-msgstr ""
+msgstr "%s: (Fehler 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "Öffnen von %s fehlgeschlagen: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: Kein RPM-Paket (oder Paket-Liste)\n"
@@ -2748,71 +2531,69 @@ msgstr "%s: Kein RPM-Paket (oder Paket-Liste)\n"
 #: lib/rpminstall.c:141
 #, c-format
 msgid "Updating / installing...\n"
-msgstr ""
-"Aktualisierung/ Installation...\n"
-"\n"
+msgstr "Aktualisierung/ Installation …\n"
 
 #: lib/rpminstall.c:143
 #, c-format
 msgid "Cleaning up / removing...\n"
-msgstr "Aufräumen/ Entfernen...\n"
+msgstr "Aufräumen/ Entfernen …\n"
 
 #: lib/rpminstall.c:192
 msgid "Preparing..."
-msgstr "Vorbereiten..."
+msgstr "Vorbereiten …"
 
 #: lib/rpminstall.c:194
 msgid "Preparing packages..."
-msgstr "Pakete vorbereiten..."
+msgstr "Pakete vorbereiten …"
 
 #: lib/rpminstall.c:270 tools/rpmgraph.c:168
 msgid "Failed dependencies:\n"
-msgstr "Fehlgeschlagende Abhängigkeiten:\n"
+msgstr "Fehlgeschlagene Abhängigkeiten:\n"
 
 #: lib/rpminstall.c:321
 #, c-format
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: Kein RPM-Paket (oder Paket-Liste): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s kann nicht installiert werden\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
-msgstr "Empfange %s\n"
+msgstr "%s wird geholt\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
-msgstr "überspringe %s - Übertragung fehlgeschlagen\n"
+msgstr "%s wird übersprungen - Übertragung fehlgeschlagen\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "Paket %s ist nicht verschiebbar\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "Fehler beim Lesen von Datei %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
-msgstr "\"%s\" bezeichnet mehrere Pakete:\n"
+msgstr "»%s« bezeichnet mehrere Pakete:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
-msgstr "Kann %s nicht öffnen: %s\n"
+msgstr "%s kann nicht geöffnet werden: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
-msgstr "Installiere %s\n"
+msgstr "%s wird installiert\n"
 
 #: lib/rpmlead.c:100
 msgid "not an rpm package"
@@ -2820,7 +2601,7 @@ msgstr "ist kein RPM-Paket"
 
 #: lib/rpmlead.c:104
 msgid "illegal signature type"
-msgstr "Illegaler Signatur-Typ"
+msgstr "Ungültiger Signatur-Typ"
 
 #: lib/rpmlead.c:108
 msgid "unsupported RPM package version"
@@ -2835,37 +2616,35 @@ msgstr "Lesen fehlgeschlagen: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "kein RPM-Paket\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
-msgstr ""
-"kann keine %s Blockierung auf %s (%s) erstellen\n"
-"\n"
+msgstr "%s-Sperre auf %s kann nicht erstellt werden (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
-msgstr "warte auf %s Blockierung auf %s\n"
+msgstr "Auf %s-Sperre auf %s wird gewartet\n"
 
 #: lib/rpmplugins.c:65
 #, c-format
 msgid "Failed to dlopen %s %s\n"
-msgstr "Dlopen %s %s fehlgeschlagen\n"
+msgstr "»dlopen« %s %s fehlgeschlagen\n"
 
 #: lib/rpmplugins.c:73
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
-msgstr "Auflösen des Symbols fehlgeschlagen %s: %s\n"
+msgstr "Auflösen des Symbols %s fehlgeschlagen: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Plugin %s nicht geladen\n"
+msgstr "Plugin %%__%s_%s ist nicht konfiguriert\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
 msgid "Plugin %s not loaded\n"
-msgstr "Plugin %s nicht geladen\n"
+msgstr "Plugin %s ist nicht geladen\n"
 
 #: lib/rpmprob.c:109
 msgid "different"
@@ -2894,15 +2673,12 @@ msgstr "Der Pfad %s im Paket %s ist nicht verschiebbar"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr ""
-"Datei %s kollidiert zwischen den versuchten Installationen von %s und %s"
+msgstr "Datei %s kollidiert zwischen den versuchten Installationen von %s und %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"Datei %s aus der Installation von %s kollidiert mit der Datei aus dem Paket "
-"%s"
+msgstr "Datei %s aus der Installation von %s kollidiert mit der Datei aus dem Paket %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2912,14 +2688,12 @@ msgstr "Paket %s (welches neuer als %s ist) ist bereits installiert"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"Installation des Pakets %s benötigt %<PRIu64>%cB auf dem %s-Dateisystem"
+msgstr "Installation des Pakets %s benötigt %<PRIu64>%cB auf dem %s-Dateisystem"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"Installation des Pakets %s benötigt %<PRIu64>-Inodes auf dem %s-Dateisystem"
+msgstr "Installation des Pakets %s benötigt %<PRIu64>-Inodes auf dem %s-Dateisystem"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2948,7 +2722,7 @@ msgstr "Unbekannter Fehler %d trat während dem Verarbeiten des Pakets %s auf"
 #: lib/rpmrc.c:222
 #, c-format
 msgid "missing second ':' at %s:%d\n"
-msgstr "Fehlender zweiter ':' bei %s:%d\n"
+msgstr "Fehlender zweiter »:« bei %s:%d\n"
 
 #: lib/rpmrc.c:225
 #, c-format
@@ -2968,7 +2742,7 @@ msgstr "Zu viele Argumente in der Datenzeile bei %s:%d\n"
 #: lib/rpmrc.c:382
 #, c-format
 msgid "Bad arch/os number: %s (%s:%d)\n"
-msgstr "Ungültige Architektur/Betriebssystem-Nummer: %s (%s:%d)\n"
+msgstr "Ungültige Architektur-/Betriebssystem-Nummer: %s (%s:%d)\n"
 
 #: lib/rpmrc.c:413
 #, c-format
@@ -2983,7 +2757,7 @@ msgstr "Zu viele Argumente in der Standardzeile bei %s:%d\n"
 #: lib/rpmrc.c:523
 #, c-format
 msgid "missing ':' (found 0x%02x) at %s:%d\n"
-msgstr "Fehlender ':' (0x%02x gefunden) bei %s:%d\n"
+msgstr "Fehlender »:« (0x%02x gefunden) bei %s:%d\n"
 
 #: lib/rpmrc.c:540 lib/rpmrc.c:572
 #, c-format
@@ -2993,7 +2767,7 @@ msgstr "Fehlendes Argument für %s bei %s:%d\n"
 #: lib/rpmrc.c:551
 #, c-format
 msgid "cannot open %s at %s:%d: %m\n"
-msgstr "Kann %s bei %s:%d nicht öffnen: %m\n"
+msgstr "%s bei %s:%d kann nicht geöffnet werden: %m\n"
 
 #: lib/rpmrc.c:564
 #, c-format
@@ -3003,81 +2777,62 @@ msgstr "Fehlende Architektur für %s bei %s:%d\n"
 #: lib/rpmrc.c:632
 #, c-format
 msgid "bad option '%s' at %s:%d\n"
-msgstr "Ungültige Option '%s' bei %s:%d\n"
+msgstr "Ungültige Option »%s« bei %s:%d\n"
 
 #: lib/rpmrc.c:959
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
-msgstr ""
+msgstr "»Auxiliary vector« kann nicht gelesen werden, ist /proc nicht eingehängt?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Unbekanntes System: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Bitte (in Englisch) %s kontaktieren\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
-msgstr "Kann %s nicht zum Lesen öffnen: %m.\n"
+msgstr "%s kann nicht zum Lesen geöffnet werden: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
-msgstr ""
+msgstr "Aktuelles Verzeichnis kann nicht wiederhergestellt werden: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua>-Scriptlet-Unterstützung nicht eingebaut\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
-msgstr "Konnte keine temporäre Datei erzeugen für %s: %s\n"
+msgstr "Temporäre Datei für %s konnte nicht angelegt werden: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
-msgstr "Konnte Datei-Beschreiber nicht duplizieren: %s: %s\n"
+msgstr "Datei-Deskriptor konnte nicht dupliziert werden: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Kann Icon %s nicht lesen: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Root-Verzeichnis kann nicht wiederhergestellt werden: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite fehlgeschlagen: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s Scriptlet fehlgeschlagen, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s Scriptlet fehlgeschlagen, Signal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s Scriptlet fehlgeschlagen, Beenden-Status %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Unbekanntes Format"
 
@@ -3089,149 +2844,134 @@ msgstr "installieren"
 msgid "erase"
 msgstr "löschen"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
-msgstr "Kann Paket-Datenbank in %s nicht öffnen\n"
+msgstr "Paket-Datenbank in %s kann nicht geöffnet werden\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
-msgstr "Zusätzliche '(' im Paket-Bezeichnung: %s\n"
+msgstr "Zusätzliche »(« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
-msgstr "Fehlende '(' im Paket-Label: %s\n"
+msgstr "Fehlende »(« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
-msgstr "Fehlende ')' im Paket-Bezeichung: %s\n"
+msgstr "Fehlende »)« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: Lesen des öffentlichen Schlüssels fehlgeschlagen.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "Transaktion"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(keine OpenPGP-Signatur)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
+#: lib/signature.c:235
+msgid "MD5 digest:"
+msgstr "MD5-Prüfsumme: "
+
+#: lib/signature.c:274
+msgid "Header SHA1 digest:"
+msgstr "SHA1-Prüfsumme des Headers: "
+
+#: lib/signature.c:316
 msgid "Header "
 msgstr "Header "
 
-#: lib/signature.c:377
-msgid "MD5 digest:"
-msgstr "MD5-Kurzfassung: "
-
-#: lib/signature.c:380
-msgid "Header SHA1 digest:"
-msgstr "SHA1-Kurzfassung des Headers: "
-
-#: lib/signature.c:399
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
-msgstr ""
+msgstr "Signaturüberprüfung: FALSCHE PARAMETER (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "übersprungen"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "fehlgeschlagen"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
-msgstr ""
+msgstr "Doppelter Benutzername oder Benutzer-ID für Benutzer %s\n"
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
-msgstr ""
+msgstr "Doppelter Gruppenname oder Gruppen-ID für Gruppe %s\n"
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
-msgstr ""
+msgstr "kein Status"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
-msgstr ""
+msgstr "unbekannter Status"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "fehlend   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Unerfüllte Abhängigkeiten für %s:\n"
 
 #: lib/headerfmt.c:336
 msgid "invalid field width"
-msgstr ""
+msgstr "ungültige Feldbreite"
 
 #: lib/headerfmt.c:342
 msgid "missing { after %"
@@ -3247,7 +2987,7 @@ msgstr "Leeres Tag-Format"
 
 #: lib/headerfmt.c:386
 msgid "empty tag name"
-msgstr "Unbekannter Tag"
+msgstr "Leerer Tag-Name"
 
 #: lib/headerfmt.c:393
 msgid "unknown tag"
@@ -3291,248 +3031,247 @@ msgstr "| am Ende des Ausdrucks erwartet"
 
 #: lib/headerfmt.c:735
 msgid "array iterator used with different sized arrays"
-msgstr "Zählvariable wird mit ungleich grossem Array benutzt"
+msgstr "Zählvariable wird mit ungleich großem Array benutzt"
 
 #: lib/rpmdb.c:71
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
-msgstr "Generiere %d fehlende Index(e), bitte warten...\n"
+msgstr "%d fehlende(r) Index(e), bitte warten...\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
-msgstr ""
+msgstr "%s-Index kann nicht mittels %s geöffnet werden - %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
-msgstr "Kein Datenbank-Pfad wurde gesetzt\n"
+msgstr "Datenbank-Pfad wurde nicht gesetzt\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
-msgstr "miFreeHeader: Überspringe"
+msgstr "miFreeHeader: wird übersprungen"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
-msgstr "Fehler(%d) beim Speichern des Eintrags #%d in %s\n"
+msgstr "Fehler(%d) beim Speichern des Datensatzes #%d in %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
-msgstr "rpmdbNextIterator: Überspringe"
+msgstr "rpmdbNextIterator: wird übersprungen"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
-msgstr "rpmdb: Beschädigten Header #%u erhalten -- überspringe.\n"
+msgstr "rpmdb: Beschädigten Header #%u erhalten -- wird übersprungen.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
-msgstr "%s: Kann den Header bei 0x%x nicht lesen\n"
+msgstr "%s: Header bei 0x%x kann nicht gelesen werden\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
-msgstr "Kein Datenbank-Pfad wurde gesetzt"
+msgstr "Datenbank-Pfad wurde nicht gesetzt"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
-msgstr "Erzeugen des Verzeichnises %s fehlgeschlagen: %s\n"
+msgstr "Anlegen des Verzeichnisses %s fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
-msgstr "Header #%u in der Datenbank ist ungültig -- überspringe.\n"
+msgstr "Header #%u in der Datenbank ist ungültig -- wird übersprungen.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
-msgstr "Kann ursprünglichen Eintrag %u nicht hinzufügen\n"
+msgstr "Ursprünglicher Datensatz %u kann nicht hinzugefügt werden\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"Neu bauen der Datenbank fehlgeschlagen: Datenbank verbleibt entsprechend\n"
+msgstr "Neu bauen der Datenbank fehlgeschlagen: Datenbank verbleibt entsprechend\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "Konnte die alte Datenbank nicht durch die neue ersetzen!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
-msgstr "Ersetze Dateien in %s mit Dateien aus %s für eine Wiederherstellung"
+msgstr "Für eine Wiederherstellung Dateien in %s durch Dateien aus %s ersetzen"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "Entfernen des Verzeichnisses %s fehlgeschlagen: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
-msgstr ""
+msgstr "%s Fehler(%d) von %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
-msgstr ""
+msgstr "%s Fehler(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "Unbekannte Datenbank-Option: \"%s\" ignoriert.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s hat einen ungültigen numerischen Wert, übersprungen\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s hat einen zu grossen oder zu kleinen Wert, übersprungen\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s hat einen zu grossen oder zu kleinen Integer-Wert, übersprungen\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "Keine %s-Sperre auf %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
-msgstr "verteilt"
+msgstr "gemeinsam"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exklusiv"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
-msgstr ""
+msgstr "Ungültiger Indextyp %x auf %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
+msgstr "Fehler(%d) beim Holen der Datensätze »%s« aus dem %s-Index: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "Fehler(%d) beim Speichern des Eintrags \"%s\" in %s\n"
+msgstr "Fehler(%d) beim Speichern des Datensatzes »%s« in %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "Fehler(%d) beim Entfernen des Eintrags \"%s\" aus %s\n"
+msgstr "Fehler(%d) beim Entfernen des Datensatzes »%s« aus %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
-msgstr ""
+msgstr "Fehler(%d) beim Hinzufügen des Datensatzes für Header #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
-msgstr ""
+msgstr "Fehler(%d) beim Entfernen des Datensatzes für Header #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "Fehler(%d) beim Reservieren einer neuen Paket-Instanz\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "Unbekannte Datenbank-Option: »%s« wird ignoriert.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s hat einen ungültigen numerischen Wert, wird übersprungen\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s hat einen zu großen oder zu kleinen Wert, wird übersprungen\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s hat einen zu großen oder zu kleinen Integer-Wert, wird übersprungen\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(leer)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(leer)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
-msgstr "Makro %%%s hat keine terminierten Optionen\n"
+msgstr "Makro %%%s hat nicht terminierte Optionen\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
-msgstr "Makro %%%s hat keinen terminierten Hauptteil\n"
+msgstr "Makro %%%s hat einen nicht terminierten Hauptteil\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s hat einen ungültigen Namen (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s hat einen leeren Hauptteil\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
-msgstr ""
+msgstr "Makro %%%s benötigt Leerzeichen vor dem Hauptteil\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s konnte nicht erweitert werden\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s hat einen ungültigen Namen (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
-msgstr ""
+msgstr "Makro %%%s ist definiert, wird aber nicht innerhalb des Bereichs verwendet\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Unbekannte Option %c in %s (%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
+msgstr "Zu viele Rekursionsebenen bei der Expansion des Makros. Dies wird wahrscheinlich durch eine rekursive Makro-Deklaration verursacht.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Nicht terminiertes %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
-msgstr "Ein %% ist gefolgt von einem nicht parsbaren Makro\n"
+msgstr "Auf %% folgt ein nicht auswertbares Makro\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
-msgstr ""
+msgstr "Laden der Makro-Datei %s ist fehlgeschlagen"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiv %d  leer %d\n"
@@ -3552,52 +3291,52 @@ msgstr "Datei %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Datei %s ist kleiner als %u Byte\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
-msgstr "Erzeugen des Verzeichnises fehlgeschlagen"
+msgstr "Erzeugen des Verzeichnisses fehlgeschlagen"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
-msgstr "Ungültige Syntax in lua-Scriptlet: %s\n"
+msgstr "Ungültige Syntax in Lua-Scriptlet: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
-msgstr "Ungültige Syntax in lua-Script: %s\n"
+msgstr "Ungültige Syntax in Lua-Script: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
-msgstr "lua-Script fehlgeschlagen: %s\n"
+msgstr "Lua-Script fehlgeschlagen: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
-msgstr "Ungültige Syntax in lua-Datei: %s\n"
+msgstr "Ungültige Syntax in Lua-Datei: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
-msgstr "lua hook fehlgeschlagen: %s\n"
+msgstr "Lua-Hook fehlgeschlagen: %s\n"
 
 #: rpmio/rpmio.c:280
 msgid "[none]"
-msgstr ""
+msgstr "[kein]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(kein Fehler)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "Schwerwiegender Fehler: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "Fehler: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "Warnung: "
 
@@ -3606,126 +3345,102 @@ msgstr "Warnung: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "Speicherbelegung (%u Byte) lieferte NULL zurück.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, Schlüssel-ID %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
-msgstr ""
+msgstr "(keine)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "Fehler beim Erstellen der temporären Datei %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "Fehler beim Erstellen der temporären Datei %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "Fehler beim Erstellen der temporären Datei %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "Erzeugen des Verzeichnises %s fehlgeschlagen: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
-msgstr ""
+msgstr "Nicht unterstützte PGP-Signatur\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
-msgstr ""
+msgstr "Nicht unterstützter PGP-Prüfsummenalgorithmus %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
-msgstr ""
+msgstr "Nicht unterstützter PGP-Algorithmus %u für öffentlichen Schlüssel\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Konnte %s nicht ausführen: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Pipe zum Signieren konnte nicht erzeugt werden: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: Öffnen fehlgeschlagen: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "fdopen fehlgeschlagen\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr ""
-"Konnte %s-Datei nicht öffnen: %s\n"
-"\n"
+msgstr "In die Pipe konnte nicht geschrieben werden\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Datei %s aus %%files konnte nicht geöffnet: %m\n"
+msgstr "Aus Datei %s konnte nicht gelesen werden: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
-msgstr "GPG fehlgeschlagen (%d)\n"
+msgstr "Ausführung von GPG fehlgeschlagen (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "GPG konnte die Signatur nicht schreiben\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
-msgstr "Konnte die Signatur nicht lesen\n"
+msgstr "Signatur konnte nicht gelesen werden\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature fehlgeschlagen: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
-msgstr ""
+msgstr "RPM-Pakete der Version 3 können nicht signiert werden\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
-msgstr ""
+msgstr "%s enthält bereits eine identische Signatur, wird übersprungen\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMk Temp fehlgeschlagen\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
-msgstr ""
+msgstr "Ersetzen von %s fehlgeschlagen: %s\n"
 
 #: tools/rpmgraph.c:142
 #, c-format
@@ -3735,43 +3450,3 @@ msgstr "%s: Lesen der Paket-Liste fehlgeschlagen: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "Keine Überprüfung der Header- und Nutzdaten-Signatur"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Bitte das Passwort eingeben: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Das Passwort ist richtig.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Ungültiger Eigentümer/Gruppe: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "Zeile %d: Ungültiges Zeichen in: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Konnte kein Pipe zum Signieren erzeugen: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Konnte Nutzdaten nicht nach %s schreiben: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Konnte Nutzdaten von %s nicht lesen: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Kann temporäre Datei nicht öffnen.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Konnte Signatur-Ziel %s nicht öffnen: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Konnte Header von %s nicht lesen: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Konnte Header nicht nach %s schreiben: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "keine Erfassungaktionen ausführen"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "Immuner Header-Bereich konnte nicht gelesen werden. Korruptes Paket?\n"

--- a/po/el.po
+++ b/po/el.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Duke_Dux <duke.dux@gmail.com>, 2011
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Greek (http://www.transifex.com/projects/p/rpm/language/el/)\n"
-"Language: el\n"
+"Language-Team: Greek (http://www.transifex.com/rpm-team/rpm/language/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -37,9 +37,7 @@ msgstr "Πνευματικά δικαιώματα (C) 1998-2002 - Red Hat, Inc.\
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Το πρόγραμμα αυτό μπορεί να αναδιανεμηθεί ελεύθερα υπό τους όρους της GNU "
-"GPL\n"
+msgstr "Το πρόγραμμα αυτό μπορεί να αναδιανεμηθεί ελεύθερα υπό τους όρους της GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -82,7 +80,7 @@ msgstr "Επιλογές επαλήθευσης (με -V ή --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Επιλογές Εγκατάστασης/Αναβάθμισης/Διαγραφής:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Κοινές επιλογές για όλα τα εκτελέσιμα και τις λειτουργίες rpm:"
@@ -103,7 +101,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -138,7 +136,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -203,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -223,243 +222,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, c-format
-msgid "verify %files section from <source package>"
-msgstr ""
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr ""
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -508,7 +465,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -528,9 +485,28 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr ""
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr ""
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -549,7 +525,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -598,66 +574,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -667,46 +643,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -716,144 +692,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -882,79 +863,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:565
+#: build/pack.c:526
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1005,19 +986,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1124,94 +1105,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
 #, c-format
-msgid "line %d: %s in: %s\n"
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1221,193 +1198,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1478,281 +1423,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1881,13 +1835,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1966,7 +1921,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2086,178 +2041,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2332,116 +2271,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, c-format
-msgid "no package suggests %s\n"
-msgstr ""
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, c-format
-msgid "no package enhances %s\n"
-msgstr ""
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2466,191 +2385,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-msgid "support for rich dependencies."
-msgstr ""
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Το μέγεθος της κεφαλίδας είναι πολύ μεγάλο"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Άγνωστος τύπος αρχείου"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Εσωτερικό σφάλμα"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2682,42 +2554,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2743,12 +2615,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2910,75 +2782,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, c-format
-msgid "Unable to reset nice value: %s"
-msgstr ""
-
-#: lib/rpmscript.c:354
-#, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr ""
-
-#: lib/rpmscript.c:382
-#, c-format
-msgid "Fwrite failed: %s"
-msgstr ""
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -2990,142 +2843,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3199,240 +3037,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3452,31 +3290,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3485,19 +3323,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr ""
 
@@ -3506,120 +3344,99 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:64
-#, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "αποτυχία εκτέλεσης\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:311
+#: sign/rpmgensig.c:284
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Duke_Dux <duke.dux@gmail.com>, 2011
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Greek (http://www.transifex.com/rpm-team/rpm/language/el/)\n"
+"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -37,7 +37,9 @@ msgstr "Πνευματικά δικαιώματα (C) 1998-2002 - Red Hat, Inc.\
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Το πρόγραμμα αυτό μπορεί να αναδιανεμηθεί ελεύθερα υπό τους όρους της GNU GPL\n"
+msgstr ""
+"Το πρόγραμμα αυτό μπορεί να αναδιανεμηθεί ελεύθερα υπό τους όρους της GNU "
+"GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -80,7 +82,7 @@ msgstr "Επιλογές επαλήθευσης (με -V ή --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Επιλογές Εγκατάστασης/Αναβάθμισης/Διαγραφής:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Κοινές επιλογές για όλα τα εκτελέσιμα και τις λειτουργίες rpm:"
@@ -101,7 +103,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -136,8 +138,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -202,7 +203,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -222,201 +223,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
+#, c-format
+msgid "verify %files section from <source package>"
 msgstr ""
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr ""
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr ""
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -465,48 +508,60 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+msgid "sign package(s) files"
+msgstr ""
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:127
-#, c-format
-msgid "Pass phrase is good.\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
 msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -525,7 +580,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -574,66 +629,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -643,46 +698,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -692,149 +747,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -863,79 +918,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -986,19 +1038,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1105,90 +1157,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
 #, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1198,161 +1254,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1423,290 +1511,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1835,14 +1914,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1921,7 +1999,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2041,162 +2119,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2271,96 +2365,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, c-format
+msgid "no package suggests %s\n"
+msgstr ""
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, c-format
+msgid "no package enhances %s\n"
+msgstr ""
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2385,144 +2499,191 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+msgid "support for rich dependencies."
+msgstr ""
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Το μέγεθος της κεφαλίδας είναι πολύ μεγάλο"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Άγνωστος τύπος αρχείου"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Εσωτερικό σφάλμα"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2554,42 +2715,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2615,12 +2776,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2778,60 +2939,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, c-format
+msgid "Unable to reset nice value: %s"
+msgstr ""
+
+#: lib/rpmscript.c:354
+#, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr ""
+
+#: lib/rpmscript.c:382
+#, c-format
+msgid "Fwrite failed: %s"
+msgstr ""
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2843,127 +3023,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3037,240 +3236,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3290,31 +3489,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3323,19 +3522,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr ""
 
@@ -3344,99 +3543,152 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:66
+#, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "αποτυχία εκτέλεσης\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "αποτυχία εκτέλεσης\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "αποτυχία εκτέλεσης\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "αποτυχία εκτέλεσης\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Keith Bowes <zooplah@gmail.com>, 2011,2013
 # Keith Bowes <zooplah@gmail.com>, 2011
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Esperanto (http://www.transifex.com/rpm-team/rpm/language/eo/)\n"
+"Language-Team: Esperanto (http://www.transifex.com/rpm-team/rpm/language/"
+"eo/)\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -38,7 +39,9 @@ msgstr "Kopirajto (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Oni rajtas libere redistribui ĉi tiun programon laŭ la kondiĉoj de la GPL de GNU\n"
+msgstr ""
+"Oni rajtas libere redistribui ĉi tiun programon laŭ la kondiĉoj de la GPL de "
+"GNU\n"
 
 #: cliutils.c:53
 #, c-format
@@ -81,7 +84,7 @@ msgstr "Konstatantaj elektoj (kun -V aŭ --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Elektoj por instali/promocii/forigi:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Kutimaj elektoj por ĉiuj rpm-aj reĝimoj kaj programoj:"
@@ -102,7 +105,7 @@ msgstr "neatendita mendo-aranĝo"
 msgid "unexpected query source"
 msgstr "neatendita mendo-fonto"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "nur unu ĉefa reĝimo povas esti specifita"
 
@@ -121,7 +124,8 @@ msgstr "--prefix malkongruas kun --relocate kaj - -excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate kaj --excludepath povas esti uzata nur dum instali novajn pakaĵojn"
+msgstr ""
+"--relocate kaj --excludepath povas esti uzata nur dum instali novajn pakaĵojn"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -137,8 +141,7 @@ msgid ""
 msgstr "--hash (-h) nur eblas dum pakaĵa instalado aŭ forigado"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr "--percent nur eblas dum pakaĵa instalado aŭ forigado"
 
 #: rpmqv.c:179
@@ -179,31 +182,41 @@ msgstr "oni povas specifi la parametron --allfiles nur dum pakaĵo-instalado"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "oni povas specifi la parametron --justdb nur dum instalado kaj forviŝado de pakaĵo"
+msgstr ""
+"oni povas specifi la parametron --justdb nur dum instalado kaj forviŝado de "
+"pakaĵo"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "oni povas uzi parametrojn por malaktivigi programetojn nur dum instalado kaj forviŝado de pakaĵo"
+msgstr ""
+"oni povas uzi parametrojn por malaktivigi programetojn nur dum instalado kaj "
+"forviŝado de pakaĵo"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "oni povas uzi parametrojn por malaktivigi instigilojn nur dum instalado kaj forviŝado de pakaĵo"
+msgstr ""
+"oni povas uzi parametrojn por malaktivigi instigilojn nur dum instalado kaj "
+"forviŝado de pakaĵo"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "oni povas specifi la parametron --nodeps nur dum instalado, konstatado kaj forviŝado de pakaĵo"
+msgstr ""
+"oni povas specifi la parametron --nodeps nur dum instalado, konstatado kaj "
+"forviŝado de pakaĵo"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "oni povas specifi la parametron --hash (-h) nur dum instalado kaj forviŝado de pakaĵo"
+msgstr ""
+"oni povas specifi la parametron --hash (-h) nur dum instalado kaj forviŝado "
+"de pakaĵo"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumentoj de --root (-r) devas komenciĝi per /"
 
@@ -223,201 +236,250 @@ msgstr "neniuj parametroj donitaj por mendi"
 msgid "no arguments given for verify"
 msgstr "neniuj argumentoj donitaj por konstati"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot jam specifita, %s ignorata\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "munti per %prep (elpaki fontotekstojn kaj fliki) laŭ <spec-dosiero>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<spec-dosiero>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "munti per %build (%prep, tiam traduki) laŭ <spec-dosiero>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "munti per %install (%prep, %build, tiam instali) laŭ <spec-dosiero>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "konstati la sekcion %file laŭ <spec-dosiero>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "munti fontotekstan kaj plenumeblan pakaĵojn laŭ <spec-dosiero>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "munti nur plenumeblan pakaĵon laŭ <spec-dosiero>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <spec-dosiero>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "munti per %prep (elpaki fontotekstojn kaj fliki) laŭ <spec-dosiero>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<fontoteksta pakaĵo>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "munti per %build (%prep, tiam traduki) laŭ <spec-dosiero>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"munti per %install (%prep, %build, tiam instali) laŭ <fontoteksta pakaĵo>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "konstati la sekcion %file laŭ <spec-dosiero>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "munti plenumeblan pakaĵon laŭ <fontoteksta pakaĵo>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "munti plenumeblan pakaĵon laŭ <fontoteksta pakaĵo>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "munti nur fontotekstan pakaĵon laŭ <spec-dosiero>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr "munti per %prep (elpaki fontotekstojn kaj fliki) laŭ <tar-dosiero>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tar-dosiero>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "munti per %build (%prep, tiam traduki) laŭ <tar-dosiero>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "munti per %install (%prep, %build, tiam instali) laŭ <tar-dosiero>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "konstati sekcion %files laŭ <tar-dosiero>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "munti fontotekstan kaj plenumeblan pakaĵojn laŭ <tar-dosiero>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "munti nur plenumeblan pakaĵon laŭ <tar-dosiero>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <tar-dosiero>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "munti plenumeblan pakaĵon laŭ <fontoteksta pakaĵo>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<fontoteksta pakaĵo>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "munti per %install (%prep, %build, tiam instali) laŭ <fontoteksta pakaĵo>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "superregi muntan radikon"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Ne eblas malfermi aktualan dosierujon: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "forigi muntan arbon post finita"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignori la direktivojn ExcludeArch: el spec-dosiero"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "senerarigi dosierstatan maŝinon"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "ne plenumigi iun ajn etapon de la muntado"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "ne konstati muntaĵo-dependaĵojn"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "generi pakaĵo-kapo(j)n kongrua(j)n kun (malmoderna) pakado de rpm 3"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "ne plenumigi la etapon %clean por la muntado"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "ne plenumigi la etapon %clean por la muntado"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "ne plenumigi la etapon %check por la muntado"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "ne akcepti tradukojn el spec-dosiero"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "forigi fontotekstojn post kiam finita"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "forigi spec-dosieron post kiam finita"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preterlasi rekte al specifita etapo (nur por c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "superregi celan platformon"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Multaj elektoj je [ <spec-dosiero> |  <tar-dosiero> | <fontoteksta pakaĵo> ]:"
+msgstr ""
+"Multaj elektoj je [ <spec-dosiero> |  <tar-dosiero> | <fontoteksta pakaĵo> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Malsukcesintaj muntaj dependaĵoj:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Ne eblas malfermi spec-dosieron %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Malsukcesis malfermi tar-tubon: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Pli ol unu dosiero en linio: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Malsukcesis legi spec-dosieron je %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Malsukcesis alinomi %s al %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "malsukcesis stat-i: %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Dosiero %s ne estas regula dosiero.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Dosiero %s ne aspektas kiel spec-dosiero.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Platformoj por kiu munti: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Muntanta por celon %s\n"
@@ -428,7 +490,8 @@ msgstr "iniciati datumbazon"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "remunti listojn inversigitajn de la datumbazo el instalitaj pakaĵo-kapoj"
+msgstr ""
+"remunti listojn inversigitajn de la datumbazo el instalitaj pakaĵo-kapoj"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -466,49 +529,64 @@ msgstr "listigi ŝlosilojn el RPM-ŝlosilaro"
 msgid "Keyring options:"
 msgstr "Ŝlosilaro-elektoj:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "neniuj parametroj donitaj"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "pretendi pakaĵo(j)n"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "pretendi pakaĵo(j)n (identa je --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "forigi pakaĵo-pretendojn"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "pretendi pakaĵo(j)n"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Pretendo-elektojn:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Ne eblas plenumigi: %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Vi devas valorizi \"%%_gpg_name\" en via makro-dosiero\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Enmeti pasfrazon:"
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Pasfrazo bonas.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Kontrolado de pasfrazo malsukcesis aŭ GPG-ŝlosilo eksvalidiĝis.\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix povas esti uzata nur dum instali novajn pakaĵojn"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "oni povas specifi la parametron --hash (-h) nur dum pakaĵo-forviŝado"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -526,7 +604,7 @@ msgstr "operacii je dekumaj rpm-oj generitaj de spec (apriora)"
 msgid "operate on source rpm generated by spec"
 msgstr "operacii je fontotekstaj rpm-oj generitaj de spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "uzu la jenan mendo-formaton"
 
@@ -573,68 +651,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nMuntaj eraroj ĉe RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Muntaj eraroj ĉe RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "sintaksa eraro dum analizi ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "sintaksa eraro dum analizi &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "Sintaksa eraro dum analizi ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "analiza eraro ĉe esprimo\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "( sen )\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- nur por nobroj\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! nur por nombroj\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "tipoj devas esti kongruaj\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / ne por ĉenoj\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- no por ĉenoj\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& kaj || ne por ĉenoj\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "sintaksa eraro en esprimo\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Manka '(' en %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Manka ')' en %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Nevalida ero %s: %s\n"
@@ -644,46 +725,46 @@ msgstr "Nevalida ero %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Manka %s en %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Blankospacoj ne povas sekvi: %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Fuŝa sintakso: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Fuŝa reĝimo-specifo: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Fuŝa dosierujo-specifo: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Neordinara longo de lokaĵaro: \"%s\" en %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Duplika lokaĵaro %s en %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Nevalida kapablo: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Dosiero-kapabla rego ne integra\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Dosiero devas komenciĝi per \"/\": %s\n"
@@ -693,149 +774,153 @@ msgstr "Dosiero devas komenciĝi per \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Nekonata algoritmo %u por dosieraj resumoj, uzanta je MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Dosiero listigita dufoje: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "legado de mola ligilo %s malsukcesis: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Mola ligilo almontras al BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Dosierujo ne trovita: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Dosiero ne trovita: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: ne eblas ŝargi nekonatan etikedon (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: legi publikan ŝlosilon malsukcesis.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ne ŝirmita publika ŝlosilo.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: malsukcesis kodiĝi\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Dosiero devas havi antaŭan \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Amaso %%dev ne permesata:%s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Dosierujo ne trovita laŭ amaso: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Dosiero ne trovita laŭ amaso: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Ne eblis malfermi %%files file %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "linio: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "eraro dum legi dosieron %%files %s: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "nepermesita _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Dosiero ne trovita laŭ amaso: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Ne eblas kunmiksi specialan %s-on kun aliaj formoj: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Pli ol unu dosiero en linio: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Fuŝa dosiero: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Fuŝa estro/grupo: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontrolanta ne pakita(j)n dosiero(j)n: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Insalita(j) (sed ne pakita(j) dosiero(j) trovita(j):\n%s"
+msgstr ""
+"Insalita(j) (sed ne pakita(j) dosiero(j) trovita(j):\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Procedanta dosierojn: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "Platformo (%d) de la plenumebla dosiero ne kongruas la pakaĵan platformon (%d).\n"
+msgstr ""
+"Platformo (%d) de la plenumebla dosiero ne kongruas la pakaĵan platformon "
+"(%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Platformo-dependaj dosieroj en platformo-sendependa pakaĵo\n"
 
@@ -864,79 +949,76 @@ msgstr "%s: linio: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Ne eblis kanonigi gastiganto-nomon: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Ne eblas reŝargi pretendo-kapon.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nekonata kunpremo-tipo de ŝarĝo: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Ne eblas krei regionon por neŝanĝebla kapo.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ne eblas malfermi: %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Ne eblas skribi pakaĵon: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Ne eblas skribi provizoran kapon\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Fuŝa CSA-datumo\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skribis: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Plenumiĝanta \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Plenumigo de \"%s\" malsukcesis.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Pako-controlo \"%s\" malsukcesis.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne eblas generi eligan dosiernomon por pakaĵo %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ne eblas krei %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "line %d: dua %s\n"
@@ -987,19 +1069,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linio %d: Eraro dum analizo de %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linio %d: Fuŝa elekto %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linio %d: Tro da nomoj: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linio %d: Pako ne ekzistas: %s\n"
@@ -1105,91 +1187,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linio %d: Etikedo devas havi nur unu eron: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "linio %d: Nevalida signo '%c' en: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "linio %d: Nevalida signo en: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "linio %d: Nevalida sinsekvo \"..\" en: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linio %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: linio: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linio %d: Misformita etikedo: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linio %d: Vaka etikedo: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linio %d: Oni ne rajtas fini prefikson kun \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linio %d: Docdir devas komenciĝi per '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "linio %d: Epoko-kampo devas esti sensignuma: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linio %d: Fuŝa %s: kvalifikiloj: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linio %d: Fuŝa aranĝo de BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linio %d: Nur subpakaĵoj noarch estas permesataj: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interna eraro: Fuŝa etikedo %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "linio %d: %s estas malfavorita: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Fuŝa pakaĵo-specifo: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pako jam ekzistas: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linio %d: Nekonata etikedo: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} devas ne vaki\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "ne eblas, ke %%{buildroot} estu \"/\"\n"
@@ -1199,161 +1286,195 @@ msgstr "ne eblas, ke %%{buildroot} estu \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fuŝa fonto: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Neniu flikaĵa numero %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sen responda etikedo \"Patch:\"\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Neniu fonta numero %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Neniu etikedo \"Source:\" en la spec-dosiero\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Eraro dum analizo de %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linio %d: Fuŝa elekto ĉe %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linio %d: Fuŝa elekto ĉe %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Nevalida flikaĵo-numero %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linio %d: dua %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "Dependaĵo-eroj devas komenciĝi per nombro, litero, '_' aŭ '/'"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Dosiernomo kun eldono ne permesata"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Eldono necesas"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "nevalida dependaĵo"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Eldono necesas"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "linio %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linio %d: instigiloj devas enhavi: --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linio %d: Eraro dum analizo de %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "linio %d: ena programeto devas finiĝi per '>': %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linio %d: programeto devas komenciĝi per '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+"lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linio %d: Dua %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linio %d: ne rekonas enan programeton: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr "lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
+msgstr ""
+"lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linio %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ne eblas malfermi: %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s: %d: Parametroj anticipitaj por %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "linio %d: Nefermita %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "linio %d: nefinita makroo aŭ fuŝa linio-daŭrigo\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: fuŝa kondiĉo ĉe %%if\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d %%else sen %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif sen %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: misformita frazo %%include\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Neniuj kongruaj platformoj trovitaj por muntaĵo\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pako ne enhavas: %%description: %s\n"
@@ -1397,7 +1518,9 @@ msgstr "Malsukcesis decidi konduto-nomon: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "tipo '%s' donita kun aliaj tipoj en %s %%semodule. Kompaktiganta tipojn al '%s'.\n"
+msgstr ""
+"tipo '%s' donita kun aliaj tipoj en %s %%semodule. Kompaktiganta tipojn al "
+"'%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1424,290 +1547,281 @@ msgstr "Tro da parametroj en linio: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Traktanta kondutojn: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignoris nevalidan regulesprimon %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ne eblis krei tubon por %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Ne eblis plenumigi: %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ne eblis forki: %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s malsukcesis: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "malsukcesis skribi ĉiujn datumojn al %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konvertado de %s al longa entjero malsukcesis.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Vaka dosiero-klasifikilo\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Neniuj dosieraj atributoj elektitaj\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) malsukcesis: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load malsukcesis: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rekono de dosiero \"%s\" malsukcesis: reĝimo %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Serĉi:  %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Malsukcesis trovi: %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "mendo de spec-dosiero %s malsukcesis, ne eblas analizi\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s estas Pera RPM kaj ne estas rekte instalebla\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Ne komprenata ŝarĝo (%s) en pakaĵo %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "pakaĵo %s jam aldoniĝis, preterlasanta %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "pakaĵo %s jam aldoniĝis, anstataŭigante per %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(ne cifero)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%Y-%d-%b (%a)"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(ne base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(nevalida tipo)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(ne amaso)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(nevalida XML-tipo)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(ne OpenPGP-pretendo)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Nevalida dato %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normala"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "anstataŭita"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "ne instalita"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "rete kunuzita"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "malĝusta koloro"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "manka"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(nekonata)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(ne ĉeno)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s konservita kiel %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s kreita kiel %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: forigo malsukcesis: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "dosierujo"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "dosiero"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1836,15 +1950,17 @@ msgid "relocations must have a / following the ="
 msgstr "/ devas veni post = en relokiĝoj"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "instali ĉiujn dosierojn, eĉ elektoj, kiuj aliokaze eble estus preterlasitaj"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"instali ĉiujn dosierojn, eĉ elektoj, kiuj aliokaze eble estus preterlasitaj"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "forigi ĉiujn pakaĵojn, kiuj kongruas al <pakaĵo> (ordinare eraro estas generita se <pakaĵo> specifis plurajn pakaĵojn)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"forigi ĉiujn pakaĵojn, kiuj kongruas al <pakaĵo> (ordinare eraro estas "
+"generita se <pakaĵo> specifis plurajn pakaĵojn)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1922,7 +2038,7 @@ msgstr "aktualigi la datumbazon, sed ne modifi la dosiersistemon"
 msgid "do not verify package dependencies"
 msgstr "ne konstati pakaĵo-dependaĵojn"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "ne konstati resumojn de dosieroj"
 
@@ -2000,7 +2116,8 @@ msgstr "ne plenumigi la programeto(j)n %%triggerpostrun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "malpromocii al malfreŝa eldono de la pakaĵo (--force aŭtomate faras tion)"
+msgstr ""
+"malpromocii al malfreŝa eldono de la pakaĵo (--force aŭtomate faras tion)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2042,162 +2159,182 @@ msgstr "promocii pakaĵo(j)n"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "mendi/konstati ĉiujn pakaĵojn"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "reĝimo kontroli konstaton de rpm"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "mendi/konstati pakaĵo(j)n havanta(j) dosieron"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "mendi/konstati pakaĵo(j)n en grupo"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "mendi/konstati pakaĵo-dosieron"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "mendi/konstati pakaĵo(j)n per pakaĵo-identigilo"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "mendi/konstati pakaĵo(j)n per kapo-identigilo"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm-mendanta reĝimo"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "mendi/konstati kapo-okazon"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "mendi/konstati pakaĵo(j)n el instalo-interago"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "mendi la pakaĵo(j)n okazigitaj de la pakaĵo"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm-konstata reĝimo"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "mendi/konstati la pakaĵo(j)n, kiujn havigas dependaĵon"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "ne kunfandi parametrojn"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "ne procedi ne pakaĵo-dosierojn kiel manifestojn"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "listigi ĉiujn agordo-dosierojn"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "listigi ĉiujn dokumento-dosierojn"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "ŝuti bazajn informojn pri dosieroj"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "listigi dosierojn en pakaĵo"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "preterlasi %%ghost-dosierojn"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "elmontri la statojn de la listigitaj dosieroj"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "ne konstati la grandon de la dosieroj"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "ne konstati ligilajn padojn de dosieroj"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "ne konstati estrecon de dosiero"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "ne konstati grupon de dosiero"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "ne konstati modifo-tempon de dosieroj"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "ne konstati permesojn de dosieroj"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "ne konstati kapablojn de dosieroj"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "ne konstati sekureco-kuntekstojn"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "ne konstati dosierojn en pakaĵo"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ne konstati pakaĵo-dependaĵojn"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "ne plenumigi konstato-programo(j)n"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Mankantaj trajtoj en rpmlib por %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "fontoteksta pakaĵo atendita, plenumebla trovita\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "fontoteksta pakaĵo enhavas neniun spec-dosieron\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "Elpakado de arkivo malsukcesis%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " ĉe dosiero"
 
@@ -2272,96 +2409,116 @@ msgstr "neniu pakaĵo kongruas kun %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "neniu pakaĵo postulas: %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "neniu pakaĵo postulas: %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "neniuj pakaĵo-instigiloj %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "neniu pakaĵo postulas: %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "neniu pakaĵo postulas: %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "neniu pakaĵo provizas: %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "dosiero %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "neniu pakaĵo estras dosieron %s\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "nevalida pakaĵo-numero: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "ne eblas legi rikordon %u\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakaĵo %s ne estas instalita\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nekonata etikedo: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: malsukcesis importi ŝlosilon %d.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: ŝlosilo %d ne estas ŝirmita publika ŝlosilo.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importa legado malsukcesis (%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead malsukcesis: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Ne eblis legi neŝanĝeblan kapan regionon. Ĉu koruptita pakaĵo?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread malsukcesis: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NEBONA"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "BONA"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr "(MANKAJ ŜLOSILOJ:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr "NEFIDINDAJ ŜLOSILOJ:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: malsukcesis malfermi: %s\n"
@@ -2386,144 +2543,197 @@ msgstr "Ne eblas ŝanĝi radikan dosierujon: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Ne eblas restarigi radikan dosierujon: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NE "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "JES"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Dependaĵoj de PreReq:, Provides:, kaj Obseletes: eblas havi eldonojn."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "dosiernomo(j) konservitaj kiel (dirName, basNem, dirIndex) triopo, ne kiel pado."
+msgstr ""
+"dosiernomo(j) konservitaj kiel (dirName, basNem, dirIndex) triopo, ne kiel "
+"pado."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "pakaĵo-ŝarĝo eblas esti kunpremita per bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "pakaĵo-ŝarĝo eblas esti kunpremita per xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "pakaĵo-ŝarĝo eblas esti kunpremita per lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "pakaĵo-ŝarĝa(j) dosiero(j) havas prefikson \"./\"."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "la nomo, eldono kaj promocio de pakaĵo ne subkomprenita."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "kapaj tagoj ĉiam estas ordigitaj post ŝargiĝi."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "la programeta interpretilo povas uzi parametrojn de la kapo."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "aro da malmolaj ligiloj povas esti instalita sen esti kompleta."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "pakaĵo-programetojn rajtas atingi la rpm-datumbazon dum instali."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "interna komprena de lua-programetoj."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "dosiero-resuma algoritmo estas aparte agordeble por ĉiu pakaĵo"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "rego de kapabloj de dosieroj laŭ POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "pakaĵo-programetoj eblas etendiĝi dum insntalado."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "dependaĵa komparo komprenas eldonojn kun tildo."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "ne konstati pakaĵo-dependaĵojn"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Eldono necesas"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "nevalida dependaĵo"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Nefinita %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "nevalida dependaĵo"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "uzanto %s ne ekzistas - mi uzos la ĉefuzanton\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupo %s ne ekzistas - uzos la ĉefgrupon\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Fuŝa magiaĵo"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Fuŝa kapo"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Kapo-grando tro granda"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Dosiero tro granda por arkivo"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Nekonata dosiertipo"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Malkongrueco ĉe resumo"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Interna eraro"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Arkivo-dosiero ne en kapo"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " malsukcesis - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "malfermo de %s malsukcesis: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: ne rpm-pakaĵo (aŭ pakaĵo-manifesto)\n"
@@ -2555,42 +2765,42 @@ msgstr "Malhavaj dependaĵoj:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: ne rpm-pakaĵo (aŭ pakaĵo-manifesto): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s ne eblas instaliĝi\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Riceviĝas %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "transigo de %s malsukcesis - preterlasanta\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "pakaĵo %s ne estas relokebla\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "eraro dum legi dosieron %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" specifas plurajn pakaĵojn:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "ne eblas malfermiĝi %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instaliĝas %s\n"
@@ -2616,12 +2826,12 @@ msgstr "malsukcesis legi: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "ne rpm-pakaĵo\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "ne eblas krei ŝloson %s ĉe %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "atendis ŝloson %s ĉe %s\n"
@@ -2779,60 +2989,79 @@ msgstr "manka platformo por %s ĉe %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "Fuŝa elekto '%s' ĉe %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Malsukcesis legi helpan vektoron, ĉu /proc ne surmetita?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Nekonata operaciumo: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Bonvolu kontakti %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "%s ne malfermeblas por legiĝi: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Ne eblas restarigi aktualan dosierujon: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "rego por <lua>-programetojn ne estas integraj\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Ne eblis krei provizoran dosieron por %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Ne eblis dupliki dosieran priskribilon %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Ne eblas legi piktogramon %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Ne eblas restarigi radikan dosierujon: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite malsukcesis: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "programeto %s malsukcesis, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "programeto %s malsukcesis, signalo %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "programeto %s malsukcesis, elira stato %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "nekonata formato"
 
@@ -2844,127 +3073,146 @@ msgstr "instali"
 msgid "erase"
 msgstr "forviŝi"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "ne eblas malfermi pakaĵo-datumbazon en %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "aldona '(' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "manka '(' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "manka ')' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: legi la publikan ŝlosilon malsukcesis.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "interago"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(ne OpenPGP-pretendo)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5-resumo:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Ne eblas reŝargi pretendo-kapon.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "SHA1-resuma kapo:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Kapo"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5-resumo:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "SHA1-resuma kapo:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "preterlasita"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "malsukcesa"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "manka   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Malkontentaj dependaĵoj por %s:\n"
@@ -3038,240 +3286,244 @@ msgstr "tabela iteraciilo uzata kun tabeloj kun diversaj grandoj"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generanta %d mankajn indekso(j)n, bonvolu atendi...\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "neniu dbpath estis valorizita\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preterlasanta"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "eraro (%d) konservanta rikordon #%d al en %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec malsukcesis: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp malsukcesis: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preterlasanta"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: difektita kapo #%u akirita -- preterlasanta.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ne eblas legi kapon en 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "neniu dbpath estis valorizita"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "malsukcesis krei dosierujon %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "kapo #%u en datumbazo estas fuŝa -- preterlasanta.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "ne eblas aldoni rikordon devene el %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "malsukcesis remunti datumbazon: neŝanĝita datumbazo restas\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "malsukcesis anstataŭigi la malnovan datumbazon per la nova!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "anstataŭigi dosierojn en %s per dosieroj el %s por reatingi"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "malsukcesis reatingi dosierujon %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "ne eblas atingi ŝloson %s ĉe %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "kunuzata"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "ekskluziva"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "nevalida indeksa tipo %x ĉe %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "eraro(%d) dum ricevi rikordojn \"%s\" el indekso %s: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "eraro(%d) konservi rikordon \"%s\" en %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "eraro(%d) dum forigi rikordon \"%s\" el %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "eraro(%d) aldonanta en kapo rikordon #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "eraro(%d) foriganta el kapo rikordon #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "eraro(%d) dum generi novan okazon de pakaĵo\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "nekonata elekto en db: \"%s\" ignorita.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s haves nevalidan nombran valoron, preterlasita\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s havas tro grandan aŭ mangrandan longentjeran valoron, preterlasita\n"
+msgstr ""
+"%s havas tro grandan aŭ mangrandan longentjeran valoron, preterlasita\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s havas tro grandan aŭ malgrandan mallongentjeran valoron, preterlasita\n"
+msgstr ""
+"%s havas tro grandan aŭ malgrandan mallongentjeran valoron, preterlasita\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "ne eblas atingi ŝloson %s ĉe %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "kunuzata"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "ekskluziva"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "nevalida indeksa tipo %x ĉe %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "eraro(%d) dum ricevi rikordojn \"%s\" el indekso %s: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "eraro(%d) konservi rikordon \"%s\" en %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "eraro(%d) dum forigi rikordon \"%s\" el %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "eraro(%d) aldonanta en kapo rikordon #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "eraro(%d) foriganta el kapo rikordon #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "eraro(%d) dum generi novan okazon de pakaĵo\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vaka)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vaka)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makroo %%%s havas nefinitajn elektojn\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makroo %%%s havas nefinitan korpon\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makroo %%%s havas nevalidan vomon (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makroo %%%s havas vakan korpon\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makroo %%%s malsukcesis etendiĝi\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makroo %%%s havas nevalidan nomon (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nekonata elekto %c en %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Tro da niveloj de rekursioj en makroa etendado. Verŝajne kaŭzate de rekursia makro-deklaro.\n"
+msgstr ""
+"Tro da niveloj de rekursioj en makroa etendado. Verŝajne kaŭzate de rekursia "
+"makro-deklaro.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Nefinita %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% estas sekvata de sensenca makroo\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiva %d vaka %d\n"
@@ -3291,31 +3543,31 @@ msgstr "Dosiero %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Dosiero %s estas malpli ol %u bajtoj\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "malsukcesis krei dosierujon"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nevalida sintakso en lua-programeto: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nevalida sintakso en lua-programeto: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-programeto malsukcesis: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nevalida sintakso en lua-dosiero: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hoko malsukcesis: %s\n"
@@ -3324,19 +3576,19 @@ msgstr "lua hoko malsukcesis: %s\n"
 msgid "[none]"
 msgstr "[neniu]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(neniu eraro)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "haltigenda eraro:"
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "eraro: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "averto: "
 
@@ -3345,99 +3597,154 @@ msgstr "averto: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "memora generado (%u bajtoj) donis nulon.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ŝlosila identigilo %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(neniu)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "eraro dum krei provizoran dosieron %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "eraro dum krei provizoran dosieron %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "eraro dum krei provizoran dosieron %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "malsukcesis krei dosierujon %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Nekomprenita PGP-pretendo\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Nekomprenita krampita algoritmo %u de PGP\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Nekomprenita algoritmo publika-ŝlosila %u de PGP\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Ne eblas krei tubon por pretendi: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Ne eblas plenumigi: %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: malsukcesis malfermi: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg-plenumo malsukcesis (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg malsukcesis skribi pretendon\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "ne eblas legi la pretendon\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature malsukcesis: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignure malsucksis: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: headerRead malsukcesis: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp malsukcesis\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "plenumo malsukcesis\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: headerRead malsukcesis: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s jam enhavas identan pretendon, preterlasanta\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignure malsucksis: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Ne povas pretendi pakaĵojn el RPM-v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s jam enhavas identan pretendon, preterlasanta\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp malsukcesis\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "anstataŭigo de %s malsukcesis: %s\n"
@@ -3450,3 +3757,21 @@ msgstr "%s: legi manifeston malsukcesis: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "ne konstati pretendojn de kapo+ŝarĝo"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Enmeti pasfrazon:"
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Pasfrazo bonas.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "Kontrolado de pasfrazo malsukcesis aŭ GPG-ŝlosilo eksvalidiĝis.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Fuŝa estro/grupo: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "linio %d: Nevalida signo en: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Ne eblas krei tubon por pretendi: %m"

--- a/po/eo.po
+++ b/po/eo.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Keith Bowes <zooplah@gmail.com>, 2011,2013
 # Keith Bowes <zooplah@gmail.com>, 2011
@@ -9,15 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Esperanto (http://www.transifex.com/projects/p/rpm/language/"
-"eo/)\n"
-"Language: eo\n"
+"Language-Team: Esperanto (http://www.transifex.com/rpm-team/rpm/language/eo/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: eo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -39,9 +38,7 @@ msgstr "Kopirajto (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Oni rajtas libere redistribui ĉi tiun programon laŭ la kondiĉoj de la GPL de "
-"GNU\n"
+msgstr "Oni rajtas libere redistribui ĉi tiun programon laŭ la kondiĉoj de la GPL de GNU\n"
 
 #: cliutils.c:53
 #, c-format
@@ -84,7 +81,7 @@ msgstr "Konstatantaj elektoj (kun -V aŭ --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Elektoj por instali/promocii/forigi:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Kutimaj elektoj por ĉiuj rpm-aj reĝimoj kaj programoj:"
@@ -105,7 +102,7 @@ msgstr "neatendita mendo-aranĝo"
 msgid "unexpected query source"
 msgstr "neatendita mendo-fonto"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "nur unu ĉefa reĝimo povas esti specifita"
 
@@ -124,8 +121,7 @@ msgstr "--prefix malkongruas kun --relocate kaj - -excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate kaj --excludepath povas esti uzata nur dum instali novajn pakaĵojn"
+msgstr "--relocate kaj --excludepath povas esti uzata nur dum instali novajn pakaĵojn"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -141,7 +137,8 @@ msgid ""
 msgstr "--hash (-h) nur eblas dum pakaĵa instalado aŭ forigado"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr "--percent nur eblas dum pakaĵa instalado aŭ forigado"
 
 #: rpmqv.c:179
@@ -182,41 +179,31 @@ msgstr "oni povas specifi la parametron --allfiles nur dum pakaĵo-instalado"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"oni povas specifi la parametron --justdb nur dum instalado kaj forviŝado de "
-"pakaĵo"
+msgstr "oni povas specifi la parametron --justdb nur dum instalado kaj forviŝado de pakaĵo"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"oni povas uzi parametrojn por malaktivigi programetojn nur dum instalado kaj "
-"forviŝado de pakaĵo"
+msgstr "oni povas uzi parametrojn por malaktivigi programetojn nur dum instalado kaj forviŝado de pakaĵo"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"oni povas uzi parametrojn por malaktivigi instigilojn nur dum instalado kaj "
-"forviŝado de pakaĵo"
+msgstr "oni povas uzi parametrojn por malaktivigi instigilojn nur dum instalado kaj forviŝado de pakaĵo"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"oni povas specifi la parametron --nodeps nur dum instalado, konstatado kaj "
-"forviŝado de pakaĵo"
+msgstr "oni povas specifi la parametron --nodeps nur dum instalado, konstatado kaj forviŝado de pakaĵo"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"oni povas specifi la parametron --hash (-h) nur dum instalado kaj forviŝado "
-"de pakaĵo"
+msgstr "oni povas specifi la parametron --hash (-h) nur dum instalado kaj forviŝado de pakaĵo"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumentoj de --root (-r) devas komenciĝi per /"
 
@@ -236,250 +223,201 @@ msgstr "neniuj parametroj donitaj por mendi"
 msgid "no arguments given for verify"
 msgstr "neniuj argumentoj donitaj por konstati"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot jam specifita, %s ignorata\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "munti per %prep (elpaki fontotekstojn kaj fliki) laŭ <spec-dosiero>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<spec-dosiero>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "munti per %build (%prep, tiam traduki) laŭ <spec-dosiero>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "munti per %install (%prep, %build, tiam instali) laŭ <spec-dosiero>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "konstati la sekcion %file laŭ <spec-dosiero>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "munti fontotekstan kaj plenumeblan pakaĵojn laŭ <spec-dosiero>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "munti nur plenumeblan pakaĵon laŭ <spec-dosiero>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <spec-dosiero>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "munti per %prep (elpaki fontotekstojn kaj fliki) laŭ <spec-dosiero>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<fontoteksta pakaĵo>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "munti per %build (%prep, tiam traduki) laŭ <spec-dosiero>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"munti per %install (%prep, %build, tiam instali) laŭ <fontoteksta pakaĵo>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "konstati la sekcion %file laŭ <spec-dosiero>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "munti plenumeblan pakaĵon laŭ <fontoteksta pakaĵo>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "munti plenumeblan pakaĵon laŭ <fontoteksta pakaĵo>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "munti nur fontotekstan pakaĵon laŭ <spec-dosiero>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr "munti per %prep (elpaki fontotekstojn kaj fliki) laŭ <tar-dosiero>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tar-dosiero>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "munti per %build (%prep, tiam traduki) laŭ <tar-dosiero>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "munti per %install (%prep, %build, tiam instali) laŭ <tar-dosiero>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "konstati sekcion %files laŭ <tar-dosiero>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "munti fontotekstan kaj plenumeblan pakaĵojn laŭ <tar-dosiero>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "munti nur plenumeblan pakaĵon laŭ <tar-dosiero>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <tar-dosiero>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "munti plenumeblan pakaĵon laŭ <fontoteksta pakaĵo>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<fontoteksta pakaĵo>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "munti per %install (%prep, %build, tiam instali) laŭ <fontoteksta pakaĵo>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "superregi muntan radikon"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Ne eblas malfermi aktualan dosierujon: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "forigi muntan arbon post finita"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignori la direktivojn ExcludeArch: el spec-dosiero"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "senerarigi dosierstatan maŝinon"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "ne plenumigi iun ajn etapon de la muntado"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "ne konstati muntaĵo-dependaĵojn"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "generi pakaĵo-kapo(j)n kongrua(j)n kun (malmoderna) pakado de rpm 3"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "ne plenumigi la etapon %clean por la muntado"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "ne plenumigi la etapon %clean por la muntado"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "ne plenumigi la etapon %check por la muntado"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "ne akcepti tradukojn el spec-dosiero"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "forigi fontotekstojn post kiam finita"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "forigi spec-dosieron post kiam finita"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preterlasi rekte al specifita etapo (nur por c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "superregi celan platformon"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Multaj elektoj je [ <spec-dosiero> |  <tar-dosiero> | <fontoteksta pakaĵo> ]:"
+msgstr "Multaj elektoj je [ <spec-dosiero> |  <tar-dosiero> | <fontoteksta pakaĵo> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Malsukcesintaj muntaj dependaĵoj:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Ne eblas malfermi spec-dosieron %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Malsukcesis malfermi tar-tubon: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Pli ol unu dosiero en linio: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Malsukcesis legi spec-dosieron je %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Malsukcesis alinomi %s al %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "malsukcesis stat-i: %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Dosiero %s ne estas regula dosiero.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Dosiero %s ne aspektas kiel spec-dosiero.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Platformoj por kiu munti: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Muntanta por celon %s\n"
@@ -490,8 +428,7 @@ msgstr "iniciati datumbazon"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"remunti listojn inversigitajn de la datumbazo el instalitaj pakaĵo-kapoj"
+msgstr "remunti listojn inversigitajn de la datumbazo el instalitaj pakaĵo-kapoj"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -529,7 +466,7 @@ msgstr "listigi ŝlosilojn el RPM-ŝlosilaro"
 msgid "Keyring options:"
 msgstr "Ŝlosilaro-elektoj:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "neniuj parametroj donitaj"
 
@@ -549,10 +486,29 @@ msgstr "forigi pakaĵo-pretendojn"
 msgid "Signature options:"
 msgstr "Pretendo-elektojn:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Ne eblas plenumigi: %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Vi devas valorizi \"%%_gpg_name\" en via makro-dosiero\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Enmeti pasfrazon:"
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Pasfrazo bonas.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Kontrolado de pasfrazo malsukcesis aŭ GPG-ŝlosilo eksvalidiĝis.\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -570,7 +526,7 @@ msgstr "operacii je dekumaj rpm-oj generitaj de spec (apriora)"
 msgid "operate on source rpm generated by spec"
 msgstr "operacii je fontotekstaj rpm-oj generitaj de spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "uzu la jenan mendo-formaton"
 
@@ -617,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Muntaj eraroj ĉe RPM:\n"
+msgstr "\n\nMuntaj eraroj ĉe RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "sintaksa eraro dum analizi ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "sintaksa eraro dum analizi &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "Sintaksa eraro dum analizi ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "analiza eraro ĉe esprimo\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "( sen )\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- nur por nobroj\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! nur por nombroj\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "tipoj devas esti kongruaj\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / ne por ĉenoj\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- no por ĉenoj\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& kaj || ne por ĉenoj\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "sintaksa eraro en esprimo\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Manka '(' en %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Manka ')' en %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Nevalida ero %s: %s\n"
@@ -691,46 +644,46 @@ msgstr "Nevalida ero %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Manka %s en %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Blankospacoj ne povas sekvi: %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Fuŝa sintakso: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Fuŝa reĝimo-specifo: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Fuŝa dosierujo-specifo: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Neordinara longo de lokaĵaro: \"%s\" en %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Duplika lokaĵaro %s en %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Nevalida kapablo: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Dosiero-kapabla rego ne integra\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Dosiero devas komenciĝi per \"/\": %s\n"
@@ -740,148 +693,149 @@ msgstr "Dosiero devas komenciĝi per \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Nekonata algoritmo %u por dosieraj resumoj, uzanta je MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Dosiero listigita dufoje: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "legado de mola ligilo %s malsukcesis: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Mola ligilo almontras al BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Dosierujo ne trovita: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Dosiero ne trovita: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: ne eblas ŝargi nekonatan etikedon (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: legi publikan ŝlosilon malsukcesis.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ne ŝirmita publika ŝlosilo.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: malsukcesis kodiĝi\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Dosiero devas havi antaŭan \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Amaso %%dev ne permesata:%s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Dosierujo ne trovita laŭ amaso: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Dosiero ne trovita laŭ amaso: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Ne eblis malfermi %%files file %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "linio: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "eraro dum legi dosieron %%files %s: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "nepermesita _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Ne eblas kunmiksi specialan %s-on kun aliaj formoj: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Pli ol unu dosiero en linio: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Fuŝa dosiero: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Fuŝa estro/grupo: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontrolanta ne pakita(j)n dosiero(j)n: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Insalita(j) (sed ne pakita(j) dosiero(j) trovita(j):\n"
-"%s"
+msgstr "Insalita(j) (sed ne pakita(j) dosiero(j) trovita(j):\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Procedanta dosierojn: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"Platformo (%d) de la plenumebla dosiero ne kongruas la pakaĵan platformon "
-"(%d).\n"
+msgstr "Platformo (%d) de la plenumebla dosiero ne kongruas la pakaĵan platformon (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Platformo-dependaj dosieroj en platformo-sendependa pakaĵo\n"
 
@@ -910,79 +864,79 @@ msgstr "%s: linio: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Ne eblis kanonigi gastiganto-nomon: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Ne eblas reŝargi pretendo-kapon.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nekonata kunpremo-tipo de ŝarĝo: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Ne eblas krei regionon por neŝanĝebla kapo.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ne eblas malfermi: %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Ne eblas skribi pakaĵon: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Ne eblas skribi provizoran kapon\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Fuŝa CSA-datumo\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Ne eblis malfermi dosieron %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "kreado de arkivo malsukcesis ĉe dosiero %s: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skribis: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Plenumiĝanta \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Plenumigo de \"%s\" malsukcesis.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Pako-controlo \"%s\" malsukcesis.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne eblas generi eligan dosiernomon por pakaĵo %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ne eblas krei %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "line %d: dua %s\n"
@@ -1033,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linio %d: Eraro dum analizo de %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linio %d: Fuŝa elekto %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linio %d: Tro da nomoj: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linio %d: Pako ne ekzistas: %s\n"
@@ -1151,96 +1105,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linio %d: Etikedo devas havi nur unu eron: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "linio %d: Nevalida signo '%c' en: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "linio %d: Nevalida sinsekvo \"..\" en: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "linio %d: Nevalida signo en: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linio %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "linio %d: Nevalida sinsekvo \"..\" en: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: linio: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linio %d: Misformita etikedo: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linio %d: Vaka etikedo: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linio %d: Oni ne rajtas fini prefikson kun \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linio %d: Docdir devas komenciĝi per '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "linio %d: Epoko-kampo devas esti sensignuma: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linio %d: Fuŝa %s: kvalifikiloj: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linio %d: Fuŝa aranĝo de BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linio %d: Nur subpakaĵoj noarch estas permesataj: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interna eraro: Fuŝa etikedo %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "linio %d: %s estas malfavorita: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Fuŝa pakaĵo-specifo: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pako jam ekzistas: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linio %d: Nekonata etikedo: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} devas ne vaki\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "ne eblas, ke %%{buildroot} estu \"/\"\n"
@@ -1250,195 +1199,161 @@ msgstr "ne eblas, ke %%{buildroot} estu \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fuŝa fonto: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Neniu flikaĵa numero %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sen responda etikedo \"Patch:\"\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Neniu fonta numero %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Neniu etikedo \"Source:\" en la spec-dosiero\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Eraro dum analizo de %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linio %d: Fuŝa elekto ĉe %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linio %d: Fuŝa elekto ĉe %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Nevalida flikaĵo-numero %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linio %d: dua %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "Dependaĵo-eroj devas komenciĝi per nombro, litero, '_' aŭ '/'"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Dosiernomo kun eldono ne permesata"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "nevalida dependaĵo"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Eldono necesas"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "nevalida dependaĵo"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "linio %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linio %d: instigiloj devas enhavi: --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linio %d: Eraro dum analizo de %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "linio %d: ena programeto devas finiĝi per '>': %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linio %d: programeto devas komenciĝi per '/': %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-"lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linio %d: Dua %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linio %d: ne rekonas enan programeton: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr ""
-"lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
+msgstr "lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linio %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ne eblas malfermi: %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s: %d: Parametroj anticipitaj por %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "linio %d: Nefermita %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "linio %d: nefinita makroo aŭ fuŝa linio-daŭrigo\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: fuŝa kondiĉo ĉe %%if\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d %%else sen %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif sen %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: misformita frazo %%include\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Neniuj kongruaj platformoj trovitaj por muntaĵo\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pako ne enhavas: %%description: %s\n"
@@ -1482,9 +1397,7 @@ msgstr "Malsukcesis decidi konduto-nomon: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"tipo '%s' donita kun aliaj tipoj en %s %%semodule. Kompaktiganta tipojn al "
-"'%s'.\n"
+msgstr "tipo '%s' donita kun aliaj tipoj en %s %%semodule. Kompaktiganta tipojn al '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1511,281 +1424,290 @@ msgstr "Tro da parametroj en linio: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Traktanta kondutojn: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignoris nevalidan regulesprimon %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ne eblis krei tubon por %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Ne eblis plenumigi: %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ne eblis forki: %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s malsukcesis: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "malsukcesis skribi ĉiujn datumojn al %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konvertado de %s al longa entjero malsukcesis.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Vaka dosiero-klasifikilo\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Neniuj dosieraj atributoj elektitaj\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) malsukcesis: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load malsukcesis: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rekono de dosiero \"%s\" malsukcesis: reĝimo %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Serĉi:  %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Malsukcesis trovi: %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "mendo de spec-dosiero %s malsukcesis, ne eblas analizi\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s estas Pera RPM kaj ne estas rekte instalebla\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Ne komprenata ŝarĝo (%s) en pakaĵo %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "pakaĵo %s jam aldoniĝis, preterlasanta %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "pakaĵo %s jam aldoniĝis, anstataŭigante per %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(ne cifero)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%Y-%d-%b (%a)"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(ne base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(nevalida tipo)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(ne amaso)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(nevalida XML-tipo)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(ne OpenPGP-pretendo)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Nevalida dato %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normala"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "anstataŭita"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "ne instalita"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "rete kunuzita"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "malĝusta koloro"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "manka"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(nekonata)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(ne ĉeno)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s konservita kiel %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s kreita kiel %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: forigo malsukcesis: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "dosierujo"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "dosiero"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1914,17 +1836,15 @@ msgid "relocations must have a / following the ="
 msgstr "/ devas veni post = en relokiĝoj"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"instali ĉiujn dosierojn, eĉ elektoj, kiuj aliokaze eble estus preterlasitaj"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "instali ĉiujn dosierojn, eĉ elektoj, kiuj aliokaze eble estus preterlasitaj"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"forigi ĉiujn pakaĵojn, kiuj kongruas al <pakaĵo> (ordinare eraro estas "
-"generita se <pakaĵo> specifis plurajn pakaĵojn)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "forigi ĉiujn pakaĵojn, kiuj kongruas al <pakaĵo> (ordinare eraro estas generita se <pakaĵo> specifis plurajn pakaĵojn)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2002,7 +1922,7 @@ msgstr "aktualigi la datumbazon, sed ne modifi la dosiersistemon"
 msgid "do not verify package dependencies"
 msgstr "ne konstati pakaĵo-dependaĵojn"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "ne konstati resumojn de dosieroj"
 
@@ -2080,8 +2000,7 @@ msgstr "ne plenumigi la programeto(j)n %%triggerpostrun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"malpromocii al malfreŝa eldono de la pakaĵo (--force aŭtomate faras tion)"
+msgstr "malpromocii al malfreŝa eldono de la pakaĵo (--force aŭtomate faras tion)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2123,182 +2042,162 @@ msgstr "promocii pakaĵo(j)n"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "mendi/konstati ĉiujn pakaĵojn"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "reĝimo kontroli konstaton de rpm"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "mendi/konstati pakaĵo(j)n havanta(j) dosieron"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "mendi/konstati pakaĵo(j)n en grupo"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "mendi/konstati pakaĵo-dosieron"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "mendi/konstati pakaĵo(j)n per pakaĵo-identigilo"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "mendi/konstati pakaĵo(j)n per kapo-identigilo"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm-mendanta reĝimo"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "mendi/konstati kapo-okazon"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "mendi/konstati pakaĵo(j)n el instalo-interago"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "mendi la pakaĵo(j)n okazigitaj de la pakaĵo"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm-konstata reĝimo"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "mendi/konstati la pakaĵo(j)n, kiujn havigas dependaĵon"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "mendi/konstati la pakaĵo(j)n, kiuj postulas dependaĵon"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "ne kunfandi parametrojn"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "ne procedi ne pakaĵo-dosierojn kiel manifestojn"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "listigi ĉiujn agordo-dosierojn"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "listigi ĉiujn dokumento-dosierojn"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "ŝuti bazajn informojn pri dosieroj"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "listigi dosierojn en pakaĵo"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "preterlasi %%ghost-dosierojn"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "elmontri la statojn de la listigitaj dosieroj"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "ne konstati la grandon de la dosieroj"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "ne konstati ligilajn padojn de dosieroj"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "ne konstati estrecon de dosiero"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "ne konstati grupon de dosiero"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "ne konstati modifo-tempon de dosieroj"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "ne konstati permesojn de dosieroj"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "ne konstati kapablojn de dosieroj"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "ne konstati sekureco-kuntekstojn"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "ne konstati dosierojn en pakaĵo"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ne konstati pakaĵo-dependaĵojn"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "ne plenumigi konstato-programo(j)n"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Mankantaj trajtoj en rpmlib por %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "fontoteksta pakaĵo atendita, plenumebla trovita\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "fontoteksta pakaĵo enhavas neniun spec-dosieron\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "Elpakado de arkivo malsukcesis%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " ĉe dosiero"
 
@@ -2373,116 +2272,96 @@ msgstr "neniu pakaĵo kongruas kun %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "neniu pakaĵo postulas: %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "neniu pakaĵo postulas: %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "neniuj pakaĵo-instigiloj %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "neniu pakaĵo postulas: %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "neniu pakaĵo postulas: %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "neniu pakaĵo provizas: %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "dosiero %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "neniu pakaĵo estras dosieron %s\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "nevalida pakaĵo-numero: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "ne eblas legi rikordon %u\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakaĵo %s ne estas instalita\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nekonata etikedo: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: malsukcesis importi ŝlosilon %d.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: ŝlosilo %d ne estas ŝirmita publika ŝlosilo.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importa legado malsukcesis (%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead malsukcesis: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Ne eblis legi neŝanĝeblan kapan regionon. Ĉu koruptita pakaĵo?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread malsukcesis: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NEBONA"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "BONA"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr "(MANKAJ ŜLOSILOJ:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr "NEFIDINDAJ ŜLOSILOJ:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: malsukcesis malfermi: %s\n"
@@ -2507,197 +2386,144 @@ msgstr "Ne eblas ŝanĝi radikan dosierujon: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Ne eblas restarigi radikan dosierujon: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NE "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "JES"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Dependaĵoj de PreReq:, Provides:, kaj Obseletes: eblas havi eldonojn."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"dosiernomo(j) konservitaj kiel (dirName, basNem, dirIndex) triopo, ne kiel "
-"pado."
+msgstr "dosiernomo(j) konservitaj kiel (dirName, basNem, dirIndex) triopo, ne kiel pado."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "pakaĵo-ŝarĝo eblas esti kunpremita per bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "pakaĵo-ŝarĝo eblas esti kunpremita per xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "pakaĵo-ŝarĝo eblas esti kunpremita per lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "pakaĵo-ŝarĝa(j) dosiero(j) havas prefikson \"./\"."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "la nomo, eldono kaj promocio de pakaĵo ne subkomprenita."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "kapaj tagoj ĉiam estas ordigitaj post ŝargiĝi."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "la programeta interpretilo povas uzi parametrojn de la kapo."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "aro da malmolaj ligiloj povas esti instalita sen esti kompleta."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "pakaĵo-programetojn rajtas atingi la rpm-datumbazon dum instali."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "interna komprena de lua-programetoj."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "dosiero-resuma algoritmo estas aparte agordeble por ĉiu pakaĵo"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "rego de kapabloj de dosieroj laŭ POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "pakaĵo-programetoj eblas etendiĝi dum insntalado."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "dependaĵa komparo komprenas eldonojn kun tildo."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "ne konstati pakaĵo-dependaĵojn"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Eldono necesas"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "nevalida dependaĵo"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Nefinita %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "nevalida dependaĵo"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "uzanto %s ne ekzistas - mi uzos la ĉefuzanton\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupo %s ne ekzistas - uzos la ĉefgrupon\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Fuŝa magiaĵo"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Fuŝa kapo"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Kapo-grando tro granda"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Dosiero tro granda por arkivo"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Nekonata dosiertipo"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Malkongrueco ĉe resumo"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Interna eraro"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Arkivo-dosiero ne en kapo"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " malsukcesis - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "malfermo de %s malsukcesis: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: ne rpm-pakaĵo (aŭ pakaĵo-manifesto)\n"
@@ -2729,42 +2555,42 @@ msgstr "Malhavaj dependaĵoj:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: ne rpm-pakaĵo (aŭ pakaĵo-manifesto): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s ne eblas instaliĝi\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Riceviĝas %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "transigo de %s malsukcesis - preterlasanta\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "pakaĵo %s ne estas relokebla\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "eraro dum legi dosieron %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" specifas plurajn pakaĵojn:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "ne eblas malfermiĝi %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instaliĝas %s\n"
@@ -2790,12 +2616,12 @@ msgstr "malsukcesis legi: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "ne rpm-pakaĵo\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "ne eblas krei ŝloson %s ĉe %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "atendis ŝloson %s ĉe %s\n"
@@ -2811,9 +2637,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Solvi simbolon %s malsukcesis: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Kromprogramo %s ne ŝargita\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2957,75 +2783,56 @@ msgstr "Fuŝa elekto '%s' ĉe %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Malsukcesis legi helpan vektoron, ĉu /proc ne surmetita?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Nekonata operaciumo: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Bonvolu kontakti %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "%s ne malfermeblas por legiĝi: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Ne eblas restarigi aktualan dosierujon: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "rego por <lua>-programetojn ne estas integraj\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Ne eblis krei provizoran dosieron por %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Ne eblis dupliki dosieran priskribilon %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Ne eblas legi piktogramon %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Ne eblas restarigi radikan dosierujon: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite malsukcesis: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "programeto %s malsukcesis, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "programeto %s malsukcesis, signalo %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "programeto %s malsukcesis, elira stato %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "nekonata formato"
 
@@ -3037,142 +2844,127 @@ msgstr "instali"
 msgid "erase"
 msgstr "forviŝi"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "ne eblas malfermi pakaĵo-datumbazon en %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "aldona '(' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "manka '(' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "manka ')' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: legi la publikan ŝlosilon malsukcesis.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "interago"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(ne OpenPGP-pretendo)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Kapo"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5-resumo:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "SHA1-resuma kapo:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Kapo"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "preterlasita"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "malsukcesa"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "manka   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Malkontentaj dependaĵoj por %s:\n"
@@ -3246,244 +3038,240 @@ msgstr "tabela iteraciilo uzata kun tabeloj kun diversaj grandoj"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generanta %d mankajn indekso(j)n, bonvolu atendi...\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "neniu dbpath estis valorizita\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preterlasanta"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "eraro (%d) konservanta rikordon #%d al en %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec malsukcesis: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp malsukcesis: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preterlasanta"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: difektita kapo #%u akirita -- preterlasanta.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ne eblas legi kapon en 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "neniu dbpath estis valorizita"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "malsukcesis krei dosierujon %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "kapo #%u en datumbazo estas fuŝa -- preterlasanta.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "ne eblas aldoni rikordon devene el %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "malsukcesis remunti datumbazon: neŝanĝita datumbazo restas\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "malsukcesis anstataŭigi la malnovan datumbazon per la nova!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "anstataŭigi dosierojn en %s per dosieroj el %s por reatingi"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "malsukcesis reatingi dosierujon %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "nekonata elekto en db: \"%s\" ignorita.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s haves nevalidan nombran valoron, preterlasita\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-"%s havas tro grandan aŭ mangrandan longentjeran valoron, preterlasita\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-"%s havas tro grandan aŭ malgrandan mallongentjeran valoron, preterlasita\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "ne eblas atingi ŝloson %s ĉe %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "kunuzata"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "ekskluziva"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "nevalida indeksa tipo %x ĉe %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "eraro(%d) dum ricevi rikordojn \"%s\" el indekso %s: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "eraro(%d) konservi rikordon \"%s\" en %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "eraro(%d) dum forigi rikordon \"%s\" el %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "eraro(%d) aldonanta en kapo rikordon #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "eraro(%d) foriganta el kapo rikordon #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "eraro(%d) dum generi novan okazon de pakaĵo\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "nekonata elekto en db: \"%s\" ignorita.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s haves nevalidan nombran valoron, preterlasita\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s havas tro grandan aŭ mangrandan longentjeran valoron, preterlasita\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s havas tro grandan aŭ malgrandan mallongentjeran valoron, preterlasita\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vaka)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vaka)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makroo %%%s havas nefinitajn elektojn\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makroo %%%s havas nefinitan korpon\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makroo %%%s havas nevalidan vomon (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makroo %%%s havas vakan korpon\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makroo %%%s malsukcesis etendiĝi\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makroo %%%s havas nevalidan nomon (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nekonata elekto %c en %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Tro da niveloj de rekursioj en makroa etendado. Verŝajne kaŭzate de rekursia "
-"makro-deklaro.\n"
+msgstr "Tro da niveloj de rekursioj en makroa etendado. Verŝajne kaŭzate de rekursia makro-deklaro.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Nefinita %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% estas sekvata de sensenca makroo\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiva %d vaka %d\n"
@@ -3503,31 +3291,31 @@ msgstr "Dosiero %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Dosiero %s estas malpli ol %u bajtoj\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "malsukcesis krei dosierujon"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nevalida sintakso en lua-programeto: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nevalida sintakso en lua-programeto: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-programeto malsukcesis: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nevalida sintakso en lua-dosiero: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hoko malsukcesis: %s\n"
@@ -3536,19 +3324,19 @@ msgstr "lua hoko malsukcesis: %s\n"
 msgid "[none]"
 msgstr "[neniu]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(neniu eraro)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "haltigenda eraro:"
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "eraro: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "averto: "
 
@@ -3557,121 +3345,99 @@ msgstr "averto: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "memora generado (%u bajtoj) donis nulon.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ŝlosila identigilo %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(neniu)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "eraro dum krei provizoran dosieron %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "eraro dum krei provizoran dosieron %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "eraro dum krei provizoran dosieron %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "malsukcesis krei dosierujon %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Nekomprenita PGP-pretendo\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Nekomprenita krampita algoritmo %u de PGP\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Nekomprenita algoritmo publika-ŝlosila %u de PGP\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Ne eblas plenumigi: %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Ne eblas krei tubon por pretendi: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: malsukcesis malfermi: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Ne eblis malfermi dosieron %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Ne eblis malfermi %%files file %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg-plenumo malsukcesis (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg malsukcesis skribi pretendon\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "ne eblas legi la pretendon\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignure malsucksis: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Ne povas pretendi pakaĵojn el RPM-v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s jam enhavas identan pretendon, preterlasanta\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp malsukcesis\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "anstataŭigo de %s malsukcesis: %s\n"
@@ -3684,101 +3450,3 @@ msgstr "%s: legi manifeston malsukcesis: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "ne konstati pretendojn de kapo+ŝarĝo"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Enmeti pasfrazon:"
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Pasfrazo bonas.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "Kontrolado de pasfrazo malsukcesis aŭ GPG-ŝlosilo eksvalidiĝis.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Fuŝa estro/grupo: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "linio %d: Nevalida signo en: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Ne eblas krei tubon por pretendi: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Ne eblas skribi ŝarĝon al %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Ne eblas legi ŝarĝon el %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Ne eblas malfermi provizoran dosieron.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Ne eblas malfermi celon %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Ne eblas legi kapon el %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Ne eblas skribi kapon al %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "ne plenumi ian ajn kolekto-agon"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "Neŝanĝebla kapa regiono ne eblas legiĝi. Ĉu koruptita pakaĵo?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Malsukcesis malkodi konduton por %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Malsukcesis krei provizoran dosieron por %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Malsukcesis skribi konduton %s al dosiero %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Malsukcesis krei anson por semanage\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Malsukcesis konektiĝi al konduta traktilo\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Malsukcesis komenci kondutan interagon: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Malsukcesis forigi provizoran kondutan dosieron %s: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Malsukcesis instali kondutan modulon: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Malsukcesis forigi konduto-modulon: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Malsukcesis disforkigi procezon: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Malsukcesis plenumigi: %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s haltis malnormale\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s malsukcesis kun elira kodo %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Malsukcesis cizeli kondutajn ŝanĝojn\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Malsukcesis etendi padon restorecon"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr "Malsukcesis alinomi dosiersistemon. Dosieroj ele estas misnomataj\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Malsukcesis reŝargi dosierajn kuntekstojn. Dosieroj eble estas "
-#~ "misnomataj\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Malsukcesis eltiri konduton el %s\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,10 +1,11 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
-# Adolfo Jayme Barrientos <fitoschido@ubuntu.com>, 2011
-# Adolfo Jayme Barrientos <fitoschido@ubuntu.com>, 2014
+# Adolfo Jayme Barrientos, 2011
+# Adolfo Jayme Barrientos <fitoschido@ubuntu.com>, 2011,2014
+# beckerde <domingobecker@gmail.com>, 2012
 # Claudio Rodrigo Pereyra Diaz <elsupergomez@gmail.com>, 2012
 # Daniel Cabrera <logan@fedoraproject.org>, 2011
 # beckerde <domingobecker@gmail.com>, 2012
@@ -13,15 +14,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/projects/p/rpm/language/"
-"es/)\n"
-"Language: es\n"
+"Language-Team: Spanish (http://www.transifex.com/rpm-team/rpm/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -43,9 +43,7 @@ msgstr "Copyright © 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Este programa puede redistribuirse libremente bajo los términos de la "
-"licencia GNU GPL\n"
+msgstr "Este programa puede redistribuirse libremente bajo los términos de la licencia GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -88,7 +86,7 @@ msgstr "Opciones de verificación (con -V o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opciones de Instalación/Actualización/Remoción:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opciones comunes para todos los modos rpm y ejecutables:"
@@ -109,7 +107,7 @@ msgstr "formato de consulta inesperado"
 msgid "unexpected query source"
 msgstr "fuente de consulta inesperado"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "solo puede especificarse un modo principal"
 
@@ -119,8 +117,7 @@ msgstr "solo puede forzarse la instalación y la actualización"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr ""
-"los archivos solo pueden ser reubicados durante la instalación del paquete"
+msgstr "los archivos solo pueden ser reubicados durante la instalación del paquete"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -129,9 +126,7 @@ msgstr "no se puede utilizar --prefix con --relocate o --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate y --excludepath solo pueden ser utilizados cuando se instalan "
-"nuevos paquetes"
+msgstr "--relocate y --excludepath solo pueden ser utilizados cuando se instalan nuevos paquetes"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -144,30 +139,24 @@ msgstr "los argumentos de --prefix deber iniciar con una /"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr ""
-"--hash (-h) sólo puede ser indicado durante la instalación o la eliminación "
-"de un paquete"
+msgstr "--hash (-h) sólo puede ser indicado durante la instalación o la eliminación de un paquete"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
-msgstr ""
-"--percent sólo puede ser indicado durante la instalación o la eliminación de "
-"un paquete"
+msgid ""
+"--percent may only be specified during package installation and erasure"
+msgstr "--percent sólo puede ser indicado durante la instalación o la eliminación de un paquete"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr ""
-"--replacepkgs solo puede ser especificado durante la instalación del paquete"
+msgstr "--replacepkgs solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr ""
-"--excludedocs solo puede ser especificado durante la instalación del paquete"
+msgstr "--excludedocs solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr ""
-"--includedocs solo puede ser especificado durante la instalación del paquete"
+msgstr "--includedocs solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -175,66 +164,51 @@ msgstr "solo se puede especificar una opción: --excludedocs o --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr ""
-"--ignorearch solo puede ser especificado durante la instalación del paquete"
+msgstr "--ignorearch solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr ""
-"--ignoreos solo puede ser especificado durante la instalación del paquete"
+msgstr "--ignoreos solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr ""
-"--ignoresize solo puede ser especificado durante la instalación del paquete"
+msgstr "--ignoresize solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr ""
-"--allmatches solo puede ser especificado durante la eliminación del paquete"
+msgstr "--allmatches solo puede ser especificado durante la eliminación del paquete"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr ""
-"--allfiles solo puede ser especificado durante la instalación del paquete"
+msgstr "--allfiles solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb solo puede ser especificado durante la instalación y eliminación "
-"del paquete"
+msgstr "--justdb solo puede ser especificado durante la instalación y eliminación del paquete"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"las opciones para desactivar scripts sólo pueden ser especificadas durante "
-"la instalación y eliminación del paquete"
+msgstr "las opciones para desactivar scripts sólo pueden ser especificadas durante la instalación y eliminación del paquete"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"las opciones de desactivación de detonante sólo pueden ser especificadas "
-"durante la instalación y eliminación del paquete"
+msgstr "las opciones de desactivación de detonante sólo pueden ser especificadas durante la instalación y eliminación del paquete"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"solo puede especificarse --nodeps durante la instalación, eliminación o "
-"verificación del paquete"
+msgstr "solo puede especificarse --nodeps durante la instalación, eliminación o verificación del paquete"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"solo puede especificarse --test durante la instalación o la eliminación de "
-"un paquete"
+msgstr "solo puede especificarse --test durante la instalación o la eliminación de un paquete"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "los argumentos de --root (-r) deben iniciar con una /"
 
@@ -254,264 +228,201 @@ msgstr "no ha sido indicado ningún argumento para la consulta"
 msgid "no arguments given for verify"
 msgstr "no ha sido indicado ningún argumento para la verificación"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot ya especificado, ignorando %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"construir a través de %prep (desempaquetar fuentes y aplicar parches) desde "
-"<specfile>"
+msgstr "construir a través de %prep (desempaquetar fuentes y aplicar parches) desde <specfile>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "construir a través de %build (%prep, luego compilar) desde <specfile>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"construir a través de %install (%prep, %build, luego instalar) desde "
-"<specfile>"
+msgstr "construir a través de %install (%prep, %build, luego instalar) desde <specfile>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificar la sección %files de <specfile>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "construir paquetes binarios y fuente desde <specfile>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "construir paquetes binarios únicamente desde <specfile>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "construir paquete fuente únicamente desde <specfile>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"construir a través de %prep (desempaquetar fuentes y aplicar parches) desde "
-"<specfile>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<paquete fuente>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "construir a través de %build (%prep, luego compilar) desde <specfile>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"construir a través de %install (%prep, %build, luego instalar) desde "
-"<paquete fuente>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verificar la sección %files de <specfile>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "construir paquete binario desde <source package>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "construir paquete binario desde <source package>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "construir paquete fuente únicamente desde <specfile>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"construir a través de %prep (desempaquetar fuentes y aplicar parches) desde "
-"<tarball>"
+msgstr "construir a través de %prep (desempaquetar fuentes y aplicar parches) desde <tarball>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "construir a través de %build (%prep, luego compilar) desde <tarball>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"construir a través de %install (%prep, %build, luego instalar) desde "
-"<tarball>"
+msgstr "construir a través de %install (%prep, %build, luego instalar) desde <tarball>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificar sección %files desde <tarball>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "construir paquetes binarios y fuente desde <tarball>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "construir paquete binario únicamente desde <tarball>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "construir paquete fuente desde <tarball> "
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "construir paquete binario desde <source package>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<paquete fuente>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "construir a través de %install (%prep, %build, luego instalar) desde <paquete fuente>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "sobreescribir construcción de root"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "No es posible abrir directorio actual: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "remover árbol de construcción al finalizar"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorar directivas ExcludeArch desde el archivo spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "depurar archivo de la máquina de estado"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "no ejecutar ningún nivel de la construcción"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "no verificar dependencias de la construcción"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
-"genera encabezado(s) de paquete(s) compatible(s) con el empaquetamiento rpm "
-"v3 (legado)"
+msgstr "genera encabezado(s) de paquete(s) compatible(s) con el empaquetamiento rpm v3 (legado)"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "no ejecutar la fase %clean de la construcción"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "no ejecutar la fase %clean de la construcción"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "no ejecutar la fase %check de la construcción"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "no aceptar msgstr i18N desde el archivo spec"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "eliminar fuentes al finalizar"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "eliminar el archivo spec al finalizar"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "Ir a etapa especificada (solo para c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "sobreescribir plataforma de destino"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Opciones de construcción con [ <archivo spec> | <tarball> | <paquete "
-"fuente> ]:"
+msgstr "Opciones de construcción con [ <archivo spec> | <tarball> | <paquete fuente> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Fallo al construir las dependencias:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "No se puede abrir el archivo spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Falló la apertura de la tuberia para tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Más de un archivo en una línea: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Falló la lectura del archivo spec desde %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Falló al renombrar %s to %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "falló la llamada stat sobre %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "El archivo %s no es un archivo regular.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "El archivo %s no parece ser un archivo spec.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Construyendo las plataformas de destino: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Construyendo para el destino %s\n"
@@ -522,9 +433,7 @@ msgstr "inicializar base de datos"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"reconstruir lista invertida de la base de datos desde los encabezados de "
-"paquetes instalados"
+msgstr "reconstruir lista invertida de la base de datos desde los encabezados de paquetes instalados"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -562,7 +471,7 @@ msgstr "lista las llaves del administrador de llaves RPM"
 msgid "Keyring options:"
 msgstr "Opciones del llavero:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "no ha sido indicado ningún argumento"
 
@@ -582,10 +491,29 @@ msgstr "eliminar las firmas del paquete"
 msgid "Signature options:"
 msgstr "Opciones de firma:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "No se pudo ejecutar %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Debe establecer \"%%_gpg_name\" en su archivo de macro\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Introduzca la frase de acceso:"
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "La frase de acceso es correcta\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Falló la verificación de la contraseña, o la llave gpg ha expirado\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -603,7 +531,7 @@ msgstr "opera sobre rpms binarios generados por spec (predeterminado)"
 msgid "operate on source rpm generated by spec"
 msgstr "opera sobre rpm fuente generado por spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "utilizar el siguiente formato de consulta"
 
@@ -650,71 +578,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Errores de construcción RPM:\n"
+msgstr "\n\nErrores de construcción RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "error de sintaxis durante el análisis ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "error de sintaxis durante el análisis &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "error de sintaxis durante el análisis ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "error de análisis en la expresión\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "no coincidente (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- solo en números\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! solo en números\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "los tipos deben coincidir\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / no está soportado en cadenas\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- no está soportado en cadenas\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& y || no están soportados en cadenas\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "error de sintaxis en la expresión\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "'(' ausente en %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "')' ausente en %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Elemento %s no válido: %s\n"
@@ -724,46 +649,46 @@ msgstr "Elemento %s no válido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s ausente en %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Ningún espacio en blanco después de %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxis errónea: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "modo spec erróneo: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "dirmode spec erróneo: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Longitud de locale no usual: \"%s\" in %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Locale %s duplicado en %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacidad inválida %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Soporte para la capacidad del archivo no construido\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Los archivos deben iniciar con \"/\": %s\n"
@@ -773,150 +698,151 @@ msgstr "Los archivos deben iniciar con \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Algoritmo de resumen de archivo %u desconocido, regresando a MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Archivo listado dos veces: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "falló la lectura %s de symlink: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "El enlace simbólico apunta a BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "No se ha encontrado el directorio: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Archivo no encontrado: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: no se puede cargar, etiqueta (%d) desconocida.\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: falló la lectura de la clave publica.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: no es una clave pública con armadura.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: falló la codificación\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "El archivo necesita comenzar con \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob no permitido: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "El directorio no ha sido hallado por glob: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Archivo no encontrado por glob: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "No se pudo abrir el archivo %%files %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "línea: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Error leyendo %%files archivo %s: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "No se puede mezclar el %s especial con otros formatos: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Más de un archivo en una línea: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Archivo erróneo: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "propietario/grupo erróneo: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Comprobando si hay archivos desempaquetados: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Se encontraron archivos instalados (pero desempaquetados):\n"
-"%s"
+msgstr "Se encontraron archivos instalados (pero desempaquetados):\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Procesando archivos: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"Los archivos binarios (%d) no coinciden con los archivos del paquete (%d).\n"
+msgstr "Los archivos binarios (%d) no coinciden con los archivos del paquete (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
-msgstr ""
-"Binarios dependientes de la arquitectura en paquetes sin arquitectura\n"
+msgstr "Binarios dependientes de la arquitectura en paquetes sin arquitectura\n"
 
 #: build/pack.c:90
 #, c-format
@@ -943,80 +869,79 @@ msgstr "%s: línea: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "No se pudo canonizar el nombre de host: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Incapaz de recargar el encabezado de la firma\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compresion de carga útil desconocida: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "No ha sido posible crear la región inmutable del encabezado.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "No se pudo abrir %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "No ha sido possible escribir el paquete: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Incapaz de escribir el encabezado temporal\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Datos CSA erróneos\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "No es posible abrir el archivo %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "falló al crear el archivo %s: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Escrito: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Ejecutando \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Falló la ejecución de \"%s\":\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Falló la verificación \"%s\" del paquete\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
-msgstr ""
-"No se pudo generar el nombre de archivo de salida para el paquete %s: %s \n"
+msgstr "No se pudo generar el nombre de archivo de salida para el paquete %s: %s \n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "no es posible crear %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "línea %d: segundo %s\n"
@@ -1067,19 +992,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "línea %d: Error al analizar %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "línea %d: Opción errónea %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "línea %d: Demasiados nombres: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "línea %d: El paquete no existe: %s\n"
@@ -1185,96 +1110,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "línea %d: La etiqueta solo recibe patrones individuales: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "línea %d: Carácter '%c' ilegal en: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "línea %d: Secuencia \"..\" ilegal en: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "línea %d: Carácter ilegal en: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "línea %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "línea %d: Secuencia \"..\" ilegal en: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: línea: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "línea %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "línea %d: Etiqueta vacía: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "línea %d: Los prefijos deben finalizar en \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "línea %d: Docdir debe iniciar con '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "línea %d: El campo epoch debe ser un número sin signo: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "línea %d: %s erróneo: calificadores: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "línea %d: Formato BuildArchitecture erróneo: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linea %d: Solo existe soporte para subpaquetes sin arquitectura: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Error interno: Etiqueta errónea %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "línea %d: %s se encuentra obsoleta: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificación de paquete errónea: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "El paquete ya existe: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "línea %d: Etiqueta desconocida: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} no puede ser vacío\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{BuildRoot} no puede ser \"/\"\n"
@@ -1284,199 +1204,161 @@ msgstr "%%{BuildRoot} no puede ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fuente errónea: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Ningún número de parche %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sin etiqueta \"Patch:\" correspondientes\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Ningún número fuente %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "No hay etiqueta \"Source:\" en el archivo spec\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Error al analizar %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "línea %d: Argumento erróneo para %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "línea %d: opción %%setup errónea %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Número de parche %s inválido: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "línea %d: segundo %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr ""
-"Las fichas de dependencias deben comenzar con caracteres alfanuméricos, «_» "
-"o «/»"
+msgstr "Las fichas de dependencias deben comenzar con caracteres alfanuméricos, «_» o «/»"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "No se permite el nombre de archivo versionado"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "dependencia no válida"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "se necesita una versión"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "dependencia no válida"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "línea %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "línea %d: los detonantes deben tener --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "línea %d: Error al analizar %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "línea %d: el script interno debe finalizar con '>': %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "línea %d: los scripts ejecutables debe iniciar con '/': %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-"línea %d: los argumentos de intérprete no son permitidos en disparadores: "
-"%s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "línea %d: Segundo %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "línea %d: script interno no soportado: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr ""
-"línea %d: los argumentos de intérprete no son permitidos en disparadores: "
-"%s\n"
+msgstr "línea %d: los argumentos de intérprete no son permitidos en disparadores: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "línea %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "No ha sido posible abrir %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argumento esperado para %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "línea %d: %%if no cerrado\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "línea %d: macro no cerrado o continuación de línea errónea\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: mal %%si condición\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Tiene un %%else sin %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Tiene un %%endif sin %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: instrucción %%include con formato incorrecto\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "No se encontraron arquitecturas compatibles para la construcción\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "El paquete no tiene %%description: %s\n"
@@ -1484,9 +1366,7 @@ msgstr "El paquete no tiene %%description: %s\n"
 #: build/policies.c:87
 #, c-format
 msgid "Policy module '%s' duplicated with overlapping types\n"
-msgstr ""
-"El módulo '%s' de políticas se encuentra duplicado con tipos que se "
-"superponen\n"
+msgstr "El módulo '%s' de políticas se encuentra duplicado con tipos que se superponen\n"
 
 #: build/policies.c:93
 #, c-format
@@ -1522,9 +1402,7 @@ msgstr "Falló al determinar el nombre de la política: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"El tipo '%s' ha sido ofrecido con otro tipos en %%semodule %s. Compactando "
-"tipos a '%s'.\n"
+msgstr "El tipo '%s' ha sido ofrecido con otro tipos en %%semodule %s. Compactando tipos a '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1551,281 +1429,290 @@ msgstr "Demasiados argumentos en la línea: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Procesando políticas: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorando regex no válido %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "No se pudo crear una tuberia para %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "No se pudo ejecutar la llamada exec %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "No se pudo ejecutar la llamada al sistema fork para %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "Falló %s: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "falló la escritura de todos los datos a %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Falló la conversión de %s a entero largo.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Clasificador de archivo vacío\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "No han sido configurados atributos de archivo\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "falló magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "falló magic_load: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Falló la identificación del archivo \"%s\": modo %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Buscando %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Falló la búsqueda de %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "la consulta del archivo spec %s falló, no se pudo analizar\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s es un RPM Delta y no puede ser instalado directamente\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Carga útil (%s) no soportada en el paquete %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "el paquete %s ya fue añadido, omitiendo %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "el paquete %s ya fue añadido, reemplazando con %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(no es un número)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(no base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(tipo no válido)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(no es un blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(tipo xml no válido)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(no es una firma OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Fecha no válida %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normal        "
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "reemplazado"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "no instalado"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "compartido en red"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "color incorrecto"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "no se encuentra"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(desconocido) "
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(no es una cadena)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s guardado como %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s creado como %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: falló al eliminar: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "directorio"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "archivo"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1874,8 +1761,7 @@ msgstr "no verificar resumen del paquete(s)"
 
 #: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
-msgstr ""
-"no verificar la base de datos de lo(s) encabezado(s) cuando sean recuperadas"
+msgstr "no verificar la base de datos de lo(s) encabezado(s) cuando sean recuperadas"
 
 #: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
@@ -1955,18 +1841,15 @@ msgid "relocations must have a / following the ="
 msgstr "realocaciones deben tener una / después de ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"instalar todos los archivos, incluso los de configuración, que de otra "
-"manera serían salteados."
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "instalar todos los archivos, incluso los de configuración, que de otra manera serían salteados."
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"remueve todos los paquetes que coincidan con <paquetes> (normalmente un "
-"error es generado si <paquete> especifica multiples paquetes) "
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "remueve todos los paquetes que coincidan con <paquetes> (normalmente un error es generado si <paquete> especifica multiples paquetes) "
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2044,7 +1927,7 @@ msgstr "actualizar la base de datos, mas no modificar el sistema de archivos"
 msgid "do not verify package dependencies"
 msgstr "no verificar las dependencias del paquete"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "no verificar el digest de los archivos"
 
@@ -2122,9 +2005,7 @@ msgstr "no ejecutar ningún %%triggerpostun scriptlet(s)"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"actualiza a una versión antigua del paquete (--force en actualizaciones hace "
-"esto automaticamente)"
+msgstr "actualiza a una versión antigua del paquete (--force en actualizaciones hace esto automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2166,182 +2047,162 @@ msgstr "actualizar paquete(s)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "consultar/verificar todos los paquetes"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "modo rpm checksig"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "consultar/verificar archivo propietario de paquete(s)"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "consultar/verificar paquete(s) en grupo"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "consultar/verificar un archivo de paquete"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "consultar/verificar paquete(s) con identificador de paquete"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "consultar/verificar paquete(s)con identificador de cabecera"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "modo de consulta rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "consultar/verificar una instancia de la cabecera"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "consultar/verificar paquete(s) de la transacción de la instalación"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "consultar los paquetes lanzados por el paquete"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "modo de verificación de rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "consultar/verificar los paquetes que requieren una dependencia"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "consultar/verificar paquetes que proporcionan una dependencia"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "consultar/verificar los paquetes que requieren una dependencia"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "consultar/verificar los paquetes que requieren una dependencia"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "consultar/verificar los paquetes que requieren una dependencia"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "consultar/verificar los paquetes que requieren una dependencia"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "ningún argumento para glob"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "no procese los archivos que no pertenecen al paquete como manifiestos"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "listar todos los archivos de configuración"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "listar todos los archivos de documentación"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "Volcar información de archivo básica"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "listar archivos del paquete"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "saltar archivos %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "mostrar el estado de los archivos listados"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "no verificar el tamaño de los archivos"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "no verificar la ruta symlink de los archivos"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "no verificar el propietario de los archivos"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "no verificar el grupo de los archivos"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "no verificar el tiempo de modificación de los archivos"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "no verificar el modo de los archivos"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "no verificar las capacidades de los archivos"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "no verificar los contextos de seguridad del archivo"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "no verificar los archivos en el paquete"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "no verificar las dependencias de paquetes"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "no ejecutar scripts de verificación"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "No se encuentran características rpmlib para %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "se esperaba el paquete fuente, paquete binario encontrado\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "el paquete fuente no contiene archivo .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "falló el desempaquetado de archivos %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " en archivo"
 
@@ -2416,118 +2277,96 @@ msgstr "ningún paquete coincide con %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "ningún paquete requiere %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "ningún paquete requiere %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "sin detonante de paquetes %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "ningún paquete requiere %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "ningún paquete requiere %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ningún paquete proporciona %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "archivo %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "el archivo %s no es propiedad de ningún paquete\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de paquete inválido: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "el registro %u no pudo ser leído\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "el paquete %s no está instalado\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconocida:\"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: falló la importación de la llave %d\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: la llave %d no es una llave pública protegida.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: falló la lectura para importar(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: falló headerRead: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: la cabecera de región no modificable no pudo ser leída. ¿Estará corrupto "
-"el paquete?\n"
+msgstr "%s: la cabecera de región no modificable no pudo ser leída. ¿Estará corrupto el paquete?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread falló: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NO ESTA BIEN"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "BIEN"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (FALTAN LAS CLAVES:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CLAVES NO CONFIABLES:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: falló la apertura: %s\n"
@@ -2552,205 +2391,144 @@ msgstr "No se puede cambiar el directorio raíz: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "No es posible restablecer el directorio raíz: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "SI"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, y Obsoletes: dependencias soportan versiones."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"nombres de archivos almacenados como (dirName,baseName,dirIndex) \"tuple\", "
-"no como ruta."
+msgstr "nombres de archivos almacenados como (dirName,baseName,dirIndex) \"tuple\", no como ruta."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "la carga del paquete puede ser comprimida utilizando bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "la carga del paquete puede ser comprimida utilizando xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "la carga del paquete puede ser comprimida tilizando bzip2. "
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "los archivos de carga del paquete tienen el prefijo  \"./\"."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
-msgstr ""
-"nombre-versión-lanzamiento del paquete no se proporciona implícitamente."
+msgstr "nombre-versión-lanzamiento del paquete no se proporciona implícitamente."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
-msgstr ""
-"las etiquetas del encabezado son siempre ordenadas después de ser cargadas."
+msgstr "las etiquetas del encabezado son siempre ordenadas después de ser cargadas."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "el intérprete de scriptlet puede utilizar argumentos del encabezado."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
-msgstr ""
-"un conjunto de enlaces fijos de archivo puede ser instalado aunque no se "
-"haya completado."
+msgstr "un conjunto de enlaces fijos de archivo puede ser instalado aunque no se haya completado."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"scriplets de paquete pueden acceder a la base de datos rpm mientras se está "
-"imstalando."
+msgstr "scriplets de paquete pueden acceder a la base de datos rpm mientras se está imstalando."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "soporte interno para scripts lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "el algoritmo de digest se puede configurar por paquete"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "soporte para capacidades de archivo POSIX1e."
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
-msgstr ""
-"los scriptlets de los paquetes pueden ser expandidos en el momento de la "
-"instalación."
+msgstr "los scriptlets de los paquetes pueden ser expandidos en el momento de la instalación."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "la comparación de dependencias admite versiones con virgulilla."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "no verificar las dependencias del paquete"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "se necesita una versión"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "dependencia no válida"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "No terminado %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "dependencia no válida"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "usuario %s no existe - utilizando root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupo %s no existe - utilizando root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Magic erróneo"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Encabezado erróneo/imposible de leer"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "El tamaño del encabezado es demasiado extenso"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Archivo muy grande para compactar"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Tipo de archivo desconocido"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "El digest no coincide"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Error interno"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "El fichero del archivo no se encuentra en el encabezado"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " falló - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "la apertura de %s falló: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: no es un paquete rpm (o manifiesto de paquete)\n"
@@ -2782,42 +2560,42 @@ msgstr "Error de dependencias:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: no es un paquete rpm (o manifiesto de paquete): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s no puede ser instalado\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Recuperando %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "omitiendo %s - transferencia fallida\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paquete %s no es reubicable\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "error al leer del archivo %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" especifica varios paquetes:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "no se puede abrir %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instalando %s\n"
@@ -2843,12 +2621,12 @@ msgstr "falló la lectura: %s  (%d)\n"
 msgid "not an rpm package\n"
 msgstr "no es un paquete rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "no es posible crear el bloqueo %s sobre %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "esperando el bloqueo %s sobre %s\n"
@@ -2864,9 +2642,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Falló al resolver el símbolo %s: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "El complemento %s no ha sido cargado\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2905,9 +2683,7 @@ msgstr "conflicto del archivo %s entre instalaciones intentadas de %s y %s"
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"el archivo %s de la instalación de %s entra en conflicto con el archivo del "
-"paquete %s"
+msgstr "el archivo %s de la instalación de %s entra en conflicto con el archivo del paquete %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2917,16 +2693,12 @@ msgstr "el paquete %s (que es más nuevo que %s) ya está instalado"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"para la instalación del paquete %s es necesario %<PRIu64>%cB en el sistema "
-"de archivos %s"
+msgstr "para la instalación del paquete %s es necesario %<PRIu64>%cB en el sistema de archivos %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"para la instalación del paquete %s es necesario %<PRIu64> inodos en el "
-"sistema de archivos %s"
+msgstr "para la instalación del paquete %s es necesario %<PRIu64> inodos en el sistema de archivos %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2950,8 +2722,7 @@ msgstr "%s es sustituido por %s%s"
 #: lib/rpmprob.c:172
 #, c-format
 msgid "unknown error %d encountered while manipulating package %s"
-msgstr ""
-"se encontró el error desconocido %d mientras se manipulaba el paquete %s"
+msgstr "se encontró el error desconocido %d mientras se manipulaba el paquete %s"
 
 #: lib/rpmrc.c:222
 #, c-format
@@ -3017,76 +2788,56 @@ msgstr "opción errónea '%s' en %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Falló al leer el vector auxiliar, ¿estará montado /proc?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconocido: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Por favor contacte %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "No se puede abrir %s para lectura: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "No es posible restaurar el directorio actual: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
-msgstr ""
-"soporte interno para macro de inclución de guiones <lua>, no fue construido\n"
+msgstr "soporte interno para macro de inclución de guiones <lua>, no fue construido\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "No se pudo crear un archivo temporal para %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "No se pudo duplicar el descritor de archivo %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "No ha sido posible leer el icono %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "No es posible restablecer el directorio raíz: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite falló: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s: macro de ejecución de guión fallido, waitpid(%d) rd %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s: macro de ejecución de guión fallido, señal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s: macro de ejecución de guión fallido, estado de terminación %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "formato desconocido"
 
@@ -3098,142 +2849,127 @@ msgstr "instalar "
 msgid "erase"
 msgstr "borrar"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "no se puede abrir la base de datos Packages en %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' extra en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' ausente en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' ausente en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: lectura de la clave publica fallida.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transacción"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(no es una firma OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Encabezado"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "Resumen MD5: "
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Resumen SHA1 del encabezado:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Encabezado"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "ignorado"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "falló"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "falta %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dependencias no satisfechas para %s:\n"
@@ -3307,247 +3043,240 @@ msgstr "iterador de arreglo usado con arreglos de diferente tamaño"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generando %d índice(s) faltante(s), espere…\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "no se ha establecido dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: omitiendo"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "error(%d) almacenando registro #%d en %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s:  regexec falló: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp falló: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: omitiendo"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: encabezado dañado #%u recuperada -- omitiendo.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: no se pudo leer encabezado en 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "no se ha establecido dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "no se pudo crear el directorio %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "encabezado #%u erróneo en la base de datos -- omitiendo.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "no se puede añadir el registro original en %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"falló la reconstrucción de la base de datos: la base de datos original "
-"permanece en su lugar\n"
+msgstr "falló la reconstrucción de la base de datos: la base de datos original permanece en su lugar\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
-msgstr ""
-"¡falló el remplazo de la base de datos antigua con la nueva base de datos!\n"
+msgstr "¡falló el remplazo de la base de datos antigua con la nueva base de datos!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "reemplazar archivos en %s con los archivos de %s a recuperar"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "falló la eliminación del directorio %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "opciones db no reconocidas: \"%s\" ignorado.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s tiene un valor numérico no válido, omitido\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-"%s tiene un valor largo demasiado grande o demasiado pequeño, omitido\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-"%s tiene un valor entero demasiado grande o demasiado pequeño, omitido\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "no se pudo obtener bloqueo %s en %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "compartido"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "tipo de índice %x inválido en  %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "error(%d) al obtener registros «%s» desde el índice %s: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "error(%d) almacenando registros \"%s\" en %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "error(%d) eliminando registro \"%s\" de %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "error(%d) estableciendo registro de encabezado #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "error(%d) eliminando registro de encabezado #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "error(%d) asignando nueva instancia de paquete\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "opciones db no reconocidas: \"%s\" ignorado.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s tiene un valor numérico no válido, omitido\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s tiene un valor largo demasiado grande o demasiado pequeño, omitido\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s tiene un valor entero demasiado grande o demasiado pequeño, omitido\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vacío)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vacío)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "El macro %%%s tiene opciones no terminadas\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "El macro %%%s tiene un cuerpo incompleto\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "El macro %%%s tiene un nombre ilegal (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "El macro %%%s tiene un cuerpo vacío\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Falló la expansión del macro macro %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "El macro %%%s tiene un nombre ilegal (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opción desconocida %c en %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Demasiados niveles de recursión en la expansión macro. Esto seguramente haya "
-"sido provocado por una declaración macro recursiva.\n"
+msgstr "Demasiados niveles de recursión en la expansión macro. Esto seguramente haya sido provocado por una declaración macro recursiva.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "No terminado %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% está seguido por un macro no analizable\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== activo %d vacío %d\n"
@@ -3567,31 +3296,31 @@ msgstr "Archivo %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "El archivo %s tiene menos de %u bytes\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "falló al crear el directorio"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxis no válida en el macro de ejecución de scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxis no valida en el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "falló el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxis no valida en el archivo de scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "falló el enlace de lua: %s\n"
@@ -3600,19 +3329,19 @@ msgstr "falló el enlace de lua: %s\n"
 msgid "[none]"
 msgstr "[ninguno]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(ningún error)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "error fatal:"
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "error: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "advertencia:"
 
@@ -3621,121 +3350,99 @@ msgstr "advertencia:"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "la asignación de memoria (%u bytes) retornó NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID de clave %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "error al crear el archivo temporal %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "error al crear el archivo temporal %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "error al crear el archivo temporal %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "no se pudo crear el directorio %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite falló: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush fallido: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Firma PGP no soportada\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algoritmo hash PGP no soportado %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algoritmo de llave pública PGP no soportado %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "No se pudo ejecutar %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "No se pudo crear la tuberia para firmar: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: falló la apertura: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "No es posible abrir el archivo %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "No se pudo abrir el archivo %%files %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "falló la llamada al sistema exec para gpg (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg falló al escribir la firma\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "incapaz de leer la firma\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature falló: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "No es posible firmar paquetes RPM v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s ya contiene una firma idéntica, ignorando\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature falló: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "faló makeTempFile\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead falló: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "falló el reemplazo %s: %s\n"
@@ -3748,106 +3455,3 @@ msgstr "%s: falló la lectura del manifiesto: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "no verificar firma de encabezado+carga"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Introduzca la frase de acceso:"
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "La frase de acceso es correcta\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr ""
-#~ "Falló la verificación de la contraseña, o la llave gpg ha expirado\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "propietario/grupo erróneo: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "línea %d: Carácter ilegal en: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "No se pudo crear la tuberia para firmar: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "No ha sido possible escribir la carga útil de %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "No ha sido posible leer la carga útil de %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "No es posible abrir archivo temporal.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "No ha sido posible abrir sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "No ha sido posible leer el encabezado de %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "No ha sido possible escribir el encabezado de %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "no realizar ninguna acción de colección"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "No se pudo leer la región inmutable del encabezado. ¿El paquete esta "
-#~ "corrupto?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Falló al decodificar la política para %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Falló al crear archivo temporal para %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Falló al escribir la política %s en el archivo %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Falló al crear manipulador de semanage\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Falló al conectar con el manipulador de políticas\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Falló iniciar transacción de política: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Falló al eliminar el archivo de política temporal %s: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Falló al instalar módulo de política: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Falló al eliminar el módulo de política: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Falló al bifurcar el proceso: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Falló al ejecutar %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s finalizó de manera anormal\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s falló con un código de salida %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Falló al enviar modificaciones de política\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Falló al expandir el camino restoreconf"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Falló al re etiquetar el sistema de archivos. Lor archivos podrían "
-#~ "encontrarse mal etiquetados\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Falló al recargar el contexto de archivo. Los archivos podrían estar mal "
-#~ "etiquetados\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Falló al extraer la política desde %s\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Adolfo Jayme Barrientos, 2011
 # Adolfo Jayme Barrientos <fitoschido@ubuntu.com>, 2011,2014
@@ -14,14 +14,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/rpm-team/rpm/language/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -43,7 +43,9 @@ msgstr "Copyright © 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Este programa puede redistribuirse libremente bajo los términos de la licencia GNU GPL\n"
+msgstr ""
+"Este programa puede redistribuirse libremente bajo los términos de la "
+"licencia GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -86,7 +88,7 @@ msgstr "Opciones de verificación (con -V o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opciones de Instalación/Actualización/Remoción:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opciones comunes para todos los modos rpm y ejecutables:"
@@ -107,7 +109,7 @@ msgstr "formato de consulta inesperado"
 msgid "unexpected query source"
 msgstr "fuente de consulta inesperado"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "solo puede especificarse un modo principal"
 
@@ -117,7 +119,8 @@ msgstr "solo puede forzarse la instalación y la actualización"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "los archivos solo pueden ser reubicados durante la instalación del paquete"
+msgstr ""
+"los archivos solo pueden ser reubicados durante la instalación del paquete"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -126,7 +129,9 @@ msgstr "no se puede utilizar --prefix con --relocate o --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate y --excludepath solo pueden ser utilizados cuando se instalan nuevos paquetes"
+msgstr ""
+"--relocate y --excludepath solo pueden ser utilizados cuando se instalan "
+"nuevos paquetes"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,24 +144,30 @@ msgstr "los argumentos de --prefix deber iniciar con una /"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr "--hash (-h) sólo puede ser indicado durante la instalación o la eliminación de un paquete"
+msgstr ""
+"--hash (-h) sólo puede ser indicado durante la instalación o la eliminación "
+"de un paquete"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
-msgstr "--percent sólo puede ser indicado durante la instalación o la eliminación de un paquete"
+msgid "--percent may only be specified during package installation and erasure"
+msgstr ""
+"--percent sólo puede ser indicado durante la instalación o la eliminación de "
+"un paquete"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr "--replacepkgs solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--replacepkgs solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr "--excludedocs solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--excludedocs solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr "--includedocs solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--includedocs solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -164,51 +175,66 @@ msgstr "solo se puede especificar una opción: --excludedocs o --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr "--ignorearch solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--ignorearch solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr "--ignoreos solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--ignoreos solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr "--ignoresize solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--ignoresize solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr "--allmatches solo puede ser especificado durante la eliminación del paquete"
+msgstr ""
+"--allmatches solo puede ser especificado durante la eliminación del paquete"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr "--allfiles solo puede ser especificado durante la instalación del paquete"
+msgstr ""
+"--allfiles solo puede ser especificado durante la instalación del paquete"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb solo puede ser especificado durante la instalación y eliminación del paquete"
+msgstr ""
+"--justdb solo puede ser especificado durante la instalación y eliminación "
+"del paquete"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "las opciones para desactivar scripts sólo pueden ser especificadas durante la instalación y eliminación del paquete"
+msgstr ""
+"las opciones para desactivar scripts sólo pueden ser especificadas durante "
+"la instalación y eliminación del paquete"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "las opciones de desactivación de detonante sólo pueden ser especificadas durante la instalación y eliminación del paquete"
+msgstr ""
+"las opciones de desactivación de detonante sólo pueden ser especificadas "
+"durante la instalación y eliminación del paquete"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "solo puede especificarse --nodeps durante la instalación, eliminación o verificación del paquete"
+msgstr ""
+"solo puede especificarse --nodeps durante la instalación, eliminación o "
+"verificación del paquete"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "solo puede especificarse --test durante la instalación o la eliminación de un paquete"
+msgstr ""
+"solo puede especificarse --test durante la instalación o la eliminación de "
+"un paquete"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "los argumentos de --root (-r) deben iniciar con una /"
 
@@ -228,201 +254,264 @@ msgstr "no ha sido indicado ningún argumento para la consulta"
 msgid "no arguments given for verify"
 msgstr "no ha sido indicado ningún argumento para la verificación"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot ya especificado, ignorando %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "construir a través de %prep (desempaquetar fuentes y aplicar parches) desde <specfile>"
+msgstr ""
+"construir a través de %prep (desempaquetar fuentes y aplicar parches) desde "
+"<specfile>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "construir a través de %build (%prep, luego compilar) desde <specfile>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "construir a través de %install (%prep, %build, luego instalar) desde <specfile>"
+msgstr ""
+"construir a través de %install (%prep, %build, luego instalar) desde "
+"<specfile>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificar la sección %files de <specfile>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "construir paquetes binarios y fuente desde <specfile>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "construir paquetes binarios únicamente desde <specfile>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "construir paquete fuente únicamente desde <specfile>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"construir a través de %prep (desempaquetar fuentes y aplicar parches) desde "
+"<specfile>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<paquete fuente>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "construir a través de %build (%prep, luego compilar) desde <specfile>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"construir a través de %install (%prep, %build, luego instalar) desde "
+"<paquete fuente>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verificar la sección %files de <specfile>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "construir paquete binario desde <source package>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "construir paquete binario desde <source package>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "construir paquete fuente únicamente desde <specfile>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "construir a través de %prep (desempaquetar fuentes y aplicar parches) desde <tarball>"
+msgstr ""
+"construir a través de %prep (desempaquetar fuentes y aplicar parches) desde "
+"<tarball>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "construir a través de %build (%prep, luego compilar) desde <tarball>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "construir a través de %install (%prep, %build, luego instalar) desde <tarball>"
+msgstr ""
+"construir a través de %install (%prep, %build, luego instalar) desde "
+"<tarball>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificar sección %files desde <tarball>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "construir paquetes binarios y fuente desde <tarball>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "construir paquete binario únicamente desde <tarball>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "construir paquete fuente desde <tarball> "
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "construir paquete binario desde <source package>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<paquete fuente>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "construir a través de %install (%prep, %build, luego instalar) desde <paquete fuente>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "sobreescribir construcción de root"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "No es posible abrir directorio actual: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "remover árbol de construcción al finalizar"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorar directivas ExcludeArch desde el archivo spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "depurar archivo de la máquina de estado"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "no ejecutar ningún nivel de la construcción"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "no verificar dependencias de la construcción"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "genera encabezado(s) de paquete(s) compatible(s) con el empaquetamiento rpm v3 (legado)"
+msgstr ""
+"genera encabezado(s) de paquete(s) compatible(s) con el empaquetamiento rpm "
+"v3 (legado)"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "no ejecutar la fase %clean de la construcción"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "no ejecutar la fase %clean de la construcción"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "no ejecutar la fase %check de la construcción"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "no aceptar msgstr i18N desde el archivo spec"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "eliminar fuentes al finalizar"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "eliminar el archivo spec al finalizar"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "Ir a etapa especificada (solo para c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "sobreescribir plataforma de destino"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Opciones de construcción con [ <archivo spec> | <tarball> | <paquete fuente> ]:"
+msgstr ""
+"Opciones de construcción con [ <archivo spec> | <tarball> | <paquete "
+"fuente> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Fallo al construir las dependencias:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "No se puede abrir el archivo spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Falló la apertura de la tuberia para tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Más de un archivo en una línea: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Falló la lectura del archivo spec desde %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Falló al renombrar %s to %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "falló la llamada stat sobre %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "El archivo %s no es un archivo regular.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "El archivo %s no parece ser un archivo spec.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Construyendo las plataformas de destino: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Construyendo para el destino %s\n"
@@ -433,7 +522,9 @@ msgstr "inicializar base de datos"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "reconstruir lista invertida de la base de datos desde los encabezados de paquetes instalados"
+msgstr ""
+"reconstruir lista invertida de la base de datos desde los encabezados de "
+"paquetes instalados"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -471,49 +562,65 @@ msgstr "lista las llaves del administrador de llaves RPM"
 msgid "Keyring options:"
 msgstr "Opciones del llavero:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "no ha sido indicado ningún argumento"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "firma paquete(s)"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "firmar paquete(s) (idéntico a --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "eliminar las firmas del paquete"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "firma paquete(s)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opciones de firma:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "No se pudo ejecutar %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Debe establecer \"%%_gpg_name\" en su archivo de macro\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Introduzca la frase de acceso:"
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "La frase de acceso es correcta\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Falló la verificación de la contraseña, o la llave gpg ha expirado\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix solo puede ser utilizado al instalar nuevos paquetes"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr ""
+"--allmatches solo puede ser especificado durante la eliminación del paquete"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -531,7 +638,7 @@ msgstr "opera sobre rpms binarios generados por spec (predeterminado)"
 msgid "operate on source rpm generated by spec"
 msgstr "opera sobre rpm fuente generado por spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "utilizar el siguiente formato de consulta"
 
@@ -578,68 +685,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nErrores de construcción RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Errores de construcción RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "error de sintaxis durante el análisis ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "error de sintaxis durante el análisis &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "error de sintaxis durante el análisis ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "error de análisis en la expresión\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "no coincidente (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- solo en números\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! solo en números\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "los tipos deben coincidir\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / no está soportado en cadenas\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- no está soportado en cadenas\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& y || no están soportados en cadenas\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "error de sintaxis en la expresión\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "'(' ausente en %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "')' ausente en %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Elemento %s no válido: %s\n"
@@ -649,46 +759,46 @@ msgstr "Elemento %s no válido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s ausente en %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Ningún espacio en blanco después de %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxis errónea: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "modo spec erróneo: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "dirmode spec erróneo: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Longitud de locale no usual: \"%s\" in %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Locale %s duplicado en %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacidad inválida %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Soporte para la capacidad del archivo no construido\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Los archivos deben iniciar con \"/\": %s\n"
@@ -698,151 +808,155 @@ msgstr "Los archivos deben iniciar con \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Algoritmo de resumen de archivo %u desconocido, regresando a MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Archivo listado dos veces: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "falló la lectura %s de symlink: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "El enlace simbólico apunta a BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "No se ha encontrado el directorio: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Archivo no encontrado: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: no se puede cargar, etiqueta (%d) desconocida.\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: falló la lectura de la clave publica.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: no es una clave pública con armadura.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: falló la codificación\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "El archivo necesita comenzar con \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob no permitido: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "El directorio no ha sido hallado por glob: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Archivo no encontrado por glob: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "No se pudo abrir el archivo %%files %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "línea: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Error leyendo %%files archivo %s: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Archivo no encontrado por glob: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "No se puede mezclar el %s especial con otros formatos: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Más de un archivo en una línea: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Archivo erróneo: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "propietario/grupo erróneo: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Comprobando si hay archivos desempaquetados: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Se encontraron archivos instalados (pero desempaquetados):\n%s"
+msgstr ""
+"Se encontraron archivos instalados (pero desempaquetados):\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Procesando archivos: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "Los archivos binarios (%d) no coinciden con los archivos del paquete (%d).\n"
+msgstr ""
+"Los archivos binarios (%d) no coinciden con los archivos del paquete (%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
-msgstr "Binarios dependientes de la arquitectura en paquetes sin arquitectura\n"
+msgstr ""
+"Binarios dependientes de la arquitectura en paquetes sin arquitectura\n"
 
 #: build/pack.c:90
 #, c-format
@@ -869,79 +983,77 @@ msgstr "%s: línea: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "No se pudo canonizar el nombre de host: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Incapaz de recargar el encabezado de la firma\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compresion de carga útil desconocida: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "No ha sido posible crear la región inmutable del encabezado.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "No se pudo abrir %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "No ha sido possible escribir el paquete: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Incapaz de escribir el encabezado temporal\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Datos CSA erróneos\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Escrito: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Ejecutando \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Falló la ejecución de \"%s\":\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Falló la verificación \"%s\" del paquete\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
-msgstr "No se pudo generar el nombre de archivo de salida para el paquete %s: %s \n"
+msgstr ""
+"No se pudo generar el nombre de archivo de salida para el paquete %s: %s \n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "no es posible crear %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "línea %d: segundo %s\n"
@@ -992,19 +1104,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "línea %d: Error al analizar %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "línea %d: Opción errónea %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "línea %d: Demasiados nombres: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "línea %d: El paquete no existe: %s\n"
@@ -1110,91 +1222,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "línea %d: La etiqueta solo recibe patrones individuales: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "línea %d: Carácter '%c' ilegal en: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "línea %d: Carácter ilegal en: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "línea %d: Secuencia \"..\" ilegal en: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "línea %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: línea: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "línea %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "línea %d: Etiqueta vacía: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "línea %d: Los prefijos deben finalizar en \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "línea %d: Docdir debe iniciar con '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "línea %d: El campo epoch debe ser un número sin signo: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "línea %d: %s erróneo: calificadores: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "línea %d: Formato BuildArchitecture erróneo: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linea %d: Solo existe soporte para subpaquetes sin arquitectura: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Error interno: Etiqueta errónea %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "línea %d: %s se encuentra obsoleta: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificación de paquete errónea: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "El paquete ya existe: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "línea %d: Etiqueta desconocida: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} no puede ser vacío\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{BuildRoot} no puede ser \"/\"\n"
@@ -1204,161 +1321,199 @@ msgstr "%%{BuildRoot} no puede ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fuente errónea: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Ningún número de parche %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sin etiqueta \"Patch:\" correspondientes\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Ningún número fuente %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "No hay etiqueta \"Source:\" en el archivo spec\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Error al analizar %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "línea %d: Argumento erróneo para %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "línea %d: opción %%setup errónea %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Número de parche %s inválido: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "línea %d: segundo %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr "Las fichas de dependencias deben comenzar con caracteres alfanuméricos, «_» o «/»"
+msgstr ""
+"Las fichas de dependencias deben comenzar con caracteres alfanuméricos, «_» "
+"o «/»"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "No se permite el nombre de archivo versionado"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "se necesita una versión"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "dependencia no válida"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "se necesita una versión"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "línea %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "línea %d: los detonantes deben tener --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "línea %d: Error al analizar %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "línea %d: el script interno debe finalizar con '>': %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "línea %d: los scripts ejecutables debe iniciar con '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+"línea %d: los argumentos de intérprete no son permitidos en disparadores: "
+"%s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "línea %d: Segundo %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "línea %d: script interno no soportado: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr "línea %d: los argumentos de intérprete no son permitidos en disparadores: %s\n"
+msgstr ""
+"línea %d: los argumentos de intérprete no son permitidos en disparadores: "
+"%s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "línea %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "No ha sido posible abrir %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argumento esperado para %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "línea %d: %%if no cerrado\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "línea %d: macro no cerrado o continuación de línea errónea\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: mal %%si condición\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Tiene un %%else sin %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Tiene un %%endif sin %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: instrucción %%include con formato incorrecto\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "No se encontraron arquitecturas compatibles para la construcción\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "El paquete no tiene %%description: %s\n"
@@ -1366,7 +1521,9 @@ msgstr "El paquete no tiene %%description: %s\n"
 #: build/policies.c:87
 #, c-format
 msgid "Policy module '%s' duplicated with overlapping types\n"
-msgstr "El módulo '%s' de políticas se encuentra duplicado con tipos que se superponen\n"
+msgstr ""
+"El módulo '%s' de políticas se encuentra duplicado con tipos que se "
+"superponen\n"
 
 #: build/policies.c:93
 #, c-format
@@ -1402,7 +1559,9 @@ msgstr "Falló al determinar el nombre de la política: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "El tipo '%s' ha sido ofrecido con otro tipos en %%semodule %s. Compactando tipos a '%s'.\n"
+msgstr ""
+"El tipo '%s' ha sido ofrecido con otro tipos en %%semodule %s. Compactando "
+"tipos a '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1429,290 +1588,281 @@ msgstr "Demasiados argumentos en la línea: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Procesando políticas: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorando regex no válido %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "No se pudo crear una tuberia para %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "No se pudo ejecutar la llamada exec %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "No se pudo ejecutar la llamada al sistema fork para %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "Falló %s: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "falló la escritura de todos los datos a %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Falló la conversión de %s a entero largo.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Clasificador de archivo vacío\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "No han sido configurados atributos de archivo\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "falló magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "falló magic_load: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Falló la identificación del archivo \"%s\": modo %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Buscando %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Falló la búsqueda de %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "la consulta del archivo spec %s falló, no se pudo analizar\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s es un RPM Delta y no puede ser instalado directamente\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Carga útil (%s) no soportada en el paquete %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "el paquete %s ya fue añadido, omitiendo %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "el paquete %s ya fue añadido, reemplazando con %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(no es un número)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(no base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(tipo no válido)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(no es un blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(tipo xml no válido)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(no es una firma OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Fecha no válida %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal        "
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "reemplazado"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "no instalado"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "compartido en red"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "color incorrecto"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "no se encuentra"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(desconocido) "
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(no es una cadena)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s guardado como %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s creado como %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: falló al eliminar: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "directorio"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "archivo"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1761,7 +1911,8 @@ msgstr "no verificar resumen del paquete(s)"
 
 #: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
-msgstr "no verificar la base de datos de lo(s) encabezado(s) cuando sean recuperadas"
+msgstr ""
+"no verificar la base de datos de lo(s) encabezado(s) cuando sean recuperadas"
 
 #: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
@@ -1841,15 +1992,18 @@ msgid "relocations must have a / following the ="
 msgstr "realocaciones deben tener una / después de ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "instalar todos los archivos, incluso los de configuración, que de otra manera serían salteados."
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"instalar todos los archivos, incluso los de configuración, que de otra "
+"manera serían salteados."
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "remueve todos los paquetes que coincidan con <paquetes> (normalmente un error es generado si <paquete> especifica multiples paquetes) "
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"remueve todos los paquetes que coincidan con <paquetes> (normalmente un "
+"error es generado si <paquete> especifica multiples paquetes) "
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1927,7 +2081,7 @@ msgstr "actualizar la base de datos, mas no modificar el sistema de archivos"
 msgid "do not verify package dependencies"
 msgstr "no verificar las dependencias del paquete"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "no verificar el digest de los archivos"
 
@@ -2005,7 +2159,9 @@ msgstr "no ejecutar ningún %%triggerpostun scriptlet(s)"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "actualiza a una versión antigua del paquete (--force en actualizaciones hace esto automaticamente)"
+msgstr ""
+"actualiza a una versión antigua del paquete (--force en actualizaciones hace "
+"esto automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2047,162 +2203,182 @@ msgstr "actualizar paquete(s)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "consultar/verificar todos los paquetes"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "modo rpm checksig"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "consultar/verificar archivo propietario de paquete(s)"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "consultar/verificar paquete(s) en grupo"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "consultar/verificar un archivo de paquete"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "consultar/verificar paquete(s) con identificador de paquete"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "consultar/verificar paquete(s)con identificador de cabecera"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "modo de consulta rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "consultar/verificar una instancia de la cabecera"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "consultar/verificar paquete(s) de la transacción de la instalación"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "consultar los paquetes lanzados por el paquete"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "modo de verificación de rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "consultar/verificar los paquetes que requieren una dependencia"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "consultar/verificar paquetes que proporcionan una dependencia"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "consultar/verificar los paquetes que requieren una dependencia"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "consultar/verificar los paquetes que requieren una dependencia"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "consultar/verificar los paquetes que requieren una dependencia"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "consultar/verificar los paquetes que requieren una dependencia"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "ningún argumento para glob"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "no procese los archivos que no pertenecen al paquete como manifiestos"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "listar todos los archivos de configuración"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "listar todos los archivos de documentación"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "Volcar información de archivo básica"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "listar archivos del paquete"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "saltar archivos %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "mostrar el estado de los archivos listados"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "no verificar el tamaño de los archivos"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "no verificar la ruta symlink de los archivos"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "no verificar el propietario de los archivos"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "no verificar el grupo de los archivos"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "no verificar el tiempo de modificación de los archivos"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "no verificar el modo de los archivos"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "no verificar las capacidades de los archivos"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "no verificar los contextos de seguridad del archivo"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "no verificar los archivos en el paquete"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "no verificar las dependencias de paquetes"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "no ejecutar scripts de verificación"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "No se encuentran características rpmlib para %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "se esperaba el paquete fuente, paquete binario encontrado\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "el paquete fuente no contiene archivo .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "falló el desempaquetado de archivos %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " en archivo"
 
@@ -2277,96 +2453,118 @@ msgstr "ningún paquete coincide con %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "ningún paquete requiere %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "ningún paquete requiere %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "sin detonante de paquetes %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "ningún paquete requiere %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "ningún paquete requiere %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ningún paquete proporciona %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "archivo %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "el archivo %s no es propiedad de ningún paquete\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de paquete inválido: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "el registro %u no pudo ser leído\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "el paquete %s no está instalado\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconocida:\"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: falló la importación de la llave %d\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: la llave %d no es una llave pública protegida.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: falló la lectura para importar(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: falló headerRead: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: la cabecera de región no modificable no pudo ser leída. ¿Estará corrupto el paquete?\n"
+msgstr ""
+"%s: la cabecera de región no modificable no pudo ser leída. ¿Estará corrupto "
+"el paquete?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread falló: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NO ESTA BIEN"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "BIEN"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (FALTAN LAS CLAVES:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CLAVES NO CONFIABLES:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: falló la apertura: %s\n"
@@ -2391,144 +2589,205 @@ msgstr "No se puede cambiar el directorio raíz: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "No es posible restablecer el directorio raíz: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "SI"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, y Obsoletes: dependencias soportan versiones."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "nombres de archivos almacenados como (dirName,baseName,dirIndex) \"tuple\", no como ruta."
+msgstr ""
+"nombres de archivos almacenados como (dirName,baseName,dirIndex) \"tuple\", "
+"no como ruta."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "la carga del paquete puede ser comprimida utilizando bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "la carga del paquete puede ser comprimida utilizando xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "la carga del paquete puede ser comprimida tilizando bzip2. "
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "los archivos de carga del paquete tienen el prefijo  \"./\"."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
-msgstr "nombre-versión-lanzamiento del paquete no se proporciona implícitamente."
+msgstr ""
+"nombre-versión-lanzamiento del paquete no se proporciona implícitamente."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
-msgstr "las etiquetas del encabezado son siempre ordenadas después de ser cargadas."
+msgstr ""
+"las etiquetas del encabezado son siempre ordenadas después de ser cargadas."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "el intérprete de scriptlet puede utilizar argumentos del encabezado."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
-msgstr "un conjunto de enlaces fijos de archivo puede ser instalado aunque no se haya completado."
+msgstr ""
+"un conjunto de enlaces fijos de archivo puede ser instalado aunque no se "
+"haya completado."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "scriplets de paquete pueden acceder a la base de datos rpm mientras se está imstalando."
+msgstr ""
+"scriplets de paquete pueden acceder a la base de datos rpm mientras se está "
+"imstalando."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "soporte interno para scripts lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "el algoritmo de digest se puede configurar por paquete"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "soporte para capacidades de archivo POSIX1e."
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
-msgstr "los scriptlets de los paquetes pueden ser expandidos en el momento de la instalación."
+msgstr ""
+"los scriptlets de los paquetes pueden ser expandidos en el momento de la "
+"instalación."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "la comparación de dependencias admite versiones con virgulilla."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "no verificar las dependencias del paquete"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "se necesita una versión"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "dependencia no válida"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "No terminado %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "dependencia no válida"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "usuario %s no existe - utilizando root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupo %s no existe - utilizando root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Magic erróneo"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Encabezado erróneo/imposible de leer"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "El tamaño del encabezado es demasiado extenso"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Archivo muy grande para compactar"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Tipo de archivo desconocido"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "El digest no coincide"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Error interno"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "El fichero del archivo no se encuentra en el encabezado"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " falló - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "la apertura de %s falló: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: no es un paquete rpm (o manifiesto de paquete)\n"
@@ -2560,42 +2819,42 @@ msgstr "Error de dependencias:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: no es un paquete rpm (o manifiesto de paquete): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s no puede ser instalado\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Recuperando %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "omitiendo %s - transferencia fallida\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paquete %s no es reubicable\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "error al leer del archivo %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" especifica varios paquetes:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "no se puede abrir %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instalando %s\n"
@@ -2621,12 +2880,12 @@ msgstr "falló la lectura: %s  (%d)\n"
 msgid "not an rpm package\n"
 msgstr "no es un paquete rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "no es posible crear el bloqueo %s sobre %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "esperando el bloqueo %s sobre %s\n"
@@ -2683,7 +2942,9 @@ msgstr "conflicto del archivo %s entre instalaciones intentadas de %s y %s"
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "el archivo %s de la instalación de %s entra en conflicto con el archivo del paquete %s"
+msgstr ""
+"el archivo %s de la instalación de %s entra en conflicto con el archivo del "
+"paquete %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2693,12 +2954,16 @@ msgstr "el paquete %s (que es más nuevo que %s) ya está instalado"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "para la instalación del paquete %s es necesario %<PRIu64>%cB en el sistema de archivos %s"
+msgstr ""
+"para la instalación del paquete %s es necesario %<PRIu64>%cB en el sistema "
+"de archivos %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "para la instalación del paquete %s es necesario %<PRIu64> inodos en el sistema de archivos %s"
+msgstr ""
+"para la instalación del paquete %s es necesario %<PRIu64> inodos en el "
+"sistema de archivos %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2722,7 +2987,8 @@ msgstr "%s es sustituido por %s%s"
 #: lib/rpmprob.c:172
 #, c-format
 msgid "unknown error %d encountered while manipulating package %s"
-msgstr "se encontró el error desconocido %d mientras se manipulaba el paquete %s"
+msgstr ""
+"se encontró el error desconocido %d mientras se manipulaba el paquete %s"
 
 #: lib/rpmrc.c:222
 #, c-format
@@ -2784,60 +3050,80 @@ msgstr "falta la arquitectura para %s en %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "opción errónea '%s' en %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Falló al leer el vector auxiliar, ¿estará montado /proc?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconocido: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Por favor contacte %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "No se puede abrir %s para lectura: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "No es posible restaurar el directorio actual: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
-msgstr "soporte interno para macro de inclución de guiones <lua>, no fue construido\n"
+msgstr ""
+"soporte interno para macro de inclución de guiones <lua>, no fue construido\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "No se pudo crear un archivo temporal para %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "No se pudo duplicar el descritor de archivo %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "No ha sido posible leer el icono %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "No es posible restablecer el directorio raíz: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite falló: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s: macro de ejecución de guión fallido, waitpid(%d) rd %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s: macro de ejecución de guión fallido, señal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s: macro de ejecución de guión fallido, estado de terminación %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "formato desconocido"
 
@@ -2849,127 +3135,146 @@ msgstr "instalar "
 msgid "erase"
 msgstr "borrar"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "no se puede abrir la base de datos Packages en %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' extra en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' ausente en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' ausente en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: lectura de la clave publica fallida.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transacción"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(no es una firma OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "Resumen MD5: "
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Incapaz de recargar el encabezado de la firma\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Resumen SHA1 del encabezado:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Encabezado"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "Resumen MD5: "
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Resumen SHA1 del encabezado:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "ignorado"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "falló"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "falta %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dependencias no satisfechas para %s:\n"
@@ -3043,240 +3348,247 @@ msgstr "iterador de arreglo usado con arreglos de diferente tamaño"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generando %d índice(s) faltante(s), espere…\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "no se ha establecido dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: omitiendo"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "error(%d) almacenando registro #%d en %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s:  regexec falló: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp falló: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: omitiendo"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: encabezado dañado #%u recuperada -- omitiendo.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: no se pudo leer encabezado en 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "no se ha establecido dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "no se pudo crear el directorio %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "encabezado #%u erróneo en la base de datos -- omitiendo.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "no se puede añadir el registro original en %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "falló la reconstrucción de la base de datos: la base de datos original permanece en su lugar\n"
+msgstr ""
+"falló la reconstrucción de la base de datos: la base de datos original "
+"permanece en su lugar\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
-msgstr "¡falló el remplazo de la base de datos antigua con la nueva base de datos!\n"
+msgstr ""
+"¡falló el remplazo de la base de datos antigua con la nueva base de datos!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "reemplazar archivos en %s con los archivos de %s a recuperar"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "falló la eliminación del directorio %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "no se pudo obtener bloqueo %s en %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "compartido"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exclusivo"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "tipo de índice %x inválido en  %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "error(%d) al obtener registros «%s» desde el índice %s: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "error(%d) almacenando registros \"%s\" en %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "error(%d) eliminando registro \"%s\" de %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "error(%d) estableciendo registro de encabezado #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "error(%d) eliminando registro de encabezado #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "error(%d) asignando nueva instancia de paquete\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "opciones db no reconocidas: \"%s\" ignorado.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s tiene un valor numérico no válido, omitido\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s tiene un valor largo demasiado grande o demasiado pequeño, omitido\n"
+msgstr ""
+"%s tiene un valor largo demasiado grande o demasiado pequeño, omitido\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s tiene un valor entero demasiado grande o demasiado pequeño, omitido\n"
+msgstr ""
+"%s tiene un valor entero demasiado grande o demasiado pequeño, omitido\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "no se pudo obtener bloqueo %s en %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "compartido"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exclusivo"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "tipo de índice %x inválido en  %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "error(%d) al obtener registros «%s» desde el índice %s: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "error(%d) almacenando registros \"%s\" en %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "error(%d) eliminando registro \"%s\" de %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "error(%d) estableciendo registro de encabezado #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "error(%d) eliminando registro de encabezado #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "error(%d) asignando nueva instancia de paquete\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vacío)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vacío)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "El macro %%%s tiene opciones no terminadas\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "El macro %%%s tiene un cuerpo incompleto\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "El macro %%%s tiene un nombre ilegal (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "El macro %%%s tiene un cuerpo vacío\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Falló la expansión del macro macro %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "El macro %%%s tiene un nombre ilegal (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opción desconocida %c en %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Demasiados niveles de recursión en la expansión macro. Esto seguramente haya sido provocado por una declaración macro recursiva.\n"
+msgstr ""
+"Demasiados niveles de recursión en la expansión macro. Esto seguramente haya "
+"sido provocado por una declaración macro recursiva.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "No terminado %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% está seguido por un macro no analizable\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== activo %d vacío %d\n"
@@ -3296,31 +3608,31 @@ msgstr "Archivo %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "El archivo %s tiene menos de %u bytes\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "falló al crear el directorio"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxis no válida en el macro de ejecución de scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxis no valida en el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "falló el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxis no valida en el archivo de scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "falló el enlace de lua: %s\n"
@@ -3329,19 +3641,19 @@ msgstr "falló el enlace de lua: %s\n"
 msgid "[none]"
 msgstr "[ninguno]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(ningún error)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "error fatal:"
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "error: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "advertencia:"
 
@@ -3350,99 +3662,154 @@ msgstr "advertencia:"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "la asignación de memoria (%u bytes) retornó NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID de clave %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "error al crear el archivo temporal %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "error al crear el archivo temporal %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "error al crear el archivo temporal %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "no se pudo crear el directorio %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite falló: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush fallido: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Firma PGP no soportada\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algoritmo hash PGP no soportado %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algoritmo de llave pública PGP no soportado %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "No se pudo crear la tuberia para firmar: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "No se pudo ejecutar %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: falló la apertura: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "falló la llamada al sistema exec para gpg (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg falló al escribir la firma\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "incapaz de leer la firma\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature falló: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature falló: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: falló headerRead: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "faló makeTempFile\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "falló exec\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: falló headerRead: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s ya contiene una firma idéntica, ignorando\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature falló: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "No es posible firmar paquetes RPM v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s ya contiene una firma idéntica, ignorando\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature falló: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "faló makeTempFile\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead falló: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "falló el reemplazo %s: %s\n"
@@ -3455,3 +3822,22 @@ msgstr "%s: falló la lectura del manifiesto: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "no verificar firma de encabezado+carga"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Introduzca la frase de acceso:"
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "La frase de acceso es correcta\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr ""
+#~ "Falló la verificación de la contraseña, o la llave gpg ha expirado\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "propietario/grupo erróneo: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "línea %d: Carácter ilegal en: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "No se pudo crear la tuberia para firmar: %m"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/rpm-team/rpm/language/fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr "Tarkistusvalitsimet (-V tai --verify yhteydessä)"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Asennus-, päivitys- ja poistovalitsimet:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Yhteiset valitsimet kaikille rpm moodeille:"
@@ -100,7 +100,7 @@ msgstr "odottamaton kyselyn muotoilu"
 msgid "unexpected query source"
 msgstr "odottamaton kyselyn lähde"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "vain yksi päätila voidaan määritellä"
 
@@ -119,7 +119,9 @@ msgstr "--prefix valintaa ei voi käyttää --relocate tai --excludepath kanssa"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate ja --excludepath: voidaan käyttää vain uusia paketteja asennettaessa"
+msgstr ""
+"--relocate ja --excludepath: voidaan käyttää vain uusia paketteja "
+"asennettaessa"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +137,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -177,19 +178,24 @@ msgstr "--allfiles: voidaan käyttää vain paketteja asennettaessa"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb: voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
+msgstr ""
+"--justdb: voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "skriptien estovalintoja voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
+msgstr ""
+"skriptien estovalintoja voidaan käyttää vain paketteja asennettaessa tai "
+"poistettaessa"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "laukaisimien estovalintoja voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
+msgstr ""
+"laukaisimien estovalintoja voidaan käyttää vain paketteja asennettaessa tai "
+"poistettaessa"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +207,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametrit --root (-r):lle alettava /-merkillä"
 
@@ -221,201 +227,250 @@ msgstr "kyselylle ei annettu parametrejä"
 msgid "no arguments given for verify"
 msgstr "tarkistukselle ei annettu parametrejä"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot on jo määritelty, %s:ää ei huomioida\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "käännä %prep-osioon asti spec-tiedostosta"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<spec-tiedosto>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "käännä %build-osioon asti (%prep ja %build) spec-tiedostosta"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "käännä %install-osioon asti (%prep, %build ja %install) spec-tiedostosta"
+msgstr ""
+"käännä %install-osioon asti (%prep, %build ja %install) spec-tiedostosta"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "tarkista %files-osio spec-tiedostosta"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "käännä lähde- ja binääripaketit spec-tiedostosta"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "käännä vain binääripaketti spec-tiedostosta"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "käännä vain lähdepaketti spec-tiedostosta"
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "käännä %prep-osioon asti tar-tiedostosta"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "käännä %prep-osioon asti spec-tiedostosta"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tar-tiedosto>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "käännä %build-osioon asti (%prep ja %build) tar-tiedostosta"
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "käännä %install-osioon asti (%prep, %build ja %install) tar-tiedostosta"
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "tarkista %files-osio tar-tiedostosta"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "käännä lähde- ja binääripaketit tar-tiedostosta"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr "käännä vain binääripaketti tar-tiedostosta"
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr "käännä vain lähdepaketti tar-tiedostosta"
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "käännä binääripaketti lähdepaketista"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<lähdepaketti>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "käännä %build-osioon asti (%prep ja %build) spec-tiedostosta"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "käännä %install-osioon asti (%prep, %build ja %install) lähdepaketista"
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "tarkista %files-osio spec-tiedostosta"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "käännä binääripaketti lähdepaketista"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "käännä binääripaketti lähdepaketista"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "käännä vain lähdepaketti spec-tiedostosta"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "käännä %prep-osioon asti tar-tiedostosta"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tar-tiedosto>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "käännä %build-osioon asti (%prep ja %build) tar-tiedostosta"
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+"käännä %install-osioon asti (%prep, %build ja %install) tar-tiedostosta"
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "tarkista %files-osio tar-tiedostosta"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "käännä lähde- ja binääripaketit tar-tiedostosta"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr "käännä vain binääripaketti tar-tiedostosta"
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr "käännä vain lähdepaketti tar-tiedostosta"
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "käännä binääripaketti lähdepaketista"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "ohita käännösjuuri"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "hakemiston luonti epäonnistui"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "poista käännöspuu, kun valmis"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "jätä ExcludeArch-directiivit huomioimatta"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "älä suorita mitään käännöksen vaiheita"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "älä tarkista käännösriippuvuuksia"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "älä suorita mitään käännöksen vaiheita"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "poista lähdekoodit kun valmis"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "poista määrittelytiedosto kun valmis"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "siirry suoraan määriteltyyn vaiheeseen (vain c ja i yhteydessä)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "ohita kohdealusta"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Käännösvalitsimet:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Puuttuvia käännösriippuvuuksia:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "En voi avata spec-tiedostoa %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar-putken avaus epäonnistui: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "En voi avata spec-tiedostoa %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Spec-tiedoston avaaminen %s:sta epäonnistui\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Uudelleen nimeäminen %s -> %s epäonnistui: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "%s:n stat epäonnistui: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Tiedosto %s ole tavallinen tiedosto.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Tiedosto %s ei vaikuta spec-tiedostolta.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Käännetään kohdealustoille: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Käännetään kohteelle %s\n"
@@ -464,49 +519,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "ei annettu parametrejä"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "allekirjoita paketti (hylkää nykyinen allekirjoitus)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "poista paketin allekirjoitus"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "asenna paketteja"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Allekirjoitusvalitsimet:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s:ää ei voitu suorittaa: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Sinun pitää asettaa \"gpg_name:\" makrotiedostossasi\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Syötä salasana: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Salasana täsmää.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix: voidaan käyttää vain uusia paketteja asennettaessa"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches: voidaan käyttää vain paketteja poistettaessa"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +594,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "käytä seuraava kyselyformaattia"
 
@@ -571,68 +641,70 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\nRPM käännösvirheitä:\n"
+msgstr ""
+"\n"
+"RPM käännösvirheitä:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "syntaksivirhe jäsentäessä ==:aa\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "syntaksivirhe jäsentäessä &&:aa\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "syntaksivirhe jäsentäessä ||:aa\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "jäsennysvirhe lausekkeessa\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "pariton (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- vain numeroissa\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! vain numeroissa\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "tyyppien täytyy olla yhtenevät\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / ei tuettu merkkijonoille\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- ei tuettu merkkijoinoille\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& ja || ei tuettu merkkijoinoille\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "syntaksivirhe lausekkeessa\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Puuttuva '(' %s %s:ssä\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "puuttuva ')' %s:(%s:ssä\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Virheellinen %s merkki: %s\n"
@@ -642,46 +714,46 @@ msgstr "Virheellinen %s merkki: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Puuttuva %s %s %s:ssä\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Virheellinen syntaksi: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Virheellinen oikeusmäärittely %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Virheellinen hakemisto-oikeusmäärittely %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Tiedostojen täytyy alkaa \"/\": %s\n"
@@ -691,149 +763,151 @@ msgstr "Tiedostojen täytyy alkaa \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Tiedosto lueteltu kahdesti: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolinen linkki osoittaa BuildRoot:iin: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Tiedostoa ei löytynyt: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: julkisen avaimen luku epäonnistui\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ei ole panssaroitu julkinen avain.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Tiedosto tarvitsee aloitusmerkin \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Tiedostoa ei löytynyt täydennyksellä: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "%%files tiedostoa %s ei voitu avata: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "rivi: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Tiedostoa ei löytynyt täydennyksellä: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Virheellinen tiedosto: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Virheellinen omistaja/ryhmä: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Tarkistetaan paketoimattomia tiedostoja: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Löytyi asennettuja (mutta paketoimattomia) tiedostoja:\n%s"
+msgstr ""
+"Löytyi asennettuja (mutta paketoimattomia) tiedostoja:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Käsitellään tiedostoja: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +936,76 @@ msgstr "%s: rivi: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Allekirjoitusotsikon uudelleenlataus ei onnistu\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Tuntematon kuorman pakkaus: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s:aa ei voitu avata: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Pakettia ei voitu kirjoittaa: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Tilapäisotsikon kirjoitus ei onnistu\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Kirjoitettiin: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Suoritetaan \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "%s:n suoritus epäonnistui.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paketin tarkistus \"%s\" epäonnistui.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Tiedostonimen muodostus paketille %s ei onnistu: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s:n luonti ei onnistu: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "rivi %d: toinen %s\n"
@@ -985,19 +1056,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "rivi %d: virhe jäsennettäessä %%description-osiota %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "rivi %d: virheellinen valinta %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "rivi %d: liikaa nimiä: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "line %d: pakettia ei ole olemassa: %s\n"
@@ -1103,91 +1174,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "rivi %d: laiton merkki '%c' %s:ssä\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "rivi %d: laiton merkki %s:ssä\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "rivi %d: laiton merkkijono \"..\" %s:ssä\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "rivi %d: toinen %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: rivi: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "rivi %d: Epoch-kentän täytyy olla etumerkitön numero: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "rivi %d: virheellinen käännösarkkitehtuurin muoto: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Virheellinen pakettimäärittely: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paketti on jo olemassa: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "rivi %d: tuntematon nimiö: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ei voi olla tyhjä\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ei voi olla \"/\"\n"
@@ -1197,161 +1273,193 @@ msgstr "%%{buildroot} ei voi olla \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Virheellinen lähde: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Ei patchia numero %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Ei lähdettä numero %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Virhe jäsennettäessä %%setup-osiota: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "rivi %d: virheellinen argumentti %%setup:ille: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "rivi %d: virheellinen %%setup valitsin %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Virheellinen patch-numero %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "rivi %d: toinen %%prep-osio\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "rivi %d: laukaisimissa pitää olla --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "rivi %d: virhe jäsennettäessä %s:ää: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "rivi %d: sisäisen skriptin täytyy päättyä '>':n: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "rivi %d: skriptitulkin täytyy alkaa '/':lla: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "rivi %d: toinen %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "rivi %d: %s:\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ei voi avata %s:ää: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else ilman %%if:iä\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif ilman %%if:iä\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Ei yhteensopivia arkkitehtureeja käännökselle\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paketissa ei ole %%description-osiota: %s\n"
@@ -1422,290 +1530,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ei voitu luoda putkea %s:lle: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Ei voitu suorittaa %s:ää: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ei voitu suorittaa %s:ää: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) epäonnistui: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load epäonnistui: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Tiedoston \"%s\" tunnistaminen epäonnistui: moodi %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Etsitään %s:ää: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s:ää ei löytynyt\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "määrittelytiedoston %s kysely epäonnistui\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s on Delta RPM eikä sitä voida suoraan asentaa\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Tuntematon kuorma (%s) paketissa %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paketti %s on jo lisätty, ohitetaan %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paketti %s oli jo lisätty, korvataan %s:lla\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(ei ole luku)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(ei ole base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(virheellinen tyyppi)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(ei ole binääridataa)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(virheellinen xml-tyyppi)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(ei ole OpenPGP-allekirjoitus)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normaali"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "korvattu"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "ei asennettu"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "verkkojaettu"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "väärä väri"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(tuntematon)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(ei ole merkkijono)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s talletettiin %s:nä\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s luotu %s:na\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1933,17 @@ msgid "relocations must have a / following the ="
 msgstr "siirroissa pitää olla / =-merkin jälkeen"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "asenna kaikki tiedostot, myös konfiguraatiot, jotka muuten ehkä ohitettaisiin"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"asenna kaikki tiedostot, myös konfiguraatiot, jotka muuten ehkä ohitettaisiin"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "poista kaikki paketit, joiden nimeä vastaa  <paketti> (tavallisesti, jos  <paketti> määrittää useita paketteja, tulee virhe)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"poista kaikki paketit, joiden nimeä vastaa  <paketti> (tavallisesti, jos  "
+"<paketti> määrittää useita paketteja, tulee virhe)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2021,7 @@ msgstr "päivitä tietokanta, mutta älä muuta tiedostojärjestelmää"
 msgid "do not verify package dependencies"
 msgstr "älä tarkista paketin riippuvuuksia"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "älä tarkista tiedostojen tarkistussummia"
 
@@ -1998,7 +2099,9 @@ msgstr "älä suorita %%triggerpostun scriptejä"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "päivitä vanhempaan versioon (--force päivitettäessä tekee tämän automaattisesti)"
+msgstr ""
+"päivitä vanhempaan versioon (--force päivitettäessä tekee tämän "
+"automaattisesti)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2143,182 @@ msgstr "päivitä paketteja"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "kysele/tarkista kaikki paketit"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm allekirjoituksen tarkistustila"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "kysele/tarkista pakettia, jonka omistuksessa <tiedosto> on"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "kysele/tarkista paketteja ryhmässä"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "kysele/tarkista pakettitiedostoa"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm kyselytila"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm tarkistustila"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "kysele/tarkista paketteja, jotka tarjoavat ominaisuuden"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "luettele kaikki konfiguraatiotiedostot"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "luettele kaikki dokumentaatiotiedostot"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "luettele paketin tiedostot"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "ohita %%ghost tiedostot"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "näytä lueteltujen tiedostojen tilat"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "älä tarkista tiedostojen kokoa"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "älä tarkista tiedostojen symbolisen linkin polkua"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "älä tarkista tiedostojen omistajaa"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "älä tarkista tiedostojen ryhmää"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "älä tarkista tiedostojen muutosaikaa"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "älä tarkista tiedostojen oikeuksia"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "älä tarkista paketin tiedostoja"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "älä tarkista paketin riippuvuuksia"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "älä suorita tarkistusskriptejä"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "arkiston %s%s purkaminen epäonnistui: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " tiedostolle "
 
@@ -2270,96 +2393,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "mikään paketti ei tarvitse %s:a\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "mikään paketti ei tarvitse %s:a\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "mikään paketti ei laukaise %s:a\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "mikään paketti ei tarvitse %s:a\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "mikään paketti ei tarvitse %s:a\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "mikään paketti ei tarjoa %s:a\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "tiedosto %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "tiedostoa %s ei omista mikään paketti\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "virheellinen paketin numero: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "tietuetta %u ei voitu lukea\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paketti %s ei ole asennettu\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tuntematon nimiö: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Tiedoston luku epäonnistui: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "EI OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr "(PUUTTUVIA AVAIMIA:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (EPÄLUOTETTAVIA AVAIMIA:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: avaus epäonnistui: %s\n"
@@ -2384,144 +2527,192 @@ msgstr "Juurihakemiston vaihto ei onnistu: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Juurihakemiston palautus ei onnistu: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "EI "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "KYLLÄ "
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "älä tarkista paketin riippuvuuksia"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Päättämätön %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "käyttäjää %s ei ole olemassa, käytetään käyttäjää root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "ryhmää %s ei ole olemassa, käytetään ryhmää root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Virheellinen otsikkotieto"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Otsikkotieto liian suuri"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Tuntematon tiedostotyyppi"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Tarkistussumma ei täsmää"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Sisäinen virhe"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " epäonnistui - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s:n avaus ei onnistunut: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: ei ole rpm paketti (tai pakettilista)\n"
@@ -2553,42 +2744,42 @@ msgstr "Puuttuvia riippuvuuksia:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: ei ole rpm paketti (tai pakettilista): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s:ää ei voida asentaa\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Haetaan %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "ohitetaan %s - siirto epäonnistui\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paketti %s ei ole uudelleensijoitettava\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "virhe luettaessa tiedostosta %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" määrittää useita paketteja:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "virhe: en voi avata %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Asennetaan %s\n"
@@ -2614,12 +2805,12 @@ msgstr "luku epäonnistui: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "ei ole RPM paketti\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "%s-lukon luonti %s:een ei onnistu (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "odotetaan %s-lukkoa %s\n"
@@ -2686,12 +2877,14 @@ msgstr "paketti %s (joka on uudempi kuin %s) on jo asennettuna"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "paketin %s asennus tarvitsee %<PRIu64>%c tavua tiedostojärjestelmällä %s"
+msgstr ""
+"paketin %s asennus tarvitsee %<PRIu64>%c tavua tiedostojärjestelmällä %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "paketin %s asennus tarvitsee %<PRIu64> inodea tiedostojärjestelmällä %s"
+msgstr ""
+"paketin %s asennus tarvitsee %<PRIu64> inodea tiedostojärjestelmällä %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2777,60 +2970,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Tuntematon järjestelmä: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Ota yhteyttä %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "En voi avata %s luettavaksi: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Ei voitu luoda tilapäistiedostoa %s:lle: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Ikonia %s ei voida lukea: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Juurihakemiston palautus ei onnistu: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite epäonnistui: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s scripti epäonnistui, waitpid(%d) palautti %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skripti epäonnistui, signaali %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s skripti epäonnistui, palautti %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Tuntematon formaatti"
 
@@ -2842,127 +3054,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "Pakettitietokantaa %s ei voida avata\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: julkisen avaimen luku epäonnistui.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(ei ole OpenPGP-allekirjoitus)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr ""
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Allekirjoitusotsikon uudelleenlataus ei onnistu\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Otsikko "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "epäonnistui"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "puuttuva  %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Tyydyttämättömiä riippuvuuksia %s:lle:\n"
@@ -3036,240 +3267,241 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "dbpath ei ole asetettu\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: ohitetaan"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "virhe(%d) tallennettaessa tietuetta #%d %s:ään\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec epäonnistui: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp epäonnistui: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: ohitetaan"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: ohitetaan vioittunut otsikkotietue #%u.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: otsikkoa ei voida lukea (0x%x)\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "dbpath ei ole asetettu"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "hakemiston %s luonti epäonnistui: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "tietue numero %u tietokannassa viallinen -- ohitetaan.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "alkupäisen tietueen %u lisäys ei onnistu\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "tietokannan uudelleenrakennus epäonnistui: alkuperäinen kanta paikallaan\n"
+msgstr ""
+"tietokannan uudelleenrakennus epäonnistui: alkuperäinen kanta paikallaan\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "vanhan tietokannan korvaus uudella epäonnistui!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "korvaa tiedostot %s:ssä tiedostoilla %s:stä korjataksesi"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "hakemiston %s poisto epäonnistui: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "en saa %s lukitusta tietokantaan %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "jaettua"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "poissulkevaa"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "virhe(%d) tallennettaessa tietuetta %s %s:ään\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "virhe(%d) poistettaessa tietuetta %s %s:stä\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "virhe(%d) lisättäessä otsikkon #%d tietuetta\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "virhe(%d) poistettaessa otsikon #%d tietuetta\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "virhe(%d) varattaessa uutta paketti-instanssia\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "en saa %s lukitusta tietokantaan %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "jaettua"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "poissulkevaa"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "virhe(%d) tallennettaessa tietuetta %s %s:ään\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "virhe(%d) poistettaessa tietuetta %s %s:stä\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "virhe(%d) lisättäessä otsikkon #%d tietuetta\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "virhe(%d) poistettaessa otsikon #%d tietuetta\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "virhe(%d) varattaessa uutta paketti-instanssia\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tyhjä)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tyhjä)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makrossa %%%s on päättämättömiä valitsimia\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makrossa %%%s on päättämätön runko\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makron %%%s nimi on laiton (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makron %%%s runko on tyhjä\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makron %%%s laajennos ei onnistunut\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makron %%%s nimi on laiton (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Tuntematon valitsin %c %s(%s):ssä\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Päättämätön %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% seuraa makro jota ei voida jäsentää\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiivisia %d tyhjiä %d\n"
@@ -3289,31 +3521,31 @@ msgstr "Tiedosto %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "hakemiston luonti epäonnistui"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "virheellinen syntaksi lua-skriptissä: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "virheellinen syntaksi lua-skriptissä: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skripti epäonnistui: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "virheellinen syntaksi lua-tiedostossa: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua-koukku epäonnistui: %s\n"
@@ -3322,19 +3554,19 @@ msgstr "lua-koukku epäonnistui: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(ei virhettä)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "vakava virhe: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "virhe: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "varoitus: "
 
@@ -3343,99 +3575,154 @@ msgstr "varoitus: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "muistin varaus (%u tavua) palautti NULL:in.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(ei mitään)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "virhe luotaessa tilapäistä tiedostoa %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "virhe luotaessa tilapäistä tiedostoa %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "virhe luotaessa tilapäistä tiedostoa %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "hakemiston %s luonti epäonnistui: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr ""
+msgid "Could not exec %s: %s\n"
+msgstr "%s:ää ei voitu suorittaa: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: avaus epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg:n suoritus epäonnistui (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg ei voinut kirjoittaa allekirjoitusta\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "en voinut lukea allekirjoitusta\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature epäonnistui: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature epäonnistui: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "suoritus epäonnistui\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp epäonnistui\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "suoritus epäonnistui\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "suoritus epäonnistui\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature epäonnistui: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp epäonnistui\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3735,15 @@ msgstr "%s: pakettilistan luku epäonnistui: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "älä tarkista otsikon ja kuorman allekirjoitusta"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Syötä salasana: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Salasana täsmää.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Virheellinen omistaja/ryhmä: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "rivi %d: laiton merkki %s:ssä\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,21 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Finnish (http://www.transifex.com/projects/p/rpm/language/"
-"fi/)\n"
-"Language: fi\n"
+"Language-Team: Finnish (http://www.transifex.com/rpm-team/rpm/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,7 +79,7 @@ msgstr "Tarkistusvalitsimet (-V tai --verify yhteydessä)"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Asennus-, päivitys- ja poistovalitsimet:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Yhteiset valitsimet kaikille rpm moodeille:"
@@ -101,7 +100,7 @@ msgstr "odottamaton kyselyn muotoilu"
 msgid "unexpected query source"
 msgstr "odottamaton kyselyn lähde"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "vain yksi päätila voidaan määritellä"
 
@@ -120,9 +119,7 @@ msgstr "--prefix valintaa ei voi käyttää --relocate tai --excludepath kanssa"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate ja --excludepath: voidaan käyttää vain uusia paketteja "
-"asennettaessa"
+msgstr "--relocate ja --excludepath: voidaan käyttää vain uusia paketteja asennettaessa"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -138,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -179,24 +177,19 @@ msgstr "--allfiles: voidaan käyttää vain paketteja asennettaessa"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb: voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
+msgstr "--justdb: voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"skriptien estovalintoja voidaan käyttää vain paketteja asennettaessa tai "
-"poistettaessa"
+msgstr "skriptien estovalintoja voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"laukaisimien estovalintoja voidaan käyttää vain paketteja asennettaessa tai "
-"poistettaessa"
+msgstr "laukaisimien estovalintoja voidaan käyttää vain paketteja asennettaessa tai poistettaessa"
 
 #: rpmqv.c:231
 msgid ""
@@ -208,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametrit --root (-r):lle alettava /-merkillä"
 
@@ -228,250 +221,201 @@ msgstr "kyselylle ei annettu parametrejä"
 msgid "no arguments given for verify"
 msgstr "tarkistukselle ei annettu parametrejä"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot on jo määritelty, %s:ää ei huomioida\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "käännä %prep-osioon asti spec-tiedostosta"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<spec-tiedosto>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "käännä %build-osioon asti (%prep ja %build) spec-tiedostosta"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"käännä %install-osioon asti (%prep, %build ja %install) spec-tiedostosta"
+msgstr "käännä %install-osioon asti (%prep, %build ja %install) spec-tiedostosta"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "tarkista %files-osio spec-tiedostosta"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "käännä lähde- ja binääripaketit spec-tiedostosta"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "käännä vain binääripaketti spec-tiedostosta"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "käännä vain lähdepaketti spec-tiedostosta"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "käännä %prep-osioon asti spec-tiedostosta"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "käännä %prep-osioon asti tar-tiedostosta"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tar-tiedosto>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "käännä %build-osioon asti (%prep ja %build) tar-tiedostosta"
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "käännä %install-osioon asti (%prep, %build ja %install) tar-tiedostosta"
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "tarkista %files-osio tar-tiedostosta"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "käännä lähde- ja binääripaketit tar-tiedostosta"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr "käännä vain binääripaketti tar-tiedostosta"
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr "käännä vain lähdepaketti tar-tiedostosta"
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "käännä binääripaketti lähdepaketista"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<lähdepaketti>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "käännä %build-osioon asti (%prep ja %build) spec-tiedostosta"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "käännä %install-osioon asti (%prep, %build ja %install) lähdepaketista"
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "tarkista %files-osio spec-tiedostosta"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "käännä binääripaketti lähdepaketista"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "käännä binääripaketti lähdepaketista"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "käännä vain lähdepaketti spec-tiedostosta"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "käännä %prep-osioon asti tar-tiedostosta"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tar-tiedosto>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "käännä %build-osioon asti (%prep ja %build) tar-tiedostosta"
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"käännä %install-osioon asti (%prep, %build ja %install) tar-tiedostosta"
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "tarkista %files-osio tar-tiedostosta"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "käännä lähde- ja binääripaketit tar-tiedostosta"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr "käännä vain binääripaketti tar-tiedostosta"
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr "käännä vain lähdepaketti tar-tiedostosta"
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "käännä binääripaketti lähdepaketista"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "ohita käännösjuuri"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "hakemiston luonti epäonnistui"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "poista käännöspuu, kun valmis"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "jätä ExcludeArch-directiivit huomioimatta"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "älä suorita mitään käännöksen vaiheita"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "älä tarkista käännösriippuvuuksia"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "älä suorita mitään käännöksen vaiheita"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "poista lähdekoodit kun valmis"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "poista määrittelytiedosto kun valmis"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "siirry suoraan määriteltyyn vaiheeseen (vain c ja i yhteydessä)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "ohita kohdealusta"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Käännösvalitsimet:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Puuttuvia käännösriippuvuuksia:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "En voi avata spec-tiedostoa %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar-putken avaus epäonnistui: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "En voi avata spec-tiedostoa %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Spec-tiedoston avaaminen %s:sta epäonnistui\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Uudelleen nimeäminen %s -> %s epäonnistui: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "%s:n stat epäonnistui: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Tiedosto %s ole tavallinen tiedosto.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Tiedosto %s ei vaikuta spec-tiedostolta.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Käännetään kohdealustoille: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Käännetään kohteelle %s\n"
@@ -520,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "ei annettu parametrejä"
 
@@ -540,10 +484,29 @@ msgstr "poista paketin allekirjoitus"
 msgid "Signature options:"
 msgstr "Allekirjoitusvalitsimet:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "%s:ää ei voitu suorittaa: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Sinun pitää asettaa \"gpg_name:\" makrotiedostossasi\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Syötä salasana: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Salasana täsmää.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -561,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "käytä seuraava kyselyformaattia"
 
@@ -608,70 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"RPM käännösvirheitä:\n"
+msgstr "\nRPM käännösvirheitä:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "syntaksivirhe jäsentäessä ==:aa\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "syntaksivirhe jäsentäessä &&:aa\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "syntaksivirhe jäsentäessä ||:aa\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "jäsennysvirhe lausekkeessa\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "pariton (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- vain numeroissa\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! vain numeroissa\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "tyyppien täytyy olla yhtenevät\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / ei tuettu merkkijonoille\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- ei tuettu merkkijoinoille\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& ja || ei tuettu merkkijoinoille\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "syntaksivirhe lausekkeessa\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Puuttuva '(' %s %s:ssä\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "puuttuva ')' %s:(%s:ssä\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Virheellinen %s merkki: %s\n"
@@ -681,46 +642,46 @@ msgstr "Virheellinen %s merkki: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Puuttuva %s %s %s:ssä\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Virheellinen syntaksi: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Virheellinen oikeusmäärittely %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Virheellinen hakemisto-oikeusmäärittely %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Tiedostojen täytyy alkaa \"/\": %s\n"
@@ -730,146 +691,149 @@ msgstr "Tiedostojen täytyy alkaa \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Tiedosto lueteltu kahdesti: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolinen linkki osoittaa BuildRoot:iin: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Tiedostoa ei löytynyt: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: julkisen avaimen luku epäonnistui\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ei ole panssaroitu julkinen avain.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Tiedosto tarvitsee aloitusmerkin \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Tiedostoa ei löytynyt täydennyksellä: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "%%files tiedostoa %s ei voitu avata: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "rivi: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Virheellinen tiedosto: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Virheellinen omistaja/ryhmä: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Tarkistetaan paketoimattomia tiedostoja: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Löytyi asennettuja (mutta paketoimattomia) tiedostoja:\n"
-"%s"
+msgstr "Löytyi asennettuja (mutta paketoimattomia) tiedostoja:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Käsitellään tiedostoja: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -898,79 +862,79 @@ msgstr "%s: rivi: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Allekirjoitusotsikon uudelleenlataus ei onnistu\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Tuntematon kuorman pakkaus: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s:aa ei voitu avata: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Pakettia ei voitu kirjoittaa: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Tilapäisotsikon kirjoitus ei onnistu\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "%%files tiedostoa %s ei voitu avata: %m\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Tiedoston luku epäonnistui: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Kirjoitettiin: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Suoritetaan \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "%s:n suoritus epäonnistui.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paketin tarkistus \"%s\" epäonnistui.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Tiedostonimen muodostus paketille %s ei onnistu: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s:n luonti ei onnistu: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "rivi %d: toinen %s\n"
@@ -1021,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "rivi %d: virhe jäsennettäessä %%description-osiota %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "rivi %d: virheellinen valinta %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "rivi %d: liikaa nimiä: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "line %d: pakettia ei ole olemassa: %s\n"
@@ -1139,96 +1103,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "rivi %d: laiton merkki '%c' %s:ssä\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "rivi %d: laiton merkkijono \"..\" %s:ssä\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "rivi %d: laiton merkki %s:ssä\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "rivi %d: toinen %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "rivi %d: laiton merkkijono \"..\" %s:ssä\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: rivi: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "rivi %d: Epoch-kentän täytyy olla etumerkitön numero: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "rivi %d: virheellinen käännösarkkitehtuurin muoto: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Virheellinen pakettimäärittely: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paketti on jo olemassa: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "rivi %d: tuntematon nimiö: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ei voi olla tyhjä\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ei voi olla \"/\"\n"
@@ -1238,193 +1197,161 @@ msgstr "%%{buildroot} ei voi olla \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Virheellinen lähde: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Ei patchia numero %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Ei lähdettä numero %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Virhe jäsennettäessä %%setup-osiota: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "rivi %d: virheellinen argumentti %%setup:ille: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "rivi %d: virheellinen %%setup valitsin %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Virheellinen patch-numero %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "rivi %d: toinen %%prep-osio\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "rivi %d: laukaisimissa pitää olla --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "rivi %d: virhe jäsennettäessä %s:ää: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "rivi %d: sisäisen skriptin täytyy päättyä '>':n: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "rivi %d: skriptitulkin täytyy alkaa '/':lla: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "rivi %d: toinen %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "rivi %d: %s:\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ei voi avata %s:ää: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else ilman %%if:iä\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif ilman %%if:iä\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Ei yhteensopivia arkkitehtureeja käännökselle\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paketissa ei ole %%description-osiota: %s\n"
@@ -1495,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ei voitu luoda putkea %s:lle: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Ei voitu suorittaa %s:ää: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ei voitu suorittaa %s:ää: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) epäonnistui: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load epäonnistui: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Tiedoston \"%s\" tunnistaminen epäonnistui: moodi %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Etsitään %s:ää: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s:ää ei löytynyt\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "määrittelytiedoston %s kysely epäonnistui\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s on Delta RPM eikä sitä voida suoraan asentaa\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Tuntematon kuorma (%s) paketissa %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paketti %s on jo lisätty, ohitetaan %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paketti %s oli jo lisätty, korvataan %s:lla\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(ei ole luku)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(ei ole base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(virheellinen tyyppi)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(ei ole binääridataa)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(virheellinen xml-tyyppi)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(ei ole OpenPGP-allekirjoitus)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normaali"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "korvattu"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "ei asennettu"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "verkkojaettu"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "väärä väri"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(tuntematon)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(ei ole merkkijono)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s talletettiin %s:nä\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s luotu %s:na\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1898,17 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "siirroissa pitää olla / =-merkin jälkeen"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"asenna kaikki tiedostot, myös konfiguraatiot, jotka muuten ehkä ohitettaisiin"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "asenna kaikki tiedostot, myös konfiguraatiot, jotka muuten ehkä ohitettaisiin"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"poista kaikki paketit, joiden nimeä vastaa  <paketti> (tavallisesti, jos  "
-"<paketti> määrittää useita paketteja, tulee virhe)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "poista kaikki paketit, joiden nimeä vastaa  <paketti> (tavallisesti, jos  <paketti> määrittää useita paketteja, tulee virhe)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1986,7 +1920,7 @@ msgstr "päivitä tietokanta, mutta älä muuta tiedostojärjestelmää"
 msgid "do not verify package dependencies"
 msgstr "älä tarkista paketin riippuvuuksia"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "älä tarkista tiedostojen tarkistussummia"
 
@@ -2064,9 +1998,7 @@ msgstr "älä suorita %%triggerpostun scriptejä"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"päivitä vanhempaan versioon (--force päivitettäessä tekee tämän "
-"automaattisesti)"
+msgstr "päivitä vanhempaan versioon (--force päivitettäessä tekee tämän automaattisesti)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2108,182 +2040,162 @@ msgstr "päivitä paketteja"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "kysele/tarkista kaikki paketit"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm allekirjoituksen tarkistustila"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "kysele/tarkista pakettia, jonka omistuksessa <tiedosto> on"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "kysele/tarkista paketteja ryhmässä"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "kysele/tarkista pakettitiedostoa"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm kyselytila"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm tarkistustila"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "kysele/tarkista paketteja, jotka tarjoavat ominaisuuden"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "kysele/tarkista paketteja, jotka vaativat ominaisuutta"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "luettele kaikki konfiguraatiotiedostot"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "luettele kaikki dokumentaatiotiedostot"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "luettele paketin tiedostot"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "ohita %%ghost tiedostot"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "näytä lueteltujen tiedostojen tilat"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "älä tarkista tiedostojen kokoa"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "älä tarkista tiedostojen symbolisen linkin polkua"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "älä tarkista tiedostojen omistajaa"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "älä tarkista tiedostojen ryhmää"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "älä tarkista tiedostojen muutosaikaa"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "älä tarkista tiedostojen oikeuksia"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "älä tarkista paketin tiedostoja"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "älä tarkista paketin riippuvuuksia"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "älä suorita tarkistusskriptejä"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "arkiston %s%s purkaminen epäonnistui: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " tiedostolle "
 
@@ -2358,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "mikään paketti ei tarvitse %s:a\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "mikään paketti ei tarvitse %s:a\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "mikään paketti ei laukaise %s:a\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "mikään paketti ei tarvitse %s:a\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "mikään paketti ei tarvitse %s:a\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "mikään paketti ei tarjoa %s:a\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "tiedosto %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "tiedostoa %s ei omista mikään paketti\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "virheellinen paketin numero: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "tietuetta %u ei voitu lukea\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paketti %s ei ole asennettu\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tuntematon nimiö: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Tiedoston luku epäonnistui: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "EI OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr "(PUUTTUVIA AVAIMIA:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (EPÄLUOTETTAVIA AVAIMIA:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: avaus epäonnistui: %s\n"
@@ -2492,192 +2384,144 @@ msgstr "Juurihakemiston vaihto ei onnistu: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Juurihakemiston palautus ei onnistu: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "EI "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "KYLLÄ "
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "älä tarkista paketin riippuvuuksia"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Päättämätön %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "käyttäjää %s ei ole olemassa, käytetään käyttäjää root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "ryhmää %s ei ole olemassa, käytetään ryhmää root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Virheellinen otsikkotieto"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Otsikkotieto liian suuri"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Tuntematon tiedostotyyppi"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Tarkistussumma ei täsmää"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Sisäinen virhe"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " epäonnistui - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s:n avaus ei onnistunut: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: ei ole rpm paketti (tai pakettilista)\n"
@@ -2709,42 +2553,42 @@ msgstr "Puuttuvia riippuvuuksia:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: ei ole rpm paketti (tai pakettilista): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s:ää ei voida asentaa\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Haetaan %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "ohitetaan %s - siirto epäonnistui\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paketti %s ei ole uudelleensijoitettava\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "virhe luettaessa tiedostosta %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" määrittää useita paketteja:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "virhe: en voi avata %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Asennetaan %s\n"
@@ -2770,12 +2614,12 @@ msgstr "luku epäonnistui: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "ei ole RPM paketti\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "%s-lukon luonti %s:een ei onnistu (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "odotetaan %s-lukkoa %s\n"
@@ -2842,14 +2686,12 @@ msgstr "paketti %s (joka on uudempi kuin %s) on jo asennettuna"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"paketin %s asennus tarvitsee %<PRIu64>%c tavua tiedostojärjestelmällä %s"
+msgstr "paketin %s asennus tarvitsee %<PRIu64>%c tavua tiedostojärjestelmällä %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"paketin %s asennus tarvitsee %<PRIu64> inodea tiedostojärjestelmällä %s"
+msgstr "paketin %s asennus tarvitsee %<PRIu64> inodea tiedostojärjestelmällä %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2939,75 +2781,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Tuntematon järjestelmä: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Ota yhteyttä %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "En voi avata %s luettavaksi: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Ei voitu luoda tilapäistiedostoa %s:lle: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Ikonia %s ei voida lukea: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Juurihakemiston palautus ei onnistu: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite epäonnistui: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s scripti epäonnistui, waitpid(%d) palautti %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skripti epäonnistui, signaali %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s skripti epäonnistui, palautti %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Tuntematon formaatti"
 
@@ -3019,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "Pakettitietokantaa %s ei voida avata\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: julkisen avaimen luku epäonnistui.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(ei ole OpenPGP-allekirjoitus)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Otsikko "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Otsikko "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "epäonnistui"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "puuttuva  %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Tyydyttämättömiä riippuvuuksia %s:lle:\n"
@@ -3228,241 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "dbpath ei ole asetettu\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: ohitetaan"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "virhe(%d) tallennettaessa tietuetta #%d %s:ään\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec epäonnistui: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp epäonnistui: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: ohitetaan"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: ohitetaan vioittunut otsikkotietue #%u.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: otsikkoa ei voida lukea (0x%x)\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "dbpath ei ole asetettu"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "hakemiston %s luonti epäonnistui: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "tietue numero %u tietokannassa viallinen -- ohitetaan.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "alkupäisen tietueen %u lisäys ei onnistu\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"tietokannan uudelleenrakennus epäonnistui: alkuperäinen kanta paikallaan\n"
+msgstr "tietokannan uudelleenrakennus epäonnistui: alkuperäinen kanta paikallaan\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "vanhan tietokannan korvaus uudella epäonnistui!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "korvaa tiedostot %s:ssä tiedostoilla %s:stä korjataksesi"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "hakemiston %s poisto epäonnistui: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "en saa %s lukitusta tietokantaan %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "jaettua"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "poissulkevaa"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "virhe(%d) tallennettaessa tietuetta %s %s:ään\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "virhe(%d) poistettaessa tietuetta %s %s:stä\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "virhe(%d) lisättäessä otsikkon #%d tietuetta\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "virhe(%d) poistettaessa otsikon #%d tietuetta\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "virhe(%d) varattaessa uutta paketti-instanssia\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tyhjä)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tyhjä)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makrossa %%%s on päättämättömiä valitsimia\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makrossa %%%s on päättämätön runko\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makron %%%s nimi on laiton (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makron %%%s runko on tyhjä\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makron %%%s laajennos ei onnistunut\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makron %%%s nimi on laiton (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Tuntematon valitsin %c %s(%s):ssä\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Päättämätön %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% seuraa makro jota ei voida jäsentää\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiivisia %d tyhjiä %d\n"
@@ -3482,31 +3289,31 @@ msgstr "Tiedosto %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "hakemiston luonti epäonnistui"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "virheellinen syntaksi lua-skriptissä: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "virheellinen syntaksi lua-skriptissä: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skripti epäonnistui: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "virheellinen syntaksi lua-tiedostossa: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua-koukku epäonnistui: %s\n"
@@ -3515,19 +3322,19 @@ msgstr "lua-koukku epäonnistui: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(ei virhettä)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "vakava virhe: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "virhe: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "varoitus: "
 
@@ -3536,121 +3343,99 @@ msgstr "varoitus: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "muistin varaus (%u tavua) palautti NULL:in.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(ei mitään)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "virhe luotaessa tilapäistä tiedostoa %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "virhe luotaessa tilapäistä tiedostoa %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "virhe luotaessa tilapäistä tiedostoa %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "hakemiston %s luonti epäonnistui: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s:ää ei voitu suorittaa: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: avaus epäonnistui: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "%s:ää ei voitu suorittaa: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "%%files tiedostoa %s ei voitu avata: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg:n suoritus epäonnistui (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg ei voinut kirjoittaa allekirjoitusta\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "en voinut lukea allekirjoitusta\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature epäonnistui: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp epäonnistui\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3663,30 +3448,3 @@ msgstr "%s: pakettilistan luku epäonnistui: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "älä tarkista otsikon ja kuorman allekirjoitusta"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Syötä salasana: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Salasana täsmää.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Virheellinen omistaja/ryhmä: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "rivi %d: laiton merkki %s:ssä\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Kuorman kirjoitus %s:ään ei onnistu: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Kuorman luku %s:stä ei onnistu: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "En voi avata väliaikaistiedostoa.\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Otsikkotiedon lukeminen %s:stä epäonnistui: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Otsikkotiedon kirjoittaminen %s:n epäonnistui: %s\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,23 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Jérôme Fenal <jfenal@gmail.com>, 2013
-# Mathieu LEFEBVRE Mathdabomb <mathdabomb@gmail.com>, 2011-2012
+# Mathieu LEFEBVRE Mathdabomb <mathdabomb@gmail.com>, 2011-2012,2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
-"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: French (http://www.transifex.com/projects/p/rpm/language/"
-"fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-07-05 17:54+0000\n"
+"Last-Translator: Mathieu LEFEBVRE Mathdabomb <mathdabomb@gmail.com>\n"
+"Language-Team: French (http://www.transifex.com/rpm-team/rpm/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -39,9 +38,7 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Ce programme peut être librement redistribué sous les termes de la licence "
-"GNU GPL\n"
+msgstr "Ce programme peut être librement redistribué sous les termes de la licence GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -84,7 +81,7 @@ msgstr "Options de vérifications (avec -V ou --verify) :"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Options d'installation/désinstallation/mise à jour :"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Options communes à tous les modes et exécutables rpm :"
@@ -105,7 +102,7 @@ msgstr "format de requête inattendu"
 msgid "unexpected query source"
 msgstr "source de requête inattendue"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "un seul mode majeur peut être spécifié"
 
@@ -124,9 +121,7 @@ msgstr "impossible d'utiliser --prefix avec --relocate ou --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate et --excludepath ne peuvent être utilisés qu'à l'installation de "
-"nouveaux paquets"
+msgstr "--relocate et --excludepath ne peuvent être utilisés qu'à l'installation de nouveaux paquets"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,15 +134,12 @@ msgstr "les arguments de --prefix doivent commencer par un /"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr ""
-"--hash (-h) ne peut être utilisé que lors d'une installation ou une "
-"suppression de paquet"
+msgstr "--hash (-h) ne peut être utilisé que lors d'une installation ou une suppression de paquet"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
-msgstr ""
-"--percent ne peut être utilisé que lors d'une installation ou une "
-"suppression de paquet"
+msgid ""
+"--percent may only be specified during package installation and erasure"
+msgstr "--percent ne peut être utilisé que lors d'une installation ou une suppression de paquet"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
@@ -187,40 +179,31 @@ msgstr "--allfiles ne peut être utilisé qu'à l'installation de paquet"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb ne peut être utilisé qu'à l'installation/la désinstallation de "
-"paquet"
+msgstr "--justdb ne peut être utilisé qu'à l'installation/la désinstallation de paquet"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"les options désactivant les scripts ne peuvent être utilisées qu'à la "
-"(dés)installation"
+msgstr "les options désactivant les scripts ne peuvent être utilisées qu'à la (dés)installation"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"les options désactivant les triggers ne peuvent être utilisées qu'à la "
-"(dés)installation"
+msgstr "les options désactivant les triggers ne peuvent être utilisées qu'à la (dés)installation"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps ne peut être utilisé qu'à l'installation/la désinstallation/la "
-"vérification de paquet"
+msgstr "--nodeps ne peut être utilisé qu'à l'installation/la désinstallation/la vérification de paquet"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"--test ne peut être utilisé qu'à l'installation/la désinstallation de paquet"
+msgstr "--test ne peut être utilisé qu'à l'installation/la désinstallation de paquet"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "les arguments ed --root (-r) doivent commencer par un /"
 
@@ -240,270 +223,201 @@ msgstr "aucun argument fournit à la requête"
 msgid "no arguments given for verify"
 msgstr "aucun argument fournit à la vérification"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot déjà spécifié, %s ignoré\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"construction jusqu'à la section %prep (déballage des sources et applications "
-"des patchs) du <fichier_spec>"
+msgstr "construction jusqu'à la section %prep (déballage des sources et applications des patchs) du <fichier_spec>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<fichier_spec>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"construction jusqu'à la section %build (%prep, et compilation) du "
-"<fichier_spec>"
+msgstr "construction jusqu'à la section %build (%prep, et compilation) du <fichier_spec>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"construction jusqu'à la section %install (%prep, %build, et installation) du "
-"<fichier_spec>"
+msgstr "construction jusqu'à la section %install (%prep, %build, et installation) du <fichier_spec>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "vérifier la section %files du <fichier_spec>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "construire les paquet sources et binaires à partir du <fichier_spec>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "construction du paquet binaire seulement à partir du <fichier_spec>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "construction du paquet source seulement à partir du <fichier_spec>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"construction jusqu'à la section %prep (déballage des sources et applications "
-"des patchs) du <fichier_spec>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<paquet source>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"construction jusqu'à la section %build (%prep, et compilation) du "
-"<fichier_spec>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"construire jusqu'à la section %install (%prep, %build, et installation) à "
-"partir du <paquet source>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "vérifier la section %files du <fichier_spec>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "construire le paquet binaire à partir du <paquet source>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "construire le paquet binaire à partir du <paquet source>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "construction du paquet source seulement à partir du <fichier_spec>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"construire jusqu'à la section %prep (déballage des sources et application "
-"des patchs) à partir du <tarball>"
+msgstr "construire jusqu'à la section %prep (déballage des sources et application des patchs) à partir du <tarball>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-"construire jusqu'à la section %build (%prep, puis compilation) à partir du "
-"<tarball>"
+msgstr "construire jusqu'à la section %build (%prep, puis compilation) à partir du <tarball>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"construire jusqu'à la section %build (%prep, %build, puis installation) à "
-"partir du <tarball>"
+msgstr "construire jusqu'à la section %build (%prep, %build, puis installation) à partir du <tarball>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "vérifier la section %files à partir du <tarball>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "construire les paquet source et binaire à partir du <tarball>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "construire seulement le paquet binaire à partir du <tarball>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "construire seulement le paquet source à partir du <tarball>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "construire le paquet binaire à partir du <paquet source>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<paquet source>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "construire jusqu'à la section %install (%prep, %build, et installation) à partir du <paquet source>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "surcharger le buildroot"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Impossible d'ouvrir le répertoire courant : %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "effacer l'arborescence de construction une fois terminé"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorer les directives ExcludeArch: du fichier spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "déboguer la machine à états de fichiers (déballage)"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "n'exécuter aucune étape de la construction"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "ne pas vérifier les dépendances de construction"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
-"générer un(des) entête(s) de paquet compatible(s) avec l'empaquetage rpm v3 "
-"(hérité)"
+msgstr "générer un(des) entête(s) de paquet compatible(s) avec l'empaquetage rpm v3 (hérité)"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "ne pas exécuter l'étape %clean de la construction"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "ne pas exécuter l'étape %clean de la construction"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "ne pas exécuter l'étape %check de la construction"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "ne pas accepter les msgstr de l'i18n du specfile"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "effacer les sources une fois terminé"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "effacer le fichier spec une fois terminé"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "aller directement à l'étape spécifiée (seulement pour c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "surcharger la plate-forme cible"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Options de construction avec [ <fichier_spec> | <tarball> | <paquet "
-"source> ] :"
+msgstr "Options de construction avec [ <fichier_spec> | <tarball> | <paquet source> ] :"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Dépendances de construction manquantes:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Impossible d'ouvrir le fichier spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Impossible d'ouvrir le pipe de tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Plus d'un fichier sur la ligne : %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Impossible de lire le fichier spec à %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Impossible de renommer %s en %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "échec de stat sur %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Fichier %s non régulier.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Le fichier %s ne semble pas être un fichier spec.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Construction pour plate-formes cibles: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Construction pour cible %s\n"
@@ -514,9 +428,7 @@ msgstr "initialiser la base de données"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"refaire les listes inversées de la base de données à partir des entêtes des "
-"paquets installés"
+msgstr "refaire les listes inversées de la base de données à partir des entêtes des paquets installés"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -554,7 +466,7 @@ msgstr "listes les clés du trousseau RPM"
 msgid "Keyring options:"
 msgstr "Options du trousseau :"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "aucun argument fournit"
 
@@ -574,12 +486,29 @@ msgstr "supprimer les signatures de paquets"
 msgid "Signature options:"
 msgstr "Options de signatures :"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Impossible d'exécuter %s : %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
-msgstr ""
-"Vous devez affecter une valeur à \"%%_gpg_name\" dans votre fichier de "
-"macros\n"
+msgstr "Vous devez affecter une valeur à \"%%_gpg_name\" dans votre fichier de macros\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Entrez la phrase de passe : "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Phrase de passe bonne.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Échec du mot de passe ou clé GPG expirée\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -597,7 +526,7 @@ msgstr "opérer sur le(s) rpm(s) binaire(s) généré(s) par spec (défaut)"
 msgid "operate on source rpm generated by spec"
 msgstr "opérer sur le rpm source généré par spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "utiliser le format de requête suivant"
 
@@ -644,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Erreur de construction de RPM :\n"
+msgstr "\n\nErreur de construction de RPM :\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "erreur de syntaxe en analysant ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "erreur de syntaxe en analysant &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "erreur de syntaxe en analysant ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "erreur de syntaxe dans l'expression\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "( non fermée\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- seulement sur des nombres\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! seulement sur des nombres\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "les types doivent correspondre\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / non supportés sur des chaînes de caractères\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- non prix en charge sur des chaînes de caractères\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& et || ne sont pas prix en charge sur des chaînes de caractères\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "erreur de syntaxe dans l'expression\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "'(' manquante dans %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "')' manquante dans %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Lexème %s invalide : %s\n"
@@ -718,46 +644,46 @@ msgstr "Lexème %s invalide : %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s manquant(e) dans %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "espace non-blanc suivant %s() : %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Mauvaise syntaxe : %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Mauvais mode spec : %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Mauvais dirmode spec : %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Mauvaise longueur de la locale : « %s » dans %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Deux fois la même locale %s dans %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacité invalide : %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Support de capacité du fichier non intégré\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Le fichier doit commencer par « / » : %s\n"
@@ -767,147 +693,149 @@ msgstr "Le fichier doit commencer par « / » : %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Algorithme %u du fichier de digest inconnu, recourt à MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Fichier listé deux fois : %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "la lecture du symlink %s a échouée : %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Lien symbolique pointant sur BuildRoot : %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Répertoire introuvable : %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fichier non trouvé : %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
-msgstr ""
+msgstr "Pas de répertoire: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s : ne peut pas charger le tag (%d) inconnu.\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s : échec de la lecture de la clé publique.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s : n'est pas une clé publique blindée.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s : échec de l'encodage.\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Le fichier non précédé d'un \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "globale %%dev non autorisée : %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Répertoire introuvable par glob : %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Fichier non trouvé par la substitution : %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Impossible d'ouvrir le fichier %%files %s : %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "Ligne : %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Erreur de lecture du fichiers %%files %s : %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Impossible de mélanger un %s spécial avec d'autres formes : %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Plus d'un fichier sur la ligne : %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Mauvais fichier : %s : %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Mauvais possesseur/groupe : %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Vérification des fichiers non empaquetés : %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Fichier(s) installé(s) (mais non empaquetés) :\n"
-"%s"
+msgstr "Fichier(s) installé(s) (mais non empaquetés) :\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Traitement des fichiers : %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"L'architecture de binaire (%d) ne correspond pas à celle du paquet (%d).\n"
+msgstr "L'architecture de binaire (%d) ne correspond pas à celle du paquet (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binaires dépendants d'une arch dans un paquet noarch\n"
 
@@ -936,79 +864,79 @@ msgstr "%s : ligne : %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Ne peut canoniser le nom d'hôte : %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Impossible de recharger l'entête de la signature.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compression de charge inconnue : %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Impossible de créer la partie immuable de l'entête.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Impossible d'ouvrir %s : %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Impossible d'écrire le paquet : %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Impossible d'écrire un entête temporaire\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Mauvaises données CSA\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Impossible d'ouvrir le fichier %s : %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "échec de la création de l'archive dans le fichier %s : %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Écrit : %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Exécution_de « %s » :\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "L'exécution de « %s » a échouée.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "La vérification du paquet « %s » a échouée.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne peut générer le nom de fichier pour le paquet %s : %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "Ne peut créer %s : %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "ligne %d : deuxième %s\n"
@@ -1059,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "ligne %d : erreur dans l'analyse syntaxique de la %%description : %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "ligne %d : mauvaise option %s : %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "ligne %d : trop de noms : %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "ligne %d : paquet inexistant : %s\n"
@@ -1177,96 +1105,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "ligne %d : le tag n'accepte qu'un seul lexème : %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "ligne %d : caractère '%c' illégal dans : %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "ligne %d : séquence illégale « .. » dans : %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "ligne %d : caractère illégal dans : %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "ligne %d : %s : %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "ligne %d : séquence illégale « .. » dans : %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s : ligne : %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "ligne %d : tag mal formé : %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "ligne %d : tag vide : %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "ligne %d : les préfixes ne doivent pas finir par un « / » : %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "ligne %d : le docdir doit commencer par un « / » : %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "ligne %d : le champ Epoch doit être un nombre : %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "ligne %d : mauvais %s : qualificatifs : %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "ligne %d : mauvais format pour BuildArchitecture : %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "ligne %d seuls les sous-paquets noarch sont pris en charge : %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erreur interne : tag bidon %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "ligne %d : %s est obsolète : %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Mauvaise spécification de paquet : %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paquet déjà existant : %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "ligne %d : tag inconnu : %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ne peux pas être vide\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ne peut pas être « / »\n"
@@ -1276,197 +1199,161 @@ msgstr "%%{buildroot} ne peut pas être « / »\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Mauvaise source : %s : %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Pas de numéro de patch %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sans correspondance avec le tag « Patch : »\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Pas de numéro de source %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Pas de tag « Source: » dans le fichier spec\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erreur d'analyse syntaxique du %%setup : %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "ligne %d : mauvais argument à %%setup : %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "ligne %d : mauvaise option à %%setup %s : %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s : %s : %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Numéro du patch invalide %s :%s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "ligne %d : deuxième %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr ""
-"Les jetons de dépendance doivent commencer par un caractère alpha-numérique, "
-"'_' ou '/'"
+msgstr "Les jetons de dépendance doivent commencer par un caractère alpha-numérique, '_' ou '/'"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Nom de version de fichier non autorisé"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "dépendance invalide"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Version requise"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "dépendance invalide"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "ligne %d : %s : %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "ligne %d : les triggers doivent avoir -- : %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "ligne %d : erreur d'analyse syntaxique %s : %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "ligne %d : le script interne doit se terminer par '>' : %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "ligne %d : le nom du script doit commencer par un '/' : %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-"ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "ligne %d : deuxième %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "ligne %d : script interne non pris en charge :%s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr ""
-"ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
+msgstr "ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "ligne %d : %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Impossible d'ouvrir %s : %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s :%d : argument attendu pour %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "ligne %d : %%if non terminé\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "ligne %d : macro non fermée ou mauvaise continuation de ligne\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s : %d : mauvaise condition %%if\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s : %d : j'ai là un %%else sans %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s : %d : j'ai là un %%endif sans %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: directive %%include mal-formée\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Pas d'architecture compatible pour construction\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Le paquet n'a pas de %%description : %s\n"
@@ -1474,8 +1361,7 @@ msgstr "Le paquet n'a pas de %%description : %s\n"
 #: build/policies.c:87
 #, c-format
 msgid "Policy module '%s' duplicated with overlapping types\n"
-msgstr ""
-"Le module de stratégie '%s' dupliqué avec des types qui se chevauchent\n"
+msgstr "Le module de stratégie '%s' dupliqué avec des types qui se chevauchent\n"
 
 #: build/policies.c:93
 #, c-format
@@ -1511,9 +1397,7 @@ msgstr "Impossible de déterminer un nom de la stratégie : %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"Le type '%s' donnée avec les autres types dans %%semodule %s. Compactage des "
-"types vers '%s'.\n"
+msgstr "Le type '%s' donnée avec les autres types dans %%semodule %s. Compactage des types vers '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1540,283 +1424,290 @@ msgstr "Trop nombreux arguments en ligne : %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Traitement de la stratégie : %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorer l'expression régulière %s invalide\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Impossible de créer le pipe pour %s : %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Impossible d'exécuter %s : %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Impossible de forker %s : %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s a échoué : %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "échec de l'écriture de toutes les données de %s : %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
-msgstr ""
+msgstr "mauvais opérateur"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
-msgstr ""
+msgstr "mauvais format"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "La conversion de %s vers un entier long a échoué.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Classificateur de fichier vide\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Aucun fichier attributs configurés\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) a échoué : %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load a échoué : %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "La reconnaissance du fichier « %s » a échoué : mode %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Trouver %s : %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Impossible de trouver %s :\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr ""
-"échec de la requête sur le fichier spec %s, impossible de faire l'analyser "
-"syntaxique\n"
+msgstr "échec de la requête sur le fichier spec %s, impossible de faire l'analyser syntaxique\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s est un Delta RPM et ne peut être installé directement\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Charge (%s) non pris en charge dans le paquet %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "le paquet %s a déjà été rajouté, %s ignoré\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "le paquet %s a déjà été rajouté, replacé par %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(n'est pas un nombre)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(pas base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(type invalide)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(pas un blob ça)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(type xml invalide)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(pas une signature OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Date invalide %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "remplacé"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "pas installé"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "sur le réseau"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "fausse couleur"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "manquant"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(inconnu)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(pas une chaîne)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sauvé en tant que %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s créé en tant que %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s : échec de la suppression : %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "répertoire"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "fichier"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1837,7 +1728,7 @@ msgstr ""
 
 #: lib/poptALL.c:182
 msgid "MACRO"
-msgstr ""
+msgstr "MACRO"
 
 #: lib/poptALL.c:184
 msgid "print macro expansion of EXPR"
@@ -1857,7 +1748,7 @@ msgstr "<FICHIER:...>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "n'autoriser aucun plugin"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
@@ -1945,17 +1836,15 @@ msgid "relocations must have a / following the ="
 msgstr "dans les relogements un / doit suivre le ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"installer tous les fichiers, même si les configurations disent le contraire"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "installer tous les fichiers, même si les configurations disent le contraire"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"retirer tous les paquets qui correspondent à <package> (normalement on "
-"retourne une erreur si le <package> correspond à plusieurs paquets"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "retirer tous les paquets qui correspondent à <package> (normalement on retourne une erreur si le <package> correspond à plusieurs paquets"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2003,9 +1892,7 @@ msgstr "<packagefile> +"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr ""
-"afficher des marqueurs au fur et à mesure que le paquet s'installe (avec -v "
-"c'est bien(tm))"
+msgstr "afficher des marqueurs au fur et à mesure que le paquet s'installe (avec -v c'est bien(tm))"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -2029,14 +1916,13 @@ msgstr "installer le(s) paquet(s)"
 
 #: lib/poptI.c:167
 msgid "update the database, but do not modify the filesystem"
-msgstr ""
-"mettre à jour la base données, mais ne pas modifier le système de fichiers"
+msgstr "mettre à jour la base données, mais ne pas modifier le système de fichiers"
 
 #: lib/poptI.c:173
 msgid "do not verify package dependencies"
 msgstr "ne pas vérifier les dépendances du paquet"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "ne pas vérifier les sommes de hachage des fichiers"
 
@@ -2050,9 +1936,7 @@ msgstr "ne pas installer les fichiers des contextes de sécurité"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"ne pas réarranger l'ordre d'installation des paquets pour satisfaire les "
-"dépendances"
+msgstr "ne pas réarranger l'ordre d'installation des paquets pour satisfaire les dépendances"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2116,9 +2000,7 @@ msgstr "n'exécuter aucun scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"mettre à jour avec un paquet plus ancien (une m-à-j avec --force fait ça "
-"automatiquement"
+msgstr "mettre à jour avec un paquet plus ancien (une m-à-j avec --force fait ça automatiquement"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2158,187 +2040,164 @@ msgstr "mises à jour des paquets"
 
 #: lib/poptI.c:254
 msgid "reinstall package(s)"
-msgstr ""
+msgstr "réinstaller le(s) paquet(s)"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "vérifier/demander à tous les paquets"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "mode rpm vérifsign"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "vérifier/demander un paquet possèdant un fichier"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "vérifier/questionner le(s) paquet(s) d'un même groupe"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "vérifier/questionner un fichier paquet"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "questionner/vérifier le(s) paquet(s) grâce à un identifieur de paquet"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
-msgstr ""
-"questionner/vérifier le(s) paquet(s) grâce à un identificateur d'entête"
+msgstr "questionner/vérifier le(s) paquet(s) grâce à un identificateur d'entête"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "mode de requête de rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "questionner/vérifier une instance d'entête"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
-msgstr ""
-"questionner/vérifier le(s) paquet(s) à partir de la transaction "
-"d'installation"
+msgstr "questionner/vérifier le(s) paquet(s) à partir de la transaction d'installation"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "questionner le(s) paquet(s) surveillé(s) par le paquet"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "mode de vérification de rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "vérifier/demander le(s) paquet(s) qui fourni(ssen)t une dépendance"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "Ne pas passer des arguments"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "ne traite pas les fichiers non-paquet comme manifestes"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "lister les fichiers de configuration"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "lister les fichiers documents"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
-msgstr ""
+msgstr "lister les fichiers de license"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "débite les informations de base des fichiers"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "lister les fichiers du paquet"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "éviter les fichiers fantômes %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "affiche la liste des fichiers et leur état"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "ne pas vérifier la taille des fichiers"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "ne pas vérifier le chemin du lien symbolique des fichiers"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "ne pas vérifier le possesseur des fichiers"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "ne pas vérifier le groupe possesseur des fichiers"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "ne pas vérifier les dates de modification des fichiers"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "ne pas vérifier les permissions des fichiers"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "ne pas vérifier les capacités des fichiers"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "ne pas vérifier la sécurité des fichiers"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "ne pas vérifier les fichiers du paquet"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ne pas vérifier les dépendances du paquet"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "ne pas exécuter le(s) script(s) de vérification"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Éléments rpmlib manquants pour %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "paquet source attendu, paquet binaire trouvé\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "le paquet source ne contient pas de fichier .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "échec du déballage de l'archive %s%s : %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " dans fichier "
 
@@ -2386,8 +2245,7 @@ msgstr "le paquet n'as pas de liste de possesseurs/groupes de fichiers\n"
 
 #: lib/query.c:228
 msgid "package has neither file owner or id lists\n"
-msgstr ""
-"le paquet n'a ni la liste des id ni celle des possesseurs de fichiers\n"
+msgstr "le paquet n'a ni la liste des id ni celle des possesseurs de fichiers\n"
 
 #: lib/query.c:317
 #, c-format
@@ -2414,117 +2272,96 @@ msgstr "aucun paquet ne correspond à %s : %s\n"
 msgid "no package requires %s\n"
 msgstr "aucun paquet ne requiert %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "aucun paquet ne requiert %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "aucun paquet ne surveille %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "aucun paquet ne requiert %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "aucun paquet ne requiert %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "aucun paquet ne fournit %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fichier %s : %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "le fichier %s n'appartient à aucun paquet\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "numéro de paquet invalide : %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "l'enregistrement %u n'a pas pu être lu\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "le paquet %s n'est pas installé\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tag inconnu: « %s »\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s : importation de la clé %d échouée.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s : la clés %d n'est pas une clé publique blindée.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s : l'importation de lecture a échoué (%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s : échec de headerRead %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s : la région d'en-tête immuable ne peut pas être lu. Paquet corrompu ?\n"
+msgstr "%s : la région d'en-tête immuable ne peut pas être lu. Paquet corrompu ?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s : Fread a échoué : %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "PAS OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (CLES MANQUANTES :"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CLES NONCREDIBLE :"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s : échec de l'ouverture : %s\n"
@@ -2549,208 +2386,147 @@ msgstr "Impossible de changer le répertoire racine : %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Impossible de restaurer le répertoire racine : %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NON"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "OUI"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr ""
-"Les dépendances de type PreReq:, Provides: et Obsoletes: supportent les "
-"versions."
+msgstr "Les dépendances de type PreReq:, Provides: et Obsoletes: supportent les versions."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"Le(s) nom(s) de fichier sont stockés en tant que triplets (NomRep,NomFich,"
-"IndexRep), pas en tant que chemin."
+msgstr "Le(s) nom(s) de fichier sont stockés en tant que triplets (NomRep,NomFich,IndexRep), pas en tant que chemin."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "La charge du paquet est compressée avec bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "La charge du paquet est compressée avec xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "La charge du paquet est compressée avec lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
-msgstr ""
-"le(s) fichier(s) de la charge utile du paquet ont « ./ » comme préfixe."
+msgstr "le(s) fichier(s) de la charge utile du paquet ont « ./ » comme préfixe."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "le nom-version-révision du paquet n'est pas implicitement fourni."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "les tags d'entête sont toujours triés après avoir été chargés."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
-msgstr ""
-"l'interprète du scriptlet peut utiliser des arguments à partir des entêtes."
+msgstr "l'interprète du scriptlet peut utiliser des arguments à partir des entêtes."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "un lien en dur pourrait être installé sans être complet."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"les scriptlets du paquet pourrait accéder à la base de données rpm pendant "
-"l'installation."
+msgstr "les scriptlets du paquet pourrait accéder à la base de données rpm pendant l'installation."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "prise en charge interne pour les scripts LUA."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "l'algorithme de hachage de fichier est configurable par paquet"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "prise en charge des capacités du fichier POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "les scriptlets du paquet peut être étendu lors de l'installation."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "la comparaison de dépendances prend en charge les versions avec tilde."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
-msgstr ""
+msgstr "supporte les fichiers supérieurs à 4GB"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "ne pas vérifier les dépendances du paquet"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Version requise"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "dépendance invalide"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c non terminé: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "dépendance invalide"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "utilisateur %s inexistant - utilisation de root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "groupe %s inexistant - utilisation de root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Mauvaise magie, blah"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Entête mauvais ou illisible"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Entête trop gros"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Fichier trop grand pour l'archive"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Type de fichier inconnu"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
-msgstr ""
+msgstr "Fichier(s) manquant(s)"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Digest ne correspond pas"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Erreur interne"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "L'entête ne contient pas le fichier archive"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " échec - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
-msgstr ""
+msgstr "%s: (erreur 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "échec de l'ouverture de %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
-msgstr ""
-"%s: n'est pas un paquet rpm (ni une liste de paquet)\n"
-"\n"
+msgstr "%s: n'est pas un paquet rpm (ni une liste de paquet)\n\n"
 
 #: lib/rpminstall.c:141
 #, c-format
@@ -2779,42 +2555,42 @@ msgstr "Dépendances requises:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s : n'est pas un paquet rpm (ni une liste de paquet) : %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s ne peut être installé\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Récupération de %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s ignoré - échec du transfert\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "le paquet %s n'est pas localisable\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "erreur en lisant %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "« %s » spécifie plusieurs paquets\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "impossible d'ouvrir %s : %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installation de %s\n"
@@ -2840,12 +2616,12 @@ msgstr "échec de lecture : %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "pas un paquet rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "Impossible de créer %s verrou sur %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "attente pour %s verrou sur %s\n"
@@ -2861,9 +2637,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Impossible de résoudre le symbole %s : %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Plugin %s non chargé\n"
+msgstr "Plugin %%__%s_%s non configuré\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2897,15 +2673,12 @@ msgstr "le chemin %s dans le paquet %s n'est pas localisable"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr ""
-"le fichier %s entre en conflit avec les tentatives d'installation de %s et %s"
+msgstr "le fichier %s entre en conflit avec les tentatives d'installation de %s et %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"le fichier %s de l'installation de %s entre en conflit avec le fichier du "
-"paquet %s"
+msgstr "le fichier %s de l'installation de %s entre en conflit avec le fichier du paquet %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2915,16 +2688,12 @@ msgstr "le paquet %s (plus récent que %s) est déjà installé"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"installer le paquetage %s nécessite %<PRIu64>%cB sur le système de fichiers "
-"%s"
+msgstr "installer le paquetage %s nécessite %<PRIu64>%cB sur le système de fichiers %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"installer le paquet %s nécessite %<PRIu64> inodes sur le système de fichiers "
-"%s"
+msgstr "installer le paquet %s nécessite %<PRIu64> inodes sur le système de fichiers %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -3014,77 +2783,56 @@ msgstr "mauvaise option '%s' à %s : %d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Échec de la lecture du vecteur auxiliaire, /proc est-il monté ?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "système inconnu : %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Contactez %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
-msgstr ""
-"Impossible d'ouvrir %s en lecture : %m.\n"
-"\n"
+msgstr "Impossible d'ouvrir %s en lecture : %m.\n\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Impossible de restaurer le répertoire courant : %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "le support du scriptlet <lua> n'est pas intégrer\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Impossible de créer de fichier temporaire pour %s : %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Impossible de dupliquer le descripteur de fichier : %s : %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Impossible de lire l'icône %s : %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Impossible de restaurer le répertoire racine : %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s : échec de Fwrite : %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "scriptlet %s échoué, waitpid(%d) rc %d : %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "scriptlet %s échoué, signal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s scriptlet échoué, état de sortie %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Format inconnu"
 
@@ -3096,142 +2844,127 @@ msgstr "installer"
 msgid "erase"
 msgstr "effacer"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "impossible d'ouvrir la base de données paquet dans %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' supplémentaire dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' manquante dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' manquante dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: la lecture de la clé publique a échoué.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transaction"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(pas une signature OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Entête "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 :"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Hachage de l'entête SHA1 :"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Entête "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
-msgstr ""
+msgstr "Vérification de signature: MAUVAIS PARAMETRES (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "sauté"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "échoué"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
-msgstr ""
+msgstr "pas d'état"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
-msgstr ""
+msgstr "état inconnu"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "manque   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dépendances non satisfaites pour %s :\n"
@@ -3305,246 +3038,240 @@ msgstr "itérateur de tableau utilisé avec des tableaux de tailles différentes
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Génération d'index manquant(s) %d, merci d'attendre...\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
-msgstr ""
+msgstr "impossible d'ouvrir l'index %s en utilisant %s - %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "aucun dbpath n'a été fourni\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader : ignoré"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "erreur(%d) en stockant l'article nº%d dans %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s : regexec a échoué :%s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s : regcomp a échoué :%s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator : ignoré"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb : l'entête #%u endommagée a été récupérée -- ignoré.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s : impossible de lire l'entête à 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "aucun dbpath fournit"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "Impossible de créer le répertoire %s : %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "l'entête #%u dans la base de données n'est pas bon -- ignoré.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "impossible d'ajouter l'article qui était au départ à %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"Ne peut reconstruire la base de données : la base originale reste telle "
-"qu'elle est\n"
+msgstr "Ne peut reconstruire la base de données : la base originale reste telle qu'elle est\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "Ne peut remplacer la vieille base de données par la nouvelle!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
-msgstr ""
-"remplacer les fichiers dans %s avec les fichiers de %s pour faire une "
-"récupération"
+msgstr "remplacer les fichiers dans %s avec les fichiers de %s pour faire une récupération"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "Ne peut détruire le répertoire %s : %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
-msgstr ""
+msgstr "erreur(%d) %s de %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
-msgstr ""
+msgstr "erreur(%d) %s : %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "options de db inconnues : \"%s\" ignoré.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s est une valeur numérique invalide, ignoré\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s est une valeur 'long' trop petite ou trop grande, ignoré\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s est une valeur entière trop petite ou trop grande, ignoré\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "impossible d'avoir le verrou %s sur %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "partagé"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exclusif"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "type d'index %x invalide sur %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "erreur(%d) en attrapant les articles « %s » de l'index %s : %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "erreur(%d) en stockant l'article « %s » dans %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "erreur(%d) en enlevant l'article « %s » de %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "Erreur(%d) ajout de l'enregistrement de l'en-tête #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "Erreur (%d) suppression de l'enregistrement de l'en-tête #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "erreur(%d) en allouant une nouvelle instance de paquet\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "options de db inconnues : \"%s\" ignoré.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s est une valeur numérique invalide, ignoré\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s est une valeur 'long' trop petite ou trop grande, ignoré\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s est une valeur entière trop petite ou trop grande, ignoré\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vide)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vide)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s a des options non-terminées\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s a un corps sans fin\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "La macro %%%s a un nom illégal (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s a un corps vide\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
-msgstr ""
+msgstr "La macro %%%s a besoin d'un espace avant le corps\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "La macro %%%s ne peut être expansée\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "La macro %%%s a un nom illégal (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
-msgstr ""
+msgstr "Macro %%%s définie mais non utilisée sans portée\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Option inconnue %c dans %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Trop de niveaux de récursivité dans l'expansion de la macro. Il est "
-"probablement causée par une déclaration de macro récursive.\n"
+msgstr "Trop de niveaux de récursivité dans l'expansion de la macro. Il est probablement causée par une déclaration de macro récursive.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c non terminé: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% est suivi d'une macro in-analysable\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
-msgstr ""
+msgstr "Impossible de charger le fichier macro %s"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d actif(s) %d vide(s)\n"
@@ -3564,31 +3291,31 @@ msgstr "Fichier %s : %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Le fichier %s est plus petit que %u octets\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "échec de création du répertoire"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "syntaxe invalide dans le scriptlet lua : %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "syntaxe invalide dans le script lua : %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "script lua échoué : %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "syntaxe invalide dans le fichier lua : %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "crochet lua échoué : %s\n"
@@ -3597,19 +3324,19 @@ msgstr "crochet lua échoué : %s\n"
 msgid "[none]"
 msgstr "[Aucun]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(pas d'erreur)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "erreur fatale : "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "erreur : "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "attention : "
 
@@ -3618,121 +3345,99 @@ msgstr "attention : "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "l'allocation de mémoire (%u octets) a retourné NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, clé ID %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(none)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "Erreur de création du fichier temporaire %s : %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "Erreur de création du fichier temporaire %s : %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "Erreur de création du fichier temporaire %s : %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "Impossible de créer le répertoire %s : %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s : échec de Fwrite : %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s : Fflush échoué : %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Signature PGP non supportée\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algorithme %u de hashage PGP non supporté\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algorithme %u clé publique PGP non supporté\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Impossible d'exécuter %s : %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Impossible de créer le pipe pour la signature : %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s : échec de l'ouverture : %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "fdopen échoué\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Impossible d'ouvrir le fichier %s : %s\n"
+msgstr "Impossible d'écrire dans le pipe\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Impossible d'ouvrir le fichier %%files %s : %m\n"
+msgstr "Impossible de lire le fichier %s: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg exec échoué (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "échec de gpg à écrire la signature\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "impossible de lire la signature\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s : échec de rpmReadSignature : %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Ne peut signer les paquets RPM v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s contient déjà une signature identique, ignoré\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s : échec de rpmWriteSignature : %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp échoué\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s : échec de writeLead : %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "remplacer %s à échouer : %s\n"
@@ -3745,104 +3450,3 @@ msgstr "%s : échec de la lecture de la liste de paquetages : %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "ne pas vérifier la signature de l'entête+charge_utile"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Entrez la phrase de passe : "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Phrase de passe bonne.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "Échec du mot de passe ou clé GPG expirée\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Mauvais possesseur/groupe : %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "ligne %d : caractère illégal dans : %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Impossible de créer le pipe pour la signature : %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Impossible d'écrire la charge utile dans %s : %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Impossible de lire la charge utile dans %s : %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Incapable d'ouvrir un fichier temporaire.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Impossible d'ouvrir sigtarget %s : %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Impossible de lire l'entête dans %s : %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Impossible d'écrire l'entête dans %s : %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "ne jamais effectuer de mesures de recouvrement"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "La région d'entête immuable ne peut pas être lu. Paquet corrompu?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Échec de décodage de la stratégie pour %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Impossible de créer le fichier temporaire %s : %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Impossible d'écrire la stratégie %s dans le fichier %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Impossible de créer semanage handle\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Impossible de se connecter au gestionnaire de la stratégie\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Impossible de commencer la transaction de la stratégie : %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr ""
-#~ "Échec de la suppression du fichier temporaire de la stratégie %s : %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Impossible d'installer le module de stratégie :%s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Impossible de supprimer le module de stratégie :%s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Échec du fork du processus : %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Impossible d'exécuter %s : %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s terminé anormalement\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s a échoué avec le code de sortie %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Impossible de valider les changements de stratégie\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Impossible d'étendre le chemin restorecon"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Impossible de renommer les fichiers. Les fichiers peuvent être mal "
-#~ "étiqueté\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Impossible de recharger les contextes de fichiers. Les fichiers peuvent "
-#~ "être mal étiquetés\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Impossible d'extraire la stratégie depuis %s\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Jérôme Fenal <jfenal@gmail.com>, 2013
 # Mathieu LEFEBVRE Mathdabomb <mathdabomb@gmail.com>, 2011-2012,2015
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-07-05 17:54+0000\n"
 "Last-Translator: Mathieu LEFEBVRE Mathdabomb <mathdabomb@gmail.com>\n"
 "Language-Team: French (http://www.transifex.com/rpm-team/rpm/language/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -38,7 +38,9 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Ce programme peut être librement redistribué sous les termes de la licence GNU GPL\n"
+msgstr ""
+"Ce programme peut être librement redistribué sous les termes de la licence "
+"GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -81,7 +83,7 @@ msgstr "Options de vérifications (avec -V ou --verify) :"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Options d'installation/désinstallation/mise à jour :"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Options communes à tous les modes et exécutables rpm :"
@@ -102,7 +104,7 @@ msgstr "format de requête inattendu"
 msgid "unexpected query source"
 msgstr "source de requête inattendue"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "un seul mode majeur peut être spécifié"
 
@@ -121,7 +123,9 @@ msgstr "impossible d'utiliser --prefix avec --relocate ou --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate et --excludepath ne peuvent être utilisés qu'à l'installation de nouveaux paquets"
+msgstr ""
+"--relocate et --excludepath ne peuvent être utilisés qu'à l'installation de "
+"nouveaux paquets"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -134,12 +138,15 @@ msgstr "les arguments de --prefix doivent commencer par un /"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr "--hash (-h) ne peut être utilisé que lors d'une installation ou une suppression de paquet"
+msgstr ""
+"--hash (-h) ne peut être utilisé que lors d'une installation ou une "
+"suppression de paquet"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
-msgstr "--percent ne peut être utilisé que lors d'une installation ou une suppression de paquet"
+msgid "--percent may only be specified during package installation and erasure"
+msgstr ""
+"--percent ne peut être utilisé que lors d'une installation ou une "
+"suppression de paquet"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
@@ -179,31 +186,40 @@ msgstr "--allfiles ne peut être utilisé qu'à l'installation de paquet"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb ne peut être utilisé qu'à l'installation/la désinstallation de paquet"
+msgstr ""
+"--justdb ne peut être utilisé qu'à l'installation/la désinstallation de "
+"paquet"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "les options désactivant les scripts ne peuvent être utilisées qu'à la (dés)installation"
+msgstr ""
+"les options désactivant les scripts ne peuvent être utilisées qu'à la "
+"(dés)installation"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "les options désactivant les triggers ne peuvent être utilisées qu'à la (dés)installation"
+msgstr ""
+"les options désactivant les triggers ne peuvent être utilisées qu'à la "
+"(dés)installation"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps ne peut être utilisé qu'à l'installation/la désinstallation/la vérification de paquet"
+msgstr ""
+"--nodeps ne peut être utilisé qu'à l'installation/la désinstallation/la "
+"vérification de paquet"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "--test ne peut être utilisé qu'à l'installation/la désinstallation de paquet"
+msgstr ""
+"--test ne peut être utilisé qu'à l'installation/la désinstallation de paquet"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "les arguments ed --root (-r) doivent commencer par un /"
 
@@ -223,201 +239,270 @@ msgstr "aucun argument fournit à la requête"
 msgid "no arguments given for verify"
 msgstr "aucun argument fournit à la vérification"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot déjà spécifié, %s ignoré\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "construction jusqu'à la section %prep (déballage des sources et applications des patchs) du <fichier_spec>"
+msgstr ""
+"construction jusqu'à la section %prep (déballage des sources et applications "
+"des patchs) du <fichier_spec>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<fichier_spec>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "construction jusqu'à la section %build (%prep, et compilation) du <fichier_spec>"
+msgstr ""
+"construction jusqu'à la section %build (%prep, et compilation) du "
+"<fichier_spec>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "construction jusqu'à la section %install (%prep, %build, et installation) du <fichier_spec>"
+msgstr ""
+"construction jusqu'à la section %install (%prep, %build, et installation) du "
+"<fichier_spec>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "vérifier la section %files du <fichier_spec>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "construire les paquet sources et binaires à partir du <fichier_spec>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "construction du paquet binaire seulement à partir du <fichier_spec>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "construction du paquet source seulement à partir du <fichier_spec>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"construction jusqu'à la section %prep (déballage des sources et applications "
+"des patchs) du <fichier_spec>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<paquet source>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"construction jusqu'à la section %build (%prep, et compilation) du "
+"<fichier_spec>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"construire jusqu'à la section %install (%prep, %build, et installation) à "
+"partir du <paquet source>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "vérifier la section %files du <fichier_spec>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "construire le paquet binaire à partir du <paquet source>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "construire le paquet binaire à partir du <paquet source>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "construction du paquet source seulement à partir du <fichier_spec>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "construire jusqu'à la section %prep (déballage des sources et application des patchs) à partir du <tarball>"
+msgstr ""
+"construire jusqu'à la section %prep (déballage des sources et application "
+"des patchs) à partir du <tarball>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "construire jusqu'à la section %build (%prep, puis compilation) à partir du <tarball>"
+msgstr ""
+"construire jusqu'à la section %build (%prep, puis compilation) à partir du "
+"<tarball>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "construire jusqu'à la section %build (%prep, %build, puis installation) à partir du <tarball>"
+msgstr ""
+"construire jusqu'à la section %build (%prep, %build, puis installation) à "
+"partir du <tarball>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "vérifier la section %files à partir du <tarball>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "construire les paquet source et binaire à partir du <tarball>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "construire seulement le paquet binaire à partir du <tarball>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "construire seulement le paquet source à partir du <tarball>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "construire le paquet binaire à partir du <paquet source>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<paquet source>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "construire jusqu'à la section %install (%prep, %build, et installation) à partir du <paquet source>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "surcharger le buildroot"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Impossible d'ouvrir le répertoire courant : %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "effacer l'arborescence de construction une fois terminé"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorer les directives ExcludeArch: du fichier spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "déboguer la machine à états de fichiers (déballage)"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "n'exécuter aucune étape de la construction"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "ne pas vérifier les dépendances de construction"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "générer un(des) entête(s) de paquet compatible(s) avec l'empaquetage rpm v3 (hérité)"
+msgstr ""
+"générer un(des) entête(s) de paquet compatible(s) avec l'empaquetage rpm v3 "
+"(hérité)"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "ne pas exécuter l'étape %clean de la construction"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "ne pas exécuter l'étape %clean de la construction"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "ne pas exécuter l'étape %check de la construction"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "ne pas accepter les msgstr de l'i18n du specfile"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "effacer les sources une fois terminé"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "effacer le fichier spec une fois terminé"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "aller directement à l'étape spécifiée (seulement pour c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "surcharger la plate-forme cible"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Options de construction avec [ <fichier_spec> | <tarball> | <paquet source> ] :"
+msgstr ""
+"Options de construction avec [ <fichier_spec> | <tarball> | <paquet "
+"source> ] :"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Dépendances de construction manquantes:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Impossible d'ouvrir le fichier spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Impossible d'ouvrir le pipe de tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Plus d'un fichier sur la ligne : %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Impossible de lire le fichier spec à %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Impossible de renommer %s en %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "échec de stat sur %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Fichier %s non régulier.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Le fichier %s ne semble pas être un fichier spec.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Construction pour plate-formes cibles: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Construction pour cible %s\n"
@@ -428,7 +513,9 @@ msgstr "initialiser la base de données"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "refaire les listes inversées de la base de données à partir des entêtes des paquets installés"
+msgstr ""
+"refaire les listes inversées de la base de données à partir des entêtes des "
+"paquets installés"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -466,49 +553,66 @@ msgstr "listes les clés du trousseau RPM"
 msgid "Keyring options:"
 msgstr "Options du trousseau :"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "aucun argument fournit"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "signer le(s) paquet(s)"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "signer le(s) paquet(s) (identique à --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "supprimer les signatures de paquets"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "signer le(s) paquet(s)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Options de signatures :"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Impossible d'exécuter %s : %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
-msgstr "Vous devez affecter une valeur à \"%%_gpg_name\" dans votre fichier de macros\n"
+msgstr ""
+"Vous devez affecter une valeur à \"%%_gpg_name\" dans votre fichier de "
+"macros\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Entrez la phrase de passe : "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Phrase de passe bonne.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Échec du mot de passe ou clé GPG expirée\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix ne peut être utilisé qu'à l'installation de nouveaux paquets"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches ne peut être utilisé qu'à la désinstallation de paquet"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -526,7 +630,7 @@ msgstr "opérer sur le(s) rpm(s) binaire(s) généré(s) par spec (défaut)"
 msgid "operate on source rpm generated by spec"
 msgstr "opérer sur le rpm source généré par spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "utiliser le format de requête suivant"
 
@@ -573,68 +677,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nErreur de construction de RPM :\n"
+msgstr ""
+"\n"
+"\n"
+"Erreur de construction de RPM :\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "erreur de syntaxe en analysant ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "erreur de syntaxe en analysant &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "erreur de syntaxe en analysant ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "erreur de syntaxe dans l'expression\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "( non fermée\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- seulement sur des nombres\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! seulement sur des nombres\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "les types doivent correspondre\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / non supportés sur des chaînes de caractères\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- non prix en charge sur des chaînes de caractères\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& et || ne sont pas prix en charge sur des chaînes de caractères\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "erreur de syntaxe dans l'expression\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "'(' manquante dans %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "')' manquante dans %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Lexème %s invalide : %s\n"
@@ -644,46 +751,46 @@ msgstr "Lexème %s invalide : %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s manquant(e) dans %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "espace non-blanc suivant %s() : %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Mauvaise syntaxe : %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Mauvais mode spec : %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Mauvais dirmode spec : %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Mauvaise longueur de la locale : « %s » dans %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Deux fois la même locale %s dans %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacité invalide : %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Support de capacité du fichier non intégré\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Le fichier doit commencer par « / » : %s\n"
@@ -693,149 +800,152 @@ msgstr "Le fichier doit commencer par « / » : %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Algorithme %u du fichier de digest inconnu, recourt à MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Fichier listé deux fois : %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "la lecture du symlink %s a échouée : %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Lien symbolique pointant sur BuildRoot : %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Répertoire introuvable : %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fichier non trouvé : %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Pas de répertoire: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s : ne peut pas charger le tag (%d) inconnu.\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s : échec de la lecture de la clé publique.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s : n'est pas une clé publique blindée.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s : échec de l'encodage.\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Le fichier non précédé d'un \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "globale %%dev non autorisée : %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Répertoire introuvable par glob : %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Fichier non trouvé par la substitution : %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Impossible d'ouvrir le fichier %%files %s : %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "Ligne : %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Erreur de lecture du fichiers %%files %s : %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Fichier non trouvé par la substitution : %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Impossible de mélanger un %s spécial avec d'autres formes : %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Plus d'un fichier sur la ligne : %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Mauvais fichier : %s : %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Mauvais possesseur/groupe : %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Vérification des fichiers non empaquetés : %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Fichier(s) installé(s) (mais non empaquetés) :\n%s"
+msgstr ""
+"Fichier(s) installé(s) (mais non empaquetés) :\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Traitement des fichiers : %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "L'architecture de binaire (%d) ne correspond pas à celle du paquet (%d).\n"
+msgstr ""
+"L'architecture de binaire (%d) ne correspond pas à celle du paquet (%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binaires dépendants d'une arch dans un paquet noarch\n"
 
@@ -864,79 +974,76 @@ msgstr "%s : ligne : %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Ne peut canoniser le nom d'hôte : %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Impossible de recharger l'entête de la signature.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compression de charge inconnue : %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Impossible de créer la partie immuable de l'entête.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Impossible d'ouvrir %s : %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Impossible d'écrire le paquet : %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Impossible d'écrire un entête temporaire\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Mauvaises données CSA\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Écrit : %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Exécution_de « %s » :\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "L'exécution de « %s » a échouée.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "La vérification du paquet « %s » a échouée.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne peut générer le nom de fichier pour le paquet %s : %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "Ne peut créer %s : %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "ligne %d : deuxième %s\n"
@@ -987,19 +1094,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "ligne %d : erreur dans l'analyse syntaxique de la %%description : %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "ligne %d : mauvaise option %s : %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "ligne %d : trop de noms : %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "ligne %d : paquet inexistant : %s\n"
@@ -1105,91 +1212,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "ligne %d : le tag n'accepte qu'un seul lexème : %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "ligne %d : caractère '%c' illégal dans : %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "ligne %d : caractère illégal dans : %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "ligne %d : séquence illégale « .. » dans : %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "ligne %d : %s : %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s : ligne : %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "ligne %d : tag mal formé : %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "ligne %d : tag vide : %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "ligne %d : les préfixes ne doivent pas finir par un « / » : %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "ligne %d : le docdir doit commencer par un « / » : %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "ligne %d : le champ Epoch doit être un nombre : %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "ligne %d : mauvais %s : qualificatifs : %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "ligne %d : mauvais format pour BuildArchitecture : %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "ligne %d seuls les sous-paquets noarch sont pris en charge : %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erreur interne : tag bidon %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "ligne %d : %s est obsolète : %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Mauvaise spécification de paquet : %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paquet déjà existant : %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "ligne %d : tag inconnu : %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ne peux pas être vide\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ne peut pas être « / »\n"
@@ -1199,161 +1311,197 @@ msgstr "%%{buildroot} ne peut pas être « / »\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Mauvaise source : %s : %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Pas de numéro de patch %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch sans correspondance avec le tag « Patch : »\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Pas de numéro de source %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Pas de tag « Source: » dans le fichier spec\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erreur d'analyse syntaxique du %%setup : %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "ligne %d : mauvais argument à %%setup : %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "ligne %d : mauvaise option à %%setup %s : %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s : %s : %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Numéro du patch invalide %s :%s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "ligne %d : deuxième %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr "Les jetons de dépendance doivent commencer par un caractère alpha-numérique, '_' ou '/'"
+msgstr ""
+"Les jetons de dépendance doivent commencer par un caractère alpha-numérique, "
+"'_' ou '/'"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Nom de version de fichier non autorisé"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Version requise"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "dépendance invalide"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Version requise"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "ligne %d : %s : %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "ligne %d : les triggers doivent avoir -- : %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "ligne %d : erreur d'analyse syntaxique %s : %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "ligne %d : le script interne doit se terminer par '>' : %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "ligne %d : le nom du script doit commencer par un '/' : %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+"ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "ligne %d : deuxième %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "ligne %d : script interne non pris en charge :%s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr "ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
+msgstr ""
+"ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "ligne %d : %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Impossible d'ouvrir %s : %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s :%d : argument attendu pour %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "ligne %d : %%if non terminé\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "ligne %d : macro non fermée ou mauvaise continuation de ligne\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s : %d : mauvaise condition %%if\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s : %d : j'ai là un %%else sans %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s : %d : j'ai là un %%endif sans %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: directive %%include mal-formée\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Pas d'architecture compatible pour construction\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Le paquet n'a pas de %%description : %s\n"
@@ -1361,7 +1509,8 @@ msgstr "Le paquet n'a pas de %%description : %s\n"
 #: build/policies.c:87
 #, c-format
 msgid "Policy module '%s' duplicated with overlapping types\n"
-msgstr "Le module de stratégie '%s' dupliqué avec des types qui se chevauchent\n"
+msgstr ""
+"Le module de stratégie '%s' dupliqué avec des types qui se chevauchent\n"
 
 #: build/policies.c:93
 #, c-format
@@ -1397,7 +1546,9 @@ msgstr "Impossible de déterminer un nom de la stratégie : %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "Le type '%s' donnée avec les autres types dans %%semodule %s. Compactage des types vers '%s'.\n"
+msgstr ""
+"Le type '%s' donnée avec les autres types dans %%semodule %s. Compactage des "
+"types vers '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1424,290 +1575,283 @@ msgstr "Trop nombreux arguments en ligne : %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Traitement de la stratégie : %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorer l'expression régulière %s invalide\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Impossible de créer le pipe pour %s : %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Impossible d'exécuter %s : %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Impossible de forker %s : %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s a échoué : %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "échec de l'écriture de toutes les données de %s : %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "mauvais opérateur"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "mauvais format"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "La conversion de %s vers un entier long a échoué.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Classificateur de fichier vide\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Aucun fichier attributs configurés\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) a échoué : %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load a échoué : %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "La reconnaissance du fichier « %s » a échoué : mode %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Trouver %s : %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Impossible de trouver %s :\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "échec de la requête sur le fichier spec %s, impossible de faire l'analyser syntaxique\n"
+msgstr ""
+"échec de la requête sur le fichier spec %s, impossible de faire l'analyser "
+"syntaxique\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s est un Delta RPM et ne peut être installé directement\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Charge (%s) non pris en charge dans le paquet %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "le paquet %s a déjà été rajouté, %s ignoré\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "le paquet %s a déjà été rajouté, replacé par %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(n'est pas un nombre)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(pas base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(type invalide)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(pas un blob ça)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(type xml invalide)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(pas une signature OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Date invalide %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "remplacé"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "pas installé"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "sur le réseau"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "fausse couleur"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "manquant"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(inconnu)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(pas une chaîne)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sauvé en tant que %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s créé en tant que %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s : échec de la suppression : %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "répertoire"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "fichier"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1836,15 +1980,17 @@ msgid "relocations must have a / following the ="
 msgstr "dans les relogements un / doit suivre le ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "installer tous les fichiers, même si les configurations disent le contraire"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"installer tous les fichiers, même si les configurations disent le contraire"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "retirer tous les paquets qui correspondent à <package> (normalement on retourne une erreur si le <package> correspond à plusieurs paquets"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"retirer tous les paquets qui correspondent à <package> (normalement on "
+"retourne une erreur si le <package> correspond à plusieurs paquets"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1892,7 +2038,9 @@ msgstr "<packagefile> +"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "afficher des marqueurs au fur et à mesure que le paquet s'installe (avec -v c'est bien(tm))"
+msgstr ""
+"afficher des marqueurs au fur et à mesure que le paquet s'installe (avec -v "
+"c'est bien(tm))"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1916,13 +2064,14 @@ msgstr "installer le(s) paquet(s)"
 
 #: lib/poptI.c:167
 msgid "update the database, but do not modify the filesystem"
-msgstr "mettre à jour la base données, mais ne pas modifier le système de fichiers"
+msgstr ""
+"mettre à jour la base données, mais ne pas modifier le système de fichiers"
 
 #: lib/poptI.c:173
 msgid "do not verify package dependencies"
 msgstr "ne pas vérifier les dépendances du paquet"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "ne pas vérifier les sommes de hachage des fichiers"
 
@@ -1936,7 +2085,9 @@ msgstr "ne pas installer les fichiers des contextes de sécurité"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "ne pas réarranger l'ordre d'installation des paquets pour satisfaire les dépendances"
+msgstr ""
+"ne pas réarranger l'ordre d'installation des paquets pour satisfaire les "
+"dépendances"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2000,7 +2151,9 @@ msgstr "n'exécuter aucun scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "mettre à jour avec un paquet plus ancien (une m-à-j avec --force fait ça automatiquement"
+msgstr ""
+"mettre à jour avec un paquet plus ancien (une m-à-j avec --force fait ça "
+"automatiquement"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2042,162 +2195,185 @@ msgstr "mises à jour des paquets"
 msgid "reinstall package(s)"
 msgstr "réinstaller le(s) paquet(s)"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "vérifier/demander à tous les paquets"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "mode rpm vérifsign"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "vérifier/demander un paquet possèdant un fichier"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "vérifier/questionner le(s) paquet(s) d'un même groupe"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "vérifier/questionner un fichier paquet"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "questionner/vérifier le(s) paquet(s) grâce à un identifieur de paquet"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
-msgstr "questionner/vérifier le(s) paquet(s) grâce à un identificateur d'entête"
+msgstr ""
+"questionner/vérifier le(s) paquet(s) grâce à un identificateur d'entête"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "mode de requête de rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "questionner/vérifier une instance d'entête"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
-msgstr "questionner/vérifier le(s) paquet(s) à partir de la transaction d'installation"
+msgstr ""
+"questionner/vérifier le(s) paquet(s) à partir de la transaction "
+"d'installation"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "questionner le(s) paquet(s) surveillé(s) par le paquet"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "mode de vérification de rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "vérifier/demander le(s) paquet(s) qui fourni(ssen)t une dépendance"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "vérifier/demander le(s) paquet(s) qui requier(en)t une dépendance"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "Ne pas passer des arguments"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "ne traite pas les fichiers non-paquet comme manifestes"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "lister les fichiers de configuration"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "lister les fichiers documents"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "lister les fichiers de license"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "débite les informations de base des fichiers"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "lister les fichiers du paquet"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "éviter les fichiers fantômes %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "affiche la liste des fichiers et leur état"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "ne pas vérifier la taille des fichiers"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "ne pas vérifier le chemin du lien symbolique des fichiers"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "ne pas vérifier le possesseur des fichiers"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "ne pas vérifier le groupe possesseur des fichiers"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "ne pas vérifier les dates de modification des fichiers"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "ne pas vérifier les permissions des fichiers"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "ne pas vérifier les capacités des fichiers"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "ne pas vérifier la sécurité des fichiers"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "ne pas vérifier les fichiers du paquet"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ne pas vérifier les dépendances du paquet"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "ne pas exécuter le(s) script(s) de vérification"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Éléments rpmlib manquants pour %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "paquet source attendu, paquet binaire trouvé\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "le paquet source ne contient pas de fichier .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "échec du déballage de l'archive %s%s : %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " dans fichier "
 
@@ -2245,7 +2421,8 @@ msgstr "le paquet n'as pas de liste de possesseurs/groupes de fichiers\n"
 
 #: lib/query.c:228
 msgid "package has neither file owner or id lists\n"
-msgstr "le paquet n'a ni la liste des id ni celle des possesseurs de fichiers\n"
+msgstr ""
+"le paquet n'a ni la liste des id ni celle des possesseurs de fichiers\n"
 
 #: lib/query.c:317
 #, c-format
@@ -2272,96 +2449,117 @@ msgstr "aucun paquet ne correspond à %s : %s\n"
 msgid "no package requires %s\n"
 msgstr "aucun paquet ne requiert %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "aucun paquet ne requiert %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "aucun paquet ne surveille %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "aucun paquet ne requiert %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "aucun paquet ne requiert %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "aucun paquet ne fournit %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fichier %s : %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "le fichier %s n'appartient à aucun paquet\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "numéro de paquet invalide : %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "l'enregistrement %u n'a pas pu être lu\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "le paquet %s n'est pas installé\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tag inconnu: « %s »\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s : importation de la clé %d échouée.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s : la clés %d n'est pas une clé publique blindée.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s : l'importation de lecture a échoué (%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s : échec de headerRead %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s : la région d'en-tête immuable ne peut pas être lu. Paquet corrompu ?\n"
+msgstr ""
+"%s : la région d'en-tête immuable ne peut pas être lu. Paquet corrompu ?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s : Fread a échoué : %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "PAS OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (CLES MANQUANTES :"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CLES NONCREDIBLE :"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s : échec de l'ouverture : %s\n"
@@ -2386,147 +2584,208 @@ msgstr "Impossible de changer le répertoire racine : %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Impossible de restaurer le répertoire racine : %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NON"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "OUI"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "Les dépendances de type PreReq:, Provides: et Obsoletes: supportent les versions."
+msgstr ""
+"Les dépendances de type PreReq:, Provides: et Obsoletes: supportent les "
+"versions."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "Le(s) nom(s) de fichier sont stockés en tant que triplets (NomRep,NomFich,IndexRep), pas en tant que chemin."
+msgstr ""
+"Le(s) nom(s) de fichier sont stockés en tant que triplets (NomRep,NomFich,"
+"IndexRep), pas en tant que chemin."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "La charge du paquet est compressée avec bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "La charge du paquet est compressée avec xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "La charge du paquet est compressée avec lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
-msgstr "le(s) fichier(s) de la charge utile du paquet ont « ./ » comme préfixe."
+msgstr ""
+"le(s) fichier(s) de la charge utile du paquet ont « ./ » comme préfixe."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "le nom-version-révision du paquet n'est pas implicitement fourni."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "les tags d'entête sont toujours triés après avoir été chargés."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
-msgstr "l'interprète du scriptlet peut utiliser des arguments à partir des entêtes."
+msgstr ""
+"l'interprète du scriptlet peut utiliser des arguments à partir des entêtes."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "un lien en dur pourrait être installé sans être complet."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "les scriptlets du paquet pourrait accéder à la base de données rpm pendant l'installation."
+msgstr ""
+"les scriptlets du paquet pourrait accéder à la base de données rpm pendant "
+"l'installation."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "prise en charge interne pour les scripts LUA."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "l'algorithme de hachage de fichier est configurable par paquet"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "prise en charge des capacités du fichier POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "les scriptlets du paquet peut être étendu lors de l'installation."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "la comparaison de dépendances prend en charge les versions avec tilde."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "supporte les fichiers supérieurs à 4GB"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "ne pas vérifier les dépendances du paquet"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Version requise"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "dépendance invalide"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c non terminé: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "dépendance invalide"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "utilisateur %s inexistant - utilisation de root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "groupe %s inexistant - utilisation de root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Mauvaise magie, blah"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Entête mauvais ou illisible"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Entête trop gros"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Fichier trop grand pour l'archive"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Type de fichier inconnu"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Fichier(s) manquant(s)"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Digest ne correspond pas"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Erreur interne"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "L'entête ne contient pas le fichier archive"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " échec - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (erreur 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "échec de l'ouverture de %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
-msgstr "%s: n'est pas un paquet rpm (ni une liste de paquet)\n\n"
+msgstr ""
+"%s: n'est pas un paquet rpm (ni une liste de paquet)\n"
+"\n"
 
 #: lib/rpminstall.c:141
 #, c-format
@@ -2555,42 +2814,42 @@ msgstr "Dépendances requises:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s : n'est pas un paquet rpm (ni une liste de paquet) : %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s ne peut être installé\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Récupération de %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s ignoré - échec du transfert\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "le paquet %s n'est pas localisable\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "erreur en lisant %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "« %s » spécifie plusieurs paquets\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "impossible d'ouvrir %s : %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installation de %s\n"
@@ -2616,12 +2875,12 @@ msgstr "échec de lecture : %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "pas un paquet rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "Impossible de créer %s verrou sur %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "attente pour %s verrou sur %s\n"
@@ -2673,12 +2932,15 @@ msgstr "le chemin %s dans le paquet %s n'est pas localisable"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr "le fichier %s entre en conflit avec les tentatives d'installation de %s et %s"
+msgstr ""
+"le fichier %s entre en conflit avec les tentatives d'installation de %s et %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "le fichier %s de l'installation de %s entre en conflit avec le fichier du paquet %s"
+msgstr ""
+"le fichier %s de l'installation de %s entre en conflit avec le fichier du "
+"paquet %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2688,12 +2950,16 @@ msgstr "le paquet %s (plus récent que %s) est déjà installé"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "installer le paquetage %s nécessite %<PRIu64>%cB sur le système de fichiers %s"
+msgstr ""
+"installer le paquetage %s nécessite %<PRIu64>%cB sur le système de fichiers "
+"%s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "installer le paquet %s nécessite %<PRIu64> inodes sur le système de fichiers %s"
+msgstr ""
+"installer le paquet %s nécessite %<PRIu64> inodes sur le système de fichiers "
+"%s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2779,60 +3045,81 @@ msgstr "architecture manquante pour %s à %s : %d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "mauvaise option '%s' à %s : %d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Échec de la lecture du vecteur auxiliaire, /proc est-il monté ?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "système inconnu : %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Contactez %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
-msgstr "Impossible d'ouvrir %s en lecture : %m.\n\n"
+msgstr ""
+"Impossible d'ouvrir %s en lecture : %m.\n"
+"\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Impossible de restaurer le répertoire courant : %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "le support du scriptlet <lua> n'est pas intégrer\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Impossible de créer de fichier temporaire pour %s : %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Impossible de dupliquer le descripteur de fichier : %s : %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Impossible de lire l'icône %s : %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Impossible de restaurer le répertoire racine : %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s : échec de Fwrite : %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "scriptlet %s échoué, waitpid(%d) rc %d : %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "scriptlet %s échoué, signal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s scriptlet échoué, état de sortie %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Format inconnu"
 
@@ -2844,127 +3131,146 @@ msgstr "installer"
 msgid "erase"
 msgstr "effacer"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "impossible d'ouvrir la base de données paquet dans %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' supplémentaire dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' manquante dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' manquante dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: la lecture de la clé publique a échoué.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transaction"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(pas une signature OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 :"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Impossible de recharger l'entête de la signature.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Hachage de l'entête SHA1 :"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Entête "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 :"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Hachage de l'entête SHA1 :"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Vérification de signature: MAUVAIS PARAMETRES (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "sauté"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "échoué"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "pas d'état"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "état inconnu"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "manque   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dépendances non satisfaites pour %s :\n"
@@ -3038,240 +3344,246 @@ msgstr "itérateur de tableau utilisé avec des tableaux de tailles différentes
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Génération d'index manquant(s) %d, merci d'attendre...\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "impossible d'ouvrir l'index %s en utilisant %s - %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "aucun dbpath n'a été fourni\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader : ignoré"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "erreur(%d) en stockant l'article nº%d dans %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s : regexec a échoué :%s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s : regcomp a échoué :%s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator : ignoré"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb : l'entête #%u endommagée a été récupérée -- ignoré.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s : impossible de lire l'entête à 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "aucun dbpath fournit"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "Impossible de créer le répertoire %s : %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "l'entête #%u dans la base de données n'est pas bon -- ignoré.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "impossible d'ajouter l'article qui était au départ à %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "Ne peut reconstruire la base de données : la base originale reste telle qu'elle est\n"
+msgstr ""
+"Ne peut reconstruire la base de données : la base originale reste telle "
+"qu'elle est\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "Ne peut remplacer la vieille base de données par la nouvelle!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
-msgstr "remplacer les fichiers dans %s avec les fichiers de %s pour faire une récupération"
+msgstr ""
+"remplacer les fichiers dans %s avec les fichiers de %s pour faire une "
+"récupération"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "Ne peut détruire le répertoire %s : %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
-msgstr "erreur(%d) %s de %s: %s\n"
+msgstr "%s erreur(%d) de %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
-msgstr "erreur(%d) %s : %s\n"
+msgstr "%s erreur(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "impossible d'avoir le verrou %s sur %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "partagé"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exclusif"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "type d'index %x invalide sur %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "erreur(%d) en attrapant les articles « %s » de l'index %s : %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "erreur(%d) en stockant l'article « %s » dans %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "erreur(%d) en enlevant l'article « %s » de %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "Erreur(%d) ajout de l'enregistrement de l'en-tête #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "Erreur (%d) suppression de l'enregistrement de l'en-tête #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "erreur(%d) en allouant une nouvelle instance de paquet\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "options de db inconnues : \"%s\" ignoré.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s est une valeur numérique invalide, ignoré\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s est une valeur 'long' trop petite ou trop grande, ignoré\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s est une valeur entière trop petite ou trop grande, ignoré\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "impossible d'avoir le verrou %s sur %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "partagé"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exclusif"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "type d'index %x invalide sur %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "erreur(%d) en attrapant les articles « %s » de l'index %s : %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "erreur(%d) en stockant l'article « %s » dans %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "erreur(%d) en enlevant l'article « %s » de %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "Erreur(%d) ajout de l'enregistrement de l'en-tête #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "Erreur (%d) suppression de l'enregistrement de l'en-tête #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "erreur(%d) en allouant une nouvelle instance de paquet\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vide)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vide)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s a des options non-terminées\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s a un corps sans fin\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "La macro %%%s a un nom illégal (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s a un corps vide\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La macro %%%s a besoin d'un espace avant le corps\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "La macro %%%s ne peut être expansée\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "La macro %%%s a un nom illégal (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Macro %%%s définie mais non utilisée sans portée\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Option inconnue %c dans %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Trop de niveaux de récursivité dans l'expansion de la macro. Il est probablement causée par une déclaration de macro récursive.\n"
+msgstr ""
+"Trop de niveaux de récursivité dans l'expansion de la macro. Il est "
+"probablement causée par une déclaration de macro récursive.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c non terminé: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% est suivi d'une macro in-analysable\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "Impossible de charger le fichier macro %s"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d actif(s) %d vide(s)\n"
@@ -3291,31 +3603,31 @@ msgstr "Fichier %s : %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Le fichier %s est plus petit que %u octets\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "échec de création du répertoire"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "syntaxe invalide dans le scriptlet lua : %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "syntaxe invalide dans le script lua : %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "script lua échoué : %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "syntaxe invalide dans le fichier lua : %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "crochet lua échoué : %s\n"
@@ -3324,19 +3636,19 @@ msgstr "crochet lua échoué : %s\n"
 msgid "[none]"
 msgstr "[Aucun]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(pas d'erreur)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "erreur fatale : "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "erreur : "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "attention : "
 
@@ -3345,99 +3657,154 @@ msgstr "attention : "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "l'allocation de mémoire (%u octets) a retourné NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, clé ID %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(none)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "Erreur de création du fichier temporaire %s : %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "Erreur de création du fichier temporaire %s : %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "Erreur de création du fichier temporaire %s : %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "Impossible de créer le répertoire %s : %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s : échec de Fwrite : %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s : Fflush échoué : %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Signature PGP non supportée\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algorithme %u de hashage PGP non supporté\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algorithme %u clé publique PGP non supporté\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Impossible de créer le pipe pour la signature : %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Impossible d'exécuter %s : %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "fdopen échoué\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "Impossible d'écrire dans le pipe\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "Impossible de lire le fichier %s: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg exec échoué (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "échec de gpg à écrire la signature\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "impossible de lire la signature\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s : échec de rpmWriteSignature : %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s : échec de rpmReadSignature : %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s : échec de headerRead %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp échoué\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "fdopen échoué\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s : échec de headerRead %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s contient déjà une signature identique, ignoré\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s : échec de rpmReadSignature : %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Ne peut signer les paquets RPM v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s contient déjà une signature identique, ignoré\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s : échec de rpmWriteSignature : %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp échoué\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s : échec de writeLead : %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "remplacer %s à échouer : %s\n"
@@ -3450,3 +3817,21 @@ msgstr "%s : échec de la lecture de la liste de paquetages : %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "ne pas vérifier la signature de l'entête+charge_utile"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Entrez la phrase de passe : "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Phrase de passe bonne.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "Échec du mot de passe ou clé GPG expirée\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Mauvais possesseur/groupe : %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "ligne %d : caractère illégal dans : %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Impossible de créer le pipe pour la signature : %m"

--- a/po/gu.po
+++ b/po/gu.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-04-07 13:17+0300\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Gujarati (http://www.transifex.com/projects/p/rpm/language/gu/)\n"
+"Language-Team: Gujarati (http://www.transifex.com/rpm-team/rpm/language/gu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:199
+#: rpmsign.c:93 sign/rpmgensig.c:232
 #, c-format
 msgid "Could not exec %s: %s\n"
 msgstr ""
@@ -862,92 +862,74 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:238
-#, c-format
-msgid "Unable to write payload to %s: %s\n"
+#: build/pack.c:350
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:246
-#, c-format
-msgid "Unable to read payload from %s: %s\n"
-msgstr ""
-
-#: build/pack.c:346
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:374
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:385
-msgid "Unable to open temp file.\n"
-msgstr ""
-
-#: build/pack.c:392
-msgid "Unable to write temp header\n"
-msgstr ""
-
-#: build/pack.c:400
-msgid "Bad CSA data\n"
-msgstr ""
-
-#: build/pack.c:464
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:472
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:484
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:500
-#, c-format
-msgid "Unable to open sigtarget %s: %s\n"
+#: build/pack.c:495
+msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:511
-#, c-format
-msgid "Unable to read header from %s: %s\n"
+#: build/pack.c:504
+msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:521
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
-msgid "Unable to write header to %s: %s\n"
+msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:554
+#: build/pack.c:526
+#, c-format
+msgid "Fread failed in file %s: %s\n"
+msgstr ""
+
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:573
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:576
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:580
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:627
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:644
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
@@ -1175,37 +1157,37 @@ msgstr ""
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:901
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:990
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1051
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1060
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1095
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1127
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1590,19 +1572,19 @@ msgstr ""
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:341
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:335
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:337
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:339
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
@@ -1754,79 +1736,83 @@ msgstr ""
 msgid "'EXPR'"
 msgstr ""
 
-#: lib/poptALL.c:187 lib/poptALL.c:201
+#: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
 msgstr ""
 
-#: lib/poptALL.c:188 lib/poptALL.c:202
+#: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
 msgstr ""
 
-#: lib/poptALL.c:191
+#: lib/poptALL.c:193
+msgid "don't enable any plugins"
+msgstr ""
+
+#: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
 msgstr ""
 
-#: lib/poptALL.c:193
+#: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
 msgstr ""
 
-#: lib/poptALL.c:195
+#: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
 msgstr ""
 
-#: lib/poptALL.c:198
+#: lib/poptALL.c:203
 msgid "send stdout to CMD"
 msgstr ""
 
-#: lib/poptALL.c:199
+#: lib/poptALL.c:204
 msgid "CMD"
 msgstr ""
 
-#: lib/poptALL.c:204
+#: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
 msgstr ""
 
-#: lib/poptALL.c:205
+#: lib/poptALL.c:210
 msgid "ROOT"
 msgstr ""
 
-#: lib/poptALL.c:207
+#: lib/poptALL.c:212
 msgid "use database in DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:208
+#: lib/poptALL.c:213
 msgid "DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:211
+#: lib/poptALL.c:216
 msgid "display known query tags"
 msgstr ""
 
-#: lib/poptALL.c:213
+#: lib/poptALL.c:218
 msgid "display final rpmrc and macro configuration"
 msgstr ""
 
-#: lib/poptALL.c:215
+#: lib/poptALL.c:220
 msgid "provide less detailed output"
 msgstr ""
 
-#: lib/poptALL.c:217
+#: lib/poptALL.c:222
 msgid "provide more detailed output"
 msgstr ""
 
-#: lib/poptALL.c:219
+#: lib/poptALL.c:224
 msgid "print the version of rpm being used"
 msgstr ""
 
-#: lib/poptALL.c:225
+#: lib/poptALL.c:230
 msgid "debug payload file state machine"
 msgstr ""
 
-#: lib/poptALL.c:231
+#: lib/poptALL.c:236
 msgid "debug rpmio I/O"
 msgstr ""
 
-#: lib/poptALL.c:298
+#: lib/poptALL.c:303
 #, c-format
 msgid "%s: option table misconfigured (%d)\n"
 msgstr ""
@@ -1898,7 +1884,7 @@ msgstr ""
 msgid "upgrade package(s) if already installed"
 msgstr ""
 
-#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:255 lib/poptI.c:259
+#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:251 lib/poptI.c:255
 msgid "<packagefile>+"
 msgstr ""
 
@@ -2009,52 +1995,48 @@ msgid "do not execute any %%triggerpostun scriptlet(s)"
 msgstr ""
 
 #: lib/poptI.c:229
-msgid "do not perform any collection actions"
-msgstr ""
-
-#: lib/poptI.c:233
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
 msgstr ""
 
-#: lib/poptI.c:237
+#: lib/poptI.c:233
 msgid "print percentages as package installs"
 msgstr ""
 
-#: lib/poptI.c:239
+#: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
 msgstr ""
 
-#: lib/poptI.c:240
+#: lib/poptI.c:236
 msgid "<dir>"
 msgstr ""
 
-#: lib/poptI.c:242
+#: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
 msgstr ""
 
-#: lib/poptI.c:243
+#: lib/poptI.c:239
 msgid "<old>=<new>"
 msgstr ""
 
-#: lib/poptI.c:246
+#: lib/poptI.c:242
 msgid "ignore file conflicts between packages"
 msgstr ""
 
-#: lib/poptI.c:249
+#: lib/poptI.c:245
 msgid "reinstall if the package is already present"
 msgstr ""
 
-#: lib/poptI.c:251
+#: lib/poptI.c:247
 msgid "don't install, but tell if it would work or not"
 msgstr ""
 
-#: lib/poptI.c:254
+#: lib/poptI.c:250
 msgid "upgrade package(s)"
 msgstr ""
 
-#: lib/poptI.c:258
+#: lib/poptI.c:254
 msgid "reinstall package(s)"
 msgstr ""
 
@@ -2338,7 +2320,7 @@ msgstr ""
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
@@ -2348,7 +2330,7 @@ msgstr ""
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:93
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
@@ -2377,7 +2359,7 @@ msgstr ""
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:53
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2402,79 +2384,79 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:964
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:967
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:971
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:976
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:979
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:983
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:986
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:989
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:992
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:995
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:998
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1002
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1006
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1010
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1014
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1017
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1020
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
@@ -2654,10 +2636,10 @@ msgstr ""
 
 #: lib/rpmplugins.c:154
 #, c-format
-msgid "Failed to expand %%__%s_%s macro\n"
+msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:198
+#: lib/rpmplugins.c:199
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -2852,11 +2834,11 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:792
+#: lib/rpmte.c:729
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:793
+#: lib/rpmte.c:730
 msgid "erase"
 msgstr ""
 
@@ -2889,96 +2871,98 @@ msgstr ""
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:87
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:92
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:98
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:104
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:119
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:136
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:159
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:175
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:251
-msgid "Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-
-#: lib/signature.c:261
-msgid "Cannot sign RPM v3 packages\n"
-msgstr ""
-
-#: lib/signature.c:348
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:387
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:429
+#: lib/signature.c:316
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:470
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:343
+#: lib/verify.c:251
+#, c-format
+msgid "Duplicate username or UID for user %s\n"
+msgstr ""
+
+#: lib/verify.c:272
+#, c-format
+msgid "Duplicate groupname or GID for group %s\n"
+msgstr ""
+
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:345
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:396
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:448
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3209,90 +3193,6 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: plugins/sepolicy.c:215
-#, c-format
-msgid "Failed to decode policy for %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:222
-#, c-format
-msgid "Failed to create temporary file for %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:228
-#, c-format
-msgid "Failed to write %s policy to file %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:293
-msgid "Failed to create semanage handle\n"
-msgstr ""
-
-#: plugins/sepolicy.c:299
-msgid "Failed to connect to policy handler\n"
-msgstr ""
-
-#: plugins/sepolicy.c:303
-#, c-format
-msgid "Failed to begin policy transaction: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:334
-#, c-format
-msgid "Failed to remove temporary policy file %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:383
-#, c-format
-msgid "Failed to install policy module: %s (%s)\n"
-msgstr ""
-
-#: plugins/sepolicy.c:413
-#, c-format
-msgid "Failed to remove policy module: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:437 plugins/sepolicy.c:489
-#, c-format
-msgid "Failed to fork process: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:447 plugins/sepolicy.c:499
-#, c-format
-msgid "Failed to execute %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:453 plugins/sepolicy.c:505
-#, c-format
-msgid "%s terminated abnormally\n"
-msgstr ""
-
-#: plugins/sepolicy.c:457 plugins/sepolicy.c:509
-#, c-format
-msgid "%s failed with exit code %i\n"
-msgstr ""
-
-#: plugins/sepolicy.c:464
-msgid "Failed to commit policy changes\n"
-msgstr ""
-
-#: plugins/sepolicy.c:481
-msgid "Failed to expand restorecon path"
-msgstr ""
-
-#: plugins/sepolicy.c:560
-msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:564
-msgid "Failed to reload file contexts. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:591
-#, c-format
-msgid "Failed to extract policy from %s\n"
-msgstr ""
-
 #: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
@@ -3303,19 +3203,19 @@ msgstr ""
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:500 rpmio/macro.c:538
+#: rpmio/macro.c:494
+#, c-format
+msgid "Macro %%%s has unterminated opts\n"
+msgstr ""
+
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:557
-#, c-format
-msgid "Macro %%%s has illegal name (%%define)\n"
-msgstr ""
-
 #: rpmio/macro.c:563
 #, c-format
-msgid "Macro %%%s has unterminated opts\n"
+msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
 #: rpmio/macro.c:568
@@ -3333,63 +3233,63 @@ msgstr ""
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:615
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:644
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:727
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:956
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1025 rpmio/macro.c:1042
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1083
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1101
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1482
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:257
+#: rpmio/rpmfileutil.c:258
 #, c-format
 msgid "error creating temporary file %s: %m\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:322 rpmio/rpmfileutil.c:328
+#: rpmio/rpmfileutil.c:323 rpmio/rpmfileutil.c:329
 #, c-format
 msgid "File %s: %s\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:331
+#: rpmio/rpmfileutil.c:332
 #, c-format
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:599
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
@@ -3452,73 +3352,90 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:87
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:97
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:125
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:131
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:174
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
 msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:216
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+msgid "Could not write to pipe\n"
+msgstr ""
+
+#: sign/rpmgensig.c:284
+#, c-format
+msgid "Could not read from file %s: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:246
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:263
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:432
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:440 sign/rpmgensig.c:509
-msgid "rpmMkTemp failed\n"
+#: sign/rpmgensig.c:514
+msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:492
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
-#, c-format
-msgid "%s: writeLead failed: %s\n"
-msgstr ""
-
-#: sign/rpmgensig.c:522
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:536
+#: sign/rpmgensig.c:614
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:621
+#, c-format
+msgid "%s: writeLead failed: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -8,10 +8,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-04-07 13:17+0300\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Indonesian (http://www.transifex.com/projects/p/rpm/language/id/)\n"
+"Language-Team: Indonesian (http://www.transifex.com/rpm-team/rpm/language/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:199
+#: rpmsign.c:93 sign/rpmgensig.c:232
 #, c-format
 msgid "Could not exec %s: %s\n"
 msgstr ""
@@ -863,92 +863,74 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:238
-#, c-format
-msgid "Unable to write payload to %s: %s\n"
+#: build/pack.c:350
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:246
-#, c-format
-msgid "Unable to read payload from %s: %s\n"
-msgstr ""
-
-#: build/pack.c:346
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:374
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:385
-msgid "Unable to open temp file.\n"
-msgstr ""
-
-#: build/pack.c:392
-msgid "Unable to write temp header\n"
-msgstr ""
-
-#: build/pack.c:400
-msgid "Bad CSA data\n"
-msgstr ""
-
-#: build/pack.c:464
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:472
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:484
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:500
-#, c-format
-msgid "Unable to open sigtarget %s: %s\n"
+#: build/pack.c:495
+msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:511
-#, c-format
-msgid "Unable to read header from %s: %s\n"
+#: build/pack.c:504
+msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:521
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
-msgid "Unable to write header to %s: %s\n"
+msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:554
+#: build/pack.c:526
+#, c-format
+msgid "Fread failed in file %s: %s\n"
+msgstr ""
+
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:573
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:576
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:580
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:627
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:644
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
@@ -1176,37 +1158,37 @@ msgstr ""
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:901
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:990
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1051
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1060
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1095
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1127
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1591,19 +1573,19 @@ msgstr ""
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:341
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:335
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:337
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:339
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
@@ -1755,79 +1737,83 @@ msgstr ""
 msgid "'EXPR'"
 msgstr ""
 
-#: lib/poptALL.c:187 lib/poptALL.c:201
+#: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
 msgstr ""
 
-#: lib/poptALL.c:188 lib/poptALL.c:202
+#: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
 msgstr ""
 
-#: lib/poptALL.c:191
+#: lib/poptALL.c:193
+msgid "don't enable any plugins"
+msgstr ""
+
+#: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
 msgstr ""
 
-#: lib/poptALL.c:193
+#: lib/poptALL.c:198
 msgid "don't verify database header(s) when retrieved"
 msgstr ""
 
-#: lib/poptALL.c:195
+#: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
 msgstr ""
 
-#: lib/poptALL.c:198
+#: lib/poptALL.c:203
 msgid "send stdout to CMD"
 msgstr ""
 
-#: lib/poptALL.c:199
+#: lib/poptALL.c:204
 msgid "CMD"
 msgstr ""
 
-#: lib/poptALL.c:204
+#: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
 msgstr ""
 
-#: lib/poptALL.c:205
+#: lib/poptALL.c:210
 msgid "ROOT"
 msgstr ""
 
-#: lib/poptALL.c:207
+#: lib/poptALL.c:212
 msgid "use database in DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:208
+#: lib/poptALL.c:213
 msgid "DIRECTORY"
 msgstr ""
 
-#: lib/poptALL.c:211
+#: lib/poptALL.c:216
 msgid "display known query tags"
 msgstr ""
 
-#: lib/poptALL.c:213
+#: lib/poptALL.c:218
 msgid "display final rpmrc and macro configuration"
 msgstr ""
 
-#: lib/poptALL.c:215
+#: lib/poptALL.c:220
 msgid "provide less detailed output"
 msgstr ""
 
-#: lib/poptALL.c:217
+#: lib/poptALL.c:222
 msgid "provide more detailed output"
 msgstr ""
 
-#: lib/poptALL.c:219
+#: lib/poptALL.c:224
 msgid "print the version of rpm being used"
 msgstr ""
 
-#: lib/poptALL.c:225
+#: lib/poptALL.c:230
 msgid "debug payload file state machine"
 msgstr ""
 
-#: lib/poptALL.c:231
+#: lib/poptALL.c:236
 msgid "debug rpmio I/O"
 msgstr ""
 
-#: lib/poptALL.c:298
+#: lib/poptALL.c:303
 #, c-format
 msgid "%s: option table misconfigured (%d)\n"
 msgstr ""
@@ -1899,7 +1885,7 @@ msgstr ""
 msgid "upgrade package(s) if already installed"
 msgstr ""
 
-#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:255 lib/poptI.c:259
+#: lib/poptI.c:148 lib/poptI.c:164 lib/poptI.c:251 lib/poptI.c:255
 msgid "<packagefile>+"
 msgstr ""
 
@@ -2010,52 +1996,48 @@ msgid "do not execute any %%triggerpostun scriptlet(s)"
 msgstr ""
 
 #: lib/poptI.c:229
-msgid "do not perform any collection actions"
-msgstr ""
-
-#: lib/poptI.c:233
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
 msgstr ""
 
-#: lib/poptI.c:237
+#: lib/poptI.c:233
 msgid "print percentages as package installs"
 msgstr ""
 
-#: lib/poptI.c:239
+#: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
 msgstr ""
 
-#: lib/poptI.c:240
+#: lib/poptI.c:236
 msgid "<dir>"
 msgstr ""
 
-#: lib/poptI.c:242
+#: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
 msgstr ""
 
-#: lib/poptI.c:243
+#: lib/poptI.c:239
 msgid "<old>=<new>"
 msgstr ""
 
-#: lib/poptI.c:246
+#: lib/poptI.c:242
 msgid "ignore file conflicts between packages"
 msgstr ""
 
-#: lib/poptI.c:249
+#: lib/poptI.c:245
 msgid "reinstall if the package is already present"
 msgstr ""
 
-#: lib/poptI.c:251
+#: lib/poptI.c:247
 msgid "don't install, but tell if it would work or not"
 msgstr ""
 
-#: lib/poptI.c:254
+#: lib/poptI.c:250
 msgid "upgrade package(s)"
 msgstr ""
 
-#: lib/poptI.c:258
+#: lib/poptI.c:254
 msgid "reinstall package(s)"
 msgstr ""
 
@@ -2339,7 +2321,7 @@ msgstr ""
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
@@ -2349,7 +2331,7 @@ msgstr ""
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:93
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
@@ -2378,7 +2360,7 @@ msgstr ""
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:53
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2403,79 +2385,79 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:511
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:964
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:967
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:971
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:976
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:979
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:983
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:986
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:989
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:992
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:995
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:998
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1002
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1006
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1010
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1014
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1017
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1020
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
@@ -2655,10 +2637,10 @@ msgstr ""
 
 #: lib/rpmplugins.c:154
 #, c-format
-msgid "Failed to expand %%__%s_%s macro\n"
+msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:198
+#: lib/rpmplugins.c:199
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -2853,11 +2835,11 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:792
+#: lib/rpmte.c:729
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:793
+#: lib/rpmte.c:730
 msgid "erase"
 msgstr ""
 
@@ -2890,96 +2872,98 @@ msgstr ""
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:87
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:92
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:98
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:104
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:119
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:136
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:159
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:175
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:251
-msgid "Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-
-#: lib/signature.c:261
-msgid "Cannot sign RPM v3 packages\n"
-msgstr ""
-
-#: lib/signature.c:348
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:387
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:429
+#: lib/signature.c:316
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:470
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1425
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:343
+#: lib/verify.c:251
+#, c-format
+msgid "Duplicate username or UID for user %s\n"
+msgstr ""
+
+#: lib/verify.c:272
+#, c-format
+msgid "Duplicate groupname or GID for group %s\n"
+msgstr ""
+
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:345
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:396
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:448
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3210,90 +3194,6 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: plugins/sepolicy.c:215
-#, c-format
-msgid "Failed to decode policy for %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:222
-#, c-format
-msgid "Failed to create temporary file for %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:228
-#, c-format
-msgid "Failed to write %s policy to file %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:293
-msgid "Failed to create semanage handle\n"
-msgstr ""
-
-#: plugins/sepolicy.c:299
-msgid "Failed to connect to policy handler\n"
-msgstr ""
-
-#: plugins/sepolicy.c:303
-#, c-format
-msgid "Failed to begin policy transaction: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:334
-#, c-format
-msgid "Failed to remove temporary policy file %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:383
-#, c-format
-msgid "Failed to install policy module: %s (%s)\n"
-msgstr ""
-
-#: plugins/sepolicy.c:413
-#, c-format
-msgid "Failed to remove policy module: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:437 plugins/sepolicy.c:489
-#, c-format
-msgid "Failed to fork process: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:447 plugins/sepolicy.c:499
-#, c-format
-msgid "Failed to execute %s: %s\n"
-msgstr ""
-
-#: plugins/sepolicy.c:453 plugins/sepolicy.c:505
-#, c-format
-msgid "%s terminated abnormally\n"
-msgstr ""
-
-#: plugins/sepolicy.c:457 plugins/sepolicy.c:509
-#, c-format
-msgid "%s failed with exit code %i\n"
-msgstr ""
-
-#: plugins/sepolicy.c:464
-msgid "Failed to commit policy changes\n"
-msgstr ""
-
-#: plugins/sepolicy.c:481
-msgid "Failed to expand restorecon path"
-msgstr ""
-
-#: plugins/sepolicy.c:560
-msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:564
-msgid "Failed to reload file contexts. Files may be mislabeled\n"
-msgstr ""
-
-#: plugins/sepolicy.c:591
-#, c-format
-msgid "Failed to extract policy from %s\n"
-msgstr ""
-
 #: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
@@ -3304,19 +3204,19 @@ msgstr ""
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:500 rpmio/macro.c:538
+#: rpmio/macro.c:494
+#, c-format
+msgid "Macro %%%s has unterminated opts\n"
+msgstr ""
+
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:557
-#, c-format
-msgid "Macro %%%s has illegal name (%%define)\n"
-msgstr ""
-
 #: rpmio/macro.c:563
 #, c-format
-msgid "Macro %%%s has unterminated opts\n"
+msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
 #: rpmio/macro.c:568
@@ -3334,63 +3234,63 @@ msgstr ""
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:615
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:644
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:727
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:956
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1025 rpmio/macro.c:1042
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1083
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1101
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1482
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:257
+#: rpmio/rpmfileutil.c:258
 #, c-format
 msgid "error creating temporary file %s: %m\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:322 rpmio/rpmfileutil.c:328
+#: rpmio/rpmfileutil.c:323 rpmio/rpmfileutil.c:329
 #, c-format
 msgid "File %s: %s\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:331
+#: rpmio/rpmfileutil.c:332
 #, c-format
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:599
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
@@ -3453,73 +3353,90 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:87
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:97
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:125
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:131
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:174
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
 msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:216
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+msgid "Could not write to pipe\n"
+msgstr ""
+
+#: sign/rpmgensig.c:284
+#, c-format
+msgid "Could not read from file %s: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:246
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:263
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:432
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:440 sign/rpmgensig.c:509
-msgid "rpmMkTemp failed\n"
+#: sign/rpmgensig.c:514
+msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:492
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
-#, c-format
-msgid "%s: writeLead failed: %s\n"
-msgstr ""
-
-#: sign/rpmgensig.c:522
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:536
+#: sign/rpmgensig.c:614
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:621
+#, c-format
+msgid "%s: writeLead failed: %s\n"
+msgstr ""
+
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/is.po
+++ b/po/is.po
@@ -1,20 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Icelandic (http://www.transifex.com/rpm-team/rpm/language/is/)\n"
+"Language-Team: Icelandic (http://www.transifex.com/rpm-team/rpm/language/"
+"is/)\n"
+"Language: is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: is\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +80,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +101,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -135,8 +136,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -221,201 +221,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot þegar skilgreind, hunsa %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
-msgstr ""
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "ekki yfirfara skrárnar í pakkanum"
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr ""
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Get ekki opnað spec skrána %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Gat ekki opnað pípu í tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Get ekki opnað spec skrána %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Gat ekki lesið spec skrá frá %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Gat ekki endurnefnt %s sem %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "gat ekki skoðað %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Skráin %s er ekki venjuleg skrá.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Skráin %s virðist ekki vera specskrá.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Þýði fyrir markkerfi: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Þýði fyrir markkerfi %s\n"
@@ -464,48 +506,61 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "<pakkaskrá>+"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:127
-#, c-format
-msgid "Pass phrase is good.\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
 msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -524,7 +579,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -573,66 +628,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "vantar '(' í  %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "vantar ')' í %s %s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ógilt %s tákn: %s\n"
@@ -642,46 +697,46 @@ msgstr "Ógilt %s tákn: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -691,149 +746,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Skráin er tvítekin: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Skráin fannst ekki: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Skráin fannst ekki með 'glob': %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "lína: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Skráin fannst ekki með 'glob': %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ógild skrá %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +917,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Get ekki ritað í pakka: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrifaði: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -985,19 +1037,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "lína %d: Óleyfilegur rofi %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1104,90 +1156,94 @@ msgstr "lína %d: Tag tekur einungis eitt tákn: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "lína %d: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "lína %d: Skemmt tag: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "lína %d: Tómt tag: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1253,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Slæmt ílag: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "lína %d: Ógilt viðfang við %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "lína %d: Villa við þáttun %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "lína %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Get ekki opnað %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1422,290 +1510,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Gat ekki keyrt %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Gat ekki búið til undirferli (fork) %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "gat ekki fundið %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s vistað sem %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s búið til sem %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,14 +1913,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1920,7 +1998,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2040,162 +2118,182 @@ msgstr "uppfæra pakka"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "fyrirspurn/yfirferð á pakkann sam á skrá"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "fyrirspurn/yfirferð á pakkana sem uppfylla þarfir annara pakka"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "ekki yfirfara stærð skráa"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "ekki yfirfara symlink slóð skráa"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "ekki yfirfara eiganda skráa"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "ekki yfirfara hop skráa"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "ekki yfirfara heimildir skráa"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "ekki yfirfara skrárnar í pakkanum"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ekki skoða pakkaskilyrðin"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "pakkinn inniheldur enga .spec skrá\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2270,96 +2368,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, c-format
+msgid "no package suggests %s\n"
+msgstr ""
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, c-format
+msgid "no package enhances %s\n"
+msgstr ""
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2384,144 +2502,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "ekki skoða pakkaskilyrðin"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2719,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2614,12 +2780,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2777,60 +2943,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr "ólöglegur rofi '%s' á %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Gat ekki lesið táknmynd %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Gat ekki lesið táknmynd %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, c-format
+msgid "Fwrite failed: %s"
+msgstr ""
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3027,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "get ekki opnað pakka gagnagrunn í %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3240,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "deildann"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "einka"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "deildann"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "einka"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tómt)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tómt)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Óþekkt viðfang %c í %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== virkt %d tómt %d\n"
@@ -3289,31 +3493,31 @@ msgstr "Skrá %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Skráin %s er minni en %u bæti\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3526,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(engin villa)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "banvæn villa: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "villa: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "aðvörun: "
 
@@ -3343,99 +3547,148 @@ msgstr "aðvörun: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "minnisfrátekt (%u bæta) skilaði NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:66
+#, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+msgid "Fopen failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg get ekki lesið undirskriftina\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "get ekki lesið undirskriftina\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+msgid "headerReload failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+msgid "copyFile failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:622
+msgid "headerWrite failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/is.po
+++ b/po/is.po
@@ -1,22 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Icelandic (http://www.transifex.com/projects/p/rpm/language/"
-"is/)\n"
-"Language: is\n"
+"Language-Team: Icelandic (http://www.transifex.com/rpm-team/rpm/language/is/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: is\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -80,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +100,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -136,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -221,243 +221,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot þegar skilgreind, hunsa %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "ekki yfirfara skrárnar í pakkanum"
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Get ekki opnað spec skrána %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Gat ekki opnað pípu í tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Get ekki opnað spec skrána %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Gat ekki lesið spec skrá frá %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Gat ekki endurnefnt %s sem %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "gat ekki skoðað %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Skráin %s er ekki venjuleg skrá.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Skráin %s virðist ekki vera specskrá.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Þýði fyrir markkerfi: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Þýði fyrir markkerfi %s\n"
@@ -506,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -526,9 +484,28 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr ""
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr ""
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -547,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -596,66 +573,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "vantar '(' í  %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "vantar ')' í %s %s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ógilt %s tákn: %s\n"
@@ -665,46 +642,46 @@ msgstr "Ógilt %s tákn: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -714,144 +691,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Skráin er tvítekin: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Skráin fannst ekki: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Skráin fannst ekki með 'glob': %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "lína: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ógild skrá %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -880,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Get ekki ritað í pakka: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Gat ekki keyrt %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "Ógild skrá %s: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrifaði: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1003,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "lína %d: Óleyfilegur rofi %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1122,94 +1104,90 @@ msgstr "lína %d: Tag tekur einungis eitt tákn: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "lína %d: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "lína %d: Skemmt tag: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "lína %d: Tómt tag: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1219,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Slæmt ílag: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "lína %d: Ógilt viðfang við %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "lína %d: Villa við þáttun %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "lína %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Get ekki opnað %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1476,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Gat ekki keyrt %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Gat ekki búið til undirferli (fork) %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "gat ekki fundið %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s vistað sem %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s búið til sem %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1879,13 +1834,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1964,7 +1920,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2084,182 +2040,162 @@ msgstr "uppfæra pakka"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "fyrirspurn/yfirferð á pakkann sam á skrá"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "fyrirspurn/yfirferð á pakkana sem uppfylla þarfir annara pakka"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "fyrirspurn/yfirferð á pakkana sem hafa pakkaþarfir"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "ekki yfirfara stærð skráa"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "ekki yfirfara symlink slóð skráa"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "ekki yfirfara eiganda skráa"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "ekki yfirfara hop skráa"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "ekki yfirfara heimildir skráa"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "ekki yfirfara skrárnar í pakkanum"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ekki skoða pakkaskilyrðin"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "pakkinn inniheldur enga .spec skrá\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2334,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, c-format
-msgid "no package suggests %s\n"
-msgstr ""
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, c-format
-msgid "no package enhances %s\n"
-msgstr ""
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2468,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "ekki skoða pakkaskilyrðin"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2685,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2746,12 +2614,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2913,75 +2781,56 @@ msgstr "ólöglegur rofi '%s' á %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Gat ekki lesið táknmynd %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Gat ekki lesið táknmynd %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "Ógild skrá %s: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -2993,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "get ekki opnað pakka gagnagrunn í %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3202,240 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "deildann"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "einka"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tómt)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tómt)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Óþekkt viðfang %c í %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== virkt %d tómt %d\n"
@@ -3455,31 +3289,31 @@ msgstr "Skrá %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Skráin %s er minni en %u bæti\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3488,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(engin villa)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "banvæn villa: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "villa: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "aðvörun: "
 
@@ -3509,119 +3343,99 @@ msgstr "aðvörun: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "minnisfrátekt (%u bæta) skilaði NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:64
-#, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-msgid "Fopen failed\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:304
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Gat ekki keyrt %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg get ekki lesið undirskriftina\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "get ekki lesið undirskriftina\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3634,21 +3448,3 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Get ekki ritað innihald í %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Get ekki lesið innihald %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Get ekki opnað tempi skrá.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Get ekki opnað sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Get ekki lesið haus úr %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Gat ekki ritað haus í %s: %s\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,22 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Guido Grazioli <guido.grazioli@gmail.com>, 2011-2014
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:47+0000\n"
-"Last-Translator: Guido Grazioli <guido.grazioli@gmail.com>\n"
-"Language-Team: Italian (http://www.transifex.com/projects/p/rpm/language/"
-"it/)\n"
-"Language: it\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
+"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
+"Language-Team: Italian (http://www.transifex.com/rpm-team/rpm/language/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -38,9 +37,7 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Questo programma può essere ridistribuito liberamente sotto i termini della "
-"GNU GPL\n"
+msgstr "Questo programma può essere ridistribuito liberamente sotto i termini della GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -83,7 +80,7 @@ msgstr "Opzioni di verifica (con -V o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opzioni Installa/Aggiorna/Rimuovi:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opzioni comuni per tutte le modalità e gli eseguibili rpm:"
@@ -104,7 +101,7 @@ msgstr "formato di interrogazione inaspettato"
 msgid "unexpected query source"
 msgstr "origine d'interrogazione inaspettata"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "è possibile specificare solo una modalità principale"
 
@@ -114,9 +111,7 @@ msgstr "è possibile forzare solo i processi di installazione e aggiornamento"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr ""
-"i file possono essere riposizionati solo durante l'installazione del "
-"pacchetto"
+msgstr "i file possono essere riposizionati solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -125,9 +120,7 @@ msgstr "impossibile usare --prefix con --relocate o --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate e --excludepath possono essere usati solo quando si installano "
-"nuovi pacchetti"
+msgstr "--relocate e --excludepath possono essere usati solo quando si installano nuovi pacchetti"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -140,32 +133,24 @@ msgstr "gli argomenti per --prefix devono iniziare con /"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr ""
-"--hash (-h) può essere usato solo per installazione o eliminazione di "
-"pacchetti"
+msgstr "--hash (-h) può essere usato solo per installazione o eliminazione di pacchetti"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
-msgstr ""
-"--percent può essere usato solo per installazione o eliminazione di pacchetti"
+msgid ""
+"--percent may only be specified during package installation and erasure"
+msgstr "--percent può essere usato solo per installazione o eliminazione di pacchetti"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr ""
-"--replacepkgs può essere specificato solo durante l'installazione del "
-"pacchetto"
+msgstr "--replacepkgs può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr ""
-"--excludedocs può essere specificato solo durante l'installazione del "
-"pacchetto"
+msgstr "--excludedocs può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr ""
-"--includedocs può essere specificato solo durante l'installazione del "
-"pacchetto"
+msgstr "--includedocs può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -173,68 +158,51 @@ msgstr "è possibile specificare solo uno tra  --excludedocs e --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr ""
-"--ignorearch può essere specificato solo durante l'installazione del "
-"pacchetto"
+msgstr "--ignorearch può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr ""
-"--ignoreos può essere specificato solo durante l'installazione del pacchetto"
+msgstr "--ignoreos può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr ""
-"--ignoresize può essere specificato solo durante l'installazione del "
-"pacchetto"
+msgstr "--ignoresize può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr ""
-"--allmatches può essere specificato solo durante la rimozione del pacchetto"
+msgstr "--allmatches può essere specificato solo durante la rimozione del pacchetto"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr ""
-"--allfiles può essere specificato solo durante l'installazione del pacchetto"
+msgstr "--allfiles può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb può essere specificato solo durante l'installazione e la rimozione "
-"del pacchetto"
+msgstr "--justdb può essere specificato solo durante l'installazione e la rimozione del pacchetto"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"le opzioni per la disabilitazione dello script possono essere specificate "
-"solo durante l'installazione e la rimozione del pacchetto"
+msgstr "le opzioni per la disabilitazione dello script possono essere specificate solo durante l'installazione e la rimozione del pacchetto"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"le opzioni di disabilitazione dell'attivazione possono essere specificate "
-"solo durante l'installazione e la rimozione del pacchetto"
+msgstr "le opzioni di disabilitazione dell'attivazione possono essere specificate solo durante l'installazione e la rimozione del pacchetto"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps può essere specificato solamente per l'installazione, "
-"l'eliminazione e la verifica di pacchetti"
+msgstr "--nodeps può essere specificato solamente per l'installazione, l'eliminazione e la verifica di pacchetti"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"--test può essere specificato solamente per l'installazione e l'eliminazione "
-"di pacchetti"
+msgstr "--test può essere specificato solamente per l'installazione e l'eliminazione di pacchetti"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "gli argomenti per --root (-r) devono iniziare con /"
 
@@ -254,256 +222,201 @@ msgstr "non è stato specificato alcun argomento per l'interrogazione"
 msgid "no arguments given for verify"
 msgstr "non è stato specificato alcun argomento per la verifica"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot è già specificato, ignora %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"compila attraverso %prep (scompatta i sorgenti e applica le patch) da "
-"<specfile>"
+msgstr "compila attraverso %prep (scompatta i sorgenti e applica le patch) da <specfile>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "compila attraverso %build (%prep, e poi compila) da <specfile>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"compila attraverso %install (%prep, %build, e poi installa) da <specfile>"
+msgstr "compila attraverso %install (%prep, %build, e poi installa) da <specfile>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verifica sezione %files da <specfile>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "compila i pacchetti binari e sorgente da <specfile>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "compila solo il pacchetto binario da <specfile>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "compila solo il pacchetto sorgente da <specfile>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"compila attraverso %prep (scompatta i sorgenti e applica le patch) da "
-"<specfile>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<source package>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "compila attraverso %build (%prep, e poi compila) da <specfile>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"compila attraverso %install (%prep, %build, poi installa) da <source package>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verifica sezione %files da <specfile>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "compila il pacchetto binario da <source package>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "compila il pacchetto binario da <source package>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "compila solo il pacchetto sorgente da <specfile>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"compila attraverso %prep (scompatta i sorgenti ed applica le patch) da "
-"<tarball>"
+msgstr "compila attraverso %prep (scompatta i sorgenti ed applica le patch) da <tarball>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "compila attraverso %build (%prep, e poi compila) da <tarball>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "compila attraverso %install (%prep, %build, poi installa) da <tarball>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verifica la sezione %files da <tarball>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "compila i pacchetti binari e sorgenti da <tarball>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "compila solo il pacchetto binario da <tarball>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "compila solo il pacchetto sorgente da <tarball>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "compila il pacchetto binario da <source package>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<source package>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "compila attraverso %install (%prep, %build, poi installa) da <source package>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "override della build root"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Impossibile aprire la directory corrente: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "rimuovere l'albero di compilazione quando terminato"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignora le direttive ExcludeArch: dal file spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "macchina a stati del file di debug"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "non eseguire alcuna fase del processo di compilazione"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "non verificare le dipendenze di compilazione"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "genera pacchetti con intestazioni compatibili con rpm v3 (legacy)"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "non eseguire la fase %clean del processo di build"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "non eseguire la fase %clean del processo di build"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "non eseguire la fase %check del processo di build"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "non accettare i msgtr di i18N da specfile"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "rimuovi i sorgenti quando terminato"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "rimuovi lo specfile quando terminato"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "salta direttamente alla fase specificata (solo per c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "override della piattaforma target"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opzioni di build con [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Dipendenze di build fallite:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Impossibile aprire il file spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Impossibile aprire tar pipe: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Più di un file su una riga: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Impossibile leggere il file spec da %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Impossibile rinominare %s in %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "impossibile eseguire lo stat di %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Il file %s non è un file regolare.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Il file %s non sembra essere uno specfile.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Creazione piattaforme target in corso: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Creazione per il target %s in corso\n"
@@ -514,9 +427,7 @@ msgstr "inizializza database"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"ricompila gli elenchi invertiti del database dalle intestazioni dei "
-"pacchetti installati"
+msgstr "ricompila gli elenchi invertiti del database dalle intestazioni dei pacchetti installati"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -544,9 +455,7 @@ msgstr "importa una armored public key"
 
 #: rpmkeys.c:28
 msgid "don't import, but tell if it would work or not"
-msgstr ""
-"non importare realmente, riporta solo se l'operazione termina con successo "
-"oppure no"
+msgstr "non importare realmente, riporta solo se l'operazione termina con successo oppure no"
 
 #: rpmkeys.c:31 rpmkeys.c:33
 msgid "list keys from RPM keyring"
@@ -556,7 +465,7 @@ msgstr "elenca le chiavi del keyring RPM"
 msgid "Keyring options:"
 msgstr "Opzioni keyring:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "non è stato specificato alcun argomento"
 
@@ -576,10 +485,29 @@ msgstr "cancella le firme del pacchetto"
 msgid "Signature options:"
 msgstr "Opzioni della firma:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Impossibile eseguire %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "È necessario impostare \"%%_gpg_name\" nel file macro\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Inserire la passphrase:"
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "La passphrase risulta valida.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Controllo della pass phrase fallito o chiave gpg scaduta\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -597,7 +525,7 @@ msgstr "opera sugli rpm binari generati dal file spec (default)"
 msgid "operate on source rpm generated by spec"
 msgstr "opera sul file rpm sorgente generato dal file spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "usare il seguente formato di interrogazione"
 
@@ -644,71 +572,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Errori di compilazione RPM:\n"
+msgstr "\n\nErrori di compilazione RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "errore di sintassi durante il parsing di ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "errore di sintassi durante il parsing di &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "errore di sintassi durante il parsing di ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "errore durante il parsing dell'espressione\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "non corrispondente (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- solo sui numeri\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! solo sui numeri\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "i diversi tipi devono corrispondere\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / non supportato per le stringhe\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- non supportato per le stringhe\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& e || non supportati per le stringhe\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "errore di sintassi nell'espressione\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "'(' mancante in %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "')' mancante in %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Token %s non valido: %s\n"
@@ -718,46 +643,46 @@ msgstr "Token %s non valido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s mancante in %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Caratteri non validi seguono %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintassi non corretta: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Spec della modalità errata: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Spec dirmode errata: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Lunghezza inconsueta del locale: \"%s\" in %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Locale duplicato: %s in %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capability non valida: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Supporto alle file capabilities non disponibile\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Il file deve iniziare con \"/\": %s\n"
@@ -767,149 +692,149 @@ msgstr "Il file deve iniziare con \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Algoritmo di digest %u sconosciuto, ritorno a MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "File elencato due volte: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "lettura del symlink %s fallita: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Il Symlink punta alla BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Percorso esterno alla buildroot: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Directory non trovata: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "File non trovato: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Non è una directory: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: impossibile caricare tag sconosciuto (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: lettura chiave pubblica fallita.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: non è una chiave pubblica con formato 'armored'.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: errore durante l'encoding\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Il file deve essere preceduto da \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "glob %%dev non consentito: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Directory non trovata per il glob: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "File non trovato dal glob: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Impossibile aprire %%files file %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "riga: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
-msgstr ""
-"File %s vuoto nella sezione %%files\n"
-"\n"
+msgstr "File %s vuoto nella sezione %%files\n\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Errore nella lettura del file %s in %%files: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "_docdir_fmt %s non valido: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Impossibile unire %s speciali con altre forme: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Più di un file su una riga: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "File errato: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Proprietario/gruppo errato: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Controllo per file non pacchettizzati in corso: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Trovati file installati (ma non inclusi nel pacchetto):\n"
-"%s"
+msgstr "Trovati file installati (ma non inclusi nel pacchetto):\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Elaborazione file: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"L'architettura dei binari (%d) non corrisponde a quella del pacchetto (%d).\n"
+msgstr "L'architettura dei binari (%d) non corrisponde a quella del pacchetto (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binari dipendenti dall'architettura presenti in un pacchetto noarch\n"
 
@@ -938,79 +863,79 @@ msgstr "%s: linea: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Impossibile regolarizzare l'hostname: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Impossibile ricaricare intestazione della firma.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compressione payload sconosciuta: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Impossibile creare una regione dell'intestazione immutabile.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Impossibile aprire %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Impossibile scrivere il pacchetto: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Impossibile salvare intestazione di temp\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Dati CSA errati\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Impossibile aprire il file %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "creazione archivio fallita sul file %s: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Scritto: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Esecuzione \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Esecuzione di \"%s\" fallita.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Controllo pacchetto \"%s\" fallito.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Impossibile generare nome del file di output per il pacchetto %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "impossibile creare %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "riga %d: secondo %s\n"
@@ -1061,19 +986,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "riga %d: Errore durante il parsing di %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "riga  %d: Opzione %s errata: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "riga %d: Troppi nomi: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "riga %d: Pacchetto non esistente: %s\n"
@@ -1179,96 +1104,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "riga %d: Il tag necessita di un solo token: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "riga %d: Carattere '%c' illegale in: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "riga %d: Sequenza \"..\" illegale in: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "riga %d: Carattere illegale in: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linea %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "riga %d: Sequenza \"..\" illegale in: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: linea: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "riga %d: Tag malformato: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "riga %d: Tag vuoto: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "riga %d: I prefissi non devono finire con \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "riga %d: Docdir deve iniziare con '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "riga %d: Il tag Epoch deve essere un numero: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "riga %d: %s errati: qualificatori: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "riga %d: Formato BuildArchitecture errato: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "riga %d: Sono supportati solo sottopacchetti noarch: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Errore interno: bogus tag %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "riga %d: %s è deprecato: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Specifiche errate del pacchetto: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Il pacchetto è già esistente: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "riga %d: Tag sconosciuto: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} non può essere vuota\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} non può essere \"/\"\n"
@@ -1278,196 +1198,161 @@ msgstr "%%{buildroot} non può essere \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Sorgenti non validi: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nessuna patch con numero %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch senza il corrispondente tag \"Patch:\"\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nessun sorgente con numero %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Nessun tag \"Source:\" nello spec file\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Errore nel parsing di %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "riga %d: Argomento errato su %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "riga %d: Opzione di %%setup errata %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Numero patch non valido %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "riga %d: secondo %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "I token delle dipendenze devono iniziare per alfanumerico, '_' o '/'"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Nome file versionato non consentito"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "Dipendenza non valida"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Versione richiesta"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "Dipendenza non valida"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "linea %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "riga %d: i trigger devono presentare --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "riga %d: Errore nel parsing di %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "linea %d: uno script interno deve terminare con '>': %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "riga %d: il programma script deve iniziare con '/': %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr "linea %d: argomenti dell'interprete non consentiti nei trigger: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "riga %d: Secondo %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linea %d: script interno non supportato: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "linea %d: argomenti dell'interprete non consentiti nei trigger: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "riga %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Impossibile aprire %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: argomento necessario per %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
-msgstr ""
-"riga %d: %%if non bilanciato\n"
-"\n"
+msgstr "riga %d: %%if non bilanciato\n\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "linea %d: macro non chiusa o errata continuazione linea\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: condizione %%if errata\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Trovato un %%else con nessun %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Trovato un %%endif con nessun %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s: %d: istruzione %%include malformata\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
-msgstr ""
-"Non è stata trovata alcuna architettura compatibile per la compilazione\n"
+msgstr "Non è stata trovata alcuna architettura compatibile per la compilazione\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Il pacchetto non possiede alcuna %%description: %s\n"
@@ -1511,9 +1396,7 @@ msgstr "Impossibile determinare il nome della policy: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"Tipo '%s' impostato con altri tipi in %%semodule %s. Compattazione dei tipi "
-"in '%s'.\n"
+msgstr "Tipo '%s' impostato con altri tipi in %%semodule %s. Compattazione dei tipi in '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1540,282 +1423,290 @@ msgstr "Troppi argomenti alla linea: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Elaborazione policies: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Viene ignorata la regex non valida %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Impossibile creare la pipe per %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Impossibile eseguire %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Impossibile biforcare %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s fallito: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "impossibile salvare tutti i dati su %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr "operatore non valido"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr "formato non valido"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "dipendenza non valida (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Conversione di %s a long integer fallita.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "File classifier vuoto\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Non è configurato alcun attributo dei file\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) fallita: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load fallita: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Identificazione file \"%s\" fallita: modalità %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Ricerca di %s in corso: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Impossibile trovare %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr ""
-"interrogazione di specfile %s fallita, impossibile eseguire il parsing\n"
+msgstr "interrogazione di specfile %s fallita, impossibile eseguire il parsing\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s è un Delta RPM e non può essere installato direttamente\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Payload non supportato (%s) nel pacchetto %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "il pacchetto %s è già stato aggiunto, salto %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "il pacchetto %s è stato già aggiunto, sostituzione con %s in corso\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(non è un numero)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(non base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(tipo non valido)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(non è un blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(tipo xml non valido)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(non è una firma OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Formato data %u non corretto"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normale"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "sostituito"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "non installato"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "condivisa su rete"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "colore errato"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "mancanti"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(sconosciuto)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(non è una stringa)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s salvato come %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s creato come %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: rimozione fallita: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "directory"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "file"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "%s ha una signature non verificabile"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1944,18 +1835,15 @@ msgid "relocations must have a / following the ="
 msgstr "i riposizionamenti devono avere una / che segue ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"installare tutti i file, anche le configurazioni che possono altrimenti "
-"essere saltate"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "installare tutti i file, anche le configurazioni che possono altrimenti essere saltate"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"rimuovere tutti i pacchetti corrispondenti a <package> (normalmente viene "
-"generato un errore se con <package> vengono specificati pacchetti multipli)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "rimuovere tutti i pacchetti corrispondenti a <package> (normalmente viene generato un errore se con <package> vengono specificati pacchetti multipli)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2003,8 +1891,7 @@ msgstr "<packagefile>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr ""
-"mostra i caratteri hash durante l'installazione del pacchetto (utile con -v)"
+msgstr "mostra i caratteri hash durante l'installazione del pacchetto (utile con -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -2034,7 +1921,7 @@ msgstr "aggiorna il database, senza modificare il filesystem"
 msgid "do not verify package dependencies"
 msgstr "non verificare le dipendenze dei pacchetti"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "non verificare il digest dei file"
 
@@ -2048,8 +1935,7 @@ msgstr "non installare contesti di sicurezza dei file"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"non riordinare l'installazione dei pacchetti per soddisfare le dipendenze"
+msgstr "non riordinare l'installazione dei pacchetti per soddisfare le dipendenze"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2113,9 +1999,7 @@ msgstr "non eseguire alcun scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"aggiorna ad una versione più vecchia del pacchetto (sugli aggiornamenti --"
-"force esegue questa operazione automaticamente)"
+msgstr "aggiorna ad una versione più vecchia del pacchetto (sugli aggiornamenti --force esegue questa operazione automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2157,185 +2041,162 @@ msgstr "aggiorna il pacchetto/i"
 msgid "reinstall package(s)"
 msgstr "reinstalla pacchetto(i)"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "interrogare/verificare tutti i pacchetti"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "modalità rpm checksig"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "interrogare/verificare a quale pacchetto/i appartiene il file"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "interrogare/verificare il pacchetto/i in un gruppo"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "interrogare/verificare un file del pacchetto"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
-msgstr ""
-"interrogare/verificare il pacchetto/i con un identificatore del pacchetto"
+msgstr "interrogare/verificare il pacchetto/i con un identificatore del pacchetto"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
-msgstr ""
-"interrogare/verificare il pacchetto/i con un identificatore di intestazione"
+msgstr "interrogare/verificare il pacchetto/i con un identificatore di intestazione"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "modalità interrogazione rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "interrogare/verificare una istanza dell'intestazione"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
-msgstr ""
-"interrogare/verificare il pacchetto/i dalla transazione di installazione"
+msgstr "interrogare/verificare il pacchetto/i dalla transazione di installazione"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "interroga il pacchetto/i azionato dal pacchetto"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "modalità verifica rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "interrogare/verificare il pacchetto/i che fornisce una dipendenza"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "non eseguire il glob degli argomenti"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "non processare i file non-package come manifest"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "elenca tutti i file di configurazione"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "elenca tutti i file di documentazione"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr "elenca tutti i file licenza"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "emettere le informazioni di base dei file"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "elenca i file in un pacchetto"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "salta file %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "visualizza gli stati dei file elencati"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "non verificare la dimensione dei file"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "non verificare il percorso symlink dei file"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "non verificare il proprietario dei file"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "non verificare il gruppo dei file"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "non verificare l'ora di modifica dei file"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "non verificare la modalità dei file"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "non verificare le capabilities dei file"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "non verificare i contesti di sicurezza dei file"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "non verificare i file nel pacchetto"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "non verificare le dipendenze del pacchetto"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "non eseguire gli script di verifica"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Funzionalità rpmlib mancanti per %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "pacchetto sorgente atteso, trovato binario\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "il pacchetto sorgente non contiene alcun file .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "estrazione archivio fallita%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " sul file "
 
@@ -2383,8 +2244,7 @@ msgstr "il pacchetto non possiede alcun elenco gruppo/proprietario dei file\n"
 
 #: lib/query.c:228
 msgid "package has neither file owner or id lists\n"
-msgstr ""
-"il pacchetto non possiede ne un proprietario del file ne un elenco id\n"
+msgstr "il pacchetto non possiede ne un proprietario del file ne un elenco id\n"
 
 #: lib/query.c:317
 #, c-format
@@ -2411,117 +2271,96 @@ msgstr "nessun pacchetto corrisponde a %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nessun pacchetto necessita di %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "nessun pacchetto necessita di %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "nessun pacchetto attiva %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "nessun pacchetto necessita di %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "nessun pacchetto necessita di %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nessun pacchetto fornisce %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "file %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "il file %s non è posseduto da alcun pacchetto\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "numero del pacchetto non valido: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "il record %u non può essere letto\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "il pacchetto %s non è stato installato\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tag sconosciuto: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: importazione chiave %d fallita.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: chiave pubblica %d non con formato 'armored'.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: lettura importazione fallita(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead fallita: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: La regione header immutabile non può essere letta. Pacchetto corrotto?\n"
+msgstr "%s: La regione header immutabile non può essere letta. Pacchetto corrotto?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread fallito: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NON OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (CHIAVI MANCANTI:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CHIAVI NON FIDATE:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: apertura fallita: %s\n"
@@ -2546,205 +2385,144 @@ msgstr "Impossibile cambiare directory root: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Impossibile ripristinare directory root: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "SI"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr ""
-"Supporto alla versione per le dipendenze PreReq:, Provides: e Obsoletes:."
+msgstr "Supporto alla versione per le dipendenze PreReq:, Provides: e Obsoletes:."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"file name conservati come tuple (dirName,baseName,dirIndex), non come "
-"percorsi."
+msgstr "file name conservati come tuple (dirName,baseName,dirIndex), non come percorsi."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "il payload del pacchetto può essere compresso utilizzando bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "il payload del pacchetto può essere compresso utilizzando xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "il payload del pacchetto può essere compresso utilizzando lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "il/i file payload del pacchetto presentano un prefisso \"./\""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
-msgstr ""
-"il nome-versione-release del pacchetto non viene implicitamente fornito."
+msgstr "il nome-versione-release del pacchetto non viene implicitamente fornito."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
-msgstr ""
-"i tag delle intestazioni vengono sempre ordinate dopo il loro caricamento."
+msgstr "i tag delle intestazioni vengono sempre ordinate dopo il loro caricamento."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
-msgstr ""
-"l'interprete di scriptlet può utilizzare gli argomenti presenti "
-"nell'intestazione."
+msgstr "l'interprete di scriptlet può utilizzare gli argomenti presenti nell'intestazione."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "un set di file hardlink può essere installato senza che sia completo."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"le scriptlet del pacchetto potrebbero accedere al database rpm durante "
-"l'installazione."
+msgstr "le scriptlet del pacchetto potrebbero accedere al database rpm durante l'installazione."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "supporto interno per gli script lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "l'algoritmo digest di checksum dei file è configurabile per pacchetto"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "supporto per le file capabilities POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
-msgstr ""
-"le scriptlet del pacchetto possono essere espanse durante l'installazione."
+msgstr "le scriptlet del pacchetto possono essere espanse durante l'installazione."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "la comparazione delle dipendenze supporta le versioni con tilde."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr "supporto per file più grandi di 4GB"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "non verificare le dipendenze dei pacchetti"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Versione richiesta"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "Dipendenza non valida"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c non terminato: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "Dipendenza non valida"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "l'utente %s non esiste - uso dell'utente root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "il gruppo %s non esiste - uso dell'utente root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Bad magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Intestazione  errata/illeggibile"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Dimensione intestazione troppo grande"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "FIle troppo grande per l'archivio"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Tipo di file sconosciuto"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr "File mancante(i)"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Digest non corrispondente"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Errore interno"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "File archive non è nell'intestazione"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " fallito - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (errore 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "apertura di %s fallita: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: non è un pacchetto rpm (o un manifest del pacchetto)\n"
@@ -2776,42 +2554,42 @@ msgstr "Dipendenze fallite:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: non è un pacchetto rpm (o un manifest del pacchetto): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s non può essere installato\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Ripristino di %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "omissione di %s - trasferimento fallito\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "il pacchetto %s non è riposizionabile\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "errore di lettura dal file %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" specifica pacchetti multipli:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "impossibile aprire %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installazione di %s in corso\n"
@@ -2837,12 +2615,12 @@ msgstr "lettura fallita: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "non è un pacchetto rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "impossibile creare il lock %s su %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "attesa del lock %s su %s\n"
@@ -2858,9 +2636,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Impossibile risolvere il simbolo %s: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Plugin %s non caricato\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2894,34 +2672,27 @@ msgstr "il percorso %s nel pacchetto %s non è riposizionabile"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr ""
-"il file %s entra in conflitto durante il tentativo d'installazione di %s e %s"
+msgstr "il file %s entra in conflitto durante il tentativo d'installazione di %s e %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"il file %s dell'installazione di %s entra in conflitto con il file del "
-"pacchetto %s"
+msgstr "il file %s dell'installazione di %s entra in conflitto con il file del pacchetto %s"
 
 #: lib/rpmprob.c:140
 #, c-format
 msgid "package %s (which is newer than %s) is already installed"
-msgstr ""
-"il pacchetto %s (il quale risulta essere più recente di %s) è già installato"
+msgstr "il pacchetto %s (il quale risulta essere più recente di %s) è già installato"
 
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"l'installazione del pacchetto %s necessita di %<PRIu64>%cB sul filesystem %s"
+msgstr "l'installazione del pacchetto %s necessita di %<PRIu64>%cB sul filesystem %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"l'installazione del pacchetto %s necessita di %<PRIu64> inode sul filesystem "
-"%s"
+msgstr "l'installazione del pacchetto %s necessita di %<PRIu64> inode sul filesystem %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2945,9 +2716,7 @@ msgstr "%s reso obsoleto da %s%s"
 #: lib/rpmprob.c:172
 #, c-format
 msgid "unknown error %d encountered while manipulating package %s"
-msgstr ""
-"si è verificato un errore sconosciuto %d durante la manipolazione del "
-"pacchetto %s"
+msgstr "si è verificato un errore sconosciuto %d durante la manipolazione del pacchetto %s"
 
 #: lib/rpmrc.c:222
 #, c-format
@@ -3013,75 +2782,56 @@ msgstr "opzione errata '%s' su %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Impossibile leggere il vettore ausiliario, /proc non montata?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema sconosciuto: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Si prega di contattare %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Impossibile aprire %s per la lettura: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Impossibile tornare alla direcotry corrente: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "supporto agli scriptlet <lua> non disponibile\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Impossibile creare il file temporaneo per %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Impossibile duplicare il file descriptor: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Impossibile leggere l'icona %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Impossibile ripristinare directory root: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite fallito: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "scriptlet %s fallita, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "scriptlet %s fallita, segnale %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "scriptlet %s fallita, uscita con stato %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Formato sconosciuto"
 
@@ -3093,142 +2843,127 @@ msgstr "installa"
 msgid "erase"
 msgstr "elimina"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "impossibile aprire il database dei pacchetti in %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' extra nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' mancante nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' mancante nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: lettura chiave pubblica fallita.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transazione"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(non è una firma OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Header "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 digest:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Digest SHA1 header:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Header "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Verifica signature: PARAMETRI NON VALIDI (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "saltato"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "fallito"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr "nessuno stato"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr "stato sconosciuto"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "%c %s  mancanti"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dipendenze non soddisfatte per %s:\n"
@@ -3302,242 +3037,240 @@ msgstr "iteratore di array usato con array di dimensioni differenti"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generazione di %d indici mancanti, prego attendere...\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "impossibile aprire l'indice %s usando%s - %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "non è stato impostato alcun dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: salto"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "errore(%d) nella memorizzazione del record #%d in %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec fallito: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp fallito: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: salto"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: intestazione #%u danneggiata -- viene omessa.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: impossibile leggere intestazione 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "non è stato impostato alcun dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "impossibile creare la cartella %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "l'intestazione #%u nel database non è valida -- viene omessa.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "impossibile aggiungere il record originariamente su %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "ricompilazione database fallita: il database originale rimane in uso\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "sostituzione del vecchio database con il nuovo database fallita!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "per eseguire un ripristino sostituire i file in %s con i file di %s"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "rimozione della directory %s fallita: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s error(%d) da %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s error(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "opzione db non riconosciuta: \"%s\" ignorata.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s presenta un valore numeric non valido, omesso\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s presenta un valore long troppo grande o troppo piccolo, omesso\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s presenta un valore integer troppo grande o troppo piccolo, omesso\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "impossibile ottenere il %s su %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "condiviso"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "esclusivo"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "tipo indice %x non valido su %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "errore(%d) nella lettura dei record \"%s\" dall'indice %s: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "errore(%d) nella memorizzazione del record \"%s\" in %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "errore(%d) nella rimozione del record \"%s\" da %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "errore(%d) nell'impostazione del record #%d dell'intestazione\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "errore(%d) nell'eliminazione del record dell'intestazione #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "errore(%d) nell'allocazione di una nuova istanza del pacchetto\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "opzione db non riconosciuta: \"%s\" ignorata.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s presenta un valore numeric non valido, omesso\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s presenta un valore long troppo grande o troppo piccolo, omesso\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s presenta un valore integer troppo grande o troppo piccolo, omesso\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vuoto)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vuoto)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s presenta delle opzioni incomplete\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s presenta un corpo incompleto\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "La macro %%%s presenta un nome illegale (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s presenta contenuto vuoto\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La Macro %%%s richiede whitespace prima del corpo\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Impossibile espandere la macro %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "La macro %%%s presenta un nome illegale (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Macro %%%s definita ma non usata nello scope\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opzione %c sconosciuta in %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Troppo livelli di ricorsione nell'espansione della macro. Si tratta "
-"probabilmente di una macro definita ricorsivamente.\n"
+msgstr "Troppo livelli di ricorsione nell'espansione della macro. Si tratta probabilmente di una macro definita ricorsivamente.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c non terminato: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% è seguito da una macro non parsabile\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "impossibile caricare il file di macro %s"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d attivo %d vuoto\n"
@@ -3557,31 +3290,31 @@ msgstr "File %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "File %s è più piccolo di %u byte\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "impossibile creare la directory"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintassi non valida nella scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintassi non valida nello script lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "script lua fallito: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintassi non valida nel file lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hook fallito: %s\n"
@@ -3590,19 +3323,19 @@ msgstr "lua hook fallito: %s\n"
 msgid "[none]"
 msgstr "[nessuno]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(nessun errore)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "errore fatale: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "errore: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "avvertimento: "
 
@@ -3611,121 +3344,99 @@ msgstr "avvertimento: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "allocazione memoria (%u byte) ha ritornato NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID chiave %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "errore nella creazione del file temporaneo %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "errore nella creazione del file temporaneo %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "errore nella creazione del file temporaneo %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "impossibile creare la cartella %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite fallito: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush fallito: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Firma PGP non supportata\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algoritmo hash PGP %u non supportato\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algoritmo di chiave privata PGP non supportato %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Impossibile eseguire %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Impossibile creare la pipe per la firma: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: apertura fallita: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Impossibile aprire il file %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Impossibile aprire %%files file %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "esecuzione gpg fallita (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg non è riuscito a salvare la firma\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "impossibile leggere la firma\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature fallita: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Impossibile firmare pacchetti RPM v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s contiene la stessa identica signature, lo salto\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature fallito: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp fallito\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead fallito: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "sostituzione di %s fallita: %s\n"
@@ -3738,111 +3449,3 @@ msgstr "%s: lettura manifesto fallita: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "non verificare firma header+payload"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Inserire la passphrase:"
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "La passphrase risulta valida.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "Controllo della pass phrase fallito o chiave gpg scaduta\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Proprietario/gruppo errato: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "riga %d: Carattere illegale in: %s\n"
-
-#~ msgid "%s has unverifiable signature"
-#~ msgstr "%s ha una signature non verificabile"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Impossibile creare la pipe per la firma: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Impossibile salvare payload su %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Impossibile leggere payload da %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Impossibile aprire il file temp.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Impossibile aprire sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Impossibile leggere intestazione da %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Impossibile salvare intestazione su %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "non eseguire azioni sulle collezioni"
-
-#~ msgid "Failed to expand %%__%s_%s macro\n"
-#~ msgstr "Impossibile espandere la macro %%__%s_%s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "Impossibile leggere la regione immutabile dell'header. Pacchetto "
-#~ "corrotto?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Impossibile decodificare la policy per %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Impossibile creare il file temporaneo per %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Impossibile scrivere la policy %s nel file %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Errore nella creazione dell'handle semanage\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Errore nella connessione all'handler di policy\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Errore nell'inizializzazione della policy transaction: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Impossibile rimuovere il temporaneo %s della policy: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Impossibile installare il modulo di policy: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Impossibile rimuovere il modulo di policy: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Errore durante il fork del processo: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Impossibile eseguire %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s è terminato in modo anomalo\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s fallito con codice di errore %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Errore durante il commit delle modifiche alla policy\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Impossibile espandere il percorso restorecon"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Errore durante il relabel del filesystem. I file potrebbero avere label "
-#~ "non corrette\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Errore nel caricamento dei file context. I file potrebbero avere label "
-#~ "non corrette\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Impossibile estrarre la policy da %s\n"

--- a/po/it.po
+++ b/po/it.po
@@ -1,21 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Guido Grazioli <guido.grazioli@gmail.com>, 2011-2014
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Italian (http://www.transifex.com/rpm-team/rpm/language/it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -37,7 +37,9 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Questo programma può essere ridistribuito liberamente sotto i termini della GNU GPL\n"
+msgstr ""
+"Questo programma può essere ridistribuito liberamente sotto i termini della "
+"GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -80,7 +82,7 @@ msgstr "Opzioni di verifica (con -V o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opzioni Installa/Aggiorna/Rimuovi:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opzioni comuni per tutte le modalità e gli eseguibili rpm:"
@@ -101,7 +103,7 @@ msgstr "formato di interrogazione inaspettato"
 msgid "unexpected query source"
 msgstr "origine d'interrogazione inaspettata"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "è possibile specificare solo una modalità principale"
 
@@ -111,7 +113,9 @@ msgstr "è possibile forzare solo i processi di installazione e aggiornamento"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "i file possono essere riposizionati solo durante l'installazione del pacchetto"
+msgstr ""
+"i file possono essere riposizionati solo durante l'installazione del "
+"pacchetto"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -120,7 +124,9 @@ msgstr "impossibile usare --prefix con --relocate o --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate e --excludepath possono essere usati solo quando si installano nuovi pacchetti"
+msgstr ""
+"--relocate e --excludepath possono essere usati solo quando si installano "
+"nuovi pacchetti"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -133,24 +139,32 @@ msgstr "gli argomenti per --prefix devono iniziare con /"
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr "--hash (-h) può essere usato solo per installazione o eliminazione di pacchetti"
+msgstr ""
+"--hash (-h) può essere usato solo per installazione o eliminazione di "
+"pacchetti"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
-msgstr "--percent può essere usato solo per installazione o eliminazione di pacchetti"
+msgid "--percent may only be specified during package installation and erasure"
+msgstr ""
+"--percent può essere usato solo per installazione o eliminazione di pacchetti"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr "--replacepkgs può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--replacepkgs può essere specificato solo durante l'installazione del "
+"pacchetto"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr "--excludedocs può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--excludedocs può essere specificato solo durante l'installazione del "
+"pacchetto"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr "--includedocs può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--includedocs può essere specificato solo durante l'installazione del "
+"pacchetto"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -158,51 +172,68 @@ msgstr "è possibile specificare solo uno tra  --excludedocs e --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr "--ignorearch può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--ignorearch può essere specificato solo durante l'installazione del "
+"pacchetto"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr "--ignoreos può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--ignoreos può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr "--ignoresize può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--ignoresize può essere specificato solo durante l'installazione del "
+"pacchetto"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr "--allmatches può essere specificato solo durante la rimozione del pacchetto"
+msgstr ""
+"--allmatches può essere specificato solo durante la rimozione del pacchetto"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr "--allfiles può essere specificato solo durante l'installazione del pacchetto"
+msgstr ""
+"--allfiles può essere specificato solo durante l'installazione del pacchetto"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb può essere specificato solo durante l'installazione e la rimozione del pacchetto"
+msgstr ""
+"--justdb può essere specificato solo durante l'installazione e la rimozione "
+"del pacchetto"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "le opzioni per la disabilitazione dello script possono essere specificate solo durante l'installazione e la rimozione del pacchetto"
+msgstr ""
+"le opzioni per la disabilitazione dello script possono essere specificate "
+"solo durante l'installazione e la rimozione del pacchetto"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "le opzioni di disabilitazione dell'attivazione possono essere specificate solo durante l'installazione e la rimozione del pacchetto"
+msgstr ""
+"le opzioni di disabilitazione dell'attivazione possono essere specificate "
+"solo durante l'installazione e la rimozione del pacchetto"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps può essere specificato solamente per l'installazione, l'eliminazione e la verifica di pacchetti"
+msgstr ""
+"--nodeps può essere specificato solamente per l'installazione, "
+"l'eliminazione e la verifica di pacchetti"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "--test può essere specificato solamente per l'installazione e l'eliminazione di pacchetti"
+msgstr ""
+"--test può essere specificato solamente per l'installazione e l'eliminazione "
+"di pacchetti"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "gli argomenti per --root (-r) devono iniziare con /"
 
@@ -222,201 +253,256 @@ msgstr "non è stato specificato alcun argomento per l'interrogazione"
 msgid "no arguments given for verify"
 msgstr "non è stato specificato alcun argomento per la verifica"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot è già specificato, ignora %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "compila attraverso %prep (scompatta i sorgenti e applica le patch) da <specfile>"
+msgstr ""
+"compila attraverso %prep (scompatta i sorgenti e applica le patch) da "
+"<specfile>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "compila attraverso %build (%prep, e poi compila) da <specfile>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "compila attraverso %install (%prep, %build, e poi installa) da <specfile>"
+msgstr ""
+"compila attraverso %install (%prep, %build, e poi installa) da <specfile>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verifica sezione %files da <specfile>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "compila i pacchetti binari e sorgente da <specfile>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "compila solo il pacchetto binario da <specfile>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "compila solo il pacchetto sorgente da <specfile>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"compila attraverso %prep (scompatta i sorgenti e applica le patch) da "
+"<specfile>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<source package>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "compila attraverso %build (%prep, e poi compila) da <specfile>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"compila attraverso %install (%prep, %build, poi installa) da <source package>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verifica sezione %files da <specfile>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "compila il pacchetto binario da <source package>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "compila il pacchetto binario da <source package>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "compila solo il pacchetto sorgente da <specfile>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "compila attraverso %prep (scompatta i sorgenti ed applica le patch) da <tarball>"
+msgstr ""
+"compila attraverso %prep (scompatta i sorgenti ed applica le patch) da "
+"<tarball>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "compila attraverso %build (%prep, e poi compila) da <tarball>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "compila attraverso %install (%prep, %build, poi installa) da <tarball>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verifica la sezione %files da <tarball>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "compila i pacchetti binari e sorgenti da <tarball>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "compila solo il pacchetto binario da <tarball>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "compila solo il pacchetto sorgente da <tarball>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "compila il pacchetto binario da <source package>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<source package>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "compila attraverso %install (%prep, %build, poi installa) da <source package>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "override della build root"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Impossibile aprire la directory corrente: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "rimuovere l'albero di compilazione quando terminato"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignora le direttive ExcludeArch: dal file spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "macchina a stati del file di debug"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "non eseguire alcuna fase del processo di compilazione"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "non verificare le dipendenze di compilazione"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "genera pacchetti con intestazioni compatibili con rpm v3 (legacy)"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "non eseguire la fase %clean del processo di build"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "non eseguire la fase %clean del processo di build"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "non eseguire la fase %check del processo di build"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "non accettare i msgtr di i18N da specfile"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "rimuovi i sorgenti quando terminato"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "rimuovi lo specfile quando terminato"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "salta direttamente alla fase specificata (solo per c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "override della piattaforma target"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opzioni di build con [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Dipendenze di build fallite:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Impossibile aprire il file spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Impossibile aprire tar pipe: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Più di un file su una riga: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Impossibile leggere il file spec da %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Impossibile rinominare %s in %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "impossibile eseguire lo stat di %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Il file %s non è un file regolare.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Il file %s non sembra essere uno specfile.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Creazione piattaforme target in corso: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Creazione per il target %s in corso\n"
@@ -427,7 +513,9 @@ msgstr "inizializza database"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "ricompila gli elenchi invertiti del database dalle intestazioni dei pacchetti installati"
+msgstr ""
+"ricompila gli elenchi invertiti del database dalle intestazioni dei "
+"pacchetti installati"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -455,7 +543,9 @@ msgstr "importa una armored public key"
 
 #: rpmkeys.c:28
 msgid "don't import, but tell if it would work or not"
-msgstr "non importare realmente, riporta solo se l'operazione termina con successo oppure no"
+msgstr ""
+"non importare realmente, riporta solo se l'operazione termina con successo "
+"oppure no"
 
 #: rpmkeys.c:31 rpmkeys.c:33
 msgid "list keys from RPM keyring"
@@ -465,49 +555,65 @@ msgstr "elenca le chiavi del keyring RPM"
 msgid "Keyring options:"
 msgstr "Opzioni keyring:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "non è stato specificato alcun argomento"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "firma i pacchetti"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "firma pacchetto/i (identico a --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "cancella le firme del pacchetto"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "firma i pacchetti"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opzioni della firma:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Impossibile eseguire %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "È necessario impostare \"%%_gpg_name\" nel file macro\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Inserire la passphrase:"
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "La passphrase risulta valida.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Controllo della pass phrase fallito o chiave gpg scaduta\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix può essere usato solo quando si installano nuovi pacchetti"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr ""
+"--allmatches può essere specificato solo durante la rimozione del pacchetto"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -525,7 +631,7 @@ msgstr "opera sugli rpm binari generati dal file spec (default)"
 msgid "operate on source rpm generated by spec"
 msgstr "opera sul file rpm sorgente generato dal file spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "usare il seguente formato di interrogazione"
 
@@ -572,68 +678,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nErrori di compilazione RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Errori di compilazione RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "errore di sintassi durante il parsing di ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "errore di sintassi durante il parsing di &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "errore di sintassi durante il parsing di ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "errore durante il parsing dell'espressione\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "non corrispondente (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- solo sui numeri\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! solo sui numeri\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "i diversi tipi devono corrispondere\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / non supportato per le stringhe\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- non supportato per le stringhe\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& e || non supportati per le stringhe\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "errore di sintassi nell'espressione\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "'(' mancante in %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "')' mancante in %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Token %s non valido: %s\n"
@@ -643,46 +752,46 @@ msgstr "Token %s non valido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s mancante in %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Caratteri non validi seguono %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintassi non corretta: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Spec della modalità errata: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Spec dirmode errata: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Lunghezza inconsueta del locale: \"%s\" in %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Locale duplicato: %s in %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capability non valida: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Supporto alle file capabilities non disponibile\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Il file deve iniziare con \"/\": %s\n"
@@ -692,149 +801,154 @@ msgstr "Il file deve iniziare con \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Algoritmo di digest %u sconosciuto, ritorno a MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "File elencato due volte: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "lettura del symlink %s fallita: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Il Symlink punta alla BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Percorso esterno alla buildroot: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Directory non trovata: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "File non trovato: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Non è una directory: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: impossibile caricare tag sconosciuto (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: lettura chiave pubblica fallita.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: non è una chiave pubblica con formato 'armored'.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: errore durante l'encoding\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Il file deve essere preceduto da \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "glob %%dev non consentito: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Directory non trovata per il glob: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "File non trovato dal glob: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Impossibile aprire %%files file %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "riga: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
-msgstr "File %s vuoto nella sezione %%files\n\n"
+msgstr ""
+"File %s vuoto nella sezione %%files\n"
+"\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Errore nella lettura del file %s in %%files: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "_docdir_fmt %s non valido: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "File non trovato dal glob: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Impossibile unire %s speciali con altre forme: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Più di un file su una riga: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "File errato: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Proprietario/gruppo errato: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Controllo per file non pacchettizzati in corso: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Trovati file installati (ma non inclusi nel pacchetto):\n%s"
+msgstr ""
+"Trovati file installati (ma non inclusi nel pacchetto):\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Elaborazione file: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "L'architettura dei binari (%d) non corrisponde a quella del pacchetto (%d).\n"
+msgstr ""
+"L'architettura dei binari (%d) non corrisponde a quella del pacchetto (%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binari dipendenti dall'architettura presenti in un pacchetto noarch\n"
 
@@ -863,79 +977,76 @@ msgstr "%s: linea: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Impossibile regolarizzare l'hostname: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Impossibile ricaricare intestazione della firma.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compressione payload sconosciuta: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Impossibile creare una regione dell'intestazione immutabile.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Impossibile aprire %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Impossibile scrivere il pacchetto: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Impossibile salvare intestazione di temp\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Dati CSA errati\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Scritto: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Esecuzione \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Esecuzione di \"%s\" fallita.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Controllo pacchetto \"%s\" fallito.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Impossibile generare nome del file di output per il pacchetto %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "impossibile creare %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "riga %d: secondo %s\n"
@@ -986,19 +1097,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "riga %d: Errore durante il parsing di %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "riga  %d: Opzione %s errata: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "riga %d: Troppi nomi: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "riga %d: Pacchetto non esistente: %s\n"
@@ -1104,91 +1215,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "riga %d: Il tag necessita di un solo token: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "riga %d: Carattere '%c' illegale in: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "riga %d: Carattere illegale in: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "riga %d: Sequenza \"..\" illegale in: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linea %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: linea: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "riga %d: Tag malformato: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "riga %d: Tag vuoto: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "riga %d: I prefissi non devono finire con \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "riga %d: Docdir deve iniziare con '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "riga %d: Il tag Epoch deve essere un numero: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "riga %d: %s errati: qualificatori: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "riga %d: Formato BuildArchitecture errato: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "riga %d: Sono supportati solo sottopacchetti noarch: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Errore interno: bogus tag %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "riga %d: %s è deprecato: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Specifiche errate del pacchetto: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Il pacchetto è già esistente: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "riga %d: Tag sconosciuto: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} non può essere vuota\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} non può essere \"/\"\n"
@@ -1198,161 +1314,196 @@ msgstr "%%{buildroot} non può essere \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Sorgenti non validi: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nessuna patch con numero %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch senza il corrispondente tag \"Patch:\"\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nessun sorgente con numero %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Nessun tag \"Source:\" nello spec file\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Errore nel parsing di %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "riga %d: Argomento errato su %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "riga %d: Opzione di %%setup errata %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Numero patch non valido %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "riga %d: secondo %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "I token delle dipendenze devono iniziare per alfanumerico, '_' o '/'"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Nome file versionato non consentito"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Versione richiesta"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "Dipendenza non valida"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Versione richiesta"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "linea %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "riga %d: i trigger devono presentare --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "riga %d: Errore nel parsing di %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "linea %d: uno script interno deve terminare con '>': %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "riga %d: il programma script deve iniziare con '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "linea %d: argomenti dell'interprete non consentiti nei trigger: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "riga %d: Secondo %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linea %d: script interno non supportato: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "linea %d: argomenti dell'interprete non consentiti nei trigger: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "riga %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Impossibile aprire %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: argomento necessario per %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
-msgstr "riga %d: %%if non bilanciato\n\n"
+msgstr ""
+"riga %d: %%if non bilanciato\n"
+"\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "linea %d: macro non chiusa o errata continuazione linea\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: condizione %%if errata\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Trovato un %%else con nessun %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Trovato un %%endif con nessun %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s: %d: istruzione %%include malformata\n"
 
-#: build/parseSpec.c:669
-msgid "No compatible architectures found for build\n"
-msgstr "Non è stata trovata alcuna architettura compatibile per la compilazione\n"
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
+msgid "No compatible architectures found for build\n"
+msgstr ""
+"Non è stata trovata alcuna architettura compatibile per la compilazione\n"
+
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Il pacchetto non possiede alcuna %%description: %s\n"
@@ -1396,7 +1547,9 @@ msgstr "Impossibile determinare il nome della policy: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "Tipo '%s' impostato con altri tipi in %%semodule %s. Compattazione dei tipi in '%s'.\n"
+msgstr ""
+"Tipo '%s' impostato con altri tipi in %%semodule %s. Compattazione dei tipi "
+"in '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1423,290 +1576,282 @@ msgstr "Troppi argomenti alla linea: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Elaborazione policies: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Viene ignorata la regex non valida %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Impossibile creare la pipe per %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Impossibile eseguire %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Impossibile biforcare %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s fallito: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "impossibile salvare tutti i dati su %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "operatore non valido"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "formato non valido"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "dipendenza non valida (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Conversione di %s a long integer fallita.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "File classifier vuoto\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Non è configurato alcun attributo dei file\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) fallita: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load fallita: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Identificazione file \"%s\" fallita: modalità %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Ricerca di %s in corso: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Impossibile trovare %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "interrogazione di specfile %s fallita, impossibile eseguire il parsing\n"
+msgstr ""
+"interrogazione di specfile %s fallita, impossibile eseguire il parsing\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s è un Delta RPM e non può essere installato direttamente\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Payload non supportato (%s) nel pacchetto %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "il pacchetto %s è già stato aggiunto, salto %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "il pacchetto %s è stato già aggiunto, sostituzione con %s in corso\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(non è un numero)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(non base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(tipo non valido)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(non è un blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(tipo xml non valido)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(non è una firma OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Formato data %u non corretto"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normale"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "sostituito"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "non installato"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "condivisa su rete"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "colore errato"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "mancanti"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(sconosciuto)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(non è una stringa)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s salvato come %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s creato come %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: rimozione fallita: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "directory"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "file"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "%s ha una signature non verificabile"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1835,15 +1980,18 @@ msgid "relocations must have a / following the ="
 msgstr "i riposizionamenti devono avere una / che segue ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "installare tutti i file, anche le configurazioni che possono altrimenti essere saltate"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"installare tutti i file, anche le configurazioni che possono altrimenti "
+"essere saltate"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "rimuovere tutti i pacchetti corrispondenti a <package> (normalmente viene generato un errore se con <package> vengono specificati pacchetti multipli)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"rimuovere tutti i pacchetti corrispondenti a <package> (normalmente viene "
+"generato un errore se con <package> vengono specificati pacchetti multipli)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1891,7 +2039,8 @@ msgstr "<packagefile>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "mostra i caratteri hash durante l'installazione del pacchetto (utile con -v)"
+msgstr ""
+"mostra i caratteri hash durante l'installazione del pacchetto (utile con -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1921,7 +2070,7 @@ msgstr "aggiorna il database, senza modificare il filesystem"
 msgid "do not verify package dependencies"
 msgstr "non verificare le dipendenze dei pacchetti"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "non verificare il digest dei file"
 
@@ -1935,7 +2084,8 @@ msgstr "non installare contesti di sicurezza dei file"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "non riordinare l'installazione dei pacchetti per soddisfare le dipendenze"
+msgstr ""
+"non riordinare l'installazione dei pacchetti per soddisfare le dipendenze"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1999,7 +2149,9 @@ msgstr "non eseguire alcun scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "aggiorna ad una versione più vecchia del pacchetto (sugli aggiornamenti --force esegue questa operazione automaticamente)"
+msgstr ""
+"aggiorna ad una versione più vecchia del pacchetto (sugli aggiornamenti --"
+"force esegue questa operazione automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2041,162 +2193,185 @@ msgstr "aggiorna il pacchetto/i"
 msgid "reinstall package(s)"
 msgstr "reinstalla pacchetto(i)"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "interrogare/verificare tutti i pacchetti"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "modalità rpm checksig"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "interrogare/verificare a quale pacchetto/i appartiene il file"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "interrogare/verificare il pacchetto/i in un gruppo"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "interrogare/verificare un file del pacchetto"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
-msgstr "interrogare/verificare il pacchetto/i con un identificatore del pacchetto"
+msgstr ""
+"interrogare/verificare il pacchetto/i con un identificatore del pacchetto"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
-msgstr "interrogare/verificare il pacchetto/i con un identificatore di intestazione"
+msgstr ""
+"interrogare/verificare il pacchetto/i con un identificatore di intestazione"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "modalità interrogazione rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "interrogare/verificare una istanza dell'intestazione"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
-msgstr "interrogare/verificare il pacchetto/i dalla transazione di installazione"
+msgstr ""
+"interrogare/verificare il pacchetto/i dalla transazione di installazione"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "interroga il pacchetto/i azionato dal pacchetto"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "modalità verifica rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "interrogare/verificare il pacchetto/i che fornisce una dipendenza"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "interrogare/verificare il pacchetto/i che necessita di una dipendenza"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "non eseguire il glob degli argomenti"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "non processare i file non-package come manifest"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "elenca tutti i file di configurazione"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "elenca tutti i file di documentazione"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "elenca tutti i file licenza"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "emettere le informazioni di base dei file"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "elenca i file in un pacchetto"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "salta file %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "visualizza gli stati dei file elencati"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "non verificare la dimensione dei file"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "non verificare il percorso symlink dei file"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "non verificare il proprietario dei file"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "non verificare il gruppo dei file"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "non verificare l'ora di modifica dei file"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "non verificare la modalità dei file"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "non verificare le capabilities dei file"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "non verificare i contesti di sicurezza dei file"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "non verificare i file nel pacchetto"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "non verificare le dipendenze del pacchetto"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "non eseguire gli script di verifica"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Funzionalità rpmlib mancanti per %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "pacchetto sorgente atteso, trovato binario\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "il pacchetto sorgente non contiene alcun file .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "estrazione archivio fallita%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " sul file "
 
@@ -2244,7 +2419,8 @@ msgstr "il pacchetto non possiede alcun elenco gruppo/proprietario dei file\n"
 
 #: lib/query.c:228
 msgid "package has neither file owner or id lists\n"
-msgstr "il pacchetto non possiede ne un proprietario del file ne un elenco id\n"
+msgstr ""
+"il pacchetto non possiede ne un proprietario del file ne un elenco id\n"
 
 #: lib/query.c:317
 #, c-format
@@ -2271,96 +2447,117 @@ msgstr "nessun pacchetto corrisponde a %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nessun pacchetto necessita di %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "nessun pacchetto necessita di %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "nessun pacchetto attiva %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "nessun pacchetto necessita di %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "nessun pacchetto necessita di %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nessun pacchetto fornisce %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "file %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "il file %s non è posseduto da alcun pacchetto\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "numero del pacchetto non valido: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "il record %u non può essere letto\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "il pacchetto %s non è stato installato\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tag sconosciuto: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: importazione chiave %d fallita.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: chiave pubblica %d non con formato 'armored'.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: lettura importazione fallita(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead fallita: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: La regione header immutabile non può essere letta. Pacchetto corrotto?\n"
+msgstr ""
+"%s: La regione header immutabile non può essere letta. Pacchetto corrotto?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread fallito: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NON OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (CHIAVI MANCANTI:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CHIAVI NON FIDATE:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: apertura fallita: %s\n"
@@ -2385,144 +2582,205 @@ msgstr "Impossibile cambiare directory root: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Impossibile ripristinare directory root: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "SI"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "Supporto alla versione per le dipendenze PreReq:, Provides: e Obsoletes:."
+msgstr ""
+"Supporto alla versione per le dipendenze PreReq:, Provides: e Obsoletes:."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "file name conservati come tuple (dirName,baseName,dirIndex), non come percorsi."
+msgstr ""
+"file name conservati come tuple (dirName,baseName,dirIndex), non come "
+"percorsi."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "il payload del pacchetto può essere compresso utilizzando bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "il payload del pacchetto può essere compresso utilizzando xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "il payload del pacchetto può essere compresso utilizzando lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "il/i file payload del pacchetto presentano un prefisso \"./\""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
-msgstr "il nome-versione-release del pacchetto non viene implicitamente fornito."
+msgstr ""
+"il nome-versione-release del pacchetto non viene implicitamente fornito."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
-msgstr "i tag delle intestazioni vengono sempre ordinate dopo il loro caricamento."
+msgstr ""
+"i tag delle intestazioni vengono sempre ordinate dopo il loro caricamento."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
-msgstr "l'interprete di scriptlet può utilizzare gli argomenti presenti nell'intestazione."
+msgstr ""
+"l'interprete di scriptlet può utilizzare gli argomenti presenti "
+"nell'intestazione."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "un set di file hardlink può essere installato senza che sia completo."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "le scriptlet del pacchetto potrebbero accedere al database rpm durante l'installazione."
+msgstr ""
+"le scriptlet del pacchetto potrebbero accedere al database rpm durante "
+"l'installazione."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "supporto interno per gli script lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "l'algoritmo digest di checksum dei file è configurabile per pacchetto"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "supporto per le file capabilities POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
-msgstr "le scriptlet del pacchetto possono essere espanse durante l'installazione."
+msgstr ""
+"le scriptlet del pacchetto possono essere espanse durante l'installazione."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "la comparazione delle dipendenze supporta le versioni con tilde."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "supporto per file più grandi di 4GB"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "non verificare le dipendenze dei pacchetti"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Versione richiesta"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "Dipendenza non valida"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c non terminato: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "Dipendenza non valida"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "l'utente %s non esiste - uso dell'utente root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "il gruppo %s non esiste - uso dell'utente root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Bad magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Intestazione  errata/illeggibile"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Dimensione intestazione troppo grande"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "FIle troppo grande per l'archivio"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Tipo di file sconosciuto"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "File mancante(i)"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Digest non corrispondente"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Errore interno"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "File archive non è nell'intestazione"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " fallito - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (errore 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "apertura di %s fallita: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: non è un pacchetto rpm (o un manifest del pacchetto)\n"
@@ -2554,42 +2812,42 @@ msgstr "Dipendenze fallite:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: non è un pacchetto rpm (o un manifest del pacchetto): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s non può essere installato\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Ripristino di %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "omissione di %s - trasferimento fallito\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "il pacchetto %s non è riposizionabile\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "errore di lettura dal file %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" specifica pacchetti multipli:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "impossibile aprire %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installazione di %s in corso\n"
@@ -2615,12 +2873,12 @@ msgstr "lettura fallita: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "non è un pacchetto rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "impossibile creare il lock %s su %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "attesa del lock %s su %s\n"
@@ -2672,27 +2930,34 @@ msgstr "il percorso %s nel pacchetto %s non è riposizionabile"
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr "il file %s entra in conflitto durante il tentativo d'installazione di %s e %s"
+msgstr ""
+"il file %s entra in conflitto durante il tentativo d'installazione di %s e %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "il file %s dell'installazione di %s entra in conflitto con il file del pacchetto %s"
+msgstr ""
+"il file %s dell'installazione di %s entra in conflitto con il file del "
+"pacchetto %s"
 
 #: lib/rpmprob.c:140
 #, c-format
 msgid "package %s (which is newer than %s) is already installed"
-msgstr "il pacchetto %s (il quale risulta essere più recente di %s) è già installato"
+msgstr ""
+"il pacchetto %s (il quale risulta essere più recente di %s) è già installato"
 
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "l'installazione del pacchetto %s necessita di %<PRIu64>%cB sul filesystem %s"
+msgstr ""
+"l'installazione del pacchetto %s necessita di %<PRIu64>%cB sul filesystem %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "l'installazione del pacchetto %s necessita di %<PRIu64> inode sul filesystem %s"
+msgstr ""
+"l'installazione del pacchetto %s necessita di %<PRIu64> inode sul filesystem "
+"%s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2716,7 +2981,9 @@ msgstr "%s reso obsoleto da %s%s"
 #: lib/rpmprob.c:172
 #, c-format
 msgid "unknown error %d encountered while manipulating package %s"
-msgstr "si è verificato un errore sconosciuto %d durante la manipolazione del pacchetto %s"
+msgstr ""
+"si è verificato un errore sconosciuto %d durante la manipolazione del "
+"pacchetto %s"
 
 #: lib/rpmrc.c:222
 #, c-format
@@ -2778,60 +3045,79 @@ msgstr "architettura mancante per %s su %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "opzione errata '%s' su %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Impossibile leggere il vettore ausiliario, /proc non montata?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema sconosciuto: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Si prega di contattare %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Impossibile aprire %s per la lettura: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Impossibile tornare alla direcotry corrente: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "supporto agli scriptlet <lua> non disponibile\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Impossibile creare il file temporaneo per %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Impossibile duplicare il file descriptor: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Impossibile leggere l'icona %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Impossibile ripristinare directory root: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite fallito: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "scriptlet %s fallita, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "scriptlet %s fallita, segnale %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "scriptlet %s fallita, uscita con stato %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Formato sconosciuto"
 
@@ -2843,127 +3129,146 @@ msgstr "installa"
 msgid "erase"
 msgstr "elimina"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "impossibile aprire il database dei pacchetti in %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' extra nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' mancante nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' mancante nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: lettura chiave pubblica fallita.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transazione"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(non è una firma OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Impossibile ricaricare intestazione della firma.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Digest SHA1 header:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Header "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 digest:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Digest SHA1 header:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Verifica signature: PARAMETRI NON VALIDI (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "saltato"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "fallito"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "nessuno stato"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "stato sconosciuto"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "%c %s  mancanti"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dipendenze non soddisfatte per %s:\n"
@@ -3037,240 +3342,242 @@ msgstr "iteratore di array usato con array di dimensioni differenti"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generazione di %d indici mancanti, prego attendere...\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "impossibile aprire l'indice %s usando%s - %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "non è stato impostato alcun dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: salto"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "errore(%d) nella memorizzazione del record #%d in %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec fallito: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp fallito: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: salto"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: intestazione #%u danneggiata -- viene omessa.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: impossibile leggere intestazione 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "non è stato impostato alcun dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "impossibile creare la cartella %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "l'intestazione #%u nel database non è valida -- viene omessa.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "impossibile aggiungere il record originariamente su %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "ricompilazione database fallita: il database originale rimane in uso\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "sostituzione del vecchio database con il nuovo database fallita!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "per eseguire un ripristino sostituire i file in %s con i file di %s"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "rimozione della directory %s fallita: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s error(%d) da %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s error(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "impossibile ottenere il %s su %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "condiviso"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "esclusivo"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "tipo indice %x non valido su %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "errore(%d) nella lettura dei record \"%s\" dall'indice %s: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "errore(%d) nella memorizzazione del record \"%s\" in %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "errore(%d) nella rimozione del record \"%s\" da %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "errore(%d) nell'impostazione del record #%d dell'intestazione\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "errore(%d) nell'eliminazione del record dell'intestazione #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "errore(%d) nell'allocazione di una nuova istanza del pacchetto\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "opzione db non riconosciuta: \"%s\" ignorata.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s presenta un valore numeric non valido, omesso\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s presenta un valore long troppo grande o troppo piccolo, omesso\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s presenta un valore integer troppo grande o troppo piccolo, omesso\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "impossibile ottenere il %s su %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "condiviso"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "esclusivo"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "tipo indice %x non valido su %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "errore(%d) nella lettura dei record \"%s\" dall'indice %s: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "errore(%d) nella memorizzazione del record \"%s\" in %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "errore(%d) nella rimozione del record \"%s\" da %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "errore(%d) nell'impostazione del record #%d dell'intestazione\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "errore(%d) nell'eliminazione del record dell'intestazione #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "errore(%d) nell'allocazione di una nuova istanza del pacchetto\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vuoto)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vuoto)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s presenta delle opzioni incomplete\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s presenta un corpo incompleto\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "La macro %%%s presenta un nome illegale (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s presenta contenuto vuoto\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La Macro %%%s richiede whitespace prima del corpo\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Impossibile espandere la macro %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "La macro %%%s presenta un nome illegale (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Macro %%%s definita ma non usata nello scope\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opzione %c sconosciuta in %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Troppo livelli di ricorsione nell'espansione della macro. Si tratta probabilmente di una macro definita ricorsivamente.\n"
+msgstr ""
+"Troppo livelli di ricorsione nell'espansione della macro. Si tratta "
+"probabilmente di una macro definita ricorsivamente.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c non terminato: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% è seguito da una macro non parsabile\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "impossibile caricare il file di macro %s"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d attivo %d vuoto\n"
@@ -3290,31 +3597,31 @@ msgstr "File %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "File %s è più piccolo di %u byte\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "impossibile creare la directory"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintassi non valida nella scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintassi non valida nello script lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "script lua fallito: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintassi non valida nel file lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hook fallito: %s\n"
@@ -3323,19 +3630,19 @@ msgstr "lua hook fallito: %s\n"
 msgid "[none]"
 msgstr "[nessuno]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(nessun errore)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "errore fatale: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "errore: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "avvertimento: "
 
@@ -3344,99 +3651,154 @@ msgstr "avvertimento: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "allocazione memoria (%u byte) ha ritornato NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID chiave %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "errore nella creazione del file temporaneo %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "errore nella creazione del file temporaneo %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "errore nella creazione del file temporaneo %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "impossibile creare la cartella %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite fallito: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush fallito: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Firma PGP non supportata\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Algoritmo hash PGP %u non supportato\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Algoritmo di chiave privata PGP non supportato %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Impossibile creare la pipe per la firma: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Impossibile eseguire %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: apertura fallita: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "esecuzione gpg fallita (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg non è riuscito a salvare la firma\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "impossibile leggere la firma\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature fallito: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature fallita: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: headerRead fallita: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp fallito\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "exec fallito\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: headerRead fallita: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s contiene la stessa identica signature, lo salto\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature fallita: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Impossibile firmare pacchetti RPM v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s contiene la stessa identica signature, lo salto\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature fallito: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp fallito\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead fallito: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "sostituzione di %s fallita: %s\n"
@@ -3449,3 +3811,24 @@ msgstr "%s: lettura manifesto fallita: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "non verificare firma header+payload"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Inserire la passphrase:"
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "La passphrase risulta valida.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "Controllo della pass phrase fallito o chiave gpg scaduta\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Proprietario/gruppo errato: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "riga %d: Carattere illegale in: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "%s ha una signature non verificabile"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Impossibile creare la pipe per la firma: %m"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Hajime Taira <htaira@redhat.com>, 2011-2012
 # Tadashi Jokagi <elf@poyo.jp>, 2012
@@ -12,14 +12,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Japanese (http://www.transifex.com/rpm-team/rpm/language/ja/)\n"
+"Language-Team: Japanese (http://www.transifex.com/rpm-team/rpm/language/"
+"ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -84,7 +85,7 @@ msgstr "検証オプション (-V または --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "インストール/アップグレード/アンインストールオプション:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "すべてのモード・コマンドで共通のオプション:"
@@ -105,7 +106,7 @@ msgstr "予期せぬ問い合わせのフォーマット"
 msgid "unexpected query source"
 msgstr "予期せぬ問い合わせのソース"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "一つのメジャーモードのみを指定して下さい"
 
@@ -124,7 +125,9 @@ msgstr "--prefix は --relocate や --excludepath とは同時には使用でき
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate と --excludepath は新しいパッケージをインストールする時のみ使用できます。"
+msgstr ""
+"--relocate と --excludepath は新しいパッケージをインストールする時のみ使用で"
+"きます。"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -140,8 +143,7 @@ msgid ""
 msgstr "--hash (-h) はパッケージのインストール時または削除時のみ指定できます。"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr "--percent はパッケージのインストール時または削除時のみ指定できます。"
 
 #: rpmqv.c:179
@@ -188,25 +190,30 @@ msgstr "--justdb はパッケージ インストール・削除時のみ指定�
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "スクリプトを無効にするようなオプションは、パッケージのインストール、削除時のみ指定できます。"
+msgstr ""
+"スクリプトを無効にするようなオプションは、パッケージのインストール、削除時の"
+"み指定できます。"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "トリガーを無効にするようなオプションはパッケージのインストール、削除時のみ指定できます。"
+msgstr ""
+"トリガーを無効にするようなオプションはパッケージのインストール、削除時のみ指"
+"定できます。"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps はパッケージのインストール時、削除時および検証時のみ指定できます。"
+msgstr ""
+"--nodeps はパッケージのインストール時、削除時および検証時のみ指定できます。"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test はパッケージのインストール時および削除時のみ指定できます。"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) の引数は / から始まらなければなりません。"
 
@@ -226,201 +233,249 @@ msgstr "問い合わせのための引数が指定されていません。"
 msgid "no arguments given for verify"
 msgstr "検証のための引数が指定されていません。"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "BuildRoot は既に指定されています。%s を無視します\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "<specfile> の %prep (ソース展開と patch の適用) まで実行"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "<specfile> の %build (%prep とコンパイル) まで実行"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "<specfile> の %install (%prep, %build, インストール) まで実行"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "<specfile> の %files セクションを検証"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "<specfile> を元に、バイナリ/ソースパッケージ作成"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "<specfile> を元に、バイナリパッケージのみ作成"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "<specfile> を元に、ソースパッケージのみ作成"
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "<tarball> から %prep (ソース展開とパッチ適用) まで実行"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "<specfile> の %prep (ソース展開と patch の適用) まで実行"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "<tarball> から %build (%prep とコンパイル) まで実行"
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "<tarball> から %install (%prep, %build, インストール) まで実行"
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "<tarball> から %files セクションを検証"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "<tarball> を元に、バイナリ/ソースパッケージを作成"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr "<tarball> を元に、バイナリパッケージのみを作成"
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr "<tarball> を元に、ソースパッケージのみを作成"
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "<source package> を元にバイナリパッケージを作成"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "<specfile> の %build (%prep とコンパイル) まで実行"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "<source package> から %install (%prep, %build, インストール) まで実行"
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "<specfile> の %files セクションを検証"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "<source package> を元にバイナリパッケージを作成"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "<source package> を元にバイナリパッケージを作成"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "<specfile> を元に、ソースパッケージのみ作成"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "<tarball> から %prep (ソース展開とパッチ適用) まで実行"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "<tarball> から %build (%prep とコンパイル) まで実行"
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "<tarball> から %install (%prep, %build, インストール) まで実行"
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "<tarball> から %files セクションを検証"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "<tarball> を元に、バイナリ/ソースパッケージを作成"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr "<tarball> を元に、バイナリパッケージのみを作成"
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr "<tarball> を元に、ソースパッケージのみを作成"
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "<source package> を元にバイナリパッケージを作成"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "build root を強制指定"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "カレントディレクトリーを開けません: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "パッケージ作成後ツリーを削除"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "spec ファイルの ExcludeArch: を無視"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "ファイル状態マシーンのデバッグ"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "ビルドのどの段階も実行しない"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "ビルド依存性を検証しない"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "レガシーなRPM v3のパッケージングと互換性のあるパッケージのヘッダーの生成"
+msgstr ""
+"レガシーなRPM v3のパッケージングと互換性のあるパッケージのヘッダーの生成"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "ビルドの %clean 段階を実行しない"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "ビルドの %clean 段階を実行しない"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "ビルドの %check 段階を実行しない"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "specfile から i18N msgstr を受け付けない"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "終了後ソースを削除します。"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "終了時に spec ファイルを削除"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "指定した過程までスキップします (c, i でのみ有効)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "ターゲットプラットフォームを強制指定"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "[ <specfile> | <tarball> | <source package> ] とのビルドオプション:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "ビルド依存性の失敗:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "spec ファイル %s を開けません: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar パイプのオープンに失敗しました: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "１ 行に複数のファイル: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "%s から spec ファイルの読み込みに失敗しました。\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s を %s に名前を変更できませんでした: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat %s に失敗しました: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s は通常ファイルではありません。\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "ファイル %s は spec ファイルではないようです。\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "ビルド対象プラットフォーム: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "ターゲット %s 用にビルド中\n"
@@ -431,7 +486,9 @@ msgstr "データベースを初期化します。"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "インストールされたパッケージヘッダーから、データベースのインデックスを再構築します。"
+msgstr ""
+"インストールされたパッケージヘッダーから、データベースのインデックスを再構築"
+"します。"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -469,49 +526,64 @@ msgstr "RPMキーリングからキーを一覧表示する。"
 msgid "Keyring options:"
 msgstr "キーリングのオプション:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "引数が指定されていません。"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "署名パッケージ"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "パッケージに署名する (--addsign と同一です)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "パッケージの署名を削除する"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "署名パッケージ"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "署名オプション:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s を実行できませんでした: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "マクロファイル内で \"%%_gpg_name\" を設定しなければなりません。\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "パスフレーズの入力: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "パスフレーズは正常です。\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "パスフレーズのチェックに失敗しました、または GPG キーが失効しています\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix は新規パッケージのインストール時のみ使用できます。"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches はパッケージ削除時のみ指定できます。"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -529,7 +601,7 @@ msgstr "specファイルによって生成されたバイナリRPMを操作す�
 msgid "operate on source rpm generated by spec"
 msgstr "specファイルによって生成されたソースRPMを操作する。"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "以下の問い合わせ書式を使用します。"
 
@@ -576,68 +648,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM ビルドのエラー:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM ビルドのエラー:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "構文解析中の文法エラー ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "構文解析中の文法エラー &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "構文解析中の文法エラー ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "式中で構文解析エラー\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "( が一致しません\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- は数のみ使用可能です\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! は数にのみ使用可能です\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "型は一致していなければなりません\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / は文字列には使えません\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- は文字列には使えません\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& と || は文字列には使えません\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "式中で文法エラー\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s に '(' がありません %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s(%s の後に ')' がありません\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "無効なトークン %s: %s\n"
@@ -647,46 +722,46 @@ msgstr "無効なトークン %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s が %s %s にありません\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() に続く空白がありません: %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "文法エラー: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "不正なモード指定: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "不正なディレクトリモード指定: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "異常なロケール長: \"%s\" (%%lang(%s))\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "重複する位置 %s が %%lang(%s) にあります\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "不正なケーパビリティです: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "ファイル ケーパビリティのサポートが組み込まれていません\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "ファイルは \"/\" から始まらなければなりません: %s\n"
@@ -694,151 +769,157 @@ msgstr "ファイルは \"/\" から始まらなければなりません: %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr "不明なファイルのダイジェスト アルゴリズム %u です。MD5 にフォールバックします。\n"
+msgstr ""
+"不明なファイルのダイジェスト アルゴリズム %u です。MD5 にフォールバックしま"
+"す。\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "ファイルが2回表記されています: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "シンボリックリンク %s の読み込みに失敗しました: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "シンボリックリンクが BuildRoot を指しています: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "ディレクトリーがありません: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "ファイルが見つかりません: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: 不明なタグ (%d) を読み込めませんでした。\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: 公開鍵の読み込みに失敗しました。\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ASCII 形式の公開鍵ではありません。\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: エンコードに失敗\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "ファイルは先頭に \"/\" が必要です: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev グロブは許可されません: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "ディレクトリーがグロブにより見つかりませんでした: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "ファイルが見つかりません (by glob): %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "%%files のファイル %s を開けません: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "%s行目: \n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "%%files ファイル %s の読み込み中にエラー: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "不正な _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "ファイルが見つかりません (by glob): %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "他の形式で特別な %s を混ぜることはできません: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "１ 行に複数のファイル: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不正なファイル: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "不正な所有者/グループ: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "パッケージに含まれないファイルの検査中: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "インストール済み(ただしパッケージに含まれない)ファイルが見つかりました:\n%s"
+msgstr ""
+"インストール済み(ただしパッケージに含まれない)ファイルが見つかりました:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "ファイルの処理中: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "バイナリのアーキテクチャー (%d) がパッケージのアーキテクチャー (%d) と一致しません。\n"
+msgstr ""
+"バイナリのアーキテクチャー (%d) がパッケージのアーキテクチャー (%d) と一致し"
+"ません。\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch パッケージ内にアーキテクチャ依存のバイナリー\n"
 
@@ -867,79 +948,76 @@ msgstr "%s: 行: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "ホスト名を正式なものにできません: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "署名ヘッダーの再読み込みができません。\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "不明なペイロード圧縮: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "不変ヘッダー領域を作成できません。\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s のオープンに失敗: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "パッケージの書き込みに失敗: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "一時ヘッダーの書き込みができません。\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "不正な CSA データ\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "書き込み完了: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "「%s」を実行しています:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」の実行に失敗しました。\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "パッケージ \"%s\" のチェックに失敗しました。\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "パッケージ %s の出力ファイル名を生成できませんでした: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s を作成できません: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d 行目: 2番目の %s\n"
@@ -990,19 +1068,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d 行目: %%description の構文解析エラー: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d 行目: 不正なオプション %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "%d 行目: 名前が多すぎます: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "%d 行目: パッケージが存在しません: %s\n"
@@ -1108,91 +1186,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "%d 行目: タグはトークンを 1つしかとりません: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "%d 行目: 不正な文字 '%c' : %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "%d 行目: 不正な文字 '-' : %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "%d 行目: 不正なシーケンス 「..」 : %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "%d 行目: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: 行: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d 行目: 不完全な形のタグ: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d 行目: 空のタグ: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d 行目: Prefix は \"/\" で終わってはいけません: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d 行目: Docdir は '/' で始まらなければなりません: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "%d 行目: Epoch フィールドは数字でなければなりません: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d 行目: 不正な修飾子 %s : %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d 行目: 不正な BuildArchtecture フォーマット: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "%d 行目: noarch サブ パッケージでのみサポート: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "内部エラー: にせのタグ %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "%d 行目: %s は非推奨: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不正なパッケージの指定: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "パッケージは既に存在しています: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d 行目: 不明なタグ: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} を空にすることができません\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} を \"\" にすることができません\n"
@@ -1202,161 +1285,194 @@ msgstr "%%{buildroot} を \"\" にすることができません\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不正なソース: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "パッチ番号 %u はありません\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "\"Patch:\" タグに該当しない %%patch\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "ソース番号 %u はありません\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "spec ファイルに「Source:」タグがありません\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup の構文解析エラー: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d 行目: %%setup への不正な引数: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d 行目: 不正な %%setup オプション %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無効なパッケージ番号 %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d 行目: ふたつ目の %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr "依存関係トークンは、英数字、'_' または '/' で始まらなければいけません。"
+msgstr ""
+"依存関係トークンは、英数字、'_' または '/' で始まらなければいけません。"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "バージョン付きファイル名は許可されません"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "バージョン要件"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "無効な依存性"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "バージョン要件"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "%d 行目: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "%d 行目: トリガーには -- がなければなりません: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "%d 行目: %s の構文解析エラー: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "%d 行目: 内部スクリプトは '>' で終わらなければなりません: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "%d 行目: スクリプトプログラムは '/' で始まらなければなりません: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "%d 行目: インタープリター引数はトリガーにおいて許可されません: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "%d 行目: 2番目の %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "%d 行目: 未サポートの内部スクリプト: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "%d 行目: インタープリター引数はトリガーにおいて許可されません: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "%d 行目: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s を開けません: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: %s に対して期待される引数\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "%d 行目: %%if が閉じていません\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "%d 行目: 終了していないマクロまたは行の不正な継続\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: 不正な %%if 条件\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%if がないのに %%else があります\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%if がないのに %%endif があります\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: 不正な形式の %%include 文\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "作成(build)可能な互換アーキテクチャはありません\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "パッケージには %%description がありません: %s\n"
@@ -1369,7 +1485,9 @@ msgstr "ポリシーモジュール '%s' がオーバーラッピングタイプ
 #: build/policies.c:93
 #, c-format
 msgid "Base modules '%s' and '%s' have overlapping types\n"
-msgstr "ベースモジュール '%s' と '%s' がオーバーラッピングタイプを持っています。\n\n"
+msgstr ""
+"ベースモジュール '%s' と '%s' がオーバーラッピングタイプを持っています。\n"
+"\n"
 
 #: build/policies.c:101
 msgid "Failed to get policies from header\n"
@@ -1400,7 +1518,9 @@ msgstr "ポリシー名 %s の定義に失敗しました。\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "'%s' 形式が %%semodule %s において他の形式とともに与えられます。形式を '%s' に固めています。\n"
+msgstr ""
+"'%s' 形式が %%semodule %s において他の形式とともに与えられます。形式を '%s' "
+"に固めています。\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1427,290 +1547,281 @@ msgstr "オプションが多すぎます: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "ポリシーの処理中: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "不正な正規表現 %s を無視します\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "%s のためのパイプ作成ができません: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s を実行できませんでした: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s のフォークに失敗しました: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s は失敗しました。 %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "%s へ全データの書き込みに失敗しました: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s の整数(long int)への変換に失敗しました。\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "空のファイル分類子\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "構成すべきファイル属性がありません。\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) に失敗しました: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load に失敗しました: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "ファイル \"%s\" の承認に失敗しました: モード %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "%s を検索しています: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s の検索に失敗しました:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "スペックファイル %s の問い合わせに失敗しました。解析できません。\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s はデルタ RPM で、直接インストールできません。\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "パッケージ %s 内にサポートしていないペイロード (%s) です。\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "パッケージ %s は既に追加されています。%s を飛ばします。\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "パッケージ %s は既に追加されています。 %s と置換します。\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(数字ではありません)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(base64 ではありません)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(不正なタイプ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(blob ではありません)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(不正な XML タイプ)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(OpenPGP 署名ではありません)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "無効な日付 %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "通常"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "置換"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "未インストール"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "ネット共有"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "間違った色"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "見つかりません"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(不明)  "
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(文字列でない)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s は %s として保存されました。\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s は %s として作成されました。\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: 削除に失敗しました: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "ディレクトリー"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "ファイル"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1839,15 +1950,16 @@ msgid "relocations must have a / following the ="
 msgstr "再配置は = の次に / でなければなりません。"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr "設定がスキップを指示していても、全ファイルをインストールします。"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "<package> と一致するパッケージ全てを削除します(通常は <package> が複数のパッケージを指す場合はエラーになります)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"<package> と一致するパッケージ全てを削除します(通常は <package> が複数のパッ"
+"ケージを指す場合はエラーになります)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1895,7 +2007,8 @@ msgstr "<packagefile>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "パッケージをインストールにつれて '#' を表示します (-v と使用すると良い)"
+msgstr ""
+"パッケージをインストールにつれて '#' を表示します (-v と使用すると良い)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1925,7 +2038,7 @@ msgstr "データベースを更新しますが、ファイルシステムの変
 msgid "do not verify package dependencies"
 msgstr "パッケージの依存関係の検証を行いません。"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "ファイルのダイジェストを検証しません。"
 
@@ -2003,7 +2116,9 @@ msgstr "%%triggerpostun スクリプトを実行しません。"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "古いバージョンのパッケージにアップグレードします(アップグレード時の --force はこれを自動的に行います)"
+msgstr ""
+"古いバージョンのパッケージにアップグレードします(アップグレード時の --force "
+"はこれを自動的に行います)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2045,162 +2160,183 @@ msgstr "パッケージをアップグレードします。"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "すべてのパッケージについて問い合わせ/検証します。"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm の署名検査モード"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "<file> を所有しているパッケージを問い合わせ/検証します。"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "グループに所属するパッケージを問い合わせ/検証します。"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "パッケージファイルの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "パッケージ ID で問い合わせ/検証します。"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "ヘッダー ID でパッケージを問い合わせ/検証します。"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm 問い合わせモード"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "ヘッダー インスタンスの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
-msgstr "インストール トランザクションからのパッケージの問い合わせ/検証をします。"
+msgstr ""
+"インストール トランザクションからのパッケージの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "パッケージによってトリガーされるパッケージを問い合わせます。"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "RPM 検証モード"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "依存性を提供するパッケージの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "引数を glob パターンとしてみなしません。"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "リスト内の非パッケージファイルを処理しません。"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "全ての設定ファイルを列挙します。"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "全てのドキュメントファイルを列挙します。"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "基本的なファイル情報をダンプします。"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "パッケージ中のファイルを列挙します。"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost ファイルをスキップします。"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "列挙したファイルの状態を表示します。"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "ファイル容量を検証しません。"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "ファイルのシンボリックリンクを検証しません。"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "ファイルの所有者を検証しません。"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "ファイルの所有グループを検証しません。"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "ファイルの最終更新日を検証しません。"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "ファイルのモードを検証しません。"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "ファイルのケーパビリティ (capability) を検証しません。"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "ファイルのセキュリティ コンテキストを検証しません。"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "パッケージ中のファイルを検証しません。"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "パッケージの依存関係を検証しません。"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "検証スクリプトを実行しません。"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "%s の rpmlib 機能が見つかりません:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "ソースパッケージが期待されますが、これはバイナリパッケージです\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "ソースパッケージに .spec ファイルがありません\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "アーカイブの伸長に失敗%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ": ファイル "
 
@@ -2275,96 +2411,118 @@ msgstr "%s に一致するパッケージは存在しません: %s\n"
 msgid "no package requires %s\n"
 msgstr "%s を必要とするパッケージは存在しません。\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "%s を必要とするパッケージは存在しません。\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "%s をトリガーするパッケージが存在しません。\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "%s を必要とするパッケージは存在しません。\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "%s を必要とするパッケージは存在しません。\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s を提供するパッケージは存在しません。\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ファイル %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "ファイル %s はどのパッケージにも属していません。\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無効なパッケージ番号: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "レコード %u は読み込めませんでした\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "パッケージ %s はインストールされていません。\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "不明なタグ: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: キー %d のインポートに失敗しました。\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: キー %d は ASCII 形式の公開鍵ではありません。\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: インポート読み込みに失敗しました(%d)。\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead に失敗しました: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: 不変のヘッダー領域が読み込めませんでした。パッケージが壊れていませんか？\n"
+msgstr ""
+"%s: 不変のヘッダー領域が読み込めませんでした。パッケージが壊れていません"
+"か？\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread に失敗しました: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "OK ではありません。"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr "(見つからない鍵:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr "(信頼できない鍵:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: オープンに失敗しました: %s\n"
@@ -2389,144 +2547,198 @@ msgstr "ルート ディレクトリーの変更に失敗しました: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "ルート ディレクトリーの復元に失敗しました: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "YES"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "「PreReq:」「Provides:」「Obsoletes:」の依存関係をサポートしたバージョン。"
+msgstr ""
+"「PreReq:」「Provides:」「Obsoletes:」の依存関係をサポートしたバージョン。"
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "ファイル名が、パスではなく (dirName, baseName, dirIndex) の組で格納されます。"
+msgstr ""
+"ファイル名が、パスではなく (dirName, baseName, dirIndex) の組で格納されます。"
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "パッケージ ペイロードが bzip2 を用いて圧縮できます。"
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "パッケージ ペイロードが xz を用いて圧縮できます。"
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "パッケージ ペイロードが lzma を用いて圧縮できます。"
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "パッケージ ペイロード ファイルが「./」接頭語を持っています。"
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "「パッケージ名-バージョン-リリース」が暗黙で提供されません。"
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "ヘッダー タグが読み込まれた後、常にソートされます。"
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "スクリプト インタプリターがヘッダーから引数を使用できます。"
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "ハードリンク ファイル群が完全でなくてもインストールできます。"
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "インストール中に、パッケージスクリプトが rpm データベースにアクセスできます。"
+msgstr ""
+"インストール中に、パッケージスクリプトが rpm データベースにアクセスできます。"
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "lua スクリプトの内部サポート。"
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "ファイルのダイジェストアルゴリズムはパッケージ毎の設定です"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "POSIX..1e ファイル ケーパビリティ (capability) のためのサポート"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "パッケージのスクリプトはインストール時間を長くすることができます。"
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "依存性の比較はチルダを持つバージョンをサポートします"
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "パッケージの依存関係の検証を行いません。"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "バージョン要件"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "無効な依存性"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "終端されていない %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "無効な依存性"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "ユーザー %s は存在しません - root を使用します\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "グループ %s は存在しません - root を使用します\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "不正なマジック"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "不正な/不可読なヘッダー"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "ヘッダーサイズが大きすぎます。"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "ファイルがアーカイブのために大きすぎます"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "不明なファイルタイプ"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "ダイジェストが適合しません"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "内部エラー"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "アーカイブファイルがヘッダーにありません。"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr "失敗 - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s のオープンに失敗: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: RPM パッケージ(またはパッケージのリスト)ではありません。\n"
@@ -2558,42 +2770,42 @@ msgstr "依存性の欠如:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: RPM パッケージ(またはパッケージのリスト)ではありません: %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s をインストールできません。\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s を取得中\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s をスキップします - 転送に失敗しました\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "パッケージ %s は再配置できません。\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "ファイル %s の読み込みエラー\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" は複数のパッケージを指定しています:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s を開けません: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s をインストール中です。\n"
@@ -2619,12 +2831,12 @@ msgstr "読み込みの失敗: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "rpm パッケージではありません。\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "%s ロックを（%s 上に）作成できません。(%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "%s ロックを待っています。(%s 上)\n"
@@ -2681,7 +2893,9 @@ msgstr "ファイル %s は %s と %s のインストールで競合していま
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "ファイル %s (パッケージ %s から) は、パッケージ %s からのファイルと競合しています。"
+msgstr ""
+"ファイル %s (パッケージ %s から) は、パッケージ %s からのファイルと競合してい"
+"ます。"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2691,12 +2905,16 @@ msgstr "パッケージ %s (%s より新しいもの) は既にインストー�
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "パッケージ %s のインストールには %<PRIu64>%cB の領域が %s ファイルシステム上に必要です。"
+msgstr ""
+"パッケージ %s のインストールには %<PRIu64>%cB の領域が %s ファイルシステム上"
+"に必要です。"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "パッケージ %s のインストールには %<PRIu64> の inode が %s ファイルシステム上に必要です。"
+msgstr ""
+"パッケージ %s のインストールには %<PRIu64> の inode が %s ファイルシステム上"
+"に必要です。"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2782,60 +3000,80 @@ msgstr "%s 用のアーキテクチャが見つかりません (%s:%d)\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "不正なオプションです: '%s' (%s:%d)\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
-msgstr "補助ベクトルの読み込みに失敗しました、/proc がマウントされていないですか?\n"
+msgstr ""
+"補助ベクトルの読み込みに失敗しました、/proc がマウントされていないですか?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "不明なシステム: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "%s に連絡してください。\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "%s を読み込み用に開けません: %m。\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "カレントディレクトリを戻せません: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> スクリプトは組み込みでサポートしていません\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "%s の一時ファイルを作成できませんでした: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "ファイル ディスクリプターの複製ができません: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "アイコン %s を読むことができません: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "ルート ディレクトリーの復元に失敗しました: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite に失敗しました: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s スクリプトの実行に失敗しました。waitpid (%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s スクリプトの実行に失敗しました。シグナル %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s スクリプトの実行に失敗しました。終了ステータス %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "不明な書式"
 
@@ -2847,127 +3085,146 @@ msgstr "インストール"
 msgid "erase"
 msgstr "削除"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "%s にある Package データベースを開けません。\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "パッケージラベル中に余分な「(」があります: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "パッケージラベル中に「(」がありません: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "パッケージラベル中に「)」がありません: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: 公開鍵の読み込みに失敗しました。\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "トランザクション"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(OpenPGP 署名ではありません)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 ダイジェスト:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "署名ヘッダーの再読み込みができません。\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "ヘッダー SHA1 ダイジェスト:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "ヘッダー "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 ダイジェスト:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "ヘッダー SHA1 ダイジェスト:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "スキップした"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "失敗"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "%c %s が見つかりません。"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "%s のための依存性を満たしていません。\n"
@@ -3041,240 +3298,243 @@ msgstr "配列の繰り返し指定が、サイズが異なる配列の間で使
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "失われたインデックス %d を生成しています、お待ちください...\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "dbpath が設定されていません\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: スキップします。"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "エラー(%d) - レコード #%d を %s に格納時\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: 正規表現に失敗しました: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp に失敗しました: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: スキップします。"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
-msgstr "rpmdb: 破損したヘッダーインスタンス #%u を取得しました。スキップします。\n"
+msgstr ""
+"rpmdb: 破損したヘッダーインスタンス #%u を取得しました。スキップします。\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ヘッダーを読むことができません (0x%x)\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "dbpath が設定されていません。"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "ディレクトリー %s の作成に失敗しました: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "データベース中のヘッダー #%u は不正です -- スキップします。\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "元々 %u にあったレコードを追加できません。\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "データベースの再構築に失敗: オリジナルのデータベースは残っています。\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "古いデータベースを新しいデータベースで置き換えるのに失敗!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "復元するには %s 内のファイルを %s 内のファイルで置き換えて下さい"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "ディレクトリー %s の削除に失敗しました: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "%sロックを獲得できません (%s/%s)\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "共有"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "排他"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "不正なインデックス形式 %x が %s/%s にあります\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "エラー(%d) \"%s\" レコードの %s インデックスから取得中: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "エラー(%d) - レコード \"%s\" を %s に格納時\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "エラー(%d) - レコード \"%s\" を %s から削除時\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "エラー(%d) - ヘッダー #%d レコードの追加時\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "エラー(%d) - ヘッダー #%d レコードの削除時\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "エラー(%d) - 新しいパッケージインスタンスの割り当て時\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "不明なデータベースオプション: \"%s\" は無視します。\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s には不正な数値があります。スキップします\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s には大き/小さ過ぎるlong値があります。スキップします\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s には大き/小さ過ぎる整数値があります。スキップします\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "%sロックを獲得できません (%s/%s)\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "共有"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "排他"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "不正なインデックス形式 %x が %s/%s にあります\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "エラー(%d) \"%s\" レコードの %s インデックスから取得中: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "エラー(%d) - レコード \"%s\" を %s に格納時\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "エラー(%d) - レコード \"%s\" を %s から削除時\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "エラー(%d) - ヘッダー #%d レコードの追加時\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "エラー(%d) - ヘッダー #%d レコードの削除時\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "エラー(%d) - 新しいパッケージインスタンスの割り当て時\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(空)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(空)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "マクロ %%%s はオプションが終端されていません。\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "マクロ %%%s はボディが終端していません。\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "マクロ %%%s は不正な名前です (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "マクロ %%%s のボディは空です。\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "マクロ %%%s の展開に失敗しました。\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "マクロ %%%s は不正な名前です (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "不明なオプション %c (%s(%s)中に)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "マクロ展開の再帰呼び出しが深すぎます。これは再帰的マクロ定義が原因で発生している可能性があります。\n"
+msgstr ""
+"マクロ展開の再帰呼び出しが深すぎます。これは再帰的マクロ定義が原因で発生して"
+"いる可能性があります。\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "終端されていない %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% の後ろに構文解析できないマクロが続いています。\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 有効 %d 空 %d\n"
@@ -3294,31 +3554,31 @@ msgstr "ファイル %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "ファイル %s は %u バイトより小さくなっています。\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "ディレクトリーの作成に失敗しました"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "lua スクリプトで不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "lua スクリプトで不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua スクリプトに失敗しました: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua ファイルに不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua のフックに失敗しました: %s\n"
@@ -3327,19 +3587,19 @@ msgstr "lua のフックに失敗しました: %s\n"
 msgid "[none]"
 msgstr "[なし]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(エラーなし)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "致命的なエラー: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "エラー: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "警告: "
 
@@ -3348,99 +3608,154 @@ msgstr "警告: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "メモリ割り当て (%u バイト) が NULL を返しました。\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s、鍵 ID %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(なし)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "一時ファイル %s の作成に失敗しました: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "一時ファイル %s の作成に失敗しました: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "一時ファイル %s の作成に失敗しました: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "ディレクトリー %s の作成に失敗しました: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "サポートされない PGP 署名\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "サポートされない PGP ハッシュアルゴリズム %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "サポートされない PGP 公開鍵アルゴリズム %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "署名のためのパイプ作成ができません: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "%s を実行できませんでした: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: オープンに失敗しました: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg の実行に失敗しました (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg が署名を書き込むのに失敗しました。\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "署名を読み込めませんでした。\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature に失敗しました: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature に失敗しました: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: headerRead に失敗しました: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp に失敗しました。\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "実行失敗\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: headerRead に失敗しました: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s はすでに同一の署名を含みます、スキップしています\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature に失敗しました: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM v3 パッケージを署名できません\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s はすでに同一の署名を含みます、スキップしています\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp に失敗しました。\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "%s の置換に失敗: %s\n"
@@ -3453,3 +3768,22 @@ msgstr "%s: manifest の読み込みに失敗: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "ヘッダーとペイロード署名を検証しません。"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "パスフレーズの入力: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "パスフレーズは正常です。\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr ""
+#~ "パスフレーズのチェックに失敗しました、または GPG キーが失効しています\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "不正な所有者/グループ: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "%d 行目: 不正な文字 '-' : %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "署名のためのパイプ作成ができません: %m"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,25 +1,25 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Hajime Taira <htaira@redhat.com>, 2011-2012
 # Tadashi Jokagi <elf@poyo.jp>, 2012
 # Tadashi Jokagi <elf@elf.no-ip.org>, 2011
+# Tadashi Jokagi <elf@poyo.jp>, 2012
 # Tomoyuki KATO <tomo@dream.daynight.jp>, 2012-2013
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Japanese (http://www.transifex.com/projects/p/rpm/language/"
-"ja/)\n"
-"Language: ja\n"
+"Language-Team: Japanese (http://www.transifex.com/rpm-team/rpm/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -84,7 +84,7 @@ msgstr "検証オプション (-V または --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "インストール/アップグレード/アンインストールオプション:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "すべてのモード・コマンドで共通のオプション:"
@@ -105,7 +105,7 @@ msgstr "予期せぬ問い合わせのフォーマット"
 msgid "unexpected query source"
 msgstr "予期せぬ問い合わせのソース"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "一つのメジャーモードのみを指定して下さい"
 
@@ -124,9 +124,7 @@ msgstr "--prefix は --relocate や --excludepath とは同時には使用でき
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate と --excludepath は新しいパッケージをインストールする時のみ使用で"
-"きます。"
+msgstr "--relocate と --excludepath は新しいパッケージをインストールする時のみ使用できます。"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -142,7 +140,8 @@ msgid ""
 msgstr "--hash (-h) はパッケージのインストール時または削除時のみ指定できます。"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr "--percent はパッケージのインストール時または削除時のみ指定できます。"
 
 #: rpmqv.c:179
@@ -189,30 +188,25 @@ msgstr "--justdb はパッケージ インストール・削除時のみ指定�
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"スクリプトを無効にするようなオプションは、パッケージのインストール、削除時の"
-"み指定できます。"
+msgstr "スクリプトを無効にするようなオプションは、パッケージのインストール、削除時のみ指定できます。"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"トリガーを無効にするようなオプションはパッケージのインストール、削除時のみ指"
-"定できます。"
+msgstr "トリガーを無効にするようなオプションはパッケージのインストール、削除時のみ指定できます。"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps はパッケージのインストール時、削除時および検証時のみ指定できます。"
+msgstr "--nodeps はパッケージのインストール時、削除時および検証時のみ指定できます。"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test はパッケージのインストール時および削除時のみ指定できます。"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) の引数は / から始まらなければなりません。"
 
@@ -232,249 +226,201 @@ msgstr "問い合わせのための引数が指定されていません。"
 msgid "no arguments given for verify"
 msgstr "検証のための引数が指定されていません。"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "BuildRoot は既に指定されています。%s を無視します\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "<specfile> の %prep (ソース展開と patch の適用) まで実行"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "<specfile> の %build (%prep とコンパイル) まで実行"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "<specfile> の %install (%prep, %build, インストール) まで実行"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "<specfile> の %files セクションを検証"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "<specfile> を元に、バイナリ/ソースパッケージ作成"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "<specfile> を元に、バイナリパッケージのみ作成"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "<specfile> を元に、ソースパッケージのみ作成"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "<specfile> の %prep (ソース展開と patch の適用) まで実行"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "<tarball> から %prep (ソース展開とパッチ適用) まで実行"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "<tarball> から %build (%prep とコンパイル) まで実行"
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "<tarball> から %install (%prep, %build, インストール) まで実行"
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "<tarball> から %files セクションを検証"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "<tarball> を元に、バイナリ/ソースパッケージを作成"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr "<tarball> を元に、バイナリパッケージのみを作成"
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr "<tarball> を元に、ソースパッケージのみを作成"
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "<source package> を元にバイナリパッケージを作成"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "<specfile> の %build (%prep とコンパイル) まで実行"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "<source package> から %install (%prep, %build, インストール) まで実行"
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "<specfile> の %files セクションを検証"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "<source package> を元にバイナリパッケージを作成"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "<source package> を元にバイナリパッケージを作成"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "<specfile> を元に、ソースパッケージのみ作成"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "<tarball> から %prep (ソース展開とパッチ適用) まで実行"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "<tarball> から %build (%prep とコンパイル) まで実行"
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "<tarball> から %install (%prep, %build, インストール) まで実行"
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "<tarball> から %files セクションを検証"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "<tarball> を元に、バイナリ/ソースパッケージを作成"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr "<tarball> を元に、バイナリパッケージのみを作成"
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr "<tarball> を元に、ソースパッケージのみを作成"
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "<source package> を元にバイナリパッケージを作成"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "build root を強制指定"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "カレントディレクトリーを開けません: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "パッケージ作成後ツリーを削除"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "spec ファイルの ExcludeArch: を無視"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "ファイル状態マシーンのデバッグ"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "ビルドのどの段階も実行しない"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "ビルド依存性を検証しない"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
-"レガシーなRPM v3のパッケージングと互換性のあるパッケージのヘッダーの生成"
+msgstr "レガシーなRPM v3のパッケージングと互換性のあるパッケージのヘッダーの生成"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "ビルドの %clean 段階を実行しない"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "ビルドの %clean 段階を実行しない"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "ビルドの %check 段階を実行しない"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "specfile から i18N msgstr を受け付けない"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "終了後ソースを削除します。"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "終了時に spec ファイルを削除"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "指定した過程までスキップします (c, i でのみ有効)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "ターゲットプラットフォームを強制指定"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "[ <specfile> | <tarball> | <source package> ] とのビルドオプション:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "ビルド依存性の失敗:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "spec ファイル %s を開けません: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar パイプのオープンに失敗しました: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "１ 行に複数のファイル: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "%s から spec ファイルの読み込みに失敗しました。\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s を %s に名前を変更できませんでした: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat %s に失敗しました: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s は通常ファイルではありません。\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "ファイル %s は spec ファイルではないようです。\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "ビルド対象プラットフォーム: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "ターゲット %s 用にビルド中\n"
@@ -485,9 +431,7 @@ msgstr "データベースを初期化します。"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"インストールされたパッケージヘッダーから、データベースのインデックスを再構築"
-"します。"
+msgstr "インストールされたパッケージヘッダーから、データベースのインデックスを再構築します。"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -525,7 +469,7 @@ msgstr "RPMキーリングからキーを一覧表示する。"
 msgid "Keyring options:"
 msgstr "キーリングのオプション:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "引数が指定されていません。"
 
@@ -545,10 +489,29 @@ msgstr "パッケージの署名を削除する"
 msgid "Signature options:"
 msgstr "署名オプション:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "%s を実行できませんでした: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "マクロファイル内で \"%%_gpg_name\" を設定しなければなりません。\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "パスフレーズの入力: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "パスフレーズは正常です。\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "パスフレーズのチェックに失敗しました、または GPG キーが失効しています\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -566,7 +529,7 @@ msgstr "specファイルによって生成されたバイナリRPMを操作す�
 msgid "operate on source rpm generated by spec"
 msgstr "specファイルによって生成されたソースRPMを操作する。"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "以下の問い合わせ書式を使用します。"
 
@@ -613,71 +576,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM ビルドのエラー:\n"
+msgstr "\n\nRPM ビルドのエラー:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "構文解析中の文法エラー ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "構文解析中の文法エラー &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "構文解析中の文法エラー ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "式中で構文解析エラー\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "( が一致しません\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- は数のみ使用可能です\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! は数にのみ使用可能です\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "型は一致していなければなりません\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / は文字列には使えません\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- は文字列には使えません\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& と || は文字列には使えません\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "式中で文法エラー\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s に '(' がありません %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s(%s の後に ')' がありません\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "無効なトークン %s: %s\n"
@@ -687,46 +647,46 @@ msgstr "無効なトークン %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s が %s %s にありません\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() に続く空白がありません: %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "文法エラー: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "不正なモード指定: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "不正なディレクトリモード指定: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "異常なロケール長: \"%s\" (%%lang(%s))\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "重複する位置 %s が %%lang(%s) にあります\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "不正なケーパビリティです: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "ファイル ケーパビリティのサポートが組み込まれていません\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "ファイルは \"/\" から始まらなければなりません: %s\n"
@@ -734,152 +694,151 @@ msgstr "ファイルは \"/\" から始まらなければなりません: %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr ""
-"不明なファイルのダイジェスト アルゴリズム %u です。MD5 にフォールバックしま"
-"す。\n"
+msgstr "不明なファイルのダイジェスト アルゴリズム %u です。MD5 にフォールバックします。\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "ファイルが2回表記されています: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "シンボリックリンク %s の読み込みに失敗しました: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "シンボリックリンクが BuildRoot を指しています: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "ディレクトリーがありません: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "ファイルが見つかりません: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: 不明なタグ (%d) を読み込めませんでした。\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: 公開鍵の読み込みに失敗しました。\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ASCII 形式の公開鍵ではありません。\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: エンコードに失敗\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "ファイルは先頭に \"/\" が必要です: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev グロブは許可されません: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "ディレクトリーがグロブにより見つかりませんでした: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "ファイルが見つかりません (by glob): %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "%%files のファイル %s を開けません: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "%s行目: \n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "%%files ファイル %s の読み込み中にエラー: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "不正な _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "他の形式で特別な %s を混ぜることはできません: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "１ 行に複数のファイル: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不正なファイル: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "不正な所有者/グループ: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "パッケージに含まれないファイルの検査中: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"インストール済み(ただしパッケージに含まれない)ファイルが見つかりました:\n"
-"%s"
+msgstr "インストール済み(ただしパッケージに含まれない)ファイルが見つかりました:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "ファイルの処理中: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"バイナリのアーキテクチャー (%d) がパッケージのアーキテクチャー (%d) と一致し"
-"ません。\n"
+msgstr "バイナリのアーキテクチャー (%d) がパッケージのアーキテクチャー (%d) と一致しません。\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch パッケージ内にアーキテクチャ依存のバイナリー\n"
 
@@ -908,79 +867,79 @@ msgstr "%s: 行: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "ホスト名を正式なものにできません: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "署名ヘッダーの再読み込みができません。\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "不明なペイロード圧縮: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "不変ヘッダー領域を作成できません。\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s のオープンに失敗: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "パッケージの書き込みに失敗: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "一時ヘッダーの書き込みができません。\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "不正な CSA データ\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "%s ファイルを開けませんでした: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "ファイル %s にアーカイブの作成を失敗しました: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "書き込み完了: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "「%s」を実行しています:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」の実行に失敗しました。\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "パッケージ \"%s\" のチェックに失敗しました。\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "パッケージ %s の出力ファイル名を生成できませんでした: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s を作成できません: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d 行目: 2番目の %s\n"
@@ -1031,19 +990,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d 行目: %%description の構文解析エラー: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d 行目: 不正なオプション %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "%d 行目: 名前が多すぎます: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "%d 行目: パッケージが存在しません: %s\n"
@@ -1149,96 +1108,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "%d 行目: タグはトークンを 1つしかとりません: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "%d 行目: 不正な文字 '%c' : %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "%d 行目: 不正なシーケンス 「..」 : %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "%d 行目: 不正な文字 '-' : %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "%d 行目: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "%d 行目: 不正なシーケンス 「..」 : %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: 行: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d 行目: 不完全な形のタグ: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d 行目: 空のタグ: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d 行目: Prefix は \"/\" で終わってはいけません: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d 行目: Docdir は '/' で始まらなければなりません: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "%d 行目: Epoch フィールドは数字でなければなりません: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d 行目: 不正な修飾子 %s : %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d 行目: 不正な BuildArchtecture フォーマット: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "%d 行目: noarch サブ パッケージでのみサポート: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "内部エラー: にせのタグ %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "%d 行目: %s は非推奨: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不正なパッケージの指定: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "パッケージは既に存在しています: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d 行目: 不明なタグ: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} を空にすることができません\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} を \"\" にすることができません\n"
@@ -1248,194 +1202,161 @@ msgstr "%%{buildroot} を \"\" にすることができません\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不正なソース: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "パッチ番号 %u はありません\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "\"Patch:\" タグに該当しない %%patch\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "ソース番号 %u はありません\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "spec ファイルに「Source:」タグがありません\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup の構文解析エラー: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d 行目: %%setup への不正な引数: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d 行目: 不正な %%setup オプション %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無効なパッケージ番号 %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d 行目: ふたつ目の %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr ""
-"依存関係トークンは、英数字、'_' または '/' で始まらなければいけません。"
+msgstr "依存関係トークンは、英数字、'_' または '/' で始まらなければいけません。"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "バージョン付きファイル名は許可されません"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "無効な依存性"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "バージョン要件"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "無効な依存性"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "%d 行目: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "%d 行目: トリガーには -- がなければなりません: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "%d 行目: %s の構文解析エラー: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "%d 行目: 内部スクリプトは '>' で終わらなければなりません: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "%d 行目: スクリプトプログラムは '/' で始まらなければなりません: %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr "%d 行目: インタープリター引数はトリガーにおいて許可されません: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "%d 行目: 2番目の %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "%d 行目: 未サポートの内部スクリプト: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "%d 行目: インタープリター引数はトリガーにおいて許可されません: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "%d 行目: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s を開けません: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: %s に対して期待される引数\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "%d 行目: %%if が閉じていません\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "%d 行目: 終了していないマクロまたは行の不正な継続\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: 不正な %%if 条件\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%if がないのに %%else があります\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%if がないのに %%endif があります\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: 不正な形式の %%include 文\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "作成(build)可能な互換アーキテクチャはありません\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "パッケージには %%description がありません: %s\n"
@@ -1448,9 +1369,7 @@ msgstr "ポリシーモジュール '%s' がオーバーラッピングタイプ
 #: build/policies.c:93
 #, c-format
 msgid "Base modules '%s' and '%s' have overlapping types\n"
-msgstr ""
-"ベースモジュール '%s' と '%s' がオーバーラッピングタイプを持っています。\n"
-"\n"
+msgstr "ベースモジュール '%s' と '%s' がオーバーラッピングタイプを持っています。\n\n"
 
 #: build/policies.c:101
 msgid "Failed to get policies from header\n"
@@ -1481,9 +1400,7 @@ msgstr "ポリシー名 %s の定義に失敗しました。\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"'%s' 形式が %%semodule %s において他の形式とともに与えられます。形式を '%s' "
-"に固めています。\n"
+msgstr "'%s' 形式が %%semodule %s において他の形式とともに与えられます。形式を '%s' に固めています。\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1510,281 +1427,290 @@ msgstr "オプションが多すぎます: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "ポリシーの処理中: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "不正な正規表現 %s を無視します\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "%s のためのパイプ作成ができません: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s を実行できませんでした: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s のフォークに失敗しました: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s は失敗しました。 %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "%s へ全データの書き込みに失敗しました: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s の整数(long int)への変換に失敗しました。\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "空のファイル分類子\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "構成すべきファイル属性がありません。\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) に失敗しました: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load に失敗しました: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "ファイル \"%s\" の承認に失敗しました: モード %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "%s を検索しています: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s の検索に失敗しました:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "スペックファイル %s の問い合わせに失敗しました。解析できません。\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s はデルタ RPM で、直接インストールできません。\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "パッケージ %s 内にサポートしていないペイロード (%s) です。\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "パッケージ %s は既に追加されています。%s を飛ばします。\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "パッケージ %s は既に追加されています。 %s と置換します。\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(数字ではありません)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(base64 ではありません)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(不正なタイプ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(blob ではありません)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(不正な XML タイプ)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(OpenPGP 署名ではありません)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "無効な日付 %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "通常"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "置換"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "未インストール"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "ネット共有"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "間違った色"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "見つかりません"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(不明)  "
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(文字列でない)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s は %s として保存されました。\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s は %s として作成されました。\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: 削除に失敗しました: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "ディレクトリー"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "ファイル"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1913,16 +1839,15 @@ msgid "relocations must have a / following the ="
 msgstr "再配置は = の次に / でなければなりません。"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr "設定がスキップを指示していても、全ファイルをインストールします。"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"<package> と一致するパッケージ全てを削除します(通常は <package> が複数のパッ"
-"ケージを指す場合はエラーになります)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "<package> と一致するパッケージ全てを削除します(通常は <package> が複数のパッケージを指す場合はエラーになります)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1970,8 +1895,7 @@ msgstr "<packagefile>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr ""
-"パッケージをインストールにつれて '#' を表示します (-v と使用すると良い)"
+msgstr "パッケージをインストールにつれて '#' を表示します (-v と使用すると良い)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -2001,7 +1925,7 @@ msgstr "データベースを更新しますが、ファイルシステムの変
 msgid "do not verify package dependencies"
 msgstr "パッケージの依存関係の検証を行いません。"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "ファイルのダイジェストを検証しません。"
 
@@ -2079,9 +2003,7 @@ msgstr "%%triggerpostun スクリプトを実行しません。"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"古いバージョンのパッケージにアップグレードします(アップグレード時の --force "
-"はこれを自動的に行います)"
+msgstr "古いバージョンのパッケージにアップグレードします(アップグレード時の --force はこれを自動的に行います)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2123,183 +2045,162 @@ msgstr "パッケージをアップグレードします。"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "すべてのパッケージについて問い合わせ/検証します。"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm の署名検査モード"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "<file> を所有しているパッケージを問い合わせ/検証します。"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "グループに所属するパッケージを問い合わせ/検証します。"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "パッケージファイルの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "パッケージ ID で問い合わせ/検証します。"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "ヘッダー ID でパッケージを問い合わせ/検証します。"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm 問い合わせモード"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "ヘッダー インスタンスの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
-msgstr ""
-"インストール トランザクションからのパッケージの問い合わせ/検証をします。"
+msgstr "インストール トランザクションからのパッケージの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "パッケージによってトリガーされるパッケージを問い合わせます。"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "RPM 検証モード"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "依存性を提供するパッケージの問い合わせ/検証をします。"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "依存性を要求するパッケージの問い合わせ/検証をします。"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "引数を glob パターンとしてみなしません。"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "リスト内の非パッケージファイルを処理しません。"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "全ての設定ファイルを列挙します。"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "全てのドキュメントファイルを列挙します。"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "基本的なファイル情報をダンプします。"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "パッケージ中のファイルを列挙します。"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost ファイルをスキップします。"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "列挙したファイルの状態を表示します。"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "ファイル容量を検証しません。"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "ファイルのシンボリックリンクを検証しません。"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "ファイルの所有者を検証しません。"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "ファイルの所有グループを検証しません。"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "ファイルの最終更新日を検証しません。"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "ファイルのモードを検証しません。"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "ファイルのケーパビリティ (capability) を検証しません。"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "ファイルのセキュリティ コンテキストを検証しません。"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "パッケージ中のファイルを検証しません。"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "パッケージの依存関係を検証しません。"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "検証スクリプトを実行しません。"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "%s の rpmlib 機能が見つかりません:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "ソースパッケージが期待されますが、これはバイナリパッケージです\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "ソースパッケージに .spec ファイルがありません\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "アーカイブの伸長に失敗%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ": ファイル "
 
@@ -2374,118 +2275,96 @@ msgstr "%s に一致するパッケージは存在しません: %s\n"
 msgid "no package requires %s\n"
 msgstr "%s を必要とするパッケージは存在しません。\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "%s を必要とするパッケージは存在しません。\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "%s をトリガーするパッケージが存在しません。\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "%s を必要とするパッケージは存在しません。\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "%s を必要とするパッケージは存在しません。\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s を提供するパッケージは存在しません。\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ファイル %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "ファイル %s はどのパッケージにも属していません。\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無効なパッケージ番号: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "レコード %u は読み込めませんでした\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "パッケージ %s はインストールされていません。\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "不明なタグ: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: キー %d のインポートに失敗しました。\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: キー %d は ASCII 形式の公開鍵ではありません。\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: インポート読み込みに失敗しました(%d)。\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead に失敗しました: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: 不変のヘッダー領域が読み込めませんでした。パッケージが壊れていません"
-"か？\n"
+msgstr "%s: 不変のヘッダー領域が読み込めませんでした。パッケージが壊れていませんか？\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread に失敗しました: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "OK ではありません。"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr "(見つからない鍵:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr "(信頼できない鍵:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: オープンに失敗しました: %s\n"
@@ -2510,198 +2389,144 @@ msgstr "ルート ディレクトリーの変更に失敗しました: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "ルート ディレクトリーの復元に失敗しました: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NO "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "YES"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr ""
-"「PreReq:」「Provides:」「Obsoletes:」の依存関係をサポートしたバージョン。"
+msgstr "「PreReq:」「Provides:」「Obsoletes:」の依存関係をサポートしたバージョン。"
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"ファイル名が、パスではなく (dirName, baseName, dirIndex) の組で格納されます。"
+msgstr "ファイル名が、パスではなく (dirName, baseName, dirIndex) の組で格納されます。"
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "パッケージ ペイロードが bzip2 を用いて圧縮できます。"
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "パッケージ ペイロードが xz を用いて圧縮できます。"
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "パッケージ ペイロードが lzma を用いて圧縮できます。"
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "パッケージ ペイロード ファイルが「./」接頭語を持っています。"
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "「パッケージ名-バージョン-リリース」が暗黙で提供されません。"
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "ヘッダー タグが読み込まれた後、常にソートされます。"
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "スクリプト インタプリターがヘッダーから引数を使用できます。"
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "ハードリンク ファイル群が完全でなくてもインストールできます。"
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"インストール中に、パッケージスクリプトが rpm データベースにアクセスできます。"
+msgstr "インストール中に、パッケージスクリプトが rpm データベースにアクセスできます。"
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "lua スクリプトの内部サポート。"
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "ファイルのダイジェストアルゴリズムはパッケージ毎の設定です"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "POSIX..1e ファイル ケーパビリティ (capability) のためのサポート"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "パッケージのスクリプトはインストール時間を長くすることができます。"
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "依存性の比較はチルダを持つバージョンをサポートします"
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "パッケージの依存関係の検証を行いません。"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "バージョン要件"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "無効な依存性"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "終端されていない %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "無効な依存性"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "ユーザー %s は存在しません - root を使用します\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "グループ %s は存在しません - root を使用します\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "不正なマジック"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "不正な/不可読なヘッダー"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "ヘッダーサイズが大きすぎます。"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "ファイルがアーカイブのために大きすぎます"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "不明なファイルタイプ"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "ダイジェストが適合しません"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "内部エラー"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "アーカイブファイルがヘッダーにありません。"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr "失敗 - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s のオープンに失敗: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: RPM パッケージ(またはパッケージのリスト)ではありません。\n"
@@ -2733,42 +2558,42 @@ msgstr "依存性の欠如:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: RPM パッケージ(またはパッケージのリスト)ではありません: %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s をインストールできません。\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s を取得中\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s をスキップします - 転送に失敗しました\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "パッケージ %s は再配置できません。\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "ファイル %s の読み込みエラー\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" は複数のパッケージを指定しています:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s を開けません: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s をインストール中です。\n"
@@ -2794,12 +2619,12 @@ msgstr "読み込みの失敗: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "rpm パッケージではありません。\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "%s ロックを（%s 上に）作成できません。(%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "%s ロックを待っています。(%s 上)\n"
@@ -2815,9 +2640,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "シンボル %s の解決に失敗: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "%s プラグインは読み込まれていません。\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2856,9 +2681,7 @@ msgstr "ファイル %s は %s と %s のインストールで競合していま
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"ファイル %s (パッケージ %s から) は、パッケージ %s からのファイルと競合してい"
-"ます。"
+msgstr "ファイル %s (パッケージ %s から) は、パッケージ %s からのファイルと競合しています。"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2868,16 +2691,12 @@ msgstr "パッケージ %s (%s より新しいもの) は既にインストー�
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"パッケージ %s のインストールには %<PRIu64>%cB の領域が %s ファイルシステム上"
-"に必要です。"
+msgstr "パッケージ %s のインストールには %<PRIu64>%cB の領域が %s ファイルシステム上に必要です。"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"パッケージ %s のインストールには %<PRIu64> の inode が %s ファイルシステム上"
-"に必要です。"
+msgstr "パッケージ %s のインストールには %<PRIu64> の inode が %s ファイルシステム上に必要です。"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2965,78 +2784,58 @@ msgstr "不正なオプションです: '%s' (%s:%d)\n"
 
 #: lib/rpmrc.c:959
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
-msgstr ""
-"補助ベクトルの読み込みに失敗しました、/proc がマウントされていないですか?\n"
+msgstr "補助ベクトルの読み込みに失敗しました、/proc がマウントされていないですか?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "不明なシステム: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "%s に連絡してください。\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "%s を読み込み用に開けません: %m。\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "カレントディレクトリを戻せません: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> スクリプトは組み込みでサポートしていません\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "%s の一時ファイルを作成できませんでした: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "ファイル ディスクリプターの複製ができません: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "アイコン %s を読むことができません: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "ルート ディレクトリーの復元に失敗しました: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite に失敗しました: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s スクリプトの実行に失敗しました。waitpid (%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s スクリプトの実行に失敗しました。シグナル %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s スクリプトの実行に失敗しました。終了ステータス %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "不明な書式"
 
@@ -3048,142 +2847,127 @@ msgstr "インストール"
 msgid "erase"
 msgstr "削除"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "%s にある Package データベースを開けません。\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "パッケージラベル中に余分な「(」があります: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "パッケージラベル中に「(」がありません: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "パッケージラベル中に「)」がありません: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: 公開鍵の読み込みに失敗しました。\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "トランザクション"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(OpenPGP 署名ではありません)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "ヘッダー "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 ダイジェスト:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "ヘッダー SHA1 ダイジェスト:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "ヘッダー "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "スキップした"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "失敗"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "%c %s が見つかりません。"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "%s のための依存性を満たしていません。\n"
@@ -3257,243 +3041,240 @@ msgstr "配列の繰り返し指定が、サイズが異なる配列の間で使
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "失われたインデックス %d を生成しています、お待ちください...\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "dbpath が設定されていません\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: スキップします。"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "エラー(%d) - レコード #%d を %s に格納時\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: 正規表現に失敗しました: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp に失敗しました: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: スキップします。"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
-msgstr ""
-"rpmdb: 破損したヘッダーインスタンス #%u を取得しました。スキップします。\n"
+msgstr "rpmdb: 破損したヘッダーインスタンス #%u を取得しました。スキップします。\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ヘッダーを読むことができません (0x%x)\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "dbpath が設定されていません。"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "ディレクトリー %s の作成に失敗しました: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "データベース中のヘッダー #%u は不正です -- スキップします。\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "元々 %u にあったレコードを追加できません。\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "データベースの再構築に失敗: オリジナルのデータベースは残っています。\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "古いデータベースを新しいデータベースで置き換えるのに失敗!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "復元するには %s 内のファイルを %s 内のファイルで置き換えて下さい"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "ディレクトリー %s の削除に失敗しました: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "不明なデータベースオプション: \"%s\" は無視します。\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s には不正な数値があります。スキップします\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s には大き/小さ過ぎるlong値があります。スキップします\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s には大き/小さ過ぎる整数値があります。スキップします\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "%sロックを獲得できません (%s/%s)\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "共有"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "不正なインデックス形式 %x が %s/%s にあります\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "エラー(%d) \"%s\" レコードの %s インデックスから取得中: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "エラー(%d) - レコード \"%s\" を %s に格納時\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "エラー(%d) - レコード \"%s\" を %s から削除時\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "エラー(%d) - ヘッダー #%d レコードの追加時\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "エラー(%d) - ヘッダー #%d レコードの削除時\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "エラー(%d) - 新しいパッケージインスタンスの割り当て時\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "不明なデータベースオプション: \"%s\" は無視します。\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s には不正な数値があります。スキップします\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s には大き/小さ過ぎるlong値があります。スキップします\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s には大き/小さ過ぎる整数値があります。スキップします\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(空)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(空)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "マクロ %%%s はオプションが終端されていません。\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "マクロ %%%s はボディが終端していません。\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "マクロ %%%s は不正な名前です (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "マクロ %%%s のボディは空です。\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "マクロ %%%s の展開に失敗しました。\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "マクロ %%%s は不正な名前です (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "不明なオプション %c (%s(%s)中に)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"マクロ展開の再帰呼び出しが深すぎます。これは再帰的マクロ定義が原因で発生して"
-"いる可能性があります。\n"
+msgstr "マクロ展開の再帰呼び出しが深すぎます。これは再帰的マクロ定義が原因で発生している可能性があります。\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "終端されていない %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% の後ろに構文解析できないマクロが続いています。\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 有効 %d 空 %d\n"
@@ -3513,31 +3294,31 @@ msgstr "ファイル %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "ファイル %s は %u バイトより小さくなっています。\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "ディレクトリーの作成に失敗しました"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "lua スクリプトで不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "lua スクリプトで不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua スクリプトに失敗しました: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua ファイルに不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua のフックに失敗しました: %s\n"
@@ -3546,19 +3327,19 @@ msgstr "lua のフックに失敗しました: %s\n"
 msgid "[none]"
 msgstr "[なし]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(エラーなし)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "致命的なエラー: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "エラー: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "警告: "
 
@@ -3567,121 +3348,99 @@ msgstr "警告: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "メモリ割り当て (%u バイト) が NULL を返しました。\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s、鍵 ID %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(なし)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "一時ファイル %s の作成に失敗しました: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "一時ファイル %s の作成に失敗しました: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "一時ファイル %s の作成に失敗しました: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "ディレクトリー %s の作成に失敗しました: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "サポートされない PGP 署名\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "サポートされない PGP ハッシュアルゴリズム %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "サポートされない PGP 公開鍵アルゴリズム %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s を実行できませんでした: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "署名のためのパイプ作成ができません: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: オープンに失敗しました: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "%s ファイルを開けませんでした: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "%%files のファイル %s を開けません: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg の実行に失敗しました (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg が署名を書き込むのに失敗しました。\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "署名を読み込めませんでした。\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature に失敗しました: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM v3 パッケージを署名できません\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s はすでに同一の署名を含みます、スキップしています\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp に失敗しました。\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "%s の置換に失敗: %s\n"
@@ -3694,106 +3453,3 @@ msgstr "%s: manifest の読み込みに失敗: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "ヘッダーとペイロード署名を検証しません。"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "パスフレーズの入力: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "パスフレーズは正常です。\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr ""
-#~ "パスフレーズのチェックに失敗しました、または GPG キーが失効しています\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "不正な所有者/グループ: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "%d 行目: 不正な文字 '-' : %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "署名のためのパイプ作成ができません: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "%s への Payload 書き込みに失敗: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "%s から Payload 読み込みに失敗: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "一時ファイルを開けません。\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "sigtarget %s のオープンに失敗: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "%s からヘッダー読み込みに失敗: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "%s へのヘッダー書き込みに失敗: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "いかなる収集活動も行わないでください。"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "不変なヘッダー領域を読むことができませんでした。パッケージが壊れていません"
-#~ "か？\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "%s に対するポリシーのデコードに失敗しました\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "%s の一時ファイルの作成に失敗しました: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "%s ポリシーをファイル %s に書き込みに失敗しました\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "semanage ハンドルの作成に失敗しました。\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "ポリシーのハンドラーへの接続に失敗しました\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "ポリシーのトランザクションの開始に失敗しました: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "一時ポリシーファイル %s の削除に失敗しました: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "ポリシーモジュールのインストールに失敗しました: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "ポリシーモジュールの削除に失敗しました: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "プロセスのフォークに失敗: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "%s の実行に失敗しました。%s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s が異常終了しました。\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s が終了コード %i で失敗しました\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "ポリシーの変更を確定した際にエラーが発生しました。\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "restorecon パスの展開に失敗しました"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "ファイルシステムのリラベルに失敗しました。ファイルはミスラベルされたかもし"
-#~ "れません。\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "ファイルのコンテキストの再読み込みに失敗しました。ファイルは違うラベルがつ"
-#~ "けられたかもしれません。\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "%s からのポリシーの展開に失敗しました。\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,21 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Korean (http://www.transifex.com/projects/p/rpm/language/"
-"ko/)\n"
-"Language: ko\n"
+"Language-Team: Korean (http://www.transifex.com/rpm-team/rpm/language/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,7 +79,7 @@ msgstr "검증 옵션 (-V 또는 --verify 옵션과 함께 사용):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "설치/업그레이드/삭제 옵션:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +100,7 @@ msgstr "부적절한 질의 형식 입니다"
 msgid "unexpected query source"
 msgstr "부적절한 질의 소스 입니다"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "하나의 주(major) 모드만 지정할 수 있습니다"
 
@@ -120,9 +119,7 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate 와 --excludepath 옵션은 최신의 패키지를 설치할 때에만 사용할 수 있"
-"습니다"
+msgstr "--relocate 와 --excludepath 옵션은 최신의 패키지를 설치할 때에만 사용할 수 있습니다"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -138,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -203,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 옵션의 인수는 반드시 '/' 로 시작해야 합니다"
 
@@ -223,249 +221,201 @@ msgstr "질의에 필요한 인수가 지정되지 않았습니다"
 msgid "no arguments given for verify"
 msgstr "검증에 필요한 인수가 지정되지 않았습니다"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot는 이미 지정되어 있습니다, %s(을)를 무시합니다\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "<spec파일>의 %prep (소스를 풀고 패치를 적용하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<spec파일>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "<spec파일>의 %build (%prep과 컴파일하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "<spec파일>의 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "<spec파일>의 %files 항목(section)을 검사합니다"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "<spec파일>로 소스와 바이너리 패키지를 제작합니다"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "<spec파일>로 바이너리 패키지 만을 제작합니다"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "<spec파일>의 %prep (소스를 풀고 패치를 적용하는 과정)으로 제작합니다"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<소스 패키지>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "<spec파일>의 %build (%prep과 컴파일하는 과정)으로 제작합니다"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"<소스 패키지>를 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "<spec파일>의 %files 항목(section)을 검사합니다"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "<소스 패키지>로 바이너리 패키지를 제작합니다"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "<소스 패키지>로 바이너리 패키지를 제작합니다"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr "<tar파일>을 %prep (소스를 풀고 패치를 적용하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tar파일>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "<tar파일>을 %build (%prep과 컴파일하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "<tar파일>을 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "<tar파일>의 %files 항목(section)을 검사합니다"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "<tar파일>로 소스와 바이너리 패키지를 제작합니다"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "<tar파일>로 바이너리 패키지 만을 제작합니다"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "<tar파일>로 소스 패키지 만을 제작합니다"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "<소스 패키지>로 바이너리 패키지를 제작합니다"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<소스 패키지>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "<소스 패키지>를 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "buildroot를 교체(override)합니다"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "패키지 제작 후에 소스 파일을 풀고 작업한 디렉토리를 삭제합니다"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ExcludeArch를 무시함: spec 파일에서 지정(directive)됩니다"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "컴퓨터의 상태(state) 파일을 디버그 합니다"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "패키지 제작의 어떠한 단계도 실행하지 않습니다"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "패키지 제작 의존성을 검사하지 않습니다"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "패키지 제작의 어떠한 단계도 실행하지 않습니다"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "spec파일의 i18N msgstr을 사용(accept)하지 않습니다"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "패키지 제작 후에 소스 파일을 삭제합니다"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "패키지 제작 후에 spec파일을 삭제합니다"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "지정된 단계로 바로 진행합니다 (c,i 에서만 사용 가능)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "목표대상(target) 플랫폼을 교체(override)합니다"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"다음과 함께 사용하는 제작 옵션 [ <spec파일> | <tar파일> | <소스 패키지> ]:"
+msgstr "다음과 함께 사용하는 제작 옵션 [ <spec파일> | <tar파일> | <소스 패키지> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "%s spec 파일을 열 수 없음: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar 파이프를 여는데 실패함: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "%s spec 파일을 열 수 없음: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "%s에서 spec 파일을 읽는데 실패했습니다\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s의 이름을 %s(으)로 변경하는데 실패함: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "%s의 상태(stat)를 표시하는데 실패함: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s 파일은 정규(regular) 파일이 아닙니다.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s 파일은 spec 파일이 아닌 것 같습니다.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "목표대상(target) 플랫폼으로 제작 중: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "%s(을)를 제작하고 있습니다\n"
@@ -476,9 +426,7 @@ msgstr "데이터베이스를 초기화 합니다"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"설치된 패키지 헤더에서 상반된 목록(inverted lists)의 데이터베이스를 재구축 합"
-"니다"
+msgstr "설치된 패키지 헤더에서 상반된 목록(inverted lists)의 데이터베이스를 재구축 합니다"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -516,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -536,10 +484,29 @@ msgstr ""
 msgid "Signature options:"
 msgstr "서명 옵션:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "%s(을)를 실행할 수 없음: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "매크로 파일 안에 반드시 \"%%_gpg_name\"을 설정해야 합니다\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "패스 구문(pass phrase) 입력: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "패스 구문(pass phrase)이 일치합니다.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -557,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "다음의 질의 형식을 사용하십시요"
 
@@ -604,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM 제작 오류:\n"
+msgstr "\n\nRPM 제작 오류:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "'==' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "'&&' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "'||' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "표현식에서 오류가 발생했습니다\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "'(' 가 일치하지 않습니다\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "'-' 는 숫자에만 사용합니다\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "'!' 는 숫자에만 사용합니다\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "유형은 반드시 일치해야 합니다\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "'* /' 는 문자열에서 사용할 수 없습니다\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "'-' 는 문자열에서 사용할 수 없습니다\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "'&&' 와 '||' 는 문자열에서 사용할 수 없습니다\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "표현식에서 구문 오류가 발생했습니다\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s %s에 '(' 가 없습니다\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s(%s에 ')' 가 없습니다\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "부적합한 %s 토큰: %s\n"
@@ -678,46 +642,46 @@ msgstr "부적합한 %s 토큰: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%2$s %3$s에 %1$s 가 없습니다\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 다음에 공백이 없음: %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "잘못된 구문: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "잘못된 모드 spec: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "잘못된 dir모드 spec: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "파일은 반드시 \"/\" 로 시작해야함: %s\n"
@@ -727,144 +691,149 @@ msgstr "파일은 반드시 \"/\" 로 시작해야함: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "파일 목록이 중복됨: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "BuildRoot에 심볼릭링크함: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "파일을 찾을 수 없음: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "파일은 \"/\" 로 시작해야함: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "glob으로 파일을 찾을 수 없음: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "행: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "잘못된 파일: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "잘못된 소유자/그룹: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -893,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "호스트명을 정규화(canonicalize) 할 수 없음: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "서명(signature) 헤더를 다시 읽어올 수 없습니다.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "고정 헤더 영역(immutable header region)을 생성할 수 없습니다.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "패키지를 작성할 수 없음: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "임시(temp) 헤더를 작성할 수 없습니다\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "잘못된 CSA 데이터\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "%s(을)를 실행할 수 없음: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread이 실패했습니다: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "작성: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "%s 패키지의 출력 파일명을 생성할 수 없음: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s(을)를 생성할 수 없음: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d 번째 행: 두번째 %s\n"
@@ -1016,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d 번째 행: %%description에서 오류가 발생했습니다: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d 번째 행: %s(은)는 잘못된 옵션입니다: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "%d 번째 행: 이름이 너무 많습니다: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "%d 번째 행: 패키지가 존재하지 않습니다: %s\n"
@@ -1135,94 +1104,90 @@ msgstr "%d 번째 행: 태그에 하나의 토큰만 있습니다: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "%d 번째 행: 두번째 %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d 번째 행: 올바르지 못한 태그입니다: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d 번째 행: 태그가 비어있습니다: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d 번째 행: Prefixes는 절대 \"/\" 로 끝나서는 안됩니다: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d 번째 행: Docdir은 반드시 '/' 로 시작해야 합니다: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d 번째 행: 잘못된 %s: 수식자(qualifier): %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d 번째 행: 잘못된 BuildArchitecture 형식입니다: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "내부 오류: 보거스(Bogus) 태그 %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "잘못된 패키지 지정: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "패키지가 이미 존재함: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d 번째 행: 알 수 없는 태그입니다: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1232,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "잘못된 소스: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup에서 오류 발생: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d 번째 행: %%setup에 잘못된 인수가 있습니다: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d 번째 행: %%setup에 잘못된 %s 옵션: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d 번째 행: 두번째 %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "%d 번째 행: 트리거는 반드시 '--' 를 포함해야 합니다: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "%d 번째 행: %s에서 오류가 발생했습니다: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "%d 번째 행: 스크립트 프로그램은 반드시 '/' 로 시작해야 합니다: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "%d 번째 행: 두번째 %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "%d 번째 행: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else가 %%if 없이 사용되었습니다\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif가 %%if 없이 사용되었습니다\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "패키지 제작에 호환하는 아키텍쳐를 찾을 수 없습니다\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "패키지에 %%description이 없음: %s\n"
@@ -1489,282 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s(을)를 실행할 수 없음: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s(을)를 fork 할 수 없음: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s(을)를 찾는데 실패함:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr ""
-"%s spec 파일을 질의하는데 실패했습니다, 파일을 처리(parse)할 수 없습니다\n"
+msgstr "%s spec 파일을 질의하는데 실패했습니다, 파일을 처리(parse)할 수 없습니다\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(숫자가 아닙니다)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(base64가 아닙니다)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(부적합한 타입)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(BLOB[Binary Large OBject]이 아닙니다)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s(이)가 %s(으)로 저장되었습니다\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s(이)가 %s(으)로 생성되었습니다\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1893,18 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "재배치시에는 반드시 '=' 뒤에 '/' 가 와야 합니다"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"특정 파일을 생략하기 위한 설정이 적용된 경우에도, 패키지 안의 모든 파일을 설"
-"치합니다"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "특정 파일을 생략하기 위한 설정이 적용된 경우에도, 패키지 안의 모든 파일을 설치합니다"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"<패키지> 이름과 일치하는 패키지는 모두 제거합니다 (<패키지>에 여러개의 패키지"
-"를 동시에 지정할 경우에는 오류가 발생합니다)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "<패키지> 이름과 일치하는 패키지는 모두 제거합니다 (<패키지>에 여러개의 패키지를 동시에 지정할 경우에는 오류가 발생합니다)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1952,9 +1890,7 @@ msgstr "<패키지파일>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr ""
-"패키지 설치를 해시마크(#)로 표시합니다 (-v 옵션과 함께 사용하는 것이 좋습니"
-"다)"
+msgstr "패키지 설치를 해시마크(#)로 표시합니다 (-v 옵션과 함께 사용하는 것이 좋습니다)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1984,7 +1920,7 @@ msgstr "파일시스템을 변경하지 않고, 데이터베이스를 갱신합�
 msgid "do not verify package dependencies"
 msgstr "패키지의 의존성을 검사하지 않습니다"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2036,9 +1972,7 @@ msgstr ""
 
 #: lib/poptI.c:213
 msgid "do not execute any scriptlet(s) triggered by this package"
-msgstr ""
-"이 패키지에 의해 생성되는(triggered) 어떠한 스크립틀릿(scriptlet)도 실행하지 "
-"않습니다"
+msgstr "이 패키지에 의해 생성되는(triggered) 어떠한 스크립틀릿(scriptlet)도 실행하지 않습니다"
 
 #: lib/poptI.c:216
 #, c-format
@@ -2064,9 +1998,7 @@ msgstr "어떠한 %%triggerpostun 스크립틀릿(scriptlet)도 실행하지 않
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"이전 버전의 패키지로 다운그레이드 합니다 (--force 옵션을 사용시에는 이 옵션"
-"이 자동으로 적용됩니다)"
+msgstr "이전 버전의 패키지로 다운그레이드 합니다 (--force 옵션을 사용시에는 이 옵션이 자동으로 적용됩니다)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2074,8 +2006,7 @@ msgstr "패키지 설치를 퍼센트(%)로 표시합니다"
 
 #: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
-msgstr ""
-"재배치 기능이 있는 패키지의 경우, 지정한 <디렉토리>로 재배치하여 설치합니다"
+msgstr "재배치 기능이 있는 패키지의 경우, 지정한 <디렉토리>로 재배치하여 설치합니다"
 
 #: lib/poptI.c:236
 msgid "<dir>"
@@ -2109,182 +2040,162 @@ msgstr "패키지를 업그레이드 합니다"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "모든 패키지에 대해 질의/검증합니다"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "파일이 들어있는 패키지에 대해 질의/검증 합니다"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "그룹 안의 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "패키지 식별자(identifier)를 사용하여 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "헤더 식별자(identifier)를 사용하여 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm 질의 모드"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "설치 내용을 통해 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "패키지로 인해 생성되는(triggered) 패키지에 대해 질의합니다"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm 검증 모드"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "의존성을 제공하는 패키지에 대해 질의/검증 합니다"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "모든 설정 파일을 나열합니다"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "모든 문서 파일을 나열합니다"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "기본 파일 정보를 보여줍니다"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "패키지 안의 파일을 나열합니다"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost 파일을 생략합니다"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "나열된 파일의 상태(state)를 보여줍니다"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "파일의 용량을 검사하지 않습니다"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "파일의 심볼릭 링크 경로를 검사하지 않습니다"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "파일의 소유자를 검사하지 않습니다"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "파일의 그룹을 검사하지 않습니다"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "파일의 최종 변경 시간을 검사하지 않습니다"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "파일의 모드를 검사하지 않습니다"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "패키지 안의 파일을 검사하지 않습니다"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "패키지의 의존성을 검사하지 않습니다"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "소스 패키지가 필요하며, 바이너리가 검색되었습니다\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "소스 패키지에 .spec 파일이 포함되어 있지 않습니다\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "아카이브를 푸는데 실패함%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " 다음 파일의 "
 
@@ -2359,116 +2270,96 @@ msgstr "%s(와)과 일치하는 패키지가 없음: %s\n"
 msgid "no package requires %s\n"
 msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "%s(을)를 생성하는(trigger) 패키지가 없습니다\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s(을)를 제공하는 패키지가 없습니다\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "%s 파일: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "%s 파일은 어떤 패키지에도 들어있지 않습니다\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "부적합한 패키지 번호: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "%s 패키지가 설치되어 있지 않습니다\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread이 실패했습니다: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "올바르지 않음"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "확인"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (키를 찾을 수 없음:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (키를 신뢰할 수 없음:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: 여는데 실패했습니다: %s\n"
@@ -2493,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "아니오"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "예"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "패키지의 의존성을 검사하지 않습니다"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c(이)가 종료되지 않음: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "%s 사용자가 존재하지 않습니다 - root를 이용합니다\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "%s 그룹이 존재하지 않습니다 - root를 이용합니다\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "잘못된 magic 입니다"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "잘못된/읽을 수 없는 헤더입니다"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "헤더의 크기가 너무 큽니다"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "알 수 없는 파일 유형입니다"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "내부 오류"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "헤더에 아카이브 파일이 없습니다"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " 실패함 - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s(을)를 여는데 실패함: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2710,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s(은)는 설치할 수 없습니다\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s(을)를 복구합니다\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "%s 파일을 읽는 도중 오류가 발생했습니다\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s(을)를 설치합니다\n"
@@ -2771,12 +2614,12 @@ msgstr "읽는데 실패함: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2872,8 +2715,7 @@ msgstr ""
 #: lib/rpmprob.c:172
 #, c-format
 msgid "unknown error %d encountered while manipulating package %s"
-msgstr ""
-"%2$s 패키지를 처리하는 과정에서 알 수 없는 오류 %1$d(이)가 발생했습니다"
+msgstr "%2$s 패키지를 처리하는 과정에서 알 수 없는 오류 %1$d(이)가 발생했습니다"
 
 #: lib/rpmrc.c:222
 #, c-format
@@ -2939,75 +2781,56 @@ msgstr "%2$s에 잘못된 '%1$s' 옵션:%3$d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "알 수 없는 시스템: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "%s 아이콘을 읽을 수 없음: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "%s 아이콘을 읽을 수 없음: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite이 실패했습니다: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -3019,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "%s 안의 패키지 데이터베이스를 열 수 없습니다\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3228,241 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "db경로가 설정되어 있지 않습니다\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: 0x%x의 헤더를 읽을 수 없습니다\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "db경로가 설정되어 있지 않습니다"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "%u에 처음부터 레코드를 추가할 수 없습니다\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"데이터베이스를 재구축하는데 실패함: 원본 데이터베이스는 그대로 유지됩니다\n"
+msgstr "데이터베이스를 재구축하는데 실패함: 원본 데이터베이스는 그대로 유지됩니다\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "이전 데이터베이스를 새로운 데이터베이스로 교체하는데 실패했습니다!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "복구하기 위해 %2$s의 파일을 %1$s의 파일로 교체합니다"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "%s 디렉토리를 삭제하는데 실패함: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "인증되지 않은 db 옵션: \"%s\"(을)를 무시합니다.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s(은)는 부적합한 수치 값입니다, 생략합니다\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s(은)는 너무 크거나 너무 적은 정수(long) 값입니다, 생략합니다\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s(은)는 너무 크거나 너무 적은 정수(int) 값입니다, 생략합니다\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "%2$s/%3$s의 잠금된(lock) %1$s(을)를 얻을 수 없습니다\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "공유됨"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "폐쇄적(exclusive)"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "새로운 패키지를 배치하는 도중 오류(%d)가 발생했습니다\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "인증되지 않은 db 옵션: \"%s\"(을)를 무시합니다.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s(은)는 부적합한 수치 값입니다, 생략합니다\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s(은)는 너무 크거나 너무 적은 정수(long) 값입니다, 생략합니다\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s(은)는 너무 크거나 너무 적은 정수(int) 값입니다, 생략합니다\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(비어있음)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(비어있음)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "매크로 %%%s에 종료되지 않은 옵션이 있습니다\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "매크로 %%%s에 종료되지 않은 내용(body)이 있습니다\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "매크로 %%%s에 부적합한 이름이 있습니다 (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "매크로 %%%s에 비어있는 내용(body)이 있습니다\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "매크로 %%%s(을)를 확장(expand)하는데 실패했습니다\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "매크로 %%%s에 부적합한 이름이 있습니다 (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "%2$s(%3$s)에 알 수 없는 옵션 %1$c(이)가 있습니다\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c(이)가 종료되지 않음: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "'%%' 다음에 처리할 수 없는(unparseable) 매크로가 있습니다\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d 활성 %d 비어있음\n"
@@ -3482,31 +3289,31 @@ msgstr "%s 파일: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "%s 파일이 %u 바이트 보다 적습니다\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3515,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(오류 없음)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "치명적 오류: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "오류: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "경고: "
 
@@ -3536,121 +3343,99 @@ msgstr "경고: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "메모리 할당 값 (%u 바이트)이 NULL을 반환하였습니다.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "%s 파일을 읽는 도중 오류가 발생했습니다\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "%s 파일을 읽는 도중 오류가 발생했습니다\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "%s 디렉토리를 삭제하는데 실패함: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s(을)를 실행할 수 없음: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: 여는데 실패했습니다: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "%s(을)를 실행할 수 없음: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "%s(을)를 실행할 수 없음: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg 서명을 작성하는데 실패했습니다\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "서명을 읽을 수 없습니다\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3663,30 +3448,3 @@ msgstr "%s: 읽는데 실패했습니다: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "패스 구문(pass phrase) 입력: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "패스 구문(pass phrase)이 일치합니다.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "잘못된 소유자/그룹: %s\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "%s에 payload를 작성할 수 없음: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "%s의 payload를 읽을 수 없음: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "임시 파일을 열 수 없습니다.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "서명할 대상 %s(을)를 열 수 없음: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "%s의 헤더를 읽을 수 없음: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "%s에 헤더를 작성할 수 없음: %s\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Korean (http://www.transifex.com/rpm-team/rpm/language/ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr "검증 옵션 (-V 또는 --verify 옵션과 함께 사용):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "설치/업그레이드/삭제 옵션:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr "부적절한 질의 형식 입니다"
 msgid "unexpected query source"
 msgstr "부적절한 질의 소스 입니다"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "하나의 주(major) 모드만 지정할 수 있습니다"
 
@@ -119,7 +119,9 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate 와 --excludepath 옵션은 최신의 패키지를 설치할 때에만 사용할 수 있습니다"
+msgstr ""
+"--relocate 와 --excludepath 옵션은 최신의 패키지를 설치할 때에만 사용할 수 있"
+"습니다"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +137,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 옵션의 인수는 반드시 '/' 로 시작해야 합니다"
 
@@ -221,201 +222,249 @@ msgstr "질의에 필요한 인수가 지정되지 않았습니다"
 msgid "no arguments given for verify"
 msgstr "검증에 필요한 인수가 지정되지 않았습니다"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot는 이미 지정되어 있습니다, %s(을)를 무시합니다\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "<spec파일>의 %prep (소스를 풀고 패치를 적용하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<spec파일>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "<spec파일>의 %build (%prep과 컴파일하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "<spec파일>의 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "<spec파일>의 %files 항목(section)을 검사합니다"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "<spec파일>로 소스와 바이너리 패키지를 제작합니다"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "<spec파일>로 바이너리 패키지 만을 제작합니다"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "<spec파일>의 %prep (소스를 풀고 패치를 적용하는 과정)으로 제작합니다"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<소스 패키지>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "<spec파일>의 %build (%prep과 컴파일하는 과정)으로 제작합니다"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"<소스 패키지>를 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "<spec파일>의 %files 항목(section)을 검사합니다"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "<소스 패키지>로 바이너리 패키지를 제작합니다"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "<소스 패키지>로 바이너리 패키지를 제작합니다"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr "<tar파일>을 %prep (소스를 풀고 패치를 적용하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tar파일>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "<tar파일>을 %build (%prep과 컴파일하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "<tar파일>을 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "<tar파일>의 %files 항목(section)을 검사합니다"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "<tar파일>로 소스와 바이너리 패키지를 제작합니다"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "<tar파일>로 바이너리 패키지 만을 제작합니다"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "<tar파일>로 소스 패키지 만을 제작합니다"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "<소스 패키지>로 바이너리 패키지를 제작합니다"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<소스 패키지>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "<소스 패키지>를 %install (%prep, %build와 설치하는 과정)으로 제작합니다"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "buildroot를 교체(override)합니다"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "패키지 제작 후에 소스 파일을 풀고 작업한 디렉토리를 삭제합니다"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ExcludeArch를 무시함: spec 파일에서 지정(directive)됩니다"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "컴퓨터의 상태(state) 파일을 디버그 합니다"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "패키지 제작의 어떠한 단계도 실행하지 않습니다"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "패키지 제작 의존성을 검사하지 않습니다"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "패키지 제작의 어떠한 단계도 실행하지 않습니다"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "spec파일의 i18N msgstr을 사용(accept)하지 않습니다"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "패키지 제작 후에 소스 파일을 삭제합니다"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "패키지 제작 후에 spec파일을 삭제합니다"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "지정된 단계로 바로 진행합니다 (c,i 에서만 사용 가능)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "목표대상(target) 플랫폼을 교체(override)합니다"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "다음과 함께 사용하는 제작 옵션 [ <spec파일> | <tar파일> | <소스 패키지> ]:"
+msgstr ""
+"다음과 함께 사용하는 제작 옵션 [ <spec파일> | <tar파일> | <소스 패키지> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "%s spec 파일을 열 수 없음: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar 파이프를 여는데 실패함: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "%s spec 파일을 열 수 없음: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "%s에서 spec 파일을 읽는데 실패했습니다\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s의 이름을 %s(으)로 변경하는데 실패함: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "%s의 상태(stat)를 표시하는데 실패함: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s 파일은 정규(regular) 파일이 아닙니다.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s 파일은 spec 파일이 아닌 것 같습니다.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "목표대상(target) 플랫폼으로 제작 중: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "%s(을)를 제작하고 있습니다\n"
@@ -426,7 +475,9 @@ msgstr "데이터베이스를 초기화 합니다"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "설치된 패키지 헤더에서 상반된 목록(inverted lists)의 데이터베이스를 재구축 합니다"
+msgstr ""
+"설치된 패키지 헤더에서 상반된 목록(inverted lists)의 데이터베이스를 재구축 합"
+"니다"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -464,49 +515,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "<패키지파일>+"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "서명 옵션:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "%s(을)를 실행할 수 없음: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "매크로 파일 안에 반드시 \"%%_gpg_name\"을 설정해야 합니다\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "패스 구문(pass phrase) 입력: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "패스 구문(pass phrase)이 일치합니다.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix 옵션은 최신의 패키지를 설치할 때에만 사용할 수 있습니다"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches 옵션은 패키지 삭제시에만 지정할 수 있습니다"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +590,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "다음의 질의 형식을 사용하십시요"
 
@@ -571,68 +637,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM 제작 오류:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM 제작 오류:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "'==' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "'&&' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "'||' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "표현식에서 오류가 발생했습니다\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "'(' 가 일치하지 않습니다\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "'-' 는 숫자에만 사용합니다\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "'!' 는 숫자에만 사용합니다\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "유형은 반드시 일치해야 합니다\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "'* /' 는 문자열에서 사용할 수 없습니다\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "'-' 는 문자열에서 사용할 수 없습니다\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "'&&' 와 '||' 는 문자열에서 사용할 수 없습니다\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "표현식에서 구문 오류가 발생했습니다\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s %s에 '(' 가 없습니다\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s(%s에 ')' 가 없습니다\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "부적합한 %s 토큰: %s\n"
@@ -642,46 +711,46 @@ msgstr "부적합한 %s 토큰: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%2$s %3$s에 %1$s 가 없습니다\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 다음에 공백이 없음: %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "잘못된 구문: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "잘못된 모드 spec: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "잘못된 dir모드 spec: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "파일은 반드시 \"/\" 로 시작해야함: %s\n"
@@ -691,149 +760,149 @@ msgstr "파일은 반드시 \"/\" 로 시작해야함: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "파일 목록이 중복됨: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "BuildRoot에 심볼릭링크함: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "파일을 찾을 수 없음: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "파일은 \"/\" 로 시작해야함: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "glob으로 파일을 찾을 수 없음: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "행: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "glob으로 파일을 찾을 수 없음: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "잘못된 파일: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "잘못된 소유자/그룹: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +931,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "호스트명을 정규화(canonicalize) 할 수 없음: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "서명(signature) 헤더를 다시 읽어올 수 없습니다.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "고정 헤더 영역(immutable header region)을 생성할 수 없습니다.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "패키지를 작성할 수 없음: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "임시(temp) 헤더를 작성할 수 없습니다\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "잘못된 CSA 데이터\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "작성: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "%s 패키지의 출력 파일명을 생성할 수 없음: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s(을)를 생성할 수 없음: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d 번째 행: 두번째 %s\n"
@@ -985,19 +1051,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d 번째 행: %%description에서 오류가 발생했습니다: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d 번째 행: %s(은)는 잘못된 옵션입니다: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "%d 번째 행: 이름이 너무 많습니다: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "%d 번째 행: 패키지가 존재하지 않습니다: %s\n"
@@ -1104,90 +1170,94 @@ msgstr "%d 번째 행: 태그에 하나의 토큰만 있습니다: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "%d 번째 행: 두번째 %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d 번째 행: 올바르지 못한 태그입니다: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d 번째 행: 태그가 비어있습니다: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d 번째 행: Prefixes는 절대 \"/\" 로 끝나서는 안됩니다: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d 번째 행: Docdir은 반드시 '/' 로 시작해야 합니다: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d 번째 행: 잘못된 %s: 수식자(qualifier): %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d 번째 행: 잘못된 BuildArchitecture 형식입니다: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "내부 오류: 보거스(Bogus) 태그 %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "잘못된 패키지 지정: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "패키지가 이미 존재함: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d 번째 행: 알 수 없는 태그입니다: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1267,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "잘못된 소스: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup에서 오류 발생: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d 번째 행: %%setup에 잘못된 인수가 있습니다: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d 번째 행: %%setup에 잘못된 %s 옵션: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d 번째 행: 두번째 %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "%d 번째 행: 트리거는 반드시 '--' 를 포함해야 합니다: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "%d 번째 행: %s에서 오류가 발생했습니다: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "%d 번째 행: 스크립트 프로그램은 반드시 '/' 로 시작해야 합니다: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "%d 번째 행: 두번째 %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "%d 번째 행: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else가 %%if 없이 사용되었습니다\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif가 %%if 없이 사용되었습니다\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "패키지 제작에 호환하는 아키텍쳐를 찾을 수 없습니다\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "패키지에 %%description이 없음: %s\n"
@@ -1422,290 +1524,282 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s(을)를 실행할 수 없음: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s(을)를 fork 할 수 없음: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s(을)를 찾는데 실패함:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "%s spec 파일을 질의하는데 실패했습니다, 파일을 처리(parse)할 수 없습니다\n"
+msgstr ""
+"%s spec 파일을 질의하는데 실패했습니다, 파일을 처리(parse)할 수 없습니다\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(숫자가 아닙니다)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(base64가 아닙니다)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(부적합한 타입)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(BLOB[Binary Large OBject]이 아닙니다)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s(이)가 %s(으)로 저장되었습니다\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s(이)가 %s(으)로 생성되었습니다\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1928,18 @@ msgid "relocations must have a / following the ="
 msgstr "재배치시에는 반드시 '=' 뒤에 '/' 가 와야 합니다"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "특정 파일을 생략하기 위한 설정이 적용된 경우에도, 패키지 안의 모든 파일을 설치합니다"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"특정 파일을 생략하기 위한 설정이 적용된 경우에도, 패키지 안의 모든 파일을 설"
+"치합니다"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "<패키지> 이름과 일치하는 패키지는 모두 제거합니다 (<패키지>에 여러개의 패키지를 동시에 지정할 경우에는 오류가 발생합니다)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"<패키지> 이름과 일치하는 패키지는 모두 제거합니다 (<패키지>에 여러개의 패키지"
+"를 동시에 지정할 경우에는 오류가 발생합니다)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1890,7 +1987,9 @@ msgstr "<패키지파일>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "패키지 설치를 해시마크(#)로 표시합니다 (-v 옵션과 함께 사용하는 것이 좋습니다)"
+msgstr ""
+"패키지 설치를 해시마크(#)로 표시합니다 (-v 옵션과 함께 사용하는 것이 좋습니"
+"다)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1920,7 +2019,7 @@ msgstr "파일시스템을 변경하지 않고, 데이터베이스를 갱신합�
 msgid "do not verify package dependencies"
 msgstr "패키지의 의존성을 검사하지 않습니다"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1972,7 +2071,9 @@ msgstr ""
 
 #: lib/poptI.c:213
 msgid "do not execute any scriptlet(s) triggered by this package"
-msgstr "이 패키지에 의해 생성되는(triggered) 어떠한 스크립틀릿(scriptlet)도 실행하지 않습니다"
+msgstr ""
+"이 패키지에 의해 생성되는(triggered) 어떠한 스크립틀릿(scriptlet)도 실행하지 "
+"않습니다"
 
 #: lib/poptI.c:216
 #, c-format
@@ -1998,7 +2099,9 @@ msgstr "어떠한 %%triggerpostun 스크립틀릿(scriptlet)도 실행하지 않
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "이전 버전의 패키지로 다운그레이드 합니다 (--force 옵션을 사용시에는 이 옵션이 자동으로 적용됩니다)"
+msgstr ""
+"이전 버전의 패키지로 다운그레이드 합니다 (--force 옵션을 사용시에는 이 옵션"
+"이 자동으로 적용됩니다)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2006,7 +2109,8 @@ msgstr "패키지 설치를 퍼센트(%)로 표시합니다"
 
 #: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
-msgstr "재배치 기능이 있는 패키지의 경우, 지정한 <디렉토리>로 재배치하여 설치합니다"
+msgstr ""
+"재배치 기능이 있는 패키지의 경우, 지정한 <디렉토리>로 재배치하여 설치합니다"
 
 #: lib/poptI.c:236
 msgid "<dir>"
@@ -2040,162 +2144,182 @@ msgstr "패키지를 업그레이드 합니다"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "모든 패키지에 대해 질의/검증합니다"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "파일이 들어있는 패키지에 대해 질의/검증 합니다"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "그룹 안의 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "패키지 식별자(identifier)를 사용하여 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "헤더 식별자(identifier)를 사용하여 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm 질의 모드"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "설치 내용을 통해 패키지를 질의/검증 합니다"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "패키지로 인해 생성되는(triggered) 패키지에 대해 질의합니다"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm 검증 모드"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "의존성을 제공하는 패키지에 대해 질의/검증 합니다"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "의존성을 필요로 하는 패키지에 대해 질의/검증 합니다"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "모든 설정 파일을 나열합니다"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "모든 문서 파일을 나열합니다"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "기본 파일 정보를 보여줍니다"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "패키지 안의 파일을 나열합니다"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost 파일을 생략합니다"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "나열된 파일의 상태(state)를 보여줍니다"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "파일의 용량을 검사하지 않습니다"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "파일의 심볼릭 링크 경로를 검사하지 않습니다"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "파일의 소유자를 검사하지 않습니다"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "파일의 그룹을 검사하지 않습니다"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "파일의 최종 변경 시간을 검사하지 않습니다"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "파일의 모드를 검사하지 않습니다"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "패키지 안의 파일을 검사하지 않습니다"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "패키지의 의존성을 검사하지 않습니다"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "소스 패키지가 필요하며, 바이너리가 검색되었습니다\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "소스 패키지에 .spec 파일이 포함되어 있지 않습니다\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "아카이브를 푸는데 실패함%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " 다음 파일의 "
 
@@ -2270,96 +2394,116 @@ msgstr "%s(와)과 일치하는 패키지가 없음: %s\n"
 msgid "no package requires %s\n"
 msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "%s(을)를 생성하는(trigger) 패키지가 없습니다\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s(을)를 제공하는 패키지가 없습니다\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "%s 파일: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "%s 파일은 어떤 패키지에도 들어있지 않습니다\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "부적합한 패키지 번호: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "%s 패키지가 설치되어 있지 않습니다\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread이 실패했습니다: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "올바르지 않음"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "확인"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (키를 찾을 수 없음:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (키를 신뢰할 수 없음:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: 여는데 실패했습니다: %s\n"
@@ -2384,144 +2528,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "아니오"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "예"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "패키지의 의존성을 검사하지 않습니다"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c(이)가 종료되지 않음: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "%s 사용자가 존재하지 않습니다 - root를 이용합니다\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "%s 그룹이 존재하지 않습니다 - root를 이용합니다\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "잘못된 magic 입니다"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "잘못된/읽을 수 없는 헤더입니다"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "헤더의 크기가 너무 큽니다"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "알 수 없는 파일 유형입니다"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "내부 오류"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "헤더에 아카이브 파일이 없습니다"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " 실패함 - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s(을)를 여는데 실패함: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2745,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s(은)는 설치할 수 없습니다\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s(을)를 복구합니다\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "%s 파일을 읽는 도중 오류가 발생했습니다\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s(을)를 설치합니다\n"
@@ -2614,12 +2806,12 @@ msgstr "읽는데 실패함: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2715,7 +2907,8 @@ msgstr ""
 #: lib/rpmprob.c:172
 #, c-format
 msgid "unknown error %d encountered while manipulating package %s"
-msgstr "%2$s 패키지를 처리하는 과정에서 알 수 없는 오류 %1$d(이)가 발생했습니다"
+msgstr ""
+"%2$s 패키지를 처리하는 과정에서 알 수 없는 오류 %1$d(이)가 발생했습니다"
 
 #: lib/rpmrc.c:222
 #, c-format
@@ -2777,60 +2970,79 @@ msgstr "%2$s에 %1$s(을)를 위한 아키텍쳐가 없음:%3$d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "%2$s에 잘못된 '%1$s' 옵션:%3$d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "알 수 없는 시스템: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "%s 아이콘을 읽을 수 없음: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "%s 아이콘을 읽을 수 없음: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite이 실패했습니다: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3054,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "%s 안의 패키지 데이터베이스를 열 수 없습니다\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr ""
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "서명(signature) 헤더를 다시 읽어올 수 없습니다.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3267,241 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "db경로가 설정되어 있지 않습니다\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: 0x%x의 헤더를 읽을 수 없습니다\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "db경로가 설정되어 있지 않습니다"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "%u에 처음부터 레코드를 추가할 수 없습니다\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "데이터베이스를 재구축하는데 실패함: 원본 데이터베이스는 그대로 유지됩니다\n"
+msgstr ""
+"데이터베이스를 재구축하는데 실패함: 원본 데이터베이스는 그대로 유지됩니다\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "이전 데이터베이스를 새로운 데이터베이스로 교체하는데 실패했습니다!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "복구하기 위해 %2$s의 파일을 %1$s의 파일로 교체합니다"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "%s 디렉토리를 삭제하는데 실패함: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "%2$s/%3$s의 잠금된(lock) %1$s(을)를 얻을 수 없습니다\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "공유됨"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "폐쇄적(exclusive)"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "새로운 패키지를 배치하는 도중 오류(%d)가 발생했습니다\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "인증되지 않은 db 옵션: \"%s\"(을)를 무시합니다.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s(은)는 부적합한 수치 값입니다, 생략합니다\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s(은)는 너무 크거나 너무 적은 정수(long) 값입니다, 생략합니다\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s(은)는 너무 크거나 너무 적은 정수(int) 값입니다, 생략합니다\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "%2$s/%3$s의 잠금된(lock) %1$s(을)를 얻을 수 없습니다\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "공유됨"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "폐쇄적(exclusive)"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "새로운 패키지를 배치하는 도중 오류(%d)가 발생했습니다\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(비어있음)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(비어있음)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "매크로 %%%s에 종료되지 않은 옵션이 있습니다\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "매크로 %%%s에 종료되지 않은 내용(body)이 있습니다\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "매크로 %%%s에 부적합한 이름이 있습니다 (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "매크로 %%%s에 비어있는 내용(body)이 있습니다\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "매크로 %%%s(을)를 확장(expand)하는데 실패했습니다\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "매크로 %%%s에 부적합한 이름이 있습니다 (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "%2$s(%3$s)에 알 수 없는 옵션 %1$c(이)가 있습니다\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c(이)가 종료되지 않음: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "'%%' 다음에 처리할 수 없는(unparseable) 매크로가 있습니다\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d 활성 %d 비어있음\n"
@@ -3289,31 +3521,31 @@ msgstr "%s 파일: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "%s 파일이 %u 바이트 보다 적습니다\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3554,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(오류 없음)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "치명적 오류: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "오류: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "경고: "
 
@@ -3343,99 +3575,154 @@ msgstr "경고: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "메모리 할당 값 (%u 바이트)이 NULL을 반환하였습니다.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "%s 파일을 읽는 도중 오류가 발생했습니다\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "%s 파일을 읽는 도중 오류가 발생했습니다\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "%s 디렉토리를 삭제하는데 실패함: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr ""
+msgid "Could not exec %s: %s\n"
+msgstr "%s(을)를 실행할 수 없음: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: 여는데 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg 서명을 작성하는데 실패했습니다\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "서명을 읽을 수 없습니다\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature이 실패했습니다: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmWriteSignature이 실패했습니다: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "실행에 실패했습니다\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "실행에 실패했습니다\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "실행에 실패했습니다\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3735,12 @@ msgstr "%s: 읽는데 실패했습니다: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "패스 구문(pass phrase) 입력: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "패스 구문(pass phrase)이 일치합니다.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "잘못된 소유자/그룹: %s\n"

--- a/po/ms.po
+++ b/po/ms.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Malay (http://www.transifex.com/rpm-team/rpm/language/ms/)\n"
+"Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ms\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -135,8 +135,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +200,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -221,201 +220,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
+#, c-format
+msgid "verify %files section from <source package>"
 msgstr ""
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr ""
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr ""
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -464,48 +505,60 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+msgid "sign package(s) files"
+msgstr ""
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Tidak dapat melaksana %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:127
-#, c-format
-msgid "Pass phrase is good.\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
 msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -524,7 +577,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -573,66 +626,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -642,46 +695,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -691,149 +744,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +915,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -985,19 +1035,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1104,90 +1154,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "%s: %s: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1251,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1422,290 +1508,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,14 +1911,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1920,7 +1996,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2040,162 +2116,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2270,96 +2362,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, c-format
+msgid "no package suggests %s\n"
+msgstr ""
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, c-format
+msgid "no package enhances %s\n"
+msgstr ""
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2384,144 +2496,191 @@ msgstr "Tidak dapat untuk menukar direktori root: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+msgid "support for rich dependencies."
+msgstr ""
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2712,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2614,12 +2773,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2777,60 +2936,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistem tidak diketahui: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Sila hubungi %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Tidak dapat membuka %s untuk dibaca: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, c-format
+msgid "Unable to reset nice value: %s"
+msgstr ""
+
+#: lib/rpmscript.c:354
+#, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr ""
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "skrip lua gagal: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3020,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' tambahan dalam label pakej: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Digest SHA1 pengepala:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Pengepala"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Digest SHA1 pengepala:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Kebergantungan tidak dipenuhi untuk %s:\n"
@@ -3036,240 +3233,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec gagal: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp gagal: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "gagal untuk mencipta direktori %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "gagal untuk membuang direktori %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "terkongsi"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "terkongsi"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(kosong)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(kosong)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s gagal untuk mengembang\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Pilihan tidak diketahui %c dalam %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktif %d kosong %d\n"
@@ -3289,31 +3486,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "skrip lua gagal: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "pautan lua gagal: %s\n"
@@ -3322,19 +3519,19 @@ msgstr "pautan lua gagal: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(tiada ralat)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "ralat maut:"
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "ralat"
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr ""
 
@@ -3343,99 +3540,148 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "gagal untuk mencipta direktori %s: %s\n"
+
+#: sign/rpmgensig.c:66
+#, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "gagal untuk mencipta direktori %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Tidak dapat melaksana %s: %s\n"
+
+#: sign/rpmgensig.c:288
+msgid "Fopen failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "Pelaksanaan gpg gagal (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+msgid "headerReload failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+msgid "copyFile failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:622
+msgid "headerWrite failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Malay (http://www.transifex.com/projects/p/rpm/language/ms/)\n"
-"Language: ms\n"
+"Language-Team: Malay (http://www.transifex.com/rpm-team/rpm/language/ms/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ms\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -135,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -200,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -220,243 +221,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, c-format
-msgid "verify %files section from <source package>"
-msgstr ""
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr ""
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -505,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -525,9 +484,28 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Tidak dapat melaksana %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr ""
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr ""
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -546,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -595,66 +573,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -664,46 +642,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -713,144 +691,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -879,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Tidak dapat melaksana %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: gagal membaca manifest: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1002,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1121,94 +1104,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "%s: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1218,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1475,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1878,13 +1834,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1963,7 +1920,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2083,178 +2040,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2329,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, c-format
-msgid "no package suggests %s\n"
-msgstr ""
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, c-format
-msgid "no package enhances %s\n"
-msgstr ""
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2463,191 +2384,144 @@ msgstr "Tidak dapat untuk menukar direktori root: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-msgid "support for rich dependencies."
-msgstr ""
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2679,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2740,12 +2614,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2907,75 +2781,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistem tidak diketahui: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Sila hubungi %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Tidak dapat membuka %s untuk dibaca: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, c-format
-msgid "Unable to reset nice value: %s"
-msgstr ""
-
-#: lib/rpmscript.c:354
-#, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr ""
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "skrip lua gagal: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -2987,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' tambahan dalam label pakej: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Pengepala"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Digest SHA1 pengepala:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Pengepala"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Kebergantungan tidak dipenuhi untuk %s:\n"
@@ -3196,240 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec gagal: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp gagal: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "gagal untuk mencipta direktori %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "gagal untuk membuang direktori %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "terkongsi"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(kosong)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(kosong)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s gagal untuk mengembang\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Pilihan tidak diketahui %c dalam %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktif %d kosong %d\n"
@@ -3449,31 +3289,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "skrip lua gagal: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "pautan lua gagal: %s\n"
@@ -3482,19 +3322,19 @@ msgstr "pautan lua gagal: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(tiada ralat)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "ralat maut:"
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "ralat"
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr ""
 
@@ -3503,120 +3343,99 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "gagal untuk mencipta direktori %s: %s\n"
-
-#: sign/rpmgensig.c:64
-#, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "gagal untuk mencipta direktori %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Tidak dapat melaksana %s: %s\n"
-
-#: sign/rpmgensig.c:289
-msgid "Fopen failed\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Tidak dapat melaksana %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Tidak dapat melaksana %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "Pelaksanaan gpg gagal (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,20 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Norwegian Bokmål (http://www.transifex.com/rpm-team/rpm/language/nb/)\n"
+"Language-Team: Norwegian Bokmål (http://www.transifex.com/rpm-team/rpm/"
+"language/nb/)\n"
+"Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +80,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +101,7 @@ msgstr "ventet spørringsformat"
 msgid "unexpected query source"
 msgstr "uventet spørringskilde"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "kun ett større modi kan spesifiseres"
 
@@ -119,7 +120,8 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate og --excludepath kan kun brukes ved installasjon av nye pakker"
+msgstr ""
+"--relocate og --excludepath kan kun brukes ved installasjon av nye pakker"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +137,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -183,13 +184,17 @@ msgstr ""
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "skript som slår av alternativer kan kun spesifiseres under pakkeinstallasjon og sletting"
+msgstr ""
+"skript som slår av alternativer kan kun spesifiseres under pakkeinstallasjon "
+"og sletting"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "alternativer som slår av utløsing  kan kun spesifiseres under pakkeinstallasjon, og sletting"
+msgstr ""
+"alternativer som slår av utløsing  kan kun spesifiseres under "
+"pakkeinstallasjon, og sletting"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +206,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -221,201 +226,250 @@ msgstr "ingen argumenter oppgitt for spørring"
 msgid "no arguments given for verify"
 msgstr "ingen argumenter oppgitt for verifisering"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "Feil under lesing av spec fil fra %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <specfil>"
+msgstr ""
+"bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <specfil>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfil>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "bygg kilde- og binærpakker fra <specfil>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "spør pakke som eier <fil>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <tarball>"
-
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
+"bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <specfil>"
 
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "verifiser %files seksjon fra <tarball>"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "bygg kilde- og binærpakker fra <tarball>"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "bygg binær-pakke fra <kildepakke>"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<kildepakke>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "bygg binær-pakke fra <kildepakke>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verifiser %files seksjon fra <tarball>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "bygg binær-pakke fra <kildepakke>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "bygg binær-pakke fra <kildepakke>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "bygg binær-pakke fra <kildepakke>"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr ""
+"bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <tarball>"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "verifiser %files seksjon fra <tarball>"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "bygg kilde- og binærpakker fra <tarball>"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "bygg binær-pakke fra <kildepakke>"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "fjern byggtreet når ferdig"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "ikke kjør noen %%pre skriptlet (hvis noen)"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "fjern kildekoden når ferdig"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "hopp rett til spesifisert steg (kun for c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Kunne ikke åpne spec fil %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Kunne ikke åpne tar-rør: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Kunne ikke åpne spec fil %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Feil under lesing av spec-fil fra %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Feil under endring av navn fra %s til %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "kunne ikke kjøre stat på %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Fil %s er ikke en vanlig fil.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Fil %s ser ikke ut til å være en spec-fil.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Bygger målplattformene: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Bygger for mål %s\n"
@@ -464,49 +518,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "<pakkefil>+"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Skriv inn passord: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Passord er ok.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix kan kun brukes ved installasjon av nye pakker"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--prefix kan kun brukes ved installasjon av nye pakker"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +593,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -571,68 +640,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM-feil under bygging:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM-feil under bygging:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "syntaksfeil under lesing av ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "syntaksfeil under lesing av &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "syntaksfeil under lesing av ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "feil under lesing av uttrykk\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "ubalansert (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- kun på tall\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! kun på tall\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "typene må være like\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / ikke støttet for strenger\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- ikke støttet for strenger\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& og || ikke støttet for strenger\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "syntaksfeil i uttrykk\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Mangler '(' i %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Mangler ')' i %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ugyldig %s-tegn: %s\n"
@@ -642,46 +714,46 @@ msgstr "Ugyldig %s-tegn: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Filen må begynne med \"/\": %s\n"
@@ -691,149 +763,149 @@ msgstr "Filen må begynne med \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Fil listet to ganger: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolsk lenke peker til BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fil ikke funnet: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "Installerer %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ugyldig fil %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Ugyldig eier/gruppe: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +934,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunne ikke åpne %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunne ikke skrive pakke: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Ugyldige CSA-data\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -985,19 +1054,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linje %d: Ugyldig flagg %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1104,90 +1173,94 @@ msgstr "linje %d: Tagg tar kun et enkelt tegn: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linje %d: Ugyldig %s-nummer: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linje %d: Feilutformet tagg: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linje %d: Tom tagg: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linje %d: Prefiks må ikke slutte på \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linje %d: Docdir må begynne med '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linje %d: Ugyldig %s: kvalifikatorer: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linje %d: Ugyldig BuildArchitecture format: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Intern feil: Ugyldig tag %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ugyldig pakkespesifikasjon: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pakke eksisterer allerede: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linje %d: Ukjent tagg: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1270,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "kunne ikke opprette %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Feil under lesing av %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linje %d: Ugyldig argument til %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linje %d: Ugyldig %%setup flagg %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linje %d: %%prep for andre gang\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linje %d: triggere må ha --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linje %d: Feil under lesing av %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linje %d: skriptprogram må begynne med '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linje %d: Andre %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linje %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Kan ikke åpne %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else uten %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif uten %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Ingen kompatible arkitekturer funnet for bygging\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakken har ingen %%description: %s\n"
@@ -1422,290 +1527,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Kunne ikke kjøre %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "klarte ikke å åpne %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Klarte ikke å finne %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s lagret som %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s opprettet som %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1930,16 @@ msgid "relocations must have a / following the ="
 msgstr "relokasjoner må ha et / etter ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr "installer alle filer, selv konfigurasjoner som ellers kan hoppes over"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "fjern alle pakker som er lik <pakke> (normalt vil en feil genereres hvis <pakke> spesifiserer flere pakker)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"fjern alle pakker som er lik <pakke> (normalt vil en feil genereres hvis "
+"<pakke> spesifiserer flere pakker)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2017,7 @@ msgstr "oppdater databasen, men ikke modifiser filsystemet"
 msgid "do not verify package dependencies"
 msgstr "ikke verifiser pakkeavhengigheter"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1998,7 +2095,9 @@ msgstr "ikke kjør %%triggerpostun skriptlets"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "oppgrader til en gammel versjon av pakken (--force ved oppgraderinger gjør dette automatisk)"
+msgstr ""
+"oppgrader til en gammel versjon av pakken (--force ved oppgraderinger gjør "
+"dette automatisk)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2139,182 @@ msgstr "oppgrader pakke(r)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "spør/verifiser alle pakker"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "spør/verifiser pakke(r) som eier fil"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "spør/verifiser pakke(r) i gruppe"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm spørremodus"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "spør pakker utløst av <pakke>"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "spør etter pakker som tilbyr <funk> funksjonalitet"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "ikke verifiser størrelse på filer"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "ikke verifiser sti til symbolske lenker for filer"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "ikke verifiser eier av filer"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "ikke verifiser gruppe for filer"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "ikke verifisert endringsdato for filer"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "ikke verifiser modus for filer"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "ikke verifiser filer i pakke"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ikke verifiser pakkeavhengigheter"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "kildepakke forventet, binær funnet\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "kildepakke inneholder ikke en .spec-fil\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2270,96 +2389,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "ingen pakke krever %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "ingen pakke krever %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "ingen pakke utløser %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "ingen pakke krever %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "ingen pakke krever %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ingen pakke gir %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s eies ikke av noen pakke\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "ugyldig pakkenummer: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakke %s er ikke installert\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread feilet: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "IKKE OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: åpne feilet: %s\n"
@@ -2384,144 +2523,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NEI"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "ikke verifiser pakkeavhengigheter"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Ugyldig magi"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Ugyldig/ulesbar header"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "For stor header"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Ukjent filtype"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Intern feil"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " feilet - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "feil under åpning av %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2740,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Henter %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "feil under lesing fra fil %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "kan ikke åpne %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installerer %s\n"
@@ -2614,12 +2801,12 @@ msgstr "lesing feilet: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2777,60 +2964,79 @@ msgstr "manglende arkitektur for %s ved %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "ugyldig flagg '%s' ved %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Kan ikke lese ikon %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Kan ikke lese ikon %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite feilet: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3048,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "kan ikke åpne pakkedatabase i %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3261,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3289,31 +3514,31 @@ msgstr "Fil %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Fil %s er mindre enn %u bytes\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3547,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "fatal feil: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "feil: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "advarsel: "
 
@@ -3343,99 +3568,154 @@ msgstr "advarsel: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "feil under lesing fra fil %s\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "feil under lesing fra fil %s\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite feilet: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: åpne feilet: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature feilet: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmWriteSignature feilet: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "kjøring feilet\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "kjøring feilet\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "kjøring feilet\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature feilet: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead feilet: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3728,12 @@ msgstr "%s: lesing av manifest feilet: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Skriv inn passord: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Passord er ok.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Ugyldig eier/gruppe: %s\n"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,21 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Norwegian Bokmål (http://www.transifex.com/projects/p/rpm/"
-"language/nb/)\n"
-"Language: nb\n"
+"Language-Team: Norwegian Bokmål (http://www.transifex.com/rpm-team/rpm/language/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +100,7 @@ msgstr "ventet spørringsformat"
 msgid "unexpected query source"
 msgstr "uventet spørringskilde"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "kun ett større modi kan spesifiseres"
 
@@ -120,8 +119,7 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate og --excludepath kan kun brukes ved installasjon av nye pakker"
+msgstr "--relocate og --excludepath kan kun brukes ved installasjon av nye pakker"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -137,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -184,17 +183,13 @@ msgstr ""
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"skript som slår av alternativer kan kun spesifiseres under pakkeinstallasjon "
-"og sletting"
+msgstr "skript som slår av alternativer kan kun spesifiseres under pakkeinstallasjon og sletting"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"alternativer som slår av utløsing  kan kun spesifiseres under "
-"pakkeinstallasjon, og sletting"
+msgstr "alternativer som slår av utløsing  kan kun spesifiseres under pakkeinstallasjon, og sletting"
 
 #: rpmqv.c:231
 msgid ""
@@ -206,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -226,250 +221,201 @@ msgstr "ingen argumenter oppgitt for spørring"
 msgid "no arguments given for verify"
 msgstr "ingen argumenter oppgitt for verifisering"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "Feil under lesing av spec fil fra %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <specfil>"
+msgstr "bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <specfil>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfil>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "bygg kilde- og binærpakker fra <specfil>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "spør pakke som eier <fil>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <specfil>"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <tarball>"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "verifiser %files seksjon fra <tarball>"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "bygg kilde- og binærpakker fra <tarball>"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "bygg binær-pakke fra <kildepakke>"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<kildepakke>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "bygg binær-pakke fra <kildepakke>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verifiser %files seksjon fra <tarball>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "bygg binær-pakke fra <kildepakke>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "bygg binær-pakke fra <kildepakke>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "bygg binær-pakke fra <kildepakke>"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"bygg gjennom %prep (pakk ut kildekoden og legg til patcher) fra <tarball>"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "verifiser %files seksjon fra <tarball>"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "bygg kilde- og binærpakker fra <tarball>"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "bygg binær-pakke fra <kildepakke>"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "fjern byggtreet når ferdig"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "ikke kjør noen %%pre skriptlet (hvis noen)"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "fjern kildekoden når ferdig"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "hopp rett til spesifisert steg (kun for c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Kunne ikke åpne spec fil %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Kunne ikke åpne tar-rør: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Kunne ikke åpne spec fil %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Feil under lesing av spec-fil fra %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Feil under endring av navn fra %s til %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "kunne ikke kjøre stat på %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Fil %s er ikke en vanlig fil.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Fil %s ser ikke ut til å være en spec-fil.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Bygger målplattformene: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Bygger for mål %s\n"
@@ -518,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -538,9 +484,28 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Skriv inn passord: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Passord er ok.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -559,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -606,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM-feil under bygging:\n"
+msgstr "\n\nRPM-feil under bygging:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "syntaksfeil under lesing av ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "syntaksfeil under lesing av &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "syntaksfeil under lesing av ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "feil under lesing av uttrykk\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "ubalansert (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- kun på tall\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! kun på tall\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "typene må være like\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / ikke støttet for strenger\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- ikke støttet for strenger\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& og || ikke støttet for strenger\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "syntaksfeil i uttrykk\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Mangler '(' i %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Mangler ')' i %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ugyldig %s-tegn: %s\n"
@@ -680,46 +642,46 @@ msgstr "Ugyldig %s-tegn: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Filen må begynne med \"/\": %s\n"
@@ -729,144 +691,149 @@ msgstr "Filen må begynne med \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Fil listet to ganger: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolsk lenke peker til BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fil ikke funnet: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "Installerer %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ugyldig fil %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Ugyldig eier/gruppe: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -895,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunne ikke åpne %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunne ikke skrive pakke: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Ugyldige CSA-data\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Kunne ikke åpne %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread feilet: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1018,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linje %d: Ugyldig flagg %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1137,94 +1104,90 @@ msgstr "linje %d: Tagg tar kun et enkelt tegn: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linje %d: Ugyldig %s-nummer: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linje %d: Feilutformet tagg: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linje %d: Tom tagg: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linje %d: Prefiks må ikke slutte på \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linje %d: Docdir må begynne med '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linje %d: Ugyldig %s: kvalifikatorer: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linje %d: Ugyldig BuildArchitecture format: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Intern feil: Ugyldig tag %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ugyldig pakkespesifikasjon: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pakke eksisterer allerede: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linje %d: Ukjent tagg: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1234,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "kunne ikke opprette %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Feil under lesing av %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linje %d: Ugyldig argument til %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linje %d: Ugyldig %%setup flagg %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linje %d: %%prep for andre gang\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linje %d: triggere må ha --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linje %d: Feil under lesing av %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linje %d: skriptprogram må begynne med '/': %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linje %d: Andre %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linje %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Kan ikke åpne %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else uten %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif uten %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Ingen kompatible arkitekturer funnet for bygging\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakken har ingen %%description: %s\n"
@@ -1491,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Kunne ikke kjøre %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "klarte ikke å åpne %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Klarte ikke å finne %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s lagret som %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s opprettet som %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1894,16 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "relokasjoner må ha et / etter ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr "installer alle filer, selv konfigurasjoner som ellers kan hoppes over"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"fjern alle pakker som er lik <pakke> (normalt vil en feil genereres hvis "
-"<pakke> spesifiserer flere pakker)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "fjern alle pakker som er lik <pakke> (normalt vil en feil genereres hvis <pakke> spesifiserer flere pakker)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1981,7 +1920,7 @@ msgstr "oppdater databasen, men ikke modifiser filsystemet"
 msgid "do not verify package dependencies"
 msgstr "ikke verifiser pakkeavhengigheter"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2059,9 +1998,7 @@ msgstr "ikke kjør %%triggerpostun skriptlets"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"oppgrader til en gammel versjon av pakken (--force ved oppgraderinger gjør "
-"dette automatisk)"
+msgstr "oppgrader til en gammel versjon av pakken (--force ved oppgraderinger gjør dette automatisk)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2103,182 +2040,162 @@ msgstr "oppgrader pakke(r)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "spør/verifiser alle pakker"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "spør/verifiser pakke(r) som eier fil"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "spør/verifiser pakke(r) i gruppe"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm spørremodus"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "spør pakker utløst av <pakke>"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "spør etter pakker som tilbyr <funk> funksjonalitet"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "spør etter etter pakker som trenger <funk> funksjonalitet"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "ikke verifiser størrelse på filer"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "ikke verifiser sti til symbolske lenker for filer"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "ikke verifiser eier av filer"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "ikke verifiser gruppe for filer"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "ikke verifisert endringsdato for filer"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "ikke verifiser modus for filer"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "ikke verifiser filer i pakke"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "ikke verifiser pakkeavhengigheter"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "kildepakke forventet, binær funnet\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "kildepakke inneholder ikke en .spec-fil\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2353,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "ingen pakke krever %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "ingen pakke krever %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "ingen pakke utløser %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "ingen pakke krever %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "ingen pakke krever %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ingen pakke gir %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s eies ikke av noen pakke\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "ugyldig pakkenummer: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakke %s er ikke installert\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread feilet: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "IKKE OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: åpne feilet: %s\n"
@@ -2487,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NEI"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "ikke verifiser pakkeavhengigheter"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Ugyldig magi"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Ugyldig/ulesbar header"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "For stor header"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Ukjent filtype"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Intern feil"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " feilet - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "feil under åpning av %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2704,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Henter %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "feil under lesing fra fil %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "kan ikke åpne %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installerer %s\n"
@@ -2765,12 +2614,12 @@ msgstr "lesing feilet: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2932,75 +2781,56 @@ msgstr "ugyldig flagg '%s' ved %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Kan ikke lese ikon %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Kan ikke lese ikon %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite feilet: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -3012,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "kan ikke åpne pakkedatabase i %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3221,240 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3474,31 +3289,31 @@ msgstr "Fil %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Fil %s er mindre enn %u bytes\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3507,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "fatal feil: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "feil: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "advarsel: "
 
@@ -3528,121 +3343,99 @@ msgstr "advarsel: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "feil under lesing fra fil %s\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "feil under lesing fra fil %s\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite feilet: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: åpne feilet: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Kunne ikke åpne %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Kunne ikke åpne %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature feilet: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead feilet: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3655,30 +3448,3 @@ msgstr "%s: lesing av manifest feilet: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Skriv inn passord: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Passord er ok.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Ugyldig eier/gruppe: %s\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Kunne ikke skrive \"payload\" til %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Kunne ikke lese \"payload\" fra %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Kunne ikke åpne spec fil %s: %s\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Kunne ikke åpne sigmål %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Kunne ikke åpne spec fil %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Kunne ikke skrive header til %s: %s\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/rpm-team/rpm/language/nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -135,8 +135,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +200,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -221,201 +220,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
+#, c-format
+msgid "verify %files section from <source package>"
 msgstr ""
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
+msgid "build binary package only from <source package>"
+msgstr ""
+
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
+msgstr ""
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr ""
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -464,48 +505,61 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "<pakketbestand>+"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:127
-#, c-format
-msgid "Pass phrase is good.\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
 msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -524,7 +578,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -573,66 +627,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Ontbrekende '(' in %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Ontbrekende ')' in %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -642,46 +696,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr "Ontbrekende %s in %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -691,149 +745,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "regel: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +916,76 @@ msgstr "%s: regel: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -985,19 +1036,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1104,90 +1155,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "regel %d: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: regel: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1252,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "regel %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1422,290 +1509,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(geen getal)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(geen OpenPGP handtekening)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,14 +1912,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1920,7 +1997,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2040,162 +2117,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2270,96 +2363,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, c-format
+msgid "no package suggests %s\n"
+msgstr ""
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, c-format
+msgid "no package enhances %s\n"
+msgstr ""
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "bestand %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NIET OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (ONTBREKENDE SLEUTELS:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2384,144 +2497,191 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NEE "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+msgid "support for rich dependencies."
+msgstr ""
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Onbekend bestandstype"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Interne fout"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " mislukt - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2713,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2614,12 +2774,12 @@ msgstr "lezen mislukt: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2777,60 +2937,79 @@ msgstr "ontbrekende architectuur voor %s op %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Onbekend systeem: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, c-format
+msgid "Unable to reset nice value: %s"
+msgstr ""
+
+#: lib/rpmscript.c:354
+#, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr ""
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "lezen mislukt: %s (%d)\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3021,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "ontbrekende '(' in pakketlabel: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "ontbrekende ')' in pakketlabel: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(geen OpenPGP handtekening)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "ontbrekende   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3234,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(leeg)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(leeg)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Onbekende optie %c in %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== actief %d leeg %d\n"
@@ -3289,31 +3487,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3520,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(geen fout)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "fatale fout: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "fout: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "waarschuwing: "
 
@@ -3343,99 +3541,149 @@ msgstr "waarschuwing: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:66
+#, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr " mislukt - "
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg uitvoeren mislukt (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+msgid "headerReload failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+msgid "copyFile failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:622
+msgid "headerWrite failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,20 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Dutch (http://www.transifex.com/projects/p/rpm/language/nl/)\n"
-"Language: nl\n"
+"Language-Team: Dutch (http://www.transifex.com/rpm-team/rpm/language/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -135,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -200,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -220,243 +221,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, c-format
-msgid "verify %files section from <source package>"
-msgstr ""
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr ""
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr ""
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -505,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -525,9 +484,28 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr ""
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr ""
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -546,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -595,66 +573,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Ontbrekende '(' in %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Ontbrekende ')' in %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -664,46 +642,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr "Ontbrekende %s in %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -713,144 +691,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "regel: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -879,79 +862,79 @@ msgstr "%s: regel: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "lezen mislukt: %s (%d)\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1002,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1121,94 +1104,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "regel %d: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: regel: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1218,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "regel %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1475,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(geen getal)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(geen OpenPGP handtekening)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1878,13 +1834,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1963,7 +1920,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2083,178 +2040,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr ""
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2329,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, c-format
-msgid "no package suggests %s\n"
-msgstr ""
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, c-format
-msgid "no package enhances %s\n"
-msgstr ""
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "bestand %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NIET OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (ONTBREKENDE SLEUTELS:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2463,191 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NEE "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-msgid "support for rich dependencies."
-msgstr ""
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Onbekend bestandstype"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Interne fout"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " mislukt - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2679,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2740,12 +2614,12 @@ msgstr "lezen mislukt: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2907,75 +2781,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Onbekend systeem: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, c-format
-msgid "Unable to reset nice value: %s"
-msgstr ""
-
-#: lib/rpmscript.c:354
-#, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr ""
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "lezen mislukt: %s (%d)\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -2987,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "ontbrekende '(' in pakketlabel: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "ontbrekende ')' in pakketlabel: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(geen OpenPGP handtekening)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "ontbrekende   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3196,240 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(leeg)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(leeg)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Onbekende optie %c in %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== actief %d leeg %d\n"
@@ -3449,31 +3289,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3482,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(geen fout)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "fatale fout: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "fout: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "waarschuwing: "
 
@@ -3503,120 +3343,99 @@ msgstr "waarschuwing: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:64
-#, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr " mislukt - "
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:311
+#: sign/rpmgensig.c:284
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg uitvoeren mislukt (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Arkadiusz Miskiewicz <arekm@pld-linux.org>, 2003
 # Jakub Bogusz <qboosh@pld-linux.org>, 2002
@@ -12,15 +12,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-27 16:17+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/rpm-team/rpm/language/pl/)\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -41,7 +42,9 @@ msgstr "Copyright (C) 1998-2002 — Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Ten program może być swobodnie rozpowszechniany na warunkach licencji GNU GPL\n"
+msgstr ""
+"Ten program może być swobodnie rozpowszechniany na warunkach licencji GNU "
+"GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -84,7 +87,7 @@ msgstr "Opcje sprawdzania (z -V lub --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opcje instalacji/aktualizacji/usuwania:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Wspólne opcje dla wszystkich trybów i plików binarnych RPM:"
@@ -105,7 +108,7 @@ msgstr "nieoczekiwany format zapytania"
 msgid "unexpected query source"
 msgstr "nieoczekiwane źródło zapytania"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "może być podany tylko jeden główny tryb pracy"
 
@@ -124,7 +127,9 @@ msgstr "nie można użyć --prefix z --relocate lub --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate i --excludepath można użyć tylko podczas instalowania nowych pakietów"
+msgstr ""
+"--relocate i --excludepath można użyć tylko podczas instalowania nowych "
+"pakietów"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -140,8 +145,7 @@ msgid ""
 msgstr "--hash (-h) można podać tylko podczas instalacji i usuwaniu pakietów"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr "--percent można podać tylko podczas instalacji i usuwaniu pakietów"
 
 #: rpmqv.c:179
@@ -188,25 +192,31 @@ msgstr "--justdb można podać tylko podczas instalacji i usuwania pakietów"
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "opcje wyłączające skrypty można podać tylko podczas instalacji i usuwania pakietów"
+msgstr ""
+"opcje wyłączające skrypty można podać tylko podczas instalacji i usuwania "
+"pakietów"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "opcje wyłączające wyzwalacze można podać tylko podczas instalacji i usuwania pakietów"
+msgstr ""
+"opcje wyłączające wyzwalacze można podać tylko podczas instalacji i usuwania "
+"pakietów"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps można podać tylko podczas instalacji, usuwania i sprawdzania pakietów"
+msgstr ""
+"--nodeps można podać tylko podczas instalacji, usuwania i sprawdzania "
+"pakietów"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test można podać tylko podczas instalacji i usuwania pakietów"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametry dla --root (-r) muszą zaczynać się od /"
 
@@ -226,201 +236,256 @@ msgstr "nie podano parametrów dla zapytania"
 msgid "no arguments given for verify"
 msgstr "nie podano parametrów dla sprawdzenia"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot został już podany, ignorowanie %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-spec>"
+msgstr ""
+"zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-spec>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<plik-spec>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "zbudowanie przez %build (%prep i skompilowanie) z <pliku-spec>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-spec>"
+msgstr ""
+"zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-spec>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "sprawdzenie sekcji %files z <pliku-spec>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "zbudowanie pakietu źródłowego i binarnego z <pliku-spec>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "zbudowanie tylko pakietu binarnego z <pliku-spec>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pliku-spec>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-spec>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<pakiet-źródłowy>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "zbudowanie przez %build (%prep i skompilowanie) z <pliku-spec>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"zbudowanie przez %install (%prep, %build i zainstalowanie) z <pakietu-"
+"źródłowego>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "sprawdzenie sekcji %files z <pliku-spec>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "zbudowanie pakietu binarnego z <pakietu-źródłowego>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "zbudowanie pakietu binarnego z <pakietu-źródłowego>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "zbudowanie tylko pakietu źródłowego z <pliku-spec>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-tar>"
+msgstr ""
+"zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-tar>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<plik-tar>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "zbudowanie przez %build (%prep oraz skompilowanie) z <pliku-tar>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-tar>"
+msgstr ""
+"zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-tar>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "sprawdzenie sekcji %files z <pliku-tar>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "zbudowanie pakietu źródłowego i binarnego z <pliku-tar>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "zbudowanie tylko pakietu binarnego z <pliku-tar>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pliku-tar>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "zbudowanie pakietu binarnego z <pakietu-źródłowego>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<pakiet-źródłowy>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "zbudowanie przez %install (%prep, %build i zainstalowanie) z <pakietu-źródłowego>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "zastąpienie build root"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Nie można otworzyć bieżącego katalogu: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "usunięcie drzewa budowania po ukończeniu"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "zignorowanie dyrektywy ExcludeArch: z pliku spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "debugowanie maszyny stanów plików"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "bez wykonania żadnych etapów budowania"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "bez sprawdzania zależności budowania"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "utworzenie nagłówków pakietu zgodnych z (przestarzałymi) pakietami RPM v3"
+msgstr ""
+"utworzenie nagłówków pakietu zgodnych z (przestarzałymi) pakietami RPM v3"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "bez wykonywania etapu budowania %clean"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "bez wykonywania etapu budowania %clean"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "bez wykonywania etapu budowania %check"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "bez akceptowania wpisów msgstr i18n z pliku spec"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "usunięcie źródeł po ukończeniu"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "usunięcie pliku spec po ukończeniu"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "przejście od razu do podanego etapu (tylko dla c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "zastąpienie platformy docelowej"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opcje budowania z [ <plik-spec> | <plik-tar> | <pakiet-źródłowy> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Niespełnione zależności budowania:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Nie można otworzyć pliku spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Otwarcie potoku tar się nie powiodło: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Więcej niż jeden plik na wiersz: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Odczytanie pliku spec z %s się nie powiodło\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Zmiana nazwy %s na %s się nie powiodła: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "wykonanie stat na %s się nie powiodło: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Plik %s nie jest zwykłym plikiem.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Plik %s nie wygląda na plik spec.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Budowanie dla platform docelowych: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Budowanie dla %s\n"
@@ -431,7 +496,9 @@ msgstr "zainicjowanie bazy danych"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "przebudowanie odwrotne listy w bazie danych z nagłówków zainstalowanych pakietów"
+msgstr ""
+"przebudowanie odwrotne listy w bazie danych z nagłówków zainstalowanych "
+"pakietów"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -469,49 +536,64 @@ msgstr "wyświetlenie listy kluczy z bazy kluczy RPM"
 msgid "Keyring options:"
 msgstr "Opcje bazy kluczy:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "nie podano parametrów"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "podpisanie pakietów"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "podpisanie pakietów (identyczne z --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "usunięcie podpisów pakietów"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "podpisanie pakietów"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opcje podpisu:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Nie można wykonać %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Należy ustawić „%%_gpg_name” w pliku makr\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Proszę podać hasło: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Hasło jest dobre.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Sprawdzenie hasła się nie powiodło lub klucz GPG wygasł\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix można użyć tylko podczas instalowania nowych pakietów"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches można podać tylko podczas usuwania pakietów"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -523,13 +605,14 @@ msgstr "odpytuje pliki spec"
 
 #: rpmspec.c:30
 msgid "operate on binary rpms generated by spec (default)"
-msgstr "działa na binarnych pakietach RPM utworzonych przez plik spec (domyślnie)"
+msgstr ""
+"działa na binarnych pakietach RPM utworzonych przez plik spec (domyślnie)"
 
 #: rpmspec.c:32
 msgid "operate on source rpm generated by spec"
 msgstr "działa na źródłowych pakietach RPM utworzonych przez plik spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "użycie następującego formatu zapytania"
 
@@ -576,68 +659,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nBłędy budowania pakietu RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Błędy budowania pakietu RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "błąd składni podczas przetwarzania ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "błąd składni podczas przetwarzania &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "błąd składni podczas przetwarzania ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "błąd przetwarzania w wyrażeniu\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "niesparowane (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- tylko na liczbach\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! tylko na liczbach\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "typy muszą się zgadzać\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / nie są obsługiwane dla ciągów\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- nie jest obsługiwane dla ciągów\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& i || nie są obsługiwane dla ciągów\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "błąd składni w wyrażeniu\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Brak „(” w %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Brak „)” w %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Nieprawidłowy token %s: %s\n"
@@ -647,46 +733,46 @@ msgstr "Nieprawidłowy token %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Brak %s w %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Brak białego znaku po %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Błędna składnia: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Błędny tryb spec: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Błędny tryb katalogu spec: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Niezwykła długość lokalizacji: „%s” w %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Podwójna lokalizacja %s w %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Nieprawidłowa możliwość: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Obsługa możliwości plików nie jest wbudowana\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Plik musi zaczynać się od „/”: %s\n"
@@ -696,149 +782,153 @@ msgstr "Plik musi zaczynać się od „/”: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Nieznany algorytm skrótu pliku %u, używanie w zamian MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Plik podany dwukrotnie: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "odczytanie dowiązania symbolicznego %s się nie powiodło: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Dowiązanie symboliczne wskazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Ścieżka jest poza buildroot: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Nie odnaleziono katalogu: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Nie odnaleziono pliku: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Nie jest katalogiem: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nie można wczytać nieznanego znacznika (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: odczytanie klucza publicznego się nie powiodło.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: nie jest opakowanym kluczem publicznym.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: odkodowanie się nie powiodło\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Plik musi zaczynać się od „/”: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Wyrażenie regularne %%dev nie jest dozwolone: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Katalog nie został odnaleziony przez wyrażenie regularne: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Nie odnaleziono pliku przez wyrażenie regularne: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Nie można otworzyć pliku %s w %%files: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "wiersz: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Pusty plik %s w %%files\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Błąd podczas odczytywania pliku %s w %%files: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Nie odnaleziono pliku przez wyrażenie regularne: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Nie można mieszać specjalnego %s z innymi formami: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Więcej niż jeden plik na wiersz: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Błędny plik: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Błędny właściciel/grupa: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Sprawdzanie niespakietowanych plików: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Odnaleziono zainstalowane (ale niespakietowane) pliki:\n%s"
+msgstr ""
+"Odnaleziono zainstalowane (ale niespakietowane) pliki:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Przetwarzanie plików: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "Architektura plików binarnych (%d) nie zgadza się z architekturą pakietu (%d).\n"
+msgstr ""
+"Architektura plików binarnych (%d) nie zgadza się z architekturą pakietu "
+"(%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Pliki binarne zależne od architektury w pakiecie noarch\n"
 
@@ -867,79 +957,76 @@ msgstr "%s: wiersz: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nie można ustalić kanonicznej nazwy komputera: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Nie można ponownie wczytać nagłówka podpisu.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nieznana kompresja danych: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Nie można utworzyć niezmiennej części nagłówka.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nie można otworzyć %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nie można zapisać pakietu: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Nie można zapisać tymczasowego nagłówka\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Błędne dane CSA\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Nie można wyszukać w pliku %s: %s\n"
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "„Fread” się nie powiodło w %s: %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Wykonywanie „%s”:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Wykonanie „%s” się nie powiodło.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Sprawdzenie pakietu „%s” się nie powiodło.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nie można utworzyć wyjściowej nazwy pliku dla pakietu %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nie można utworzyć %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "wiersz %d: drugi %s\n"
@@ -990,19 +1077,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "wiersz %d: błąd podczas przetwarzania %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "wiersz %d: błędna opcja %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "wiersz %d: za dużo nazw: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "wiersz %d: pakiet nie istnieje: %s\n"
@@ -1108,91 +1195,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "wiersz %d: znacznik przyjmuje tylko jeden token: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "wiersz %d: niedozwolony znak „%c” w: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "wiersz %d: niedozwolony znak w: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "wiersz %d: niedozwolona sekwencja „..” w: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "wiersz %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: wiersz: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "wiersz %d: błędnie sformowany znacznik: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "wiersz %d: pusty znacznik: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "wiersz %d: przedrostki nie mogą kończyć się na „/”: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "wiersz %d: Docdir musi zaczynać się od „/”: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "wiersz %d: pole Epoch musi być niepodpisaną liczbą: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "wiersz %d: błędne określenia %s: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "wiersz %d: błędny format BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "wiersz %d: obsługiwane są tylko podpakiety noarch: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Wewnętrzny błąd: fałszywy znacznik %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "wiersz %d: %s jest przestarzałe: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Błędna specyfikacja pakietu: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pakiet już istnieje: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "wiersz %d: nieznany znacznik: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} nie może być puste\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} nie może być „/”\n"
@@ -1202,161 +1294,196 @@ msgstr "%%{buildroot} nie może być „/”\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Błędne źródło: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Brak łaty numer %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch bez odpowiadającego mu znacznika „Patch:”\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Brak źródła numer %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Brak znacznika „Source:” w pliku spec\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Błąd podczas przetwarzania %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "wiersz %d: błędny parametr dla %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "wiersz %d: błędna opcja %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Nieprawidłowy numer łaty %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "wiersz %d: drugie %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr "Tokeny zależności muszą zaczynać się od znaków alfanumerycznych, „_” lub „/”"
+msgstr ""
+"Tokeny zależności muszą zaczynać się od znaków alfanumerycznych, „_” lub „/”"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Wersja w nazwie pliku jest niedozwolona"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Wersja jest wymagana"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "nieprawidłowa zależność"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Wersja jest wymagana"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "wiersz %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "wiersz %d: wyzwalacze muszą posiadać --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "wiersz %d: błąd podczas przetwarzania %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "wiersz %d: wewnętrzny skrypt musi kończyć się „>”: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "wiersz %d: program skryptu musi zaczynać się od „/”: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+"wiersz %d: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "wiersz %d: drugi %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "wiersz %d: wewnętrzny skrypt jest nieobsługiwany: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr "wiersz %d: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
+msgstr ""
+"wiersz %d: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "wiersz %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nie można otworzyć %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: oczekiwano parametru dla %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "wiersz %d: niezamknięte %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "wiersz %d: niezamknięte makro lub błędna kontynuacja wiersza\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: błędny warunek %%if\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: napotkano %%else bez %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: napotkano %%endif bez %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: błędnie sformatowany zwrot %%include\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Nie odnaleziono zgodnych architektur do zbudowania\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakiet nie posiada %%description: %s\n"
@@ -1400,7 +1527,9 @@ msgstr "Ustalenie nazwy polityki się nie powiodło: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "Typ „%s” został podany razem z innymi typami w %%semodule %s. Kompaktowanie typów do „%s”.\n"
+msgstr ""
+"Typ „%s” został podany razem z innymi typami w %%semodule %s. Kompaktowanie "
+"typów do „%s”.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1427,291 +1556,285 @@ msgstr "Za dużo parametrów w wierszu: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Przetwarzanie polityk: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorowanie nieprawidłowego wyrażenia regularnego %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nie można utworzyć potoku dla %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Nie można wykonać %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nie można rozdzielić %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s się nie powiodło: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "zapisanie wszystkich danych do %s się nie powiodło: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "błędny operator"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "błędny format"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "nieprawidłowa zależność (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konwersja %s na długą liczbę całkowitą się nie powiodła.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Pusty klasyfikator pliku\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Brak skonfigurowanych atrybutów plików\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) się nie powiodło: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load się nie powiodło: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rozpoznanie pliku „%s” się nie powiodło: tryb %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Wyszukiwanie %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Odnalezienie %s się nie powiodło:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "odpytanie pliku spec %s się nie powiodło, nie można przetworzyć\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
-msgstr "%s jest pakietem RPM Delta i nie może zostać bezpośrednio zainstalowany\n"
+msgstr ""
+"%s jest pakietem RPM Delta i nie może zostać bezpośrednio zainstalowany\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nieobsługiwane dane (%s) w pakiecie %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "pakiet %s został już dodany, pomijanie %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "pakiet %s został już dodany, zastępowanie %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(nie jest liczbą)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(nie jest base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(nieprawidłowy typ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(nie jest „blob”)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(nieprawidłowy typ XML)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(nie jest podpisem OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Nieprawidłowa data %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "zwykły"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "zastąpiony"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "niezainstalowany"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "udostępniony w sieci"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "błędny kolor"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "brak"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(nieznany)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(nie jest ciągiem)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s zapisano jako %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s utworzono jako %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: usunięcie się nie powiodło: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "katalog"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "plik"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "nie można sprawdzić podpisu %s"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik[%d]: BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr "hdr SHA1: BŁĘDNY, nie jest szesnastkowy"
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr "hdr RSA: BŁĘDNY, nie jest binarny"
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr "hdr DSA: BŁĘDNY, nie jest binarny"
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik regionu: BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "offset regionu: BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "zakończenie regionu: BŁĘDNE, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr "rozmiar regionu: BŁĘDNY, ril(%d) > il(%d)"
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "rozmiar blob(%d): BŁĘDNY, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "rozmiar hdr(%d): BŁĘDNY, odczytanie zwróciło %d"
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr "magic hdr: BŁĘDNE"
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "znaczniki hdr: BŁĘDNE, liczba znaczników(%d) jest poza zakresem"
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "dane hdr: BŁĘDNE, liczba bajtów(%d) jest poza zakresem"
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "blob hdr(%zd): BŁĘDNE, odczytanie zwróciło %d"
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr "load hdr: BŁĘDNE"
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "„Fread” się nie powiodło: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr "%s: błąd: podano więcej niż jedną opcję --pipe (niezgodne aliasy biblioteki popt?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr ""
+"%s: błąd: podano więcej niż jedną opcję --pipe (niezgodne aliasy biblioteki "
+"popt?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1839,15 +1962,18 @@ msgid "relocations must have a / following the ="
 msgstr "przesunięcia muszą zawierać / po ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "zainstalowanie wszystkich plików, nawet konfiguracyjnych, które w innym przypadku by pominięto"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"zainstalowanie wszystkich plików, nawet konfiguracyjnych, które w innym "
+"przypadku by pominięto"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "usunięcie wszystkich pakietów, które zgadzają się z <pakietem> (zwykle tworzony jest błąd, jeśli <pakiet> podaje wiele pakietów)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"usunięcie wszystkich pakietów, które zgadzają się z <pakietem> (zwykle "
+"tworzony jest błąd, jeśli <pakiet> podaje wiele pakietów)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1925,7 +2051,7 @@ msgstr "zaktualizowanie bazy danych, ale bez modyfikacji systemu plików"
 msgid "do not verify package dependencies"
 msgstr "bez sprawdzania zależności pakietu"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "bez sprawdzania skrótów plików"
 
@@ -2003,7 +2129,9 @@ msgstr "bez wykonania żadnych skryptów %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "zaktualizowanie do poprzedniej wersji pakietu (--force podczas aktualizowania robi to automatycznie)"
+msgstr ""
+"zaktualizowanie do poprzedniej wersji pakietu (--force podczas "
+"aktualizowania robi to automatycznie)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2045,162 +2173,182 @@ msgstr "zaktualizowanie pakietów"
 msgid "reinstall package(s)"
 msgstr "ponowne zainstalowanie pakietów"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "odpytanie/sprawdzenie wszystkich pakietów"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "tryb sprawdzania podpisów pakietów RPM"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "odpytanie/sprawdzenie pakietów zawierających plik"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "odpytanie/sprawdzenie pakietów w grupie"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "odpytanie/sprawdzenie pliku pakietu"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "odpytanie/sprawdzenie pakietów z identyfikatorem pakietu"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "odpytanie/sprawdzenie pakietów z identyfikatorem nagłówka"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "tryb odpytywania pakietów RPM"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "odpytanie/sprawdzenie instancji nagłówka"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "odpytanie/sprawdzenie pakietów z transakcji instalacji"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "odpytanie pakietów wyzwalanych przez pakiet"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "tryb sprawdzania pakietów RPM"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "odpytanie/sprawdzenie pakietów dostarczających zależność"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "bez używania wyrażeń regularnych w parametrach"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "bez przetwarzania plików nie będących pakietami jako manifesty"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "wyświetlenie listy wszystkich plików konfiguracyjnych"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "wyświetlenie listy wszystkich plików dokumentacji"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "wyświetlenie listy wszystkich plików licencji"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "zrzucenie podstawowych informacji o pliku"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "wyświetlenie listy plików pakietu"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "pominięcie plików %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "wyświetlenie stanu wyświetlonych plików"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "bez sprawdzania rozmiaru plików"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "bez sprawdzania ścieżek dowiązań symbolicznych plików"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "bez sprawdzania właścicieli plików"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "bez sprawdzania grup plików"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "bez sprawdzania czasu modyfikacji plików"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "bez sprawdzania trybu plików"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "bez sprawdzania możliwości plików"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "bez sprawdzania kontekstów bezpieczeństwa plików"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "bez sprawdzania plików pakietu"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "bez sprawdzania zależności pakietu"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "bez wykonania żadnych skryptów sprawdzania"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Brak funkcji rpmlib dla %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "oczekiwano pakietu źródłowego, odnaleziono binarny\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "pakiet źródłowy nie zawiera pliku .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozpakowanie archiwum się nie powiodło%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " na pliku "
 
@@ -2275,96 +2423,117 @@ msgstr "brak pakietów pasujących do %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "brak pakietów wymagających %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "brak pakietów wymagających %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "brak pakietów wyzwalających %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "brak pakietów wymagających %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "brak pakietów wymagających %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "brak pakietów dostarczających %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "plik %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "plik %s nie należy do żadnego pakietu\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "nieprawidłowy numer pakietu: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "nie można odczytać wpisu %u\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakiet %s nie jest zainstalowany\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nieznany znacznik: „%s”\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: zaimportowanie klucza %d się nie powiodło.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: klucz %d nie jest opakowanym kluczem publicznym.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: zaimportowanie read się nie powiodło(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead się nie powiodło: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: nie można odczytać niezmiennego regionu nagłówka. Uszkodzony pakiet?\n"
+msgstr ""
+"%s: nie można odczytać niezmiennego regionu nagłówka. Uszkodzony pakiet?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: „Fread” się nie powiodło: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NIE DOBRZE"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (BRAK KLUCZY:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NIEZAUFANE KLUCZE:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otwarcie się nie powiodło: %s\n"
@@ -2389,144 +2558,198 @@ msgstr "Nie można zmienić katalogu roota: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Nie można przywrócić katalogu roota: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NIE "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "TAK"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Zależności PreReq:, Provides: i Obsoletes: obsługują wersje."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "nazwy plików przechowano jako krotka (dirName,baseName,dirIndex), a nie jako ścieżki."
+msgstr ""
+"nazwy plików przechowano jako krotka (dirName,baseName,dirIndex), a nie jako "
+"ścieżki."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "dane pakietu mogą zostać skompresowane używając bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "dane pakietu mogą zostać skompresowane używając xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "dane pakietu mogą zostać skompresowane używając lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "pliki danych pakietu posiadają przedrostek „./”."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "pakiet nazwa-wersja-wydanie nie jest domyślnie dostarczany."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "znaczniki nagłówka są zawsze porządkowane po wczytaniu."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "interpreter skryptów może używać parametrów z nagłówka."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "plik twardego dowiązania może zostać zainstalowany bez ukończenia."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "skrypty pakietu mogą odwoływać się do bazy danych RPM podczas instalowania."
+msgstr ""
+"skrypty pakietu mogą odwoływać się do bazy danych RPM podczas instalowania."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "wewnętrzna obsługa skryptów Lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "algorytm skrótu pliku jest konfigurowalny dla każdego pakietu osobno"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "obsługa możliwości plików POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "skrypty pakietu mogą być rozszerzane w czasie instalacji."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "rozwiązywanie zależności obsługuje wersje zawierające tyldę."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "obsługa plików większych niż 4 GB"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "bez sprawdzania zależności pakietu"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Wersja jest wymagana"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "nieprawidłowa zależność"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Niezakończone %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "nieprawidłowa zależność"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "użytkownik %s nie istnieje — używanie roota\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupa %s nie istnieje — używanie roota\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Błędne magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Błędny/nieczytelny nagłówek"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Rozmiar nagłówka jest za duży"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Plik jest za duży dla archiwum"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Nieznany typ pliku"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Brak plików"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Skrót nie zgadza się"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Wewnętrzny błąd"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Plik archiwum nie znajduje się w nagłówku"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " się nie powiodło — "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (błąd 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otwarcie %s się nie powiodło: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: nie jest pakietem RPM (ani manifestem pakietu)\n"
@@ -2558,42 +2781,42 @@ msgstr "Niespełnione zależności:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: nie jest pakietem RPM (ani manifestem pakietu): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s nie może zostać zainstalowany\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Pobieranie %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "pomijanie %s — przesłanie się nie powiodło\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "pakiet %s nie jest przesuwalny\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "błąd podczas odczytywania z pliku %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "„%s” podaje wiele pakietów:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "nie można otworzyć %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instalowanie %s\n"
@@ -2619,12 +2842,12 @@ msgstr "odczytanie się nie powiodło: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "nie jest pakietem RPM\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "nie można utworzyć blokady %s na %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "oczekiwanie na blokadę %s na %s\n"
@@ -2782,60 +3005,80 @@ msgstr "brak architektury dla %s w %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "błędna opcja „%s” w %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
-msgstr "Odczytanie pomocniczego wektora się nie powiodło, nie zamontowano /proc?\n"
+msgstr ""
+"Odczytanie pomocniczego wektora się nie powiodło, nie zamontowano /proc?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Nieznany system: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Proszę skontaktować się z %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Nie można otworzyć %s do odczytania: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Nie można przywrócić bieżącego katalogu: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "Obsługa skryptów <lua> nie jest wbudowana\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Nie można utworzyć pliku tymczasowego dla %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Nie można utworzyć kopii deskryptora pliku: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Nie można odczytać ikony %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Nie można przywrócić katalogu roota: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: „Fwrite” się nie powiodło: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "Skrypt %s się nie powiódł, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "Skrypt %s się nie powiódł, sygnał %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "Skrypt %s się nie powiódł, stan wyjścia %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Nieznany format"
 
@@ -2847,127 +3090,146 @@ msgstr "instalacja"
 msgid "erase"
 msgstr "usunięcie"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "nie można otworzyć bazy danych pakietów w %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "dodatkowe „(” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "brak „(” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "brak „)” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: odczytanie klucza publicznego się nie powiodło.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transakcji"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(nie jest podpisem OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr "rozmiar sigh(%d): BŁĘDNY, odczytanie zwróciło %d"
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr "magic sigh: BŁĘDNE"
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr "znaczniki sigh: BŁĘDNE, liczba znaczników(%d) jest poza zakresem"
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr "dane sigh: BŁĘDNE, liczba bajtów(%d) jest poza zakresem"
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr "blob sigh(%d): BŁĘDNE, odczytanie zwróciło %d"
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik sigh(%d): BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr "load sigh: BŁĘDNE"
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "pad sigh(%zd): BŁĘDNE, odczyt %zd bajtów"
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigSize sigh(%zd): BŁĘDNE, fstat(2) się nie powiodło"
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "Skrót MD5:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Nie można ponownie wczytać nagłówka podpisu.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Skrót SHA1 nagłówka:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Nagłówek "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "Skrót MD5:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Skrót SHA1 nagłówka:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Sprawdzenie podpisu: BŁĘDNE PARAMETRY (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "pominięto"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "się nie powiodło"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr "Podwójna nazwa użytkownika lub UID dla użytkownika %s\n"
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr "Podwójna nazwa grupy lub GID dla grupy %s\n"
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "brak stanu"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "nieznany stan"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "brak   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Niespełnione zależności dla %s:\n"
@@ -3041,240 +3303,244 @@ msgstr "iterator tablicy użyty na tablicach o różnych rozmiarach"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Tworzenie %d brakujących indeksów, proszę czekać…\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "nie można otworzyć indeksu %s używając %s — %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "ścieżka bazy danych nie została ustawiona\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: pomijanie"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "błąd(%d) podczas zapisywania wpisu #%d do %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: pomijanie"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: pobrano uszkodzony nagłówek #%u — pomijanie.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nie można odczytać nagłówka pod 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "ścieżka bazy danych nie została ustawiona"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "utworzenie katalogu %s się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "nagłówek #%u w bazie danych jest błędny — pomijanie.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nie można dodać wpisu będącego pierwotnie przy %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "przebudowanie bazy danych się nie powiodło: pierwotna baza danych pozostała na miejscu\n"
+msgstr ""
+"przebudowanie bazy danych się nie powiodło: pierwotna baza danych pozostała "
+"na miejscu\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "zamiana poprzedniej bazy danych na nową się nie powiodła.\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "aby odzyskać, należy zastąpić pliki w %s plikami z %s"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "usunięcie katalogu %s się nie powiodło: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s błąd(%d) z %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s błąd(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "nie można otrzymać blokady %s na %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "współdzielonej"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "wyłącznej"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "nieprawidłowy typ indeksu %x w %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "błąd(%d) podczas uzyskiwania wpisów „%s” z indeksu %s: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "błąd(%d) podczas zapisywania wpisu „%s” do %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "błąd(%d) usuwania wpisu „%s” z %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "błąd(%d) podczas dodawania wpisu nagłówka #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "błąd(%d) podczas usuwania wpisu nagłówka #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "błąd(%d) podczas przydzielania nowej instancji pakietu\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "nierozpoznana opcja bazy danych: zignorowano „%s”.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s ma nieprawidłową wartość liczbową, pominięto\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s ma za dużą lub za małą wartość long, pominięto\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s ma za dużą lub za małą wartość całkowitą, pominięto\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "nie można otrzymać blokady %s na %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "współdzielonej"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "wyłącznej"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "nieprawidłowy typ indeksu %x w %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "błąd(%d) podczas uzyskiwania wpisów „%s” z indeksu %s: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "błąd(%d) podczas zapisywania wpisu „%s” do %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "błąd(%d) usuwania wpisu „%s” z %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "błąd(%d) podczas dodawania wpisu nagłówka #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "błąd(%d) podczas usuwania wpisu nagłówka #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "błąd(%d) podczas przydzielania nowej instancji pakietu\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(puste)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(puste)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s posiada niezakończone opcje\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s posiada niezakończone ciało\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s posiada niedozwoloną nazwę (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s posiada puste ciało\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makro %%%s wymaga spacji przed treścią\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Rozwinięcie makra %%%s się nie powiodło\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s posiada niedozwoloną nazwę (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Określono makro %%%s, ale nie jest używane w ramach zakresu\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nieznana opcja %c w %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Za dużo poziomów rekurencji w rozwinięciu makra. Prawdopodobnie jest to spowodowane rekurencyjną deklaracją makra.\n"
+msgstr ""
+"Za dużo poziomów rekurencji w rozwinięciu makra. Prawdopodobnie jest to "
+"spowodowane rekurencyjną deklaracją makra.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Niezakończone %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Makro niemożliwe do przetworzenia po %%\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "wczytanie pliku makra %s się nie powiodło"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktywne %d puste %d\n"
@@ -3294,31 +3560,31 @@ msgstr "Plik %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Plik %s jest mniejszy niż %u bajtów\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "utworzenie katalogu się nie powiodło"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nieprawidłowa składnia skryptu Lua: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nieprawidłowa składnia skryptu Lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "skrypt Lua się nie powiódł: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nieprawidłowa składnia pliku Lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "hak Lua się nie powiódł: %s\n"
@@ -3327,19 +3593,19 @@ msgstr "hak Lua się nie powiódł: %s\n"
 msgid "[none]"
 msgstr "[brak]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(brak błędu)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "krytyczny błąd: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "błąd: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "ostrzeżenie: "
 
@@ -3348,99 +3614,154 @@ msgstr "ostrzeżenie: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "przydzielenie pamięci (%u bajtów) zwróciło NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, identyfikator klucza %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(brak)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "błąd podczas tworzenia pliku tymczasowego %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "błąd podczas tworzenia pliku tymczasowego %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "błąd podczas tworzenia pliku tymczasowego %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "utworzenie katalogu %s się nie powiodło: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: „Fwrite” się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: „Fflush” się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Nieobsługiwany podpis PGP\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Nieobsługiwany algorytm mieszania PGP %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Nieobsługiwany algorytm klucza publicznego PGP %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Nie można utworzyć potoku do podpisania: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Nie można wykonać %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "„fdopen” się nie powiodło\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "Nie można zapisać do potoku\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "Nie można odczytać z pliku %s: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "wykonanie gpg się nie powiodło (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "zapisanie podpisu przez gpg się nie powiodło\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "nie można odczytać podpisu\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature się nie powiodło: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature się nie powiodło: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: headerRead się nie powiodło: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp się nie powiodło\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "„fdopen” się nie powiodło\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: headerRead się nie powiodło: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s zawiera już identyczny podpis, pomijanie\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature się nie powiodło: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Nie można podpisywać pakietów RPM v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s zawiera już identyczny podpis, pomijanie\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp się nie powiodło\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "zastąpienie %s się nie powiodło: %s\n"
@@ -3453,3 +3774,27 @@ msgstr "%s: odczytanie manifestu się nie powiodło: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "bez sprawdzania podpisu nagłówka+danych"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Proszę podać hasło: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Hasło jest dobre.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "Sprawdzenie hasła się nie powiodło lub klucz GPG wygasł\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Błędny właściciel/grupa: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "wiersz %d: niedozwolony znak w: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "nie można sprawdzić podpisu %s"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "„Fread” się nie powiodło: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Nie można utworzyć potoku do podpisania: %m"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,28 +1,26 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Arkadiusz Miskiewicz <arekm@pld-linux.org>, 2003
 # Jakub Bogusz <qboosh@pld-linux.org>, 2002
 # Paweł Dziekoński <pdziekonski@mml.ch.pwr.wroc.pl>, 1999
-# Piotr Drąg <piotrdrag@gmail.com>, 2007,2011-2012
+# Piotr Drąg <piotrdrag@gmail.com>, 2007,2011-2012,2014-2015
 # Wojciech Drapiński <wojciech.drapinski@zie.pg.gda.pl>, 1999
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 16:05+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-27 16:17+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Polish (http://www.transifex.com/projects/p/rpm/language/"
-"pl/)\n"
-"Language: pl\n"
+"Language-Team: Polish (http://www.transifex.com/rpm-team/rpm/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2);\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -37,15 +35,13 @@ msgstr "RPM wersja %s\n"
 #: cliutils.c:32
 #, c-format
 msgid "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
-msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
+msgstr "Copyright (C) 1998-2002 — Red Hat, Inc.\n"
 
 #: cliutils.c:33
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Ten program może być swobodnie rozpowszechniany na warunkach licencji GNU "
-"GPL\n"
+msgstr "Ten program może być swobodnie rozpowszechniany na warunkach licencji GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -88,7 +84,7 @@ msgstr "Opcje sprawdzania (z -V lub --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opcje instalacji/aktualizacji/usuwania:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Wspólne opcje dla wszystkich trybów i plików binarnych RPM:"
@@ -109,7 +105,7 @@ msgstr "nieoczekiwany format zapytania"
 msgid "unexpected query source"
 msgstr "nieoczekiwane źródło zapytania"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "może być podany tylko jeden główny tryb pracy"
 
@@ -128,9 +124,7 @@ msgstr "nie można użyć --prefix z --relocate lub --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate i --excludepath można użyć tylko podczas instalowania nowych "
-"pakietów"
+msgstr "--relocate i --excludepath można użyć tylko podczas instalowania nowych pakietów"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -146,7 +140,8 @@ msgid ""
 msgstr "--hash (-h) można podać tylko podczas instalacji i usuwaniu pakietów"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr "--percent można podać tylko podczas instalacji i usuwaniu pakietów"
 
 #: rpmqv.c:179
@@ -193,31 +188,25 @@ msgstr "--justdb można podać tylko podczas instalacji i usuwania pakietów"
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"opcje wyłączające skrypty można podać tylko podczas instalacji i usuwania "
-"pakietów"
+msgstr "opcje wyłączające skrypty można podać tylko podczas instalacji i usuwania pakietów"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"opcje wyłączające wyzwalacze można podać tylko podczas instalacji i usuwania "
-"pakietów"
+msgstr "opcje wyłączające wyzwalacze można podać tylko podczas instalacji i usuwania pakietów"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps można podać tylko podczas instalacji, usuwania i sprawdzania "
-"pakietów"
+msgstr "--nodeps można podać tylko podczas instalacji, usuwania i sprawdzania pakietów"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test można podać tylko podczas instalacji i usuwania pakietów"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametry dla --root (-r) muszą zaczynać się od /"
 
@@ -237,256 +226,201 @@ msgstr "nie podano parametrów dla zapytania"
 msgid "no arguments given for verify"
 msgstr "nie podano parametrów dla sprawdzenia"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot został już podany, ignorowanie %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-spec>"
+msgstr "zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-spec>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<plik-spec>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "zbudowanie przez %build (%prep i skompilowanie) z <pliku-spec>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-spec>"
+msgstr "zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-spec>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "sprawdzenie sekcji %files z <pliku-spec>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "zbudowanie pakietu źródłowego i binarnego z <pliku-spec>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "zbudowanie tylko pakietu binarnego z <pliku-spec>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pliku-spec>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-spec>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<pakiet-źródłowy>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "zbudowanie przez %build (%prep i skompilowanie) z <pliku-spec>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"zbudowanie przez %install (%prep, %build i zainstalowanie) z <pakietu-"
-"źródłowego>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "sprawdzenie sekcji %files z <pliku-spec>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "zbudowanie pakietu binarnego z <pakietu-źródłowego>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "zbudowanie pakietu binarnego z <pakietu-źródłowego>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "zbudowanie tylko pakietu źródłowego z <pliku-spec>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-tar>"
+msgstr "zbudowanie przez %prep (rozpakowanie źródeł i nałożenie łat) z <pliku-tar>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<plik-tar>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "zbudowanie przez %build (%prep oraz skompilowanie) z <pliku-tar>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-tar>"
+msgstr "zbudowanie przez %install (%prep, %build i zainstalowanie) z <pliku-tar>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "sprawdzenie sekcji %files z <pliku-tar>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "zbudowanie pakietu źródłowego i binarnego z <pliku-tar>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "zbudowanie tylko pakietu binarnego z <pliku-tar>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pliku-tar>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "zbudowanie pakietu binarnego z <pakietu-źródłowego>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<pakiet-źródłowy>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "zbudowanie przez %install (%prep, %build i zainstalowanie) z <pakietu-źródłowego>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "zastąpienie build root"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Nie można otworzyć bieżącego katalogu: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "usunięcie drzewa budowania po ukończeniu"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "zignorowanie dyrektywy ExcludeArch: z pliku spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "debugowanie maszyny stanów plików"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "bez wykonania żadnych etapów budowania"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "bez sprawdzania zależności budowania"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
-"utworzenie nagłówków pakietu zgodnych z (przestarzałymi) pakietami RPM v3"
+msgstr "utworzenie nagłówków pakietu zgodnych z (przestarzałymi) pakietami RPM v3"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "bez wykonywania etapu budowania %clean"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "bez wykonywania etapu budowania %clean"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "bez wykonywania etapu budowania %check"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "bez akceptowania wpisów msgstr i18n z pliku spec"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "usunięcie źródeł po ukończeniu"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "usunięcie pliku spec po ukończeniu"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "przejście od razu do podanego etapu (tylko dla c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "zastąpienie platformy docelowej"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opcje budowania z [ <plik-spec> | <plik-tar> | <pakiet-źródłowy> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Niespełnione zależności budowania:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Nie można otworzyć pliku spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Otwarcie potoku tar się nie powiodło: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Więcej niż jeden plik na wiersz: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Odczytanie pliku spec z %s się nie powiodło\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Zmiana nazwy %s na %s się nie powiodła: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "wykonanie stat na %s się nie powiodło: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Plik %s nie jest zwykłym plikiem.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Plik %s nie wygląda na plik spec.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Budowanie dla platform docelowych: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Budowanie dla %s\n"
@@ -497,9 +431,7 @@ msgstr "zainicjowanie bazy danych"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"przebudowanie odwrotne listy w bazie danych z nagłówków zainstalowanych "
-"pakietów"
+msgstr "przebudowanie odwrotne listy w bazie danych z nagłówków zainstalowanych pakietów"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -537,7 +469,7 @@ msgstr "wyświetlenie listy kluczy z bazy kluczy RPM"
 msgid "Keyring options:"
 msgstr "Opcje bazy kluczy:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "nie podano parametrów"
 
@@ -557,10 +489,29 @@ msgstr "usunięcie podpisów pakietów"
 msgid "Signature options:"
 msgstr "Opcje podpisu:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Nie można wykonać %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
-msgstr "Należy ustawić \"%%_gpg_name\" w pliku makr\n"
+msgstr "Należy ustawić „%%_gpg_name” w pliku makr\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Proszę podać hasło: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Hasło jest dobre.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Sprawdzenie hasła się nie powiodło lub klucz GPG wygasł\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -572,14 +523,13 @@ msgstr "odpytuje pliki spec"
 
 #: rpmspec.c:30
 msgid "operate on binary rpms generated by spec (default)"
-msgstr ""
-"działa na binarnych pakietach RPM utworzonych przez plik spec (domyślnie)"
+msgstr "działa na binarnych pakietach RPM utworzonych przez plik spec (domyślnie)"
 
 #: rpmspec.c:32
 msgid "operate on source rpm generated by spec"
 msgstr "działa na źródłowych pakietach RPM utworzonych przez plik spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "użycie następującego formatu zapytania"
 
@@ -626,71 +576,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Błędy budowania pakietu RPM:\n"
+msgstr "\n\nBłędy budowania pakietu RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "błąd składni podczas przetwarzania ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "błąd składni podczas przetwarzania &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "błąd składni podczas przetwarzania ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "błąd przetwarzania w wyrażeniu\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "niesparowane (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- tylko na liczbach\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! tylko na liczbach\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "typy muszą się zgadzać\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / nie są obsługiwane dla ciągów\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- nie jest obsługiwane dla ciągów\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& i || nie są obsługiwane dla ciągów\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "błąd składni w wyrażeniu\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
-msgstr "Brak \"(\" w %s %s\n"
+msgstr "Brak „(” w %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
-msgstr "Brak \")\" w %s(%s\n"
+msgstr "Brak „)” w %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Nieprawidłowy token %s: %s\n"
@@ -700,197 +647,198 @@ msgstr "Nieprawidłowy token %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Brak %s w %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Brak białego znaku po %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Błędna składnia: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Błędny tryb spec: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Błędny tryb katalogu spec: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
-msgstr "Niezwykła długość lokalizacji: \"%s\" w %%lang(%s)\n"
+msgstr "Niezwykła długość lokalizacji: „%s” w %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Podwójna lokalizacja %s w %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Nieprawidłowa możliwość: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Obsługa możliwości plików nie jest wbudowana\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
-msgstr "Plik musi zaczynać się od \"/\": %s\n"
+msgstr "Plik musi zaczynać się od „/”: %s\n"
 
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Nieznany algorytm skrótu pliku %u, używanie w zamian MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Plik podany dwukrotnie: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "odczytanie dowiązania symbolicznego %s się nie powiodło: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Dowiązanie symboliczne wskazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Ścieżka jest poza buildroot: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Nie odnaleziono katalogu: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Nie odnaleziono pliku: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Nie jest katalogiem: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nie można wczytać nieznanego znacznika (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: odczytanie klucza publicznego się nie powiodło.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: nie jest opakowanym kluczem publicznym.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: odkodowanie się nie powiodło\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
-msgstr "Plik musi zaczynać się od \"/\": %s\n"
+msgstr "Plik musi zaczynać się od „/”: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Wyrażenie regularne %%dev nie jest dozwolone: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Katalog nie został odnaleziony przez wyrażenie regularne: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Nie odnaleziono pliku przez wyrażenie regularne: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Nie można otworzyć pliku %s w %%files: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "wiersz: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Pusty plik %s w %%files\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Błąd podczas odczytywania pliku %s w %%files: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Nie można mieszać specjalnego %s z innymi formami: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Więcej niż jeden plik na wiersz: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Błędny plik: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Błędny właściciel/grupa: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Sprawdzanie niespakietowanych plików: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Odnaleziono zainstalowane (ale niespakietowane) pliki:\n"
-"%s"
+msgstr "Odnaleziono zainstalowane (ale niespakietowane) pliki:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Przetwarzanie plików: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"Architektura plików binarnych (%d) nie zgadza się z architekturą pakietu "
-"(%d).\n"
+msgstr "Architektura plików binarnych (%d) nie zgadza się z architekturą pakietu (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Pliki binarne zależne od architektury w pakiecie noarch\n"
 
@@ -919,79 +867,79 @@ msgstr "%s: wiersz: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nie można ustalić kanonicznej nazwy komputera: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Nie można ponownie wczytać nagłówka podpisu.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nieznana kompresja danych: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Nie można utworzyć niezmiennej części nagłówka.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nie można otworzyć %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nie można zapisać pakietu: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Nie można zapisać tymczasowego nagłówka\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Błędne dane CSA\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Nie można otworzyć pliku %s: %s\n"
+msgstr "Nie można wyszukać w pliku %s: %s\n"
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "utworzenie archiwum się nie powiodło na pliku %s: %s\n"
+msgstr "„Fread” się nie powiodło w %s: %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
-msgstr "Wykonywanie \"%s\":\n"
+msgstr "Wykonywanie „%s”:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
-msgstr "Wykonanie \"%s\" się nie powiodło.\n"
+msgstr "Wykonanie „%s” się nie powiodło.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
-msgstr "Sprawdzenie pakietu \"%s\" się nie powiodło.\n"
+msgstr "Sprawdzenie pakietu „%s” się nie powiodło.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nie można utworzyć wyjściowej nazwy pliku dla pakietu %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nie można utworzyć %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "wiersz %d: drugi %s\n"
@@ -1042,19 +990,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "wiersz %d: błąd podczas przetwarzania %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "wiersz %d: błędna opcja %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "wiersz %d: za dużo nazw: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "wiersz %d: pakiet nie istnieje: %s\n"
@@ -1160,296 +1108,255 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "wiersz %d: znacznik przyjmuje tylko jeden token: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
-msgstr "wiersz %d: niedozwolony znak \"%c\" w: %s\n"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
+msgstr "wiersz %d: niedozwolony znak „%c” w: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "wiersz %d: niedozwolona sekwencja \"..\" w: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "wiersz %d: niedozwolony znak w: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "wiersz %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "wiersz %d: niedozwolona sekwencja „..” w: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: wiersz: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "wiersz %d: błędnie sformowany znacznik: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "wiersz %d: pusty znacznik: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
-msgstr "wiersz %d: przedrostki nie mogą kończyć się na \"/\": %s\n"
+msgstr "wiersz %d: przedrostki nie mogą kończyć się na „/”: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
-msgstr "wiersz %d: Docdir musi zaczynać się od \"/\": %s\n"
+msgstr "wiersz %d: Docdir musi zaczynać się od „/”: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "wiersz %d: pole Epoch musi być niepodpisaną liczbą: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "wiersz %d: błędne określenia %s: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "wiersz %d: błędny format BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "wiersz %d: obsługiwane są tylko podpakiety noarch: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Wewnętrzny błąd: fałszywy znacznik %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "wiersz %d: %s jest przestarzałe: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Błędna specyfikacja pakietu: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Pakiet już istnieje: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "wiersz %d: nieznany znacznik: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} nie może być puste\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
-msgstr "%%{buildroot} nie może być \"/\"\n"
+msgstr "%%{buildroot} nie może być „/”\n"
 
 #: build/parsePrep.c:28
 #, c-format
 msgid "Bad source: %s: %s\n"
 msgstr "Błędne źródło: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Brak łaty numer %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
-msgstr "%%patch bez odpowiadającego mu znacznika \"Patch:\"\n"
+msgstr "%%patch bez odpowiadającego mu znacznika „Patch:”\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Brak źródła numer %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
-msgstr "Brak znacznika \"Source:\" w pliku spec\n"
+msgstr "Brak znacznika „Source:” w pliku spec\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Błąd podczas przetwarzania %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "wiersz %d: błędny parametr dla %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "wiersz %d: błędna opcja %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Nieprawidłowy numer łaty %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "wiersz %d: drugie %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr ""
-"Tokeny zależności muszą zaczynać się od znaków alfanumerycznych, \"_\" lub "
-"\"/\""
+msgstr "Tokeny zależności muszą zaczynać się od znaków alfanumerycznych, „_” lub „/”"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Wersja w nazwie pliku jest niedozwolona"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "nieprawidłowa zależność"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Wersja jest wymagana"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "nieprawidłowa zależność"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "wiersz %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "wiersz %d: wyzwalacze muszą posiadać --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "wiersz %d: błąd podczas przetwarzania %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
-msgstr "wiersz %d: wewnętrzny skrypt musi kończyć się \">\": %s\n"
+msgstr "wiersz %d: wewnętrzny skrypt musi kończyć się „>”: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
-msgstr "wiersz %d: program skryptu musi zaczynać się od \"/\": %s\n"
+msgstr "wiersz %d: program skryptu musi zaczynać się od „/”: %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-"wiersz %d: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "wiersz %d: drugi %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "wiersz %d: wewnętrzny skrypt jest nieobsługiwany: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr ""
-"wiersz %d: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
+msgstr "wiersz %d: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "wiersz %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nie można otworzyć %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: oczekiwano parametru dla %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "wiersz %d: niezamknięte %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "wiersz %d: niezamknięte makro lub błędna kontynuacja wiersza\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: błędny warunek %%if\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: napotkano %%else bez %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: napotkano %%endif bez %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: błędnie sformatowany zwrot %%include\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Nie odnaleziono zgodnych architektur do zbudowania\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakiet nie posiada %%description: %s\n"
@@ -1457,12 +1364,12 @@ msgstr "Pakiet nie posiada %%description: %s\n"
 #: build/policies.c:87
 #, c-format
 msgid "Policy module '%s' duplicated with overlapping types\n"
-msgstr "Moduł polityki \"%s\" posiada kopię z pokrywającymi się typami\n"
+msgstr "Moduł polityki „%s” posiada kopię z pokrywającymi się typami\n"
 
 #: build/policies.c:93
 #, c-format
 msgid "Base modules '%s' and '%s' have overlapping types\n"
-msgstr "Podstawowe moduły \"%s\" i \"%s\" posiadają pokrywające się typy\n"
+msgstr "Podstawowe moduły „%s” i „%s” posiadają pokrywające się typy\n"
 
 #: build/policies.c:101
 msgid "Failed to get policies from header\n"
@@ -1493,9 +1400,7 @@ msgstr "Ustalenie nazwy polityki się nie powiodło: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"Typ \"%s\" został podany razem z innymi typami w %%semodule %s. "
-"Kompaktowanie typów do \"%s\".\n"
+msgstr "Typ „%s” został podany razem z innymi typami w %%semodule %s. Kompaktowanie typów do „%s”.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1522,285 +1427,291 @@ msgstr "Za dużo parametrów w wierszu: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Przetwarzanie polityk: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorowanie nieprawidłowego wyrażenia regularnego %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nie można utworzyć potoku dla %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Nie można wykonać %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nie można rozdzielić %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s się nie powiodło: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "zapisanie wszystkich danych do %s się nie powiodło: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr "błędny operator"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr "błędny format"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "nieprawidłowa zależność (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konwersja %s na długą liczbę całkowitą się nie powiodła.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Pusty klasyfikator pliku\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Brak skonfigurowanych atrybutów plików\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) się nie powiodło: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load się nie powiodło: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
-msgstr "Rozpoznanie pliku \"%s\" się nie powiodło: tryb %06o %s\n"
+msgstr "Rozpoznanie pliku „%s” się nie powiodło: tryb %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Wyszukiwanie %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Odnalezienie %s się nie powiodło:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "odpytanie pliku spec %s się nie powiodło, nie można przetworzyć\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
-msgstr ""
-"%s jest pakietem RPM Delta i nie może zostać bezpośrednio zainstalowany\n"
+msgstr "%s jest pakietem RPM Delta i nie może zostać bezpośrednio zainstalowany\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nieobsługiwane dane (%s) w pakiecie %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "pakiet %s został już dodany, pomijanie %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "pakiet %s został już dodany, zastępowanie %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(nie jest liczbą)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(nie jest base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(nieprawidłowy typ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
-msgstr "(nie jest \"blob\")"
+msgstr "(nie jest „blob”)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(nieprawidłowy typ XML)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(nie jest podpisem OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Nieprawidłowa data %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "zwykły"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "zastąpiony"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "niezainstalowany"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "udostępniony w sieci"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "błędny kolor"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "brak"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(nieznany)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(nie jest ciągiem)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s zapisano jako %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s utworzono jako %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: usunięcie się nie powiodło: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "katalog"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "plik"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "nie można sprawdzić podpisu %s"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik[%d]: BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr "hdr SHA1: BŁĘDNY, nie jest szesnastkowy"
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr "hdr RSA: BŁĘDNY, nie jest binarny"
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr "hdr DSA: BŁĘDNY, nie jest binarny"
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik regionu: BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "offset regionu: BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "zakończenie regionu: BŁĘDNE, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr "rozmiar regionu: BŁĘDNY, ril(%d) > il(%d)"
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "rozmiar blob(%d): BŁĘDNY, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "rozmiar hdr(%d): BŁĘDNY, odczytanie zwróciło %d"
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr "magic hdr: BŁĘDNE"
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "znaczniki hdr: BŁĘDNE, liczba znaczników(%d) jest poza zakresem"
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "dane hdr: BŁĘDNE, liczba bajtów(%d) jest poza zakresem"
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "blob hdr(%zd): BŁĘDNE, odczytanie zwróciło %d"
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
 msgstr "load hdr: BŁĘDNE"
 
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "„Fread” się nie powiodło: %s"
+
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr ""
-"%s: błąd: podano więcej niż jedną opcję --pipe (niezgodne aliasy biblioteki "
-"popt?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr "%s: błąd: podano więcej niż jedną opcję --pipe (niezgodne aliasy biblioteki popt?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1808,7 +1719,7 @@ msgstr "wcześniejsze określenie MAKRA z wartością WYRAŻENIE"
 
 #: lib/poptALL.c:176 lib/poptALL.c:179
 msgid "'MACRO EXPR'"
-msgstr "\"MAKRO WYRAŻENIE\""
+msgstr "„MAKRO WYRAŻENIE”"
 
 #: lib/poptALL.c:178
 msgid "define MACRO with value EXPR"
@@ -1828,19 +1739,19 @@ msgstr "wyświetlenie rozwinięcia makr z WYRAŻENIA"
 
 #: lib/poptALL.c:185
 msgid "'EXPR'"
-msgstr "\"WYRAŻENIE\""
+msgstr "„WYRAŻENIE”"
 
 #: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
-msgstr "odczytanie <PLIK:...> zamiast domyślnych plików"
+msgstr "odczytanie <PLIK:…> zamiast domyślnych plików"
 
 #: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
-msgstr "<PLIK:...>"
+msgstr "<PLIK:…>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "bez włączania wtyczek"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
@@ -1928,18 +1839,15 @@ msgid "relocations must have a / following the ="
 msgstr "przesunięcia muszą zawierać / po ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"zainstalowanie wszystkich plików, nawet konfiguracyjnych, które w innym "
-"przypadku by pominięto"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "zainstalowanie wszystkich plików, nawet konfiguracyjnych, które w innym przypadku by pominięto"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"usunięcie wszystkich pakietów, które zgadzają się z <pakietem> (zwykle "
-"tworzony jest błąd, jeśli <pakiet> podaje wiele pakietów)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "usunięcie wszystkich pakietów, które zgadzają się z <pakietem> (zwykle tworzony jest błąd, jeśli <pakiet> podaje wiele pakietów)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2017,7 +1925,7 @@ msgstr "zaktualizowanie bazy danych, ale bez modyfikacji systemu plików"
 msgid "do not verify package dependencies"
 msgstr "bez sprawdzania zależności pakietu"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "bez sprawdzania skrótów plików"
 
@@ -2095,9 +2003,7 @@ msgstr "bez wykonania żadnych skryptów %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"zaktualizowanie do poprzedniej wersji pakietu (--force podczas "
-"aktualizowania robi to automatycznie)"
+msgstr "zaktualizowanie do poprzedniej wersji pakietu (--force podczas aktualizowania robi to automatycznie)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2139,182 +2045,162 @@ msgstr "zaktualizowanie pakietów"
 msgid "reinstall package(s)"
 msgstr "ponowne zainstalowanie pakietów"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "odpytanie/sprawdzenie wszystkich pakietów"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "tryb sprawdzania podpisów pakietów RPM"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "odpytanie/sprawdzenie pakietów zawierających plik"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "odpytanie/sprawdzenie pakietów w grupie"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "odpytanie/sprawdzenie pliku pakietu"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "odpytanie/sprawdzenie pakietów z identyfikatorem pakietu"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "odpytanie/sprawdzenie pakietów z identyfikatorem nagłówka"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "tryb odpytywania pakietów RPM"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "odpytanie/sprawdzenie instancji nagłówka"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "odpytanie/sprawdzenie pakietów z transakcji instalacji"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "odpytanie pakietów wyzwalanych przez pakiet"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "tryb sprawdzania pakietów RPM"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "odpytanie/sprawdzenie pakietów dostarczających zależność"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "odpytanie/sprawdzenie pakietów wymagających zależności"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "bez używania wyrażeń regularnych w parametrach"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "bez przetwarzania plików nie będących pakietami jako manifesty"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "wyświetlenie listy wszystkich plików konfiguracyjnych"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "wyświetlenie listy wszystkich plików dokumentacji"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr "wyświetlenie listy wszystkich plików licencji"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "zrzucenie podstawowych informacji o pliku"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "wyświetlenie listy plików pakietu"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "pominięcie plików %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "wyświetlenie stanu wyświetlonych plików"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "bez sprawdzania rozmiaru plików"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "bez sprawdzania ścieżek dowiązań symbolicznych plików"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "bez sprawdzania właścicieli plików"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "bez sprawdzania grup plików"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "bez sprawdzania czasu modyfikacji plików"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "bez sprawdzania trybu plików"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "bez sprawdzania możliwości plików"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "bez sprawdzania kontekstów bezpieczeństwa plików"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "bez sprawdzania plików pakietu"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "bez sprawdzania zależności pakietu"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "bez wykonania żadnych skryptów sprawdzania"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Brak funkcji rpmlib dla %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "oczekiwano pakietu źródłowego, odnaleziono binarny\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "pakiet źródłowy nie zawiera pliku .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozpakowanie archiwum się nie powiodło%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " na pliku "
 
@@ -2389,117 +2275,96 @@ msgstr "brak pakietów pasujących do %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "brak pakietów wymagających %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "brak pakietów wymagających %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "brak pakietów wyzwalających %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "brak pakietów wymagających %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "brak pakietów wymagających %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "brak pakietów dostarczających %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "plik %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "plik %s nie należy do żadnego pakietu\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "nieprawidłowy numer pakietu: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "nie można odczytać wpisu %u\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakiet %s nie jest zainstalowany\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
-msgstr "nieznany znacznik: \"%s\"\n"
+msgstr "nieznany znacznik: „%s”\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: zaimportowanie klucza %d się nie powiodło.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: klucz %d nie jest opakowanym kluczem publicznym.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: zaimportowanie read się nie powiodło(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead się nie powiodło: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: nie można odczytać niezmiennego regionu nagłówka. Uszkodzony pakiet?\n"
+msgstr "%s: nie można odczytać niezmiennego regionu nagłówka. Uszkodzony pakiet?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
-msgstr "%s: Fread się nie powiodło: %s\n"
+msgstr "%s: „Fread” się nie powiodło: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NIE DOBRZE"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (BRAK KLUCZY:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NIEZAUFANE KLUCZE:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otwarcie się nie powiodło: %s\n"
@@ -2524,198 +2389,144 @@ msgstr "Nie można zmienić katalogu roota: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Nie można przywrócić katalogu roota: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NIE "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "TAK"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Zależności PreReq:, Provides: i Obsoletes: obsługują wersje."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"nazwy plików przechowano jako krotka (dirName,baseName,dirIndex), a nie jako "
-"ścieżki."
+msgstr "nazwy plików przechowano jako krotka (dirName,baseName,dirIndex), a nie jako ścieżki."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "dane pakietu mogą zostać skompresowane używając bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "dane pakietu mogą zostać skompresowane używając xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "dane pakietu mogą zostać skompresowane używając lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
-msgstr "pliki danych pakietu posiadają przedrostek \"./\"."
+msgstr "pliki danych pakietu posiadają przedrostek „./”."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "pakiet nazwa-wersja-wydanie nie jest domyślnie dostarczany."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "znaczniki nagłówka są zawsze porządkowane po wczytaniu."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "interpreter skryptów może używać parametrów z nagłówka."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "plik twardego dowiązania może zostać zainstalowany bez ukończenia."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"skrypty pakietu mogą odwoływać się do bazy danych RPM podczas instalowania."
+msgstr "skrypty pakietu mogą odwoływać się do bazy danych RPM podczas instalowania."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "wewnętrzna obsługa skryptów Lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "algorytm skrótu pliku jest konfigurowalny dla każdego pakietu osobno"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "obsługa możliwości plików POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "skrypty pakietu mogą być rozszerzane w czasie instalacji."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "rozwiązywanie zależności obsługuje wersje zawierające tyldę."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr "obsługa plików większych niż 4 GB"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "bez sprawdzania zależności pakietu"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Wersja jest wymagana"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "nieprawidłowa zależność"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Niezakończone %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "nieprawidłowa zależność"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
-msgstr "użytkownik %s nie istnieje - używanie roota\n"
+msgstr "użytkownik %s nie istnieje — używanie roota\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
-msgstr "grupa %s nie istnieje - używanie roota\n"
+msgstr "grupa %s nie istnieje — używanie roota\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Błędne magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Błędny/nieczytelny nagłówek"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Rozmiar nagłówka jest za duży"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Plik jest za duży dla archiwum"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Nieznany typ pliku"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr "Brak plików"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Skrót nie zgadza się"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Wewnętrzny błąd"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Plik archiwum nie znajduje się w nagłówku"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
-msgstr " się nie powiodło - "
+msgstr " się nie powiodło — "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (błąd 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otwarcie %s się nie powiodło: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: nie jest pakietem RPM (ani manifestem pakietu)\n"
@@ -2723,20 +2534,20 @@ msgstr "%s: nie jest pakietem RPM (ani manifestem pakietu)\n"
 #: lib/rpminstall.c:141
 #, c-format
 msgid "Updating / installing...\n"
-msgstr "Aktualizowanie/instalowanie...\n"
+msgstr "Aktualizowanie/instalowanie…\n"
 
 #: lib/rpminstall.c:143
 #, c-format
 msgid "Cleaning up / removing...\n"
-msgstr "Czyszczenie/usuwanie...\n"
+msgstr "Czyszczenie/usuwanie…\n"
 
 #: lib/rpminstall.c:192
 msgid "Preparing..."
-msgstr "Przygotowywanie..."
+msgstr "Przygotowywanie…"
 
 #: lib/rpminstall.c:194
 msgid "Preparing packages..."
-msgstr "Przygotowywanie pakietów..."
+msgstr "Przygotowywanie pakietów…"
 
 #: lib/rpminstall.c:270 tools/rpmgraph.c:168
 msgid "Failed dependencies:\n"
@@ -2747,42 +2558,42 @@ msgstr "Niespełnione zależności:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: nie jest pakietem RPM (ani manifestem pakietu): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s nie może zostać zainstalowany\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Pobieranie %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
-msgstr "pomijanie %s - przesłanie się nie powiodło\n"
+msgstr "pomijanie %s — przesłanie się nie powiodło\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "pakiet %s nie jest przesuwalny\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "błąd podczas odczytywania z pliku %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
-msgstr "\"%s\" podaje wiele pakietów:\n"
+msgstr "„%s” podaje wiele pakietów:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "nie można otworzyć %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instalowanie %s\n"
@@ -2808,12 +2619,12 @@ msgstr "odczytanie się nie powiodło: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "nie jest pakietem RPM\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "nie można utworzyć blokady %s na %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "oczekiwanie na blokadę %s na %s\n"
@@ -2829,9 +2640,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Rozwiązanie symbolu %s się nie powiodło: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Wtyczka %s nie jest wczytana\n"
+msgstr "Wtyczka %%__%s_%s nie jest skonfigurowana\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2914,7 +2725,7 @@ msgstr "wystąpił nieznany błąd %d podczas manipulowania pakietem %s"
 #: lib/rpmrc.c:222
 #, c-format
 msgid "missing second ':' at %s:%d\n"
-msgstr "brak drugiego \":\" w %s:%d\n"
+msgstr "brak drugiego „:” w %s:%d\n"
 
 #: lib/rpmrc.c:225
 #, c-format
@@ -2949,7 +2760,7 @@ msgstr "Za dużo parametrów w domyślnym wierszu w %s:%d\n"
 #: lib/rpmrc.c:523
 #, c-format
 msgid "missing ':' (found 0x%02x) at %s:%d\n"
-msgstr "brak \":\" (odnaleziono 0x%02x) w %s:%d\n"
+msgstr "brak „:” (odnaleziono 0x%02x) w %s:%d\n"
 
 #: lib/rpmrc.c:540 lib/rpmrc.c:572
 #, c-format
@@ -2969,82 +2780,62 @@ msgstr "brak architektury dla %s w %s:%d\n"
 #: lib/rpmrc.c:632
 #, c-format
 msgid "bad option '%s' at %s:%d\n"
-msgstr "błędna opcja \"%s\" w %s:%d\n"
+msgstr "błędna opcja „%s” w %s:%d\n"
 
 #: lib/rpmrc.c:959
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
-msgstr ""
-"Odczytanie pomocniczego wektora się nie powiodło, nie zamontowano /proc?\n"
+msgstr "Odczytanie pomocniczego wektora się nie powiodło, nie zamontowano /proc?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Nieznany system: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Proszę skontaktować się z %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Nie można otworzyć %s do odczytania: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Nie można przywrócić bieżącego katalogu: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "Obsługa skryptów <lua> nie jest wbudowana\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Nie można utworzyć pliku tymczasowego dla %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Nie można utworzyć kopii deskryptora pliku: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Nie można odczytać ikony %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Nie można przywrócić katalogu roota: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite się nie powiodło: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "Skrypt %s się nie powiódł, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "Skrypt %s się nie powiódł, sygnał %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "Skrypt %s się nie powiódł, stan wyjścia %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Nieznany format"
 
@@ -3056,142 +2847,127 @@ msgstr "instalacja"
 msgid "erase"
 msgstr "usunięcie"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "nie można otworzyć bazy danych pakietów w %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
-msgstr "dodatkowe \"(\" w etykiecie pakietu: %s\n"
+msgstr "dodatkowe „(” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
-msgstr "brak \"(\" w etykiecie pakietu: %s\n"
+msgstr "brak „(” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
-msgstr "brak \")\" w etykiecie pakietu: %s\n"
+msgstr "brak „)” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: odczytanie klucza publicznego się nie powiodło.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transakcji"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(nie jest podpisem OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr "rozmiar sigh(%d): BŁĘDNY, odczytanie zwróciło %d"
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr "magic sigh: BŁĘDNE"
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr "znaczniki sigh: BŁĘDNE, liczba znaczników(%d) jest poza zakresem"
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr "dane sigh: BŁĘDNE, liczba bajtów(%d) jest poza zakresem"
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr "blob sigh(%d): BŁĘDNE, odczytanie zwróciło %d"
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik sigh(%d): BŁĘDNY, znacznik %d typ %d offset %d licznik %d"
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr "load sigh: BŁĘDNE"
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "pad sigh(%zd): BŁĘDNE, odczyt %zd bajtów"
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigSize sigh(%zd): BŁĘDNE, fstat(2) się nie powiodło"
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Nagłówek "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "Skrót MD5:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Skrót SHA1 nagłówka:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Nagłówek "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Sprawdzenie podpisu: BŁĘDNE PARAMETRY (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "pominięto"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
-msgstr "nie powiodło się"
+msgstr "się nie powiodło"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
-msgstr ""
+msgstr "Podwójna nazwa użytkownika lub UID dla użytkownika %s\n"
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
-msgstr ""
+msgstr "Podwójna nazwa grupy lub GID dla grupy %s\n"
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr "brak stanu"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr "nieznany stan"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "brak   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Niespełnione zależności dla %s:\n"
@@ -3263,246 +3039,242 @@ msgstr "iterator tablicy użyty na tablicach o różnych rozmiarach"
 #: lib/rpmdb.c:71
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
-msgstr "Tworzenie %d brakujących indeksów, proszę czekać...\n"
+msgstr "Tworzenie %d brakujących indeksów, proszę czekać…\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
-msgstr "nie można otworzyć indeksu %s używając %s - %s (%d)\n"
+msgstr "nie można otworzyć indeksu %s używając %s — %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "ścieżka bazy danych nie została ustawiona\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: pomijanie"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "błąd(%d) podczas zapisywania wpisu #%d do %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: pomijanie"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
-msgstr "rpmdb: pobrano uszkodzony nagłówek #%u - pomijanie.\n"
+msgstr "rpmdb: pobrano uszkodzony nagłówek #%u — pomijanie.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nie można odczytać nagłówka pod 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "ścieżka bazy danych nie została ustawiona"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "utworzenie katalogu %s się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
-msgstr "nagłówek #%u w bazie danych jest błędny - pomijanie.\n"
+msgstr "nagłówek #%u w bazie danych jest błędny — pomijanie.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nie można dodać wpisu będącego pierwotnie przy %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"przebudowanie bazy danych się nie powiodło: pierwotna baza danych pozostała "
-"na miejscu\n"
+msgstr "przebudowanie bazy danych się nie powiodło: pierwotna baza danych pozostała na miejscu\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "zamiana poprzedniej bazy danych na nową się nie powiodła.\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "aby odzyskać, należy zastąpić pliki w %s plikami z %s"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "usunięcie katalogu %s się nie powiodło: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s błąd(%d) z %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s błąd(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "nierozpoznana opcja bazy danych: \"%s\" zignorowano.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s ma nieprawidłową wartość liczbową, pominięto\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s ma za dużą lub za małą wartość long, pominięto\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s ma za dużą lub za małą wartość całkowitą, pominięto\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "nie można otrzymać blokady %s na %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "współdzielonej"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "wyłącznej"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "nieprawidłowy typ indeksu %x w %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "błąd(%d) podczas uzyskiwania wpisów \"%s\" z indeksu %s: %s\n"
+msgstr "błąd(%d) podczas uzyskiwania wpisów „%s” z indeksu %s: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "błąd(%d) podczas zapisywania wpisu \"%s\" do %s\n"
+msgstr "błąd(%d) podczas zapisywania wpisu „%s” do %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "błąd(%d) usuwania wpisu \"%s\" z %s\n"
+msgstr "błąd(%d) usuwania wpisu „%s” z %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "błąd(%d) podczas dodawania wpisu nagłówka #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "błąd(%d) podczas usuwania wpisu nagłówka #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "błąd(%d) podczas przydzielania nowej instancji pakietu\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "nierozpoznana opcja bazy danych: zignorowano „%s”.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s ma nieprawidłową wartość liczbową, pominięto\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s ma za dużą lub za małą wartość long, pominięto\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s ma za dużą lub za małą wartość całkowitą, pominięto\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(puste)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(puste)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s posiada niezakończone opcje\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s posiada niezakończone ciało\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s posiada niedozwoloną nazwę (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s posiada puste ciało\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makro %%%s wymaga spacji przed treścią\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Rozwinięcie makra %%%s się nie powiodło\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s posiada niedozwoloną nazwę (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Określono makro %%%s, ale nie jest używane w ramach zakresu\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nieznana opcja %c w %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Za dużo poziomów rekurencji w rozwinięciu makra. Prawdopodobnie jest to "
-"spowodowane rekurencyjną deklaracją makra.\n"
+msgstr "Za dużo poziomów rekurencji w rozwinięciu makra. Prawdopodobnie jest to spowodowane rekurencyjną deklaracją makra.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Niezakończone %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Makro niemożliwe do przetworzenia po %%\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "wczytanie pliku makra %s się nie powiodło"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktywne %d puste %d\n"
@@ -3522,31 +3294,31 @@ msgstr "Plik %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Plik %s jest mniejszy niż %u bajtów\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "utworzenie katalogu się nie powiodło"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nieprawidłowa składnia skryptu Lua: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nieprawidłowa składnia skryptu Lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "skrypt Lua się nie powiódł: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nieprawidłowa składnia pliku Lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "hak Lua się nie powiódł: %s\n"
@@ -3555,19 +3327,19 @@ msgstr "hak Lua się nie powiódł: %s\n"
 msgid "[none]"
 msgstr "[brak]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(brak błędu)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "krytyczny błąd: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "błąd: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "ostrzeżenie: "
 
@@ -3576,121 +3348,99 @@ msgstr "ostrzeżenie: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "przydzielenie pamięci (%u bajtów) zwróciło NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, identyfikator klucza %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(brak)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "błąd podczas tworzenia pliku tymczasowego %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "błąd podczas tworzenia pliku tymczasowego %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "błąd podczas tworzenia pliku tymczasowego %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "utworzenie katalogu %s się nie powiodło: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
-msgstr "%s: Fwrite się nie powiodło: %s\n"
+msgstr "%s: „Fwrite” się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
-msgstr "%s: Fflush się nie powiodło: %s\n"
+msgstr "%s: „Fflush” się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Nieobsługiwany podpis PGP\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Nieobsługiwany algorytm mieszania PGP %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Nieobsługiwany algorytm klucza publicznego PGP %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Nie można wykonać %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Nie można utworzyć potoku do podpisania: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: otwarcie się nie powiodło: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "„fdopen” się nie powiodło\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Nie można otworzyć pliku %s: %s\n"
+msgstr "Nie można zapisać do potoku\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Nie można otworzyć pliku %s w %%files: %m\n"
+msgstr "Nie można odczytać z pliku %s: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "wykonanie gpg się nie powiodło (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "zapisanie podpisu przez gpg się nie powiodło\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "nie można odczytać podpisu\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature się nie powiodło: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Nie można podpisywać pakietów RPM v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s zawiera już identyczny podpis, pomijanie\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp się nie powiodło\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "zastąpienie %s się nie powiodło: %s\n"
@@ -3703,113 +3453,3 @@ msgstr "%s: odczytanie manifestu się nie powiodło: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "bez sprawdzania podpisu nagłówka+danych"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Proszę podać hasło: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Hasło jest dobre.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "Sprawdzenie hasła się nie powiodło lub klucz GPG wygasł\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Błędny właściciel/grupa: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "wiersz %d: niedozwolony znak w: %s\n"
-
-#~ msgid "%s has unverifiable signature"
-#~ msgstr "nie można sprawdzić podpisu %s"
-
-#~ msgid "Fread failed: %s"
-#~ msgstr "\"Fread\" się nie powiodło: %s"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Nie można utworzyć potoku do podpisania: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Nie można zapisać danych do %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Nie można odczytać danych z %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Nie można otworzyć pliku tymczasowego.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Nie można otworzyć sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Nie można odczytać nagłówka z %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Nie można zapisać nagłówka do %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "bez wykonywania żadnych działań kolekcji"
-
-#~ msgid "Failed to expand %%__%s_%s macro\n"
-#~ msgstr "Rozwinięcie makra %%__%s_%s się nie powiodło\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "Nie można odczytać niezmiennego regionu nagłówka. Uszkodzony pakiet?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Odkodowanie polityki dla %s się nie powiodło\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Utworzenie pliku tymczasowego dla %s się nie powiodło: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Zapisanie polityki %s do pliku %s się nie powiodło\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Utworzenie obsługi semanage się nie powiodło\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Połączenie z obsługą polityki się nie powiodło\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Rozpoczęcie transakcji polityki się nie powiodło: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Usunięcie tymczasowego pliku polityki %s się nie powiodło: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Zainstalowanie modułu polityki się nie powiodło: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Usunięcie modułu polityki się nie powiodło: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Rozdzielenie procesu się nie powiodło: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Wykonanie %s się nie powiodło: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s zostało nienormalnie zakończone\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s nie powiodło się z kodem wyjścia %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Wprowadzenie zmian w polityce się nie powiodło\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Rozwinięcie makra restorecon się nie powiodło"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Ponowne nadanie etykiet systemowi plików się nie powiodło. Pliki mogą "
-#~ "posiadać błędne etykiety\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Ponowne wczytanie kontekstów plików się nie powiodło. Pliki mogą posiadać "
-#~ "błędne etykiety\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Wydobycie polityki z %s się nie powiodło\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,20 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Portuguese (http://www.transifex.com/rpm-team/rpm/language/pt/)\n"
+"Language-Team: Portuguese (http://www.transifex.com/rpm-team/rpm/language/"
+"pt/)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -79,7 +80,7 @@ msgstr "Opções de verificação (com o -V ou o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opções de Instalação/Actualização/Remoção:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +101,7 @@ msgstr "formato de pesquisa inesperado"
 msgid "unexpected query source"
 msgstr "origem de pesquisa inesperada"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "só pode ser especificado um 'major mode'"
 
@@ -110,7 +111,8 @@ msgstr ""
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "os ficheiros só podem ser mudados de sítio durante a instalação do pacote"
+msgstr ""
+"os ficheiros só podem ser mudados de sítio durante a instalação do pacote"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -119,7 +121,8 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "o --relocate e o --excludepath só podem ser usados ao instalar pacotes novos"
+msgstr ""
+"o --relocate e o --excludepath só podem ser usados ao instalar pacotes novos"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +138,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -177,19 +179,24 @@ msgstr "o --allfiles só pode ser indicado durante a instalação do pacote"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "o --justdb só pode ser indicado durante a instalação ou a remoção do pacote"
+msgstr ""
+"o --justdb só pode ser indicado durante a instalação ou a remoção do pacote"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "a desactivação de 'scripts' só pode ser indicado durante a instalação ou a remoção de pacotes"
+msgstr ""
+"a desactivação de 'scripts' só pode ser indicado durante a instalação ou a "
+"remoção de pacotes"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "a desactivação dos 'triggers' só pode ser usado durante a instalação ou remoção de pacotes"
+msgstr ""
+"a desactivação dos 'triggers' só pode ser usado durante a instalação ou "
+"remoção de pacotes"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +208,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "os argumentos do --root (-r) têm de começar por /"
 
@@ -221,201 +228,256 @@ msgstr "não foram indicados argumentos para a pesquisa"
 msgid "no arguments given for verify"
 msgstr "não foram indicados argumentos para a verificação"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "O buildroot já foi especificado, a ignorar o %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "criar através do %prep (desempacotar o código e aplicar patches) do <fichspec>"
+msgstr ""
+"criar através do %prep (desempacotar o código e aplicar patches) do "
+"<fichspec>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<fichspec>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "criar através do %build (%prep e depois compilar) do <fichspec>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "criar através do %install (%prep, %build e depois instalar) do <fichspec>"
+msgstr ""
+"criar através do %install (%prep, %build e depois instalar) do <fichspec>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificar a secção %files do <fichspec>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "criar os pacotes binários e de código a partir do <fichspec>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "criar só o pacote binário a partir do <fichspec>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "criar só o pacote com código-fonte a partir do <fichspec>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"criar através do %prep (desempacotar o código e aplicar patches) do "
+"<fichspec>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<pacote de código>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "criar através do %build (%prep e depois compilar) do <fichspec>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"criar através do %install (%prep, %build e depois instalar) do <pacote de "
+"código>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verificar a secção %files do <fichspec>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "criar o pacote binário a partir do <pacote de código>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "criar o pacote binário a partir do <pacote de código>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "criar só o pacote com código-fonte a partir do <fichspec>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "criar através do %prep (desempacotar o código e aplicar patches) do <fichtar>"
+msgstr ""
+"criar através do %prep (desempacotar o código e aplicar patches) do <fichtar>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<fichtar>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "criar através do %build (%prep e depois compilar) do <fichtar>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "criar através do %install (%prep, %build e depois instalar) do <fichtar>"
+msgstr ""
+"criar através do %install (%prep, %build e depois instalar) do <fichtar>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificar a secção %files do <fichtar>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "criar os pacotes binários e de código a partir do <fichtar>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "criar só o pacote binário a partir do <fichtar>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "criar só o pacote com código-fonte a partir do <fichtar>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "criar o pacote binário a partir do <pacote de código>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<pacote de código>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "criar através do %install (%prep, %build e depois instalar) do <pacote de código>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "ignorar a raiz de criação"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "apagar as directorias de criação quando acabar"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorar as directivas ExcludeArch: do ficheiro spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "depurar máquina de estados de ficheiros"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "não executar nenhuma etapa da criação"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "não verificar as dependências de compilação"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "não executar nenhuma etapa da criação"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "não aceitar as mensagens de i18N do ficheiro spec"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "apagar o código-fonte quando acabar"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "apagar o ficheiro spec quando acabar"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "saltar directamente para a etapa indicada (só para c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "ignorar a plataforma-alvo"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opções de criação com [ <fich spec> | <fich tar> | <pacote fonte> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Não consegui abrir ficheiro spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Não consegui abrir o 'pipe' para o tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Não consegui abrir ficheiro spec %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Não consegui ler o ficheiro spec do %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Não consegui mudar o nome de %s para %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "Não consegui analisar o %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "O ficheiro %s não é um ficheiro normal.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "O ficheiro %s não parece ser um ficheiro spec.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "A construir plataformas alvo: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "A construir para o alvo %s\n"
@@ -426,7 +488,9 @@ msgstr "inicializar a base de dados"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "reconstruir as listas invertidas da base dados com os cabeçalhos dos pacotes instalados"
+msgstr ""
+"reconstruir as listas invertidas da base dados com os cabeçalhos dos pacotes "
+"instalados"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -464,49 +528,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "<pacote>+"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opções de assinatura:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Não consegui executar %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Precisa definir o \"%%_gpg_name\" no seu ficheiro de macros\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Indique a palavra-chave: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "A palavra-chave está correcta.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "o --prefix só pode ser usado ao instalar pacotes novos"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "o --allmatches só pode ser indicado ao apagar o pacote"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +603,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "usar o formato de pesquisa seguinte"
 
@@ -571,68 +650,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nErros de criação do RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Erros de criação do RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "erro de sintaxe ao analisar o ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "erro de sintaxe ao analisar o &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "erro de sintaxe ao analisar o ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "erro de análise na expressão\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "( não correspondido\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- só em números\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! só em números\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "os tipos têm de corresponder\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / não suportados em cadeias de caracteres\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- não suportado em cadeias de caracteres\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& e || não suportados em cadeias de caracteres\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "erro de sintaxe na expressão\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Falta um '(' em %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Falta um ')' em %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Elemento %s inválido: %s\n"
@@ -642,46 +724,46 @@ msgstr "Elemento %s inválido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Falta um %s em %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Carácter sem ser espaço a seguir a %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxe inválida: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Spec de modo inválido: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Spec de dirmode inválido: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "O ficheiro tem de começar por \"/\": %s\n"
@@ -691,149 +773,149 @@ msgstr "O ficheiro tem de começar por \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Ficheiro listado duas vezes: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "A 'symlink' aponta para a BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Ficheiro não encontrado: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "O ficheiro precisa de começar por \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Ficheiro não encontrado pelo glob: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "linha: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Ficheiro não encontrado pelo glob: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ficheiro inválido: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Dono/grupo inválido: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +944,78 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Não consegui canonizar o nome da máquina: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Não consegui reler o cabeçalho do assinatura.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Não consegui criar região imutável do cabeçalho.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Não consigo aceder ao %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Não consegui gravar o pacote: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
-msgstr "Não consegui gravar o cabeçalho temporário\n\n"
+msgstr ""
+"Não consegui gravar o cabeçalho temporário\n"
+"\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Dados de CSA inválidos\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Gravei: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Não consigo gerar o ficheiro de saída para o pacote %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "não consigo criar o %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linha %d: segundo %s\n"
@@ -985,19 +1066,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linha %d: Erro ao analisar a %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linha %d: Opção inválida %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linha %d: Demasiados nomes: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linha %d: O pacote não existe: %s\n"
@@ -1104,90 +1185,94 @@ msgstr "linha %d: Opção só recebe um parâmetro: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linha %d: segundo %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "Linha %d: Opção inválida: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linha %d: Opção em branco: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linha %d: Os prefixos não podem acabar em \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linha %d: A docdir tem de começar por '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linha %d: Qualificadores %s: inválidos: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linha %d: Formato da BuildArchitecture inválido: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erro interno: Opção esquisita %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Descrição do pacote inválida: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "O pacote já existe: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linha %d: Opção desconhecida: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1282,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Código-fonte inválido: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erro ao analisar o %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linha %d: Argumento inválido para %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linha %d: Opção inválida do %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linha %d: segundo %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linha %d: os 'triggers' (que activam) têm de ter --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linha %d: Erro ao analisar o %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linha %d: o programa de 'script' tem de começar por '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linha %d: Segundo %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linha %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Incapaz de aceder ao %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Descobri um %%else sem um %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Descobri um %%endif sem um %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Não foram encontradas arquitecturas compatíveis para as quais criar\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "O pacote não tem uma %%description: %s\n"
@@ -1422,290 +1539,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Não consegui executar o %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Não consegui executar à parte o %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Não consegui encontrar o %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "a pesquisa do ficheiro spec %s falhou, não consigo analisar\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(não é um número)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(não é um base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(tipo inválido)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(não é um blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s gravado como %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s criado como %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1942,18 @@ msgid "relocations must have a / following the ="
 msgstr "os novos locais têm de ter um / a seguir ao ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "instala todos os ficheiros, mesmo as configurações que de outro modo seriam ignoradas"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"instala todos os ficheiros, mesmo as configurações que de outro modo seriam "
+"ignoradas"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "remove todos os pacotes que correspondam a <pacote> (normalmente aparece um erro se o <pacote> especifica vários pacotes)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"remove todos os pacotes que correspondam a <pacote> (normalmente aparece um "
+"erro se o <pacote> especifica vários pacotes)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2031,7 @@ msgstr "actualiza a base de dados, mas não altera o sistema de ficheiros"
 msgid "do not verify package dependencies"
 msgstr "não verifica as dependências do pacote"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1934,7 +2045,8 @@ msgstr ""
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "não reorganiza a instalação dos pacotes para satisfazer as dependências"
+msgstr ""
+"não reorganiza a instalação dos pacotes para satisfazer as dependências"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1998,7 +2110,9 @@ msgstr "não executar nenhum dos scripts %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "actualiza para um versão antiga do pacote (o --force faz isto automaticamente)"
+msgstr ""
+"actualiza para um versão antiga do pacote (o --force faz isto "
+"automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2154,183 @@ msgstr "actualizar pacote(s)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "pesquisar/verificar todos os pacotes"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "pesquisar/verificar o(s) pacote(s) que contém(êm) o ficheiro"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "pesquisar/verificar o(s) pacote(s) no grupo"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "pesquisar/verificar o(s) pacote(s) com o identificador do pacote"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "pesquisar/verificar o(s) pacote(s) com o identificador do cabeçalho"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "modo de pesquisa do rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "pesquisar/verificar o(s) pacote(s) de transacção de instalação"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "pesquisar o(s) pacote(s) activados pelo pacote"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "modo de verificação do rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "pesquisar/verificar o(s) pacote(s) que oferecem uma dependência"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "listar todos os ficheiros de configuração"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "listar todos os ficheiros de documentação"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "apresentar a informação básica do ficheiro"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "listar os ficheiros no pacote"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "ignorar ficheiros %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "mostrar os estados dos ficheiros listados"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "não verificar os tamanho dos ficheiros"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "não verificar as ligações simbólicas dos ficheiros"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "não verificar o dono dos ficheiros"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "não verificar o grupo dos ficheiros"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "não verificar hora de modificação dos ficheiros"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "não verificar o modo dos ficheiros"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "não verificar os ficheiros no pacote"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "não verificar as dependências do pacote"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
-msgstr "esperava-se um pacote com código-fonte, foi encontrado um pacote binário\n"
+msgstr ""
+"esperava-se um pacote com código-fonte, foi encontrado um pacote binário\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "o pacote de código-fonte não contem um ficheiro .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "a abertura do pacote falhou%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " no ficheiro "
 
@@ -2270,96 +2405,116 @@ msgstr "nenhum pacote coincide com %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nenhum pacote precisa do %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "nenhum pacote precisa do %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "nenhum pacote activa o %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "nenhum pacote precisa do %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "nenhum pacote precisa do %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nenhum pacote oferece o %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ficheiro %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "o ficheiro %s não pertence a nenhum pacote\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "o pacote %s não está instalado\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: O fread falhou: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NÃO-OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (FALTAM AS CHAVES:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CHAVES SUSPEITAS:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: o acesso falhou: %s\n"
@@ -2384,144 +2539,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NÃO"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "SIM"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "não verifica as dependências do pacote"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c não terminado: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "o utilizador %s não existe - a usar o root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "o grupo %s não existe - a usar o root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Código de integridade inválido"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Cabeçalho inválido/ilegível"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Tamanho do cabeçalho demasiado grande"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Tipo de ficheiro desconhecido"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Erro interno"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Ficheiro de arquivo não está no cabeçalho"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " falhou - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "o acesso ao %s falhou: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2756,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "o %s não pode ser instalado\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "A obter o %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "erro ao ler do ficheiros %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "não consigo aceder ao %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "A instalar o %s\n"
@@ -2614,12 +2817,12 @@ msgstr "a leitura falhou: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2671,12 +2874,15 @@ msgstr ""
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr "o ficheiro %s está em conflito com as tentativas de instalação do %s e %s"
+msgstr ""
+"o ficheiro %s está em conflito com as tentativas de instalação do %s e %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "o ficheiro %s da instalação do %s está em conflito com o ficheiro do pacote %s"
+msgstr ""
+"o ficheiro %s da instalação do %s está em conflito com o ficheiro do pacote "
+"%s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2777,60 +2983,79 @@ msgstr "falta a arquitectura para o %s em %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "má opção '%s' em %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconhecido: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Por favor contacte o %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Não consegui ler o ícone %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Não consegui ler o ícone %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: O fwrite falhou: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3067,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "não consigo abrir a base de dados Packages em %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr ""
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Não consegui reler o cabeçalho do assinatura.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3280,241 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "não foi definido o dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: não consigo ler o cabeçalho em 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "não foi definido o dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "não consigo adicionar o registo originalmente em %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "falhou a reconstrução da base de dados: a base de dados original mantém-se\n"
+msgstr ""
+"falhou a reconstrução da base de dados: a base de dados original mantém-se\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "falhou a substituição da base de dados antiga pela nova!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "substituir os ficheiros em %s por ficheiros de %s a recuperar"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "falhou a remoção da directoria %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "não consigo trancar o %s no %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "partilhado"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exclusivo"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "erro(%d) ao criar uma nova instância do pacote\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "opção do db desconhecida: \"%s\" ignorada.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "O %s tem um valor numérico inválido, foi ignorado\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "O %s tem um valor demasiado elevado ou pequeno, foi ignorado\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "O %s tem um valor inteiro demasiado elevado ou pequeno, foi ignorado\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "não consigo trancar o %s no %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "partilhado"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exclusivo"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "erro(%d) ao criar uma nova instância do pacote\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vazio)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vazio)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "A macro %%%s tem as opções incompletas\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "A macro %%%s tem o conteúdo incompleto\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "A macro %%%s tem um nome inválido (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "A macro %%%s tem o conteúdo em branco\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "A macro %%%s não conseguiu ser expandida\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "A macro %%%s tem um nome ilegal (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opção desconhecida %c em %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c não terminado: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Segue-se uma macro impossível de analisar ao %%\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== activo %d vazio %d\n"
@@ -3289,31 +3534,31 @@ msgstr "Ficheiro %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "O ficheiro %s tem menos de %u bytes\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3567,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(nenhum erro)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "erro fatal: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "erro: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "aviso: "
 
@@ -3343,99 +3588,154 @@ msgstr "aviso: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "a alocação de memória (%u bytes) devolveu NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "erro ao ler do ficheiros %s\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "erro ao ler do ficheiros %s\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "falhou a remoção da directoria %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: O fwrite falhou: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr ""
+msgid "Could not exec %s: %s\n"
+msgstr "Não consegui executar %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: o acesso falhou: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "o gpg não conseguiu gravar a assinatura\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "incapaz de ler a assinatura\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: o rpmWriteSignature falhou: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: o rpmWriteSignature falhou: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "o exec falhou\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "o exec falhou\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "o exec falhou\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: o rpmWriteSignature falhou: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: o writeLead falhou: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3748,12 @@ msgstr "%s: a leitura do manifesto falhou: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Indique a palavra-chave: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "A palavra-chave está correcta.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Dono/grupo inválido: %s\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,21 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Portuguese (http://www.transifex.com/projects/p/rpm/language/"
-"pt/)\n"
-"Language: pt\n"
+"Language-Team: Portuguese (http://www.transifex.com/rpm-team/rpm/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,7 +79,7 @@ msgstr "Opções de verificação (com o -V ou o --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opções de Instalação/Actualização/Remoção:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -101,7 +100,7 @@ msgstr "formato de pesquisa inesperado"
 msgid "unexpected query source"
 msgstr "origem de pesquisa inesperada"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "só pode ser especificado um 'major mode'"
 
@@ -111,8 +110,7 @@ msgstr ""
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr ""
-"os ficheiros só podem ser mudados de sítio durante a instalação do pacote"
+msgstr "os ficheiros só podem ser mudados de sítio durante a instalação do pacote"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -121,8 +119,7 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"o --relocate e o --excludepath só podem ser usados ao instalar pacotes novos"
+msgstr "o --relocate e o --excludepath só podem ser usados ao instalar pacotes novos"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -138,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -179,24 +177,19 @@ msgstr "o --allfiles só pode ser indicado durante a instalação do pacote"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"o --justdb só pode ser indicado durante a instalação ou a remoção do pacote"
+msgstr "o --justdb só pode ser indicado durante a instalação ou a remoção do pacote"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"a desactivação de 'scripts' só pode ser indicado durante a instalação ou a "
-"remoção de pacotes"
+msgstr "a desactivação de 'scripts' só pode ser indicado durante a instalação ou a remoção de pacotes"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"a desactivação dos 'triggers' só pode ser usado durante a instalação ou "
-"remoção de pacotes"
+msgstr "a desactivação dos 'triggers' só pode ser usado durante a instalação ou remoção de pacotes"
 
 #: rpmqv.c:231
 msgid ""
@@ -208,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "os argumentos do --root (-r) têm de começar por /"
 
@@ -228,256 +221,201 @@ msgstr "não foram indicados argumentos para a pesquisa"
 msgid "no arguments given for verify"
 msgstr "não foram indicados argumentos para a verificação"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "O buildroot já foi especificado, a ignorar o %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"criar através do %prep (desempacotar o código e aplicar patches) do "
-"<fichspec>"
+msgstr "criar através do %prep (desempacotar o código e aplicar patches) do <fichspec>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<fichspec>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "criar através do %build (%prep e depois compilar) do <fichspec>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"criar através do %install (%prep, %build e depois instalar) do <fichspec>"
+msgstr "criar através do %install (%prep, %build e depois instalar) do <fichspec>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificar a secção %files do <fichspec>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "criar os pacotes binários e de código a partir do <fichspec>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "criar só o pacote binário a partir do <fichspec>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "criar só o pacote com código-fonte a partir do <fichspec>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"criar através do %prep (desempacotar o código e aplicar patches) do "
-"<fichspec>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<pacote de código>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "criar através do %build (%prep e depois compilar) do <fichspec>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"criar através do %install (%prep, %build e depois instalar) do <pacote de "
-"código>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verificar a secção %files do <fichspec>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "criar o pacote binário a partir do <pacote de código>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "criar o pacote binário a partir do <pacote de código>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "criar só o pacote com código-fonte a partir do <fichspec>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"criar através do %prep (desempacotar o código e aplicar patches) do <fichtar>"
+msgstr "criar através do %prep (desempacotar o código e aplicar patches) do <fichtar>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<fichtar>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "criar através do %build (%prep e depois compilar) do <fichtar>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"criar através do %install (%prep, %build e depois instalar) do <fichtar>"
+msgstr "criar através do %install (%prep, %build e depois instalar) do <fichtar>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificar a secção %files do <fichtar>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "criar os pacotes binários e de código a partir do <fichtar>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "criar só o pacote binário a partir do <fichtar>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "criar só o pacote com código-fonte a partir do <fichtar>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "criar o pacote binário a partir do <pacote de código>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<pacote de código>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "criar através do %install (%prep, %build e depois instalar) do <pacote de código>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "ignorar a raiz de criação"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "apagar as directorias de criação quando acabar"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorar as directivas ExcludeArch: do ficheiro spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "depurar máquina de estados de ficheiros"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "não executar nenhuma etapa da criação"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "não verificar as dependências de compilação"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "não executar nenhuma etapa da criação"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "não aceitar as mensagens de i18N do ficheiro spec"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "apagar o código-fonte quando acabar"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "apagar o ficheiro spec quando acabar"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "saltar directamente para a etapa indicada (só para c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "ignorar a plataforma-alvo"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opções de criação com [ <fich spec> | <fich tar> | <pacote fonte> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Não consegui abrir ficheiro spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Não consegui abrir o 'pipe' para o tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Não consegui abrir ficheiro spec %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Não consegui ler o ficheiro spec do %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Não consegui mudar o nome de %s para %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "Não consegui analisar o %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "O ficheiro %s não é um ficheiro normal.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "O ficheiro %s não parece ser um ficheiro spec.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "A construir plataformas alvo: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "A construir para o alvo %s\n"
@@ -488,9 +426,7 @@ msgstr "inicializar a base de dados"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"reconstruir as listas invertidas da base dados com os cabeçalhos dos pacotes "
-"instalados"
+msgstr "reconstruir as listas invertidas da base dados com os cabeçalhos dos pacotes instalados"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -528,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -548,10 +484,29 @@ msgstr ""
 msgid "Signature options:"
 msgstr "Opções de assinatura:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Não consegui executar %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Precisa definir o \"%%_gpg_name\" no seu ficheiro de macros\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Indique a palavra-chave: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "A palavra-chave está correcta.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -569,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "usar o formato de pesquisa seguinte"
 
@@ -616,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Erros de criação do RPM:\n"
+msgstr "\n\nErros de criação do RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "erro de sintaxe ao analisar o ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "erro de sintaxe ao analisar o &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "erro de sintaxe ao analisar o ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "erro de análise na expressão\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "( não correspondido\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- só em números\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! só em números\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "os tipos têm de corresponder\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / não suportados em cadeias de caracteres\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- não suportado em cadeias de caracteres\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& e || não suportados em cadeias de caracteres\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "erro de sintaxe na expressão\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Falta um '(' em %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Falta um ')' em %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Elemento %s inválido: %s\n"
@@ -690,46 +642,46 @@ msgstr "Elemento %s inválido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Falta um %s em %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Carácter sem ser espaço a seguir a %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxe inválida: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Spec de modo inválido: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Spec de dirmode inválido: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "O ficheiro tem de começar por \"/\": %s\n"
@@ -739,144 +691,149 @@ msgstr "O ficheiro tem de começar por \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Ficheiro listado duas vezes: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "A 'symlink' aponta para a BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Ficheiro não encontrado: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "O ficheiro precisa de começar por \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Ficheiro não encontrado pelo glob: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "linha: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ficheiro inválido: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Dono/grupo inválido: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -905,81 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Não consegui canonizar o nome da máquina: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Não consegui reler o cabeçalho do assinatura.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Não consegui criar região imutável do cabeçalho.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Não consigo aceder ao %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Não consegui gravar o pacote: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
-msgstr ""
-"Não consegui gravar o cabeçalho temporário\n"
-"\n"
+msgstr "Não consegui gravar o cabeçalho temporário\n\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Dados de CSA inválidos\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Não consegui executar %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: O fread falhou: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Gravei: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Não consigo gerar o ficheiro de saída para o pacote %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "não consigo criar o %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linha %d: segundo %s\n"
@@ -1030,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linha %d: Erro ao analisar a %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linha %d: Opção inválida %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linha %d: Demasiados nomes: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linha %d: O pacote não existe: %s\n"
@@ -1149,94 +1104,90 @@ msgstr "linha %d: Opção só recebe um parâmetro: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linha %d: segundo %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "Linha %d: Opção inválida: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linha %d: Opção em branco: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linha %d: Os prefixos não podem acabar em \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linha %d: A docdir tem de começar por '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linha %d: Qualificadores %s: inválidos: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linha %d: Formato da BuildArchitecture inválido: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erro interno: Opção esquisita %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Descrição do pacote inválida: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "O pacote já existe: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linha %d: Opção desconhecida: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1246,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Código-fonte inválido: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erro ao analisar o %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linha %d: Argumento inválido para %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linha %d: Opção inválida do %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linha %d: segundo %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linha %d: os 'triggers' (que activam) têm de ter --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linha %d: Erro ao analisar o %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linha %d: o programa de 'script' tem de começar por '/': %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linha %d: Segundo %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linha %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Incapaz de aceder ao %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Descobri um %%else sem um %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Descobri um %%endif sem um %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Não foram encontradas arquitecturas compatíveis para as quais criar\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "O pacote não tem uma %%description: %s\n"
@@ -1503,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Não consegui executar o %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Não consegui executar à parte o %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Não consegui encontrar o %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "a pesquisa do ficheiro spec %s falhou, não consigo analisar\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(não é um número)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(não é um base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(tipo inválido)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(não é um blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s gravado como %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s criado como %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1906,18 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "os novos locais têm de ter um / a seguir ao ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"instala todos os ficheiros, mesmo as configurações que de outro modo seriam "
-"ignoradas"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "instala todos os ficheiros, mesmo as configurações que de outro modo seriam ignoradas"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"remove todos os pacotes que correspondam a <pacote> (normalmente aparece um "
-"erro se o <pacote> especifica vários pacotes)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "remove todos os pacotes que correspondam a <pacote> (normalmente aparece um erro se o <pacote> especifica vários pacotes)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1995,7 +1920,7 @@ msgstr "actualiza a base de dados, mas não altera o sistema de ficheiros"
 msgid "do not verify package dependencies"
 msgstr "não verifica as dependências do pacote"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2009,8 +1934,7 @@ msgstr ""
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"não reorganiza a instalação dos pacotes para satisfazer as dependências"
+msgstr "não reorganiza a instalação dos pacotes para satisfazer as dependências"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2074,9 +1998,7 @@ msgstr "não executar nenhum dos scripts %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"actualiza para um versão antiga do pacote (o --force faz isto "
-"automaticamente)"
+msgstr "actualiza para um versão antiga do pacote (o --force faz isto automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2118,183 +2040,162 @@ msgstr "actualizar pacote(s)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "pesquisar/verificar todos os pacotes"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "pesquisar/verificar o(s) pacote(s) que contém(êm) o ficheiro"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "pesquisar/verificar o(s) pacote(s) no grupo"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "pesquisar/verificar o(s) pacote(s) com o identificador do pacote"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "pesquisar/verificar o(s) pacote(s) com o identificador do cabeçalho"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "modo de pesquisa do rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "pesquisar/verificar o(s) pacote(s) de transacção de instalação"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "pesquisar o(s) pacote(s) activados pelo pacote"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "modo de verificação do rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "pesquisar/verificar o(s) pacote(s) que oferecem uma dependência"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "pesquisar/verificar o(s) pacote(s) que precisa duma dependência"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "listar todos os ficheiros de configuração"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "listar todos os ficheiros de documentação"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "apresentar a informação básica do ficheiro"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "listar os ficheiros no pacote"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "ignorar ficheiros %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "mostrar os estados dos ficheiros listados"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "não verificar os tamanho dos ficheiros"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "não verificar as ligações simbólicas dos ficheiros"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "não verificar o dono dos ficheiros"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "não verificar o grupo dos ficheiros"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "não verificar hora de modificação dos ficheiros"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "não verificar o modo dos ficheiros"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "não verificar os ficheiros no pacote"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "não verificar as dependências do pacote"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
-msgstr ""
-"esperava-se um pacote com código-fonte, foi encontrado um pacote binário\n"
+msgstr "esperava-se um pacote com código-fonte, foi encontrado um pacote binário\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "o pacote de código-fonte não contem um ficheiro .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "a abertura do pacote falhou%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " no ficheiro "
 
@@ -2369,116 +2270,96 @@ msgstr "nenhum pacote coincide com %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nenhum pacote precisa do %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "nenhum pacote precisa do %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "nenhum pacote activa o %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "nenhum pacote precisa do %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "nenhum pacote precisa do %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nenhum pacote oferece o %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ficheiro %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "o ficheiro %s não pertence a nenhum pacote\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "o pacote %s não está instalado\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: O fread falhou: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NÃO-OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (FALTAM AS CHAVES:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CHAVES SUSPEITAS:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: o acesso falhou: %s\n"
@@ -2503,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NÃO"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "SIM"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "não verifica as dependências do pacote"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c não terminado: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "o utilizador %s não existe - a usar o root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "o grupo %s não existe - a usar o root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Código de integridade inválido"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Cabeçalho inválido/ilegível"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Tamanho do cabeçalho demasiado grande"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Tipo de ficheiro desconhecido"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Erro interno"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Ficheiro de arquivo não está no cabeçalho"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " falhou - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "o acesso ao %s falhou: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2720,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "o %s não pode ser instalado\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "A obter o %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "erro ao ler do ficheiros %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "não consigo aceder ao %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "A instalar o %s\n"
@@ -2781,12 +2614,12 @@ msgstr "a leitura falhou: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2838,15 +2671,12 @@ msgstr ""
 #: lib/rpmprob.c:130
 #, c-format
 msgid "file %s conflicts between attempted installs of %s and %s"
-msgstr ""
-"o ficheiro %s está em conflito com as tentativas de instalação do %s e %s"
+msgstr "o ficheiro %s está em conflito com as tentativas de instalação do %s e %s"
 
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"o ficheiro %s da instalação do %s está em conflito com o ficheiro do pacote "
-"%s"
+msgstr "o ficheiro %s da instalação do %s está em conflito com o ficheiro do pacote %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2951,75 +2781,56 @@ msgstr "má opção '%s' em %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconhecido: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Por favor contacte o %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Não consegui ler o ícone %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Não consegui ler o ícone %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: O fwrite falhou: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -3031,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "não consigo abrir a base de dados Packages em %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3240,241 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "não foi definido o dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: não consigo ler o cabeçalho em 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "não foi definido o dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "não consigo adicionar o registo originalmente em %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"falhou a reconstrução da base de dados: a base de dados original mantém-se\n"
+msgstr "falhou a reconstrução da base de dados: a base de dados original mantém-se\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "falhou a substituição da base de dados antiga pela nova!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "substituir os ficheiros em %s por ficheiros de %s a recuperar"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "falhou a remoção da directoria %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "opção do db desconhecida: \"%s\" ignorada.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "O %s tem um valor numérico inválido, foi ignorado\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "O %s tem um valor demasiado elevado ou pequeno, foi ignorado\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "O %s tem um valor inteiro demasiado elevado ou pequeno, foi ignorado\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "não consigo trancar o %s no %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "partilhado"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "erro(%d) ao criar uma nova instância do pacote\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "opção do db desconhecida: \"%s\" ignorada.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "O %s tem um valor numérico inválido, foi ignorado\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "O %s tem um valor demasiado elevado ou pequeno, foi ignorado\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "O %s tem um valor inteiro demasiado elevado ou pequeno, foi ignorado\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vazio)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vazio)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "A macro %%%s tem as opções incompletas\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "A macro %%%s tem o conteúdo incompleto\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "A macro %%%s tem um nome inválido (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "A macro %%%s tem o conteúdo em branco\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "A macro %%%s não conseguiu ser expandida\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "A macro %%%s tem um nome ilegal (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opção desconhecida %c em %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c não terminado: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Segue-se uma macro impossível de analisar ao %%\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== activo %d vazio %d\n"
@@ -3494,31 +3289,31 @@ msgstr "Ficheiro %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "O ficheiro %s tem menos de %u bytes\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3527,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(nenhum erro)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "erro fatal: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "erro: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "aviso: "
 
@@ -3548,121 +3343,99 @@ msgstr "aviso: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "a alocação de memória (%u bytes) devolveu NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "erro ao ler do ficheiros %s\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "erro ao ler do ficheiros %s\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "falhou a remoção da directoria %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: O fwrite falhou: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Não consegui executar %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: o acesso falhou: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Não consegui executar %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Não consegui executar %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "o gpg não conseguiu gravar a assinatura\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "incapaz de ler a assinatura\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: o rpmWriteSignature falhou: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: o writeLead falhou: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3675,30 +3448,3 @@ msgstr "%s: a leitura do manifesto falhou: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Indique a palavra-chave: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "A palavra-chave está correcta.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Dono/grupo inválido: %s\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Não consegui escrever o conteúdo de %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Não consegui ler o conteúdo de %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Não consegui abrir um ficheiro temporário.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Não consegui abrir o sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Não consegui ler o cabeçalho de %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Não consegui gravar o cabeçalho de %s: %s\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,21 +1,20 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/rpm/"
-"language/pt_BR/)\n"
-"Language: pt_BR\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/rpm-team/rpm/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -37,8 +36,7 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Este programa pode ser livremente redistribuído sob os termos da GNU GPL\n"
+msgstr "Este programa pode ser livremente redistribuído sob os termos da GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -81,7 +79,7 @@ msgstr "Opções de verificação (com -V ou --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opções de Instalação/Atualização/Remoção:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opções comuns para todos os executáveis e modos rpm:"
@@ -102,7 +100,7 @@ msgstr "formato de consulta não esperado"
 msgid "unexpected query source"
 msgstr "fonte de pesquisa não esperada"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "somente um modo principal pode ser especificado"
 
@@ -112,8 +110,7 @@ msgstr ""
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr ""
-"os arquivos somente podem ser realocados durante a instalação de pacotes"
+msgstr "os arquivos somente podem ser realocados durante a instalação de pacotes"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -122,9 +119,7 @@ msgstr "não é possível usar --prefix com --relocate ou --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate e --excludepath somente podem ser usados na instalação de novos "
-"pacotes"
+msgstr "--relocate e --excludepath somente podem ser usados na instalação de novos pacotes"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -140,23 +135,21 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr ""
-"--replacepkgs somente pode ser especificado durante a instalação de pacotes"
+msgstr "--replacepkgs somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr ""
-"--excludedocs somente pode ser especificado durante instalação de pacotes"
+msgstr "--excludedocs somente pode ser especificado durante instalação de pacotes"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr ""
-"--includedocs somente pode ser especificado durante instalação de pacotes"
+msgstr "--includedocs somente pode ser especificado durante instalação de pacotes"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -164,50 +157,39 @@ msgstr "somente um entre --excludedocs e --includedocs pode ser especificado"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr ""
-"--ignorearch somente pode ser especificado durante a instalação de pacotes"
+msgstr "--ignorearch somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr ""
-"--ignoreos somente pode ser especificado durante a instalação de pacotes"
+msgstr "--ignoreos somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr ""
-"--ignoresize somente pode ser especificado durante a instalação de pacotes"
+msgstr "--ignoresize somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr ""
-"--allmatches somente pode ser especificado durante a remoção de pacotes"
+msgstr "--allmatches somente pode ser especificado durante a remoção de pacotes"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr ""
-"--allfiles somente pode ser especificado durante a instalação de pacotes"
+msgstr "--allfiles somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb somente pode ser especificado durante a instalação ou remoção de "
-"pacotes"
+msgstr "--justdb somente pode ser especificado durante a instalação ou remoção de pacotes"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"opções de desativação de scripts somente podem ser especificadas durante a "
-"instalação ou remoção de pacotes"
+msgstr "opções de desativação de scripts somente podem ser especificadas durante a instalação ou remoção de pacotes"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"opções de desativação de disparador somente podem ser especificadas durante "
-"a instalação ou remoção de pacotes"
+msgstr "opções de desativação de disparador somente podem ser especificadas durante a instalação ou remoção de pacotes"
 
 #: rpmqv.c:231
 msgid ""
@@ -219,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "os argumentos para --root (-r) devem começar com uma /"
 
@@ -239,263 +221,201 @@ msgstr "nenhum argumento foi passado para consulta"
 msgid "no arguments given for verify"
 msgstr "nenhum argumento foi passado para verificação"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot já especificado, ignorando %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"construir através de %prep (desempacote os fontes e aplique as correções) a "
-"partir do <specfile>"
+msgstr "construir através de %prep (desempacote os fontes e aplique as correções) a partir do <specfile>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"construir através de %build (%prep, então compile) a partir do <specfile>"
+msgstr "construir através de %build (%prep, então compile) a partir do <specfile>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"construir através de %install (%prep, %build, então instale) a partir do "
-"<specfile>"
+msgstr "construir através de %install (%prep, %build, então instale) a partir do <specfile>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificar seção %files do <specfile>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "construir os pacotes fontes e binários a partir do <specfile>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "construir pacote binário somente a partir do <specfile>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "construir pacote fonte somente a partir do <specfile>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"construir através de %prep (desempacote os fontes e aplique as correções) a "
-"partir do <specfile>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<pacote fonte>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"construir através de %build (%prep, então compile) a partir do <specfile>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"construir através de %install (%prep, %build, então instale) a partir do "
-"<pacote fonte>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verificar seção %files do <specfile>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "construir pacote binário a partir do <pacote fonte>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "construir pacote binário a partir do <pacote fonte>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "construir pacote fonte somente a partir do <specfile>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"construir através de %prep (desempacote os fontes e aplique as correções) a "
-"partir do <tarball>"
+msgstr "construir através de %prep (desempacote os fontes e aplique as correções) a partir do <tarball>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-"construindo através de %build (%prep, então compile) a partir do <tarball>"
+msgstr "construindo através de %build (%prep, então compile) a partir do <tarball>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"construir através de %install (%prep, %build, então instale) a partir do "
-"<tarball>"
+msgstr "construir através de %install (%prep, %build, então instale) a partir do <tarball>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificar seção %files do <tarball>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "construir os pacotes fontes e binários a partir do <tarball>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "construir pacote binário somente a partir do <tarball>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "construir pacote fonte somente a partir do <tarball>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "construir pacote binário a partir do <pacote fonte>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<pacote fonte>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "construir através de %install (%prep, %build, então instale) a partir do <pacote fonte>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "substituir raíz da construção"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "falha ao criar o diretório"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "remover a árvore de construção quando terminar"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorar ExcludeArch: diretivas do arquivo spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "depurar máquina de estados do arquivo"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "não executar nenhum estágio da construção"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "não verificar dependências de construção"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "não executar nenhum estágio da construção"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "não aceitar msgstr's i18N do specfile"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "remover fontes ao finalizar"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "remover specfile ao finalizar"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "pule direto para o estágio especificado (somente para c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "substituir plataforma de destino"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "opções de construção com [ <specfile> | <tarball> | <pacote fonte> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Falha ao construir dependências:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Não foi possível abrir o arquivo spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Não foi possível abrir o pipe do tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Não foi possível abrir o arquivo spec %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Falha ao ler o arquivo spec de %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Falha ao renomear %s para %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "falha ao iniciar %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "O arquivo %s não é um arquivo normal.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "O arquivo %s não parece ser um specfile.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Construindo plataformas de destino: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Construindo para o destino %s\n"
@@ -506,9 +426,7 @@ msgstr "Inicializar banco de dados"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"reconstruir as listas invertidas do banco de dados a partir dos cabeçalhos "
-"dos pacotes instalados"
+msgstr "reconstruir as listas invertidas do banco de dados a partir dos cabeçalhos dos pacotes instalados"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -546,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "nenhum argumento foi passado"
 
@@ -566,10 +484,29 @@ msgstr "remover a assinatura dos pacotes"
 msgid "Signature options:"
 msgstr "Opções de assinatura:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Não foi possível executar %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Você deve definir o \"%%_gpg_name\" no seu arquivo de macro\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Digite a senha: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Senha ok.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -587,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "utilizar o seguinte formato de consulta"
 
@@ -634,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Erros na construção do RPM:\n"
+msgstr "\n\nErros na construção do RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "erro de sintaxe ao analisar ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "erro de sintaxe ao analisar &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "erro de sintaxe ao analisar ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "erro de análise na expressão\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "( sem correspondência\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- somente em números\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! somente em números\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "os tipos devem corresponder\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / não são suportados para strings\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- não é suportado para strings\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& e || não são suportados para strings\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "erro de sintaxe na expressão\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "\"(\" faltando em %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "\"(\" faltando em %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Token de %s inválido: %s\n"
@@ -708,46 +642,46 @@ msgstr "Token de %s inválido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s faltando em %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "caractere de espaço após %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxe inválida: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Modo spec inválido: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Dirmode spec inválido: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacidade inválida: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Suporte à capacidade de arquivo não embutida\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "O arquivo deve começar com uma \"/\": %s\n"
@@ -755,150 +689,151 @@ msgstr "O arquivo deve começar com uma \"/\": %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr ""
-"Algoritmo de digest %u do arquivo é desconhecido, utilizando o MD5 como "
-"alternativa\n"
+msgstr "Algoritmo de digest %u do arquivo é desconhecido, utilizando o MD5 como alternativa\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Arquivo listado duas vezes: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Ligação simbólica aponta para BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Arquivo não encontrado: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: não foi possível carregar a etiqueta desconhecida (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: falha ao ler a chave pública.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: não é uma chave pública blindada.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: falha ao codificar\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "O arquivo precisa da \"/\" inicial: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "O arquivo não foi encontrado pelo glob: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Não foi possível abrir %%files arquivo %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "linha: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Arquivo inválido: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Proprietário/grupo inválido: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Procurando por arquivos desempacotados: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Arquivo(s) instalado(s) (mas não empacotado(s)) encontrado(s):\n"
-"%s"
+msgstr "Arquivo(s) instalado(s) (mas não empacotado(s)) encontrado(s):\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Processando arquivos: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binários dependentes de arquitetura no pacote noarch\n"
 
@@ -927,80 +862,79 @@ msgstr "%s: linha: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Não foi possível canonizar o nome de máquina: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Não foi possível recarregar o cabeçalho da assinatura.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compactação de carga útil desconhecida: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Não foi possível criar uma região de cabeçalho imutável.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Não foi possível gravar o pacote: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Não foi possível gravar o cabeçalho temporário\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Dados CSA inválidos\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Não foi possível abrir %%files arquivo %s: %m\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread falhou: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Gravou: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Executando \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "A execução de \"%s\" falhou.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Falha na verificação \"%s\" do pacote.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
-msgstr ""
-"Não foi possível gerar o nome de arquivo de saída para o pacote %s: %s\n"
+msgstr "Não foi possível gerar o nome de arquivo de saída para o pacote %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "Não foi possível criar %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linha %d: segundo %s\n"
@@ -1051,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linha %d: Erro ao analisar %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linha %d: Opção inválida %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linha %d: Nomes em excesso: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linha %d: O pacote não existe: %s\n"
@@ -1169,96 +1103,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linha %d: A etiqueta toma apenas um token: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "linha %d: caractere inválido \"%c\" em: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "linha %d: caractere inválido \"..\" em: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "linha %d: caractere inválido em: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "linha %d: segundo %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "linha %d: caractere inválido \"..\" em: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: linha: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linha %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linha %d: Etiqueta vazia: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linha %d: Os prefixos não podem terminar com \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linha %d: O docdir deve começar com \"/\": %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "linha %d: campo Epoch deve ser um número sem sinal: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linha %d: %s inválido: qualificadores: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linha %d: formato BuildArchitecture inválido: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linha %d: Somente subpacotes noarch são suportados: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erro interno: tag %d falsa\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "linha %d: %s é obsoleto: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificação do pacote inválida: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "O pacote já existe: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linha %d: Etiqueta desconhecida: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} não pode ser vazio\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} não pode ser \"/\"\n"
@@ -1268,193 +1197,161 @@ msgstr "%%{buildroot} não pode ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fonte inválida: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nenhum número de patch %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch não corresponde à etiqueta \"Patch:\"\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nenhum número de fonte %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Nenhuma etiqueta \"Source:\" no arquivo .spec\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erro ao analisar %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linha %d: Argumento inválido para %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linha %d: Opção inválida %s de %%setup: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "número da correção %s inválido: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linha %d: segundo %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linha %d: os disparadores devem ter --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linha %d: Erro ao analisar %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "linha %d: o script interno deve terminar com \">\": %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linha %d: o script deve começar com \"/\": %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linha %d: Segundo %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linha %d: script interno não suportado: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linha %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Há um %%else sem um %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Há um %%endif sem um %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Nenhuma arquitetura compatível encontrada para a construção\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "O pacote não tem %%description: %s\n"
@@ -1525,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorar regex inválida %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Não foi possível criar um pipe para %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Não foi possível executar %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Não foi possível bifurcar %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "A conversão de %s para inteiro longo falhou.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Os atributos do arquivo não foram configurados\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) falhou: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load falhou: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Falha no reconhecimento do arquivo \"%s\": modo %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Localizando %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Falha ao localizar %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "a consulta ao specfile %s falhou, não foi possível analisá-lo\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s é um Delta RPM e não pode ser instalado diretamente\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Carga útil (%s) não suportada no pacote %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "o pacote %s já foi adicionado, ignorando %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "o pacote %s já foi adicionado, substituindo por %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(não é um número)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(não é base 64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(tipo inválido)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(não é um blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(tipo xml inválido)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(não é uma assinatura OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "substituído"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "não instalado"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "compartilhado pela rede"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "cor errada"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "faltando"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(desconhecido)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(não é uma sequência)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s salvo como %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s criado como %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1928,17 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "realocações devem conter uma / após o ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"instala todos os arquivos, até configurações que poderiam ser ignoradas"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "instala todos os arquivos, até configurações que poderiam ser ignoradas"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"remover todos os pacotes iguais ao <pacote> (normalmente um erro é gerado se "
-"o <pacote> especificou múltiplos pacotes)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "remover todos os pacotes iguais ao <pacote> (normalmente um erro é gerado se o <pacote> especificou múltiplos pacotes)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2016,7 +1920,7 @@ msgstr "atualizar o banco de dados, mas não modificar o sistema de arquivos"
 msgid "do not verify package dependencies"
 msgstr "não verificar as dependências do pacote"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "não verificar o digest dos arquivos"
 
@@ -2094,9 +1998,7 @@ msgstr "não executar nenhum scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"atualizar para uma versão mais antiga do pacote (--force em atualizações faz "
-"isso automaticamente)"
+msgstr "atualizar para uma versão mais antiga do pacote (--force em atualizações faz isso automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2138,182 +2040,162 @@ msgstr "atualizar pacote(s)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "consultar/verificar todos os pacotes"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "modo checksig do rpm"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "consultar/verificar pacote(s) que detém o arquivo"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "consultar/verificar pacote(s) em um grupo"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "consultar/verificar um arquivo de pacote"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "consultar/verificar pacote(s) com um identificador de pacotes"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "consultar/verificar pacote(s) com um identificador de cabeçalhos"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "modo de consulta do rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "consultar/verificar uma instância do cabeçalho"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "consultar/verificar pacote(s) da transação de instalação"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "consultar o(s) pacote(s) disparado pelo pacote"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "modo de verificação do rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "consultar/verificar pacotes que precisam de uma dependência"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "consultar/verificar pacote(s) que fornecem uma dependência"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "consultar/verificar pacotes que precisam de uma dependência"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "consultar/verificar pacotes que precisam de uma dependência"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "consultar/verificar pacotes que precisam de uma dependência"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "consultar/verificar pacotes que precisam de uma dependência"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "não fazer glob com os argumentos"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "não processar arquivos que não são de pacotes como manifestos"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "listar todos os arquivos de configuração"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "listar todos os arquivos de documentação"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "descarregar informações básicas do arquivo"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "listar arquivos do pacote"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "ignorar arquivos %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "exibir o estado dos arquivos listados"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "não verificar o tamanho dos arquivos"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "não verificar o caminho da ligação simbólica dos arquivos"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "não verificar o proprietário dos arquivos"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "não verificar o grupo dos arquivos"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "não verificar a hora de modificação dos arquivos"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "não verificar o modo dos arquivos"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "não verifica as capacidades dos arquivos"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "não verificar os contextos de segurança dos arquivos"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "não verificar os arquivos do pacote"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "não verificar as dependências do pacote"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "não executar script(s) de verificação"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Faltando recursos do rpmlib para %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "um pacote fonte era esperado, mas um binário foi encontrado\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "o pacote fonte não contém um arquivo .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "a descompactação do arquivo falhou %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " no arquivo "
 
@@ -2388,117 +2270,96 @@ msgstr "nenhum pacote corresponde com %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nenhum pacote requer %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "nenhum pacote requer %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "nenhum disparador de pacote %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "nenhum pacote requer %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "nenhum pacote requer %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nenhum pacote fornece %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "arquivo %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "o arquivo %s não pertence a nenhum pacote\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "o registro %u não pôde ser lido\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "o pacote %s não está instalado\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconhecida: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: a importação da chave %d falhou.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: %d não é uma chave pública blindada.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: leitura de importação falhou (%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: A região de cabeçalho imutável não pôde ser lida. Pacote corrompido?\n"
+msgstr "%s: A região de cabeçalho imutável não pôde ser lida. Pacote corrompido?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread falhou: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "Não está OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (CHAVES FALTANDO:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CHAVES NÃO CONFIÁVEIS:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: falha ao abrir: %s\n"
@@ -2523,200 +2384,144 @@ msgstr "Não foi possível alterar o diretório raiz: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Não foi possível restaurar o diretório raiz: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NÃO "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "SIM"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr ""
-"PreReq:, Capacidades: e Obsoletos: as dependências suportam as versões."
+msgstr "PreReq:, Capacidades: e Obsoletos: as dependências suportam as versões."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"Nome(s) de arquivo(s) armazenados como tuplas (dirName,baseName,dirIndex), "
-"não como um caminho."
+msgstr "Nome(s) de arquivo(s) armazenados como tuplas (dirName,baseName,dirIndex), não como um caminho."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "a carga útil do pacote pode ser compactada utilizando bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "a carga útil do pacote pode ser compactada utilizando o xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "a carga útil do pacote pode ser compactada utilizando lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "o(s) arquivo(s) da carga útil do pacote tem o prefixo \"./\"."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "o nome-versão-lançamento do pacote não está fornecido implicitamente."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
-msgstr ""
-"As etiquetas de cabeçalho sempre são classificadas após serem carregadas."
+msgstr "As etiquetas de cabeçalho sempre são classificadas após serem carregadas."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "o interpretador do scriptlet pode usar argumentos do cabeçalho."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
-msgstr ""
-"um conjunto de arquivos de ligação absoluta podem ser instalados sem estarem "
-"completos."
+msgstr "um conjunto de arquivos de ligação absoluta podem ser instalados sem estarem completos."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"scriptlets de pacotes podem acessar o banco de dados rpm durante a "
-"instalação."
+msgstr "scriptlets de pacotes podem acessar o banco de dados rpm durante a instalação."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "suporte interno para scripts lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "o algoritmo digest é configurável por pacote"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "suporte para as capacidades de arquivo do POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "scriptlets de pacotes podem ser expandidos durante a instalação."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "não verificar as dependências do pacote"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c incompleto: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "o usuário %s não existe - usando o root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "o grupo %s não existe - usando o root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Magic inválido"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Cabeçalho inválido/impossível de ler"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Tamanho do cabeçalho muito grande"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Tipo de arquivo desconhecido"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Digest incompatível"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Erro interno"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Arquivo de pacote não está no cabeçalho"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " falhou - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "falha ao abrir %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: não é um pacote rpm (ou um manifesto de pacote)\n"
@@ -2748,42 +2553,42 @@ msgstr "Dependências não satisfeitas:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: não é um pacote rpm (ou um manifesto de pacote): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s não pode ser instalado\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Obtendo %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "ignorando %s - a transferência falhou\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "o pacote %s não é realocável\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "erro ao ler o arquivo %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" especifica múltiplos pacotes:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instalando %s\n"
@@ -2809,12 +2614,12 @@ msgstr "falha na leitura: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "não é um pacote rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "não foi possível criar o bloqueio de transação %s em %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "esperando pelo bloqueio de transação %s em %s\n"
@@ -2881,15 +2686,12 @@ msgstr "o pacote %s (que é mais recente que o %s) já está instalado"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr ""
-"a instalação do pacote %s precisa de %<PRIu64>%cB no sistema de arquivos %s"
+msgstr "a instalação do pacote %s precisa de %<PRIu64>%cB no sistema de arquivos %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"a instalação do pacote %s precisa de %<PRIu64> inodes no sistema de arquivos "
-"%s"
+msgstr "a instalação do pacote %s precisa de %<PRIu64> inodes no sistema de arquivos %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2979,75 +2781,56 @@ msgstr "opção inválida \"%s\" em %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconhecido: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Por favor, contate %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Não foi possível abrir %s para leitura: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "suporte a scriptlet <lua> não embutido\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Não foi possível criar um arquivo temporário para %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Não foi possível duplicar o descritor do arquivo: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Não foi possível ler o ícone %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Não foi possível restaurar o diretório raiz: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite falhou: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "o scriptlet %s falhou, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "o scriptlet %s falhou, sinal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "o scriptlet %s falhou, status de saída %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Formato desconhecido"
 
@@ -3059,142 +2842,127 @@ msgstr "instalar"
 msgid "erase"
 msgstr "apagar"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "não foi possível abrir o banco de dados de pacotes em %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "\"(\" extra no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "\"(\" faltando no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "\")\" faltando no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: falha na leitura da chave pública.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transação"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(não é uma assinatura OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Cabeçalho "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "Digest MD5:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Digest do cabeçalho SHA1:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Cabeçalho "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "ignorado"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "falhou"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "%c %s faltando"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dependências não satisfeitas para %s:\n"
@@ -3268,242 +3036,240 @@ msgstr "iterador da matriz utilizado com diferentes tamanhos de matrizes"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "nenhum dbpath foi definido\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: ignorando"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "erro (%d) ao armazenar o registro #%d em %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: o regexec falhou: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: o regcomp falhou: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: ignorando"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: cabeçalho danificado #%u recuperado -- ignorando.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: não foi possível ler o cabeçalho em 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "nenhum dbpath foi definido"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "falha ao criar o diretório %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "o cabeçalho #%u do banco de dados é inválido -- ignorando.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "não é possível adicionar o registro originalmente em %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"falha ao reconstruir o banco de dados: o banco de dados original permanece "
-"no lugar\n"
+msgstr "falha ao reconstruir o banco de dados: o banco de dados original permanece no lugar\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "falha ao substituir o banco de dados velho pela novo!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "substituir arquivos em %s com arquivos de %s para recuperação"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "falha ao remover o diretório %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "opção db não reconhecida: \"%s\" ignorado.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s tem um valor numérico inválido, ignorado\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s tem valor inteiro longo muito grande ou muito pequeno, ignorado\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s tem um valor inteiro muito grande ou muito pequeno, ignorado\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "não foi possível obter o bloqueio %s em %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "compartilhado"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "erro (%d) ao armazenar o registro \"%s\" em %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "erro (%d) ao remover o registro \"%s\" a partir de %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "erro(%d) ao adicionar o registro de cabeçalho #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "erro(%d) ao remover o registro de cabeçalho #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "erro (%d) ao alocar nova instância do pacote\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "opção db não reconhecida: \"%s\" ignorado.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s tem um valor numérico inválido, ignorado\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s tem valor inteiro longo muito grande ou muito pequeno, ignorado\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s tem um valor inteiro muito grande ou muito pequeno, ignorado\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vazio)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vazio)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "O macro %%%s tem opções incompletas\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "O macro %%%s tem um corpo incompleto\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "O macro %%%s tem um nome inválido (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "O macro %%%s tem um corpo vazio\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "O macro %%%s falhou ao expandir\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "O macro %%%s tem um nome inválido (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opção desconhecida %c em %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c incompleto: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Um %% é seguido por um macro não analisável\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d ativo %d vazio\n"
@@ -3523,31 +3289,31 @@ msgstr "Arquivo %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "O arquivo %s tem menos de %u bytes\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "falha ao criar o diretório"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxe inválida no scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxe inválida no script lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "falha no script lua: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxe inválida no arquivo lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "falha na conexão lua: %s\n"
@@ -3556,19 +3322,19 @@ msgstr "falha na conexão lua: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(sem erros)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "erro fatal: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "erro: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "aviso: "
 
@@ -3577,121 +3343,99 @@ msgstr "aviso: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "a alocação de memória (%u bytes) retornou NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID da chave %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(nada)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "erro ao criar o arquivo temporário %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "erro ao criar o arquivo temporário %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "erro ao criar o arquivo temporário %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "falha ao criar o diretório %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite falhou: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush falhou: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Não foi possível executar %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Não foi possível criar um canal para assinar: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: falha ao abrir: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Não foi possível executar %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Não foi possível abrir %%files arquivo %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "a execução do gpg falhou (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "o gpg falhou ao gravar a assinatura\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "não foi possível ler a assinatura\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature falhou: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature falhou: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "o rpmMkTemp falhou\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead falhou: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3704,43 +3448,3 @@ msgstr "%s: falha na leitura do manifesto: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "não verificar a assinatura do cabeçalho+carga útil"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Digite a senha: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Senha ok.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Proprietário/grupo inválido: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "linha %d: caractere inválido em: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Não foi possível criar um canal para assinar: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Não foi possível gravar carga útil em %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Não foi possível ler carga útil a partir de %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Não foi possível abrir o arquivo temporário.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Não foi possível abrir sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Não foi possível ler o cabeçalho a partir de %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Não foi possível gravar o cabeçalho em %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "não realizar nenhuma ação de coleção"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "A região de cabeçalho imutável não pôde ser lida. Pacote corrompido?\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,20 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/rpm-team/rpm/language/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/rpm-team/rpm/"
+"language/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -36,7 +37,8 @@ msgstr "Copyright (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Este programa pode ser livremente redistribuído sob os termos da GNU GPL\n"
+msgstr ""
+"Este programa pode ser livremente redistribuído sob os termos da GNU GPL\n"
 
 #: cliutils.c:53
 #, c-format
@@ -79,7 +81,7 @@ msgstr "Opções de verificação (com -V ou --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opções de Instalação/Atualização/Remoção:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opções comuns para todos os executáveis e modos rpm:"
@@ -100,7 +102,7 @@ msgstr "formato de consulta não esperado"
 msgid "unexpected query source"
 msgstr "fonte de pesquisa não esperada"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "somente um modo principal pode ser especificado"
 
@@ -110,7 +112,8 @@ msgstr ""
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "os arquivos somente podem ser realocados durante a instalação de pacotes"
+msgstr ""
+"os arquivos somente podem ser realocados durante a instalação de pacotes"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -119,7 +122,9 @@ msgstr "não é possível usar --prefix com --relocate ou --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate e --excludepath somente podem ser usados na instalação de novos pacotes"
+msgstr ""
+"--relocate e --excludepath somente podem ser usados na instalação de novos "
+"pacotes"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,21 +140,23 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr "--replacepkgs somente pode ser especificado durante a instalação de pacotes"
+msgstr ""
+"--replacepkgs somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr "--excludedocs somente pode ser especificado durante instalação de pacotes"
+msgstr ""
+"--excludedocs somente pode ser especificado durante instalação de pacotes"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr "--includedocs somente pode ser especificado durante instalação de pacotes"
+msgstr ""
+"--includedocs somente pode ser especificado durante instalação de pacotes"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
@@ -157,39 +164,50 @@ msgstr "somente um entre --excludedocs e --includedocs pode ser especificado"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr "--ignorearch somente pode ser especificado durante a instalação de pacotes"
+msgstr ""
+"--ignorearch somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr "--ignoreos somente pode ser especificado durante a instalação de pacotes"
+msgstr ""
+"--ignoreos somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
-msgstr "--ignoresize somente pode ser especificado durante a instalação de pacotes"
+msgstr ""
+"--ignoresize somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr "--allmatches somente pode ser especificado durante a remoção de pacotes"
+msgstr ""
+"--allmatches somente pode ser especificado durante a remoção de pacotes"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr "--allfiles somente pode ser especificado durante a instalação de pacotes"
+msgstr ""
+"--allfiles somente pode ser especificado durante a instalação de pacotes"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb somente pode ser especificado durante a instalação ou remoção de pacotes"
+msgstr ""
+"--justdb somente pode ser especificado durante a instalação ou remoção de "
+"pacotes"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "opções de desativação de scripts somente podem ser especificadas durante a instalação ou remoção de pacotes"
+msgstr ""
+"opções de desativação de scripts somente podem ser especificadas durante a "
+"instalação ou remoção de pacotes"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "opções de desativação de disparador somente podem ser especificadas durante a instalação ou remoção de pacotes"
+msgstr ""
+"opções de desativação de disparador somente podem ser especificadas durante "
+"a instalação ou remoção de pacotes"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +219,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "os argumentos para --root (-r) devem começar com uma /"
 
@@ -221,201 +239,263 @@ msgstr "nenhum argumento foi passado para consulta"
 msgid "no arguments given for verify"
 msgstr "nenhum argumento foi passado para verificação"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot já especificado, ignorando %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "construir através de %prep (desempacote os fontes e aplique as correções) a partir do <specfile>"
+msgstr ""
+"construir através de %prep (desempacote os fontes e aplique as correções) a "
+"partir do <specfile>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "construir através de %build (%prep, então compile) a partir do <specfile>"
+msgstr ""
+"construir através de %build (%prep, então compile) a partir do <specfile>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "construir através de %install (%prep, %build, então instale) a partir do <specfile>"
+msgstr ""
+"construir através de %install (%prep, %build, então instale) a partir do "
+"<specfile>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verificar seção %files do <specfile>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "construir os pacotes fontes e binários a partir do <specfile>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "construir pacote binário somente a partir do <specfile>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "construir pacote fonte somente a partir do <specfile>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"construir através de %prep (desempacote os fontes e aplique as correções) a "
+"partir do <specfile>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<pacote fonte>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"construir através de %build (%prep, então compile) a partir do <specfile>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"construir através de %install (%prep, %build, então instale) a partir do "
+"<pacote fonte>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verificar seção %files do <specfile>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "construir pacote binário a partir do <pacote fonte>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "construir pacote binário a partir do <pacote fonte>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "construir pacote fonte somente a partir do <specfile>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "construir através de %prep (desempacote os fontes e aplique as correções) a partir do <tarball>"
+msgstr ""
+"construir através de %prep (desempacote os fontes e aplique as correções) a "
+"partir do <tarball>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "construindo através de %build (%prep, então compile) a partir do <tarball>"
+msgstr ""
+"construindo através de %build (%prep, então compile) a partir do <tarball>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "construir através de %install (%prep, %build, então instale) a partir do <tarball>"
+msgstr ""
+"construir através de %install (%prep, %build, então instale) a partir do "
+"<tarball>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verificar seção %files do <tarball>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "construir os pacotes fontes e binários a partir do <tarball>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "construir pacote binário somente a partir do <tarball>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "construir pacote fonte somente a partir do <tarball>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "construir pacote binário a partir do <pacote fonte>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<pacote fonte>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "construir através de %install (%prep, %build, então instale) a partir do <pacote fonte>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "substituir raíz da construção"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "falha ao criar o diretório"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "remover a árvore de construção quando terminar"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorar ExcludeArch: diretivas do arquivo spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "depurar máquina de estados do arquivo"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "não executar nenhum estágio da construção"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "não verificar dependências de construção"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "não executar nenhum estágio da construção"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "não aceitar msgstr's i18N do specfile"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "remover fontes ao finalizar"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "remover specfile ao finalizar"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "pule direto para o estágio especificado (somente para c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "substituir plataforma de destino"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "opções de construção com [ <specfile> | <tarball> | <pacote fonte> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Falha ao construir dependências:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Não foi possível abrir o arquivo spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Não foi possível abrir o pipe do tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Não foi possível abrir o arquivo spec %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Falha ao ler o arquivo spec de %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Falha ao renomear %s para %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "falha ao iniciar %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "O arquivo %s não é um arquivo normal.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "O arquivo %s não parece ser um specfile.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Construindo plataformas de destino: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Construindo para o destino %s\n"
@@ -426,7 +506,9 @@ msgstr "Inicializar banco de dados"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "reconstruir as listas invertidas do banco de dados a partir dos cabeçalhos dos pacotes instalados"
+msgstr ""
+"reconstruir as listas invertidas do banco de dados a partir dos cabeçalhos "
+"dos pacotes instalados"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -464,49 +546,65 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "nenhum argumento foi passado"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "assinar pacote(s) (idêntico ao --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "remover a assinatura dos pacotes"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "instalar pacote(s)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opções de assinatura:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Não foi possível executar %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Você deve definir o \"%%_gpg_name\" no seu arquivo de macro\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Digite a senha: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Senha ok.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix somente pode ser usado na instalação de novos pacotes"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr ""
+"--allmatches somente pode ser especificado durante a remoção de pacotes"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +622,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "utilizar o seguinte formato de consulta"
 
@@ -571,68 +669,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nErros na construção do RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Erros na construção do RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "erro de sintaxe ao analisar ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "erro de sintaxe ao analisar &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "erro de sintaxe ao analisar ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "erro de análise na expressão\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "( sem correspondência\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- somente em números\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! somente em números\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "os tipos devem corresponder\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / não são suportados para strings\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- não é suportado para strings\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& e || não são suportados para strings\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "erro de sintaxe na expressão\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "\"(\" faltando em %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "\"(\" faltando em %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Token de %s inválido: %s\n"
@@ -642,46 +743,46 @@ msgstr "Token de %s inválido: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s faltando em %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "caractere de espaço após %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sintaxe inválida: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Modo spec inválido: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Dirmode spec inválido: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Capacidade inválida: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Suporte à capacidade de arquivo não embutida\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "O arquivo deve começar com uma \"/\": %s\n"
@@ -689,151 +790,155 @@ msgstr "O arquivo deve começar com uma \"/\": %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr "Algoritmo de digest %u do arquivo é desconhecido, utilizando o MD5 como alternativa\n"
+msgstr ""
+"Algoritmo de digest %u do arquivo é desconhecido, utilizando o MD5 como "
+"alternativa\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Arquivo listado duas vezes: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Ligação simbólica aponta para BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Arquivo não encontrado: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: não foi possível carregar a etiqueta desconhecida (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: falha ao ler a chave pública.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: não é uma chave pública blindada.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: falha ao codificar\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "O arquivo precisa da \"/\" inicial: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "O arquivo não foi encontrado pelo glob: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Não foi possível abrir %%files arquivo %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "linha: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "O arquivo não foi encontrado pelo glob: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Arquivo inválido: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Proprietário/grupo inválido: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Procurando por arquivos desempacotados: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Arquivo(s) instalado(s) (mas não empacotado(s)) encontrado(s):\n%s"
+msgstr ""
+"Arquivo(s) instalado(s) (mas não empacotado(s)) encontrado(s):\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Processando arquivos: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binários dependentes de arquitetura no pacote noarch\n"
 
@@ -862,79 +967,77 @@ msgstr "%s: linha: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Não foi possível canonizar o nome de máquina: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Não foi possível recarregar o cabeçalho da assinatura.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compactação de carga útil desconhecida: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Não foi possível criar uma região de cabeçalho imutável.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Não foi possível gravar o pacote: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Não foi possível gravar o cabeçalho temporário\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Dados CSA inválidos\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Gravou: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Executando \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "A execução de \"%s\" falhou.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Falha na verificação \"%s\" do pacote.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
-msgstr "Não foi possível gerar o nome de arquivo de saída para o pacote %s: %s\n"
+msgstr ""
+"Não foi possível gerar o nome de arquivo de saída para o pacote %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "Não foi possível criar %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linha %d: segundo %s\n"
@@ -985,19 +1088,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linha %d: Erro ao analisar %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linha %d: Opção inválida %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "linha %d: Nomes em excesso: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "linha %d: O pacote não existe: %s\n"
@@ -1103,91 +1206,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linha %d: A etiqueta toma apenas um token: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "linha %d: caractere inválido \"%c\" em: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "linha %d: caractere inválido em: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "linha %d: caractere inválido \"..\" em: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "linha %d: segundo %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: linha: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linha %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linha %d: Etiqueta vazia: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linha %d: Os prefixos não podem terminar com \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linha %d: O docdir deve começar com \"/\": %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "linha %d: campo Epoch deve ser um número sem sinal: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linha %d: %s inválido: qualificadores: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linha %d: formato BuildArchitecture inválido: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linha %d: Somente subpacotes noarch são suportados: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erro interno: tag %d falsa\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "linha %d: %s é obsoleto: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificação do pacote inválida: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "O pacote já existe: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linha %d: Etiqueta desconhecida: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} não pode ser vazio\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} não pode ser \"/\"\n"
@@ -1197,161 +1305,193 @@ msgstr "%%{buildroot} não pode ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fonte inválida: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nenhum número de patch %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch não corresponde à etiqueta \"Patch:\"\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nenhum número de fonte %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Nenhuma etiqueta \"Source:\" no arquivo .spec\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erro ao analisar %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linha %d: Argumento inválido para %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linha %d: Opção inválida %s de %%setup: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "número da correção %s inválido: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linha %d: segundo %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "linha %d: os disparadores devem ter --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "linha %d: Erro ao analisar %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "linha %d: o script interno deve terminar com \">\": %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "linha %d: o script deve começar com \"/\": %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "linha %d: Segundo %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linha %d: script interno não suportado: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "linha %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Há um %%else sem um %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Há um %%endif sem um %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Nenhuma arquitetura compatível encontrada para a construção\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "O pacote não tem %%description: %s\n"
@@ -1422,290 +1562,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorar regex inválida %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Não foi possível criar um pipe para %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Não foi possível executar %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Não foi possível bifurcar %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "A conversão de %s para inteiro longo falhou.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Os atributos do arquivo não foram configurados\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) falhou: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load falhou: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Falha no reconhecimento do arquivo \"%s\": modo %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Localizando %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Falha ao localizar %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "a consulta ao specfile %s falhou, não foi possível analisá-lo\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s é um Delta RPM e não pode ser instalado diretamente\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Carga útil (%s) não suportada no pacote %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "o pacote %s já foi adicionado, ignorando %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "o pacote %s já foi adicionado, substituindo por %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(não é um número)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(não é base 64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(tipo inválido)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(não é um blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(tipo xml inválido)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(não é uma assinatura OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "substituído"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "não instalado"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "compartilhado pela rede"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "cor errada"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "faltando"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(desconhecido)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(não é uma sequência)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s salvo como %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s criado como %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1965,17 @@ msgid "relocations must have a / following the ="
 msgstr "realocações devem conter uma / após o ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "instala todos os arquivos, até configurações que poderiam ser ignoradas"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"instala todos os arquivos, até configurações que poderiam ser ignoradas"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "remover todos os pacotes iguais ao <pacote> (normalmente um erro é gerado se o <pacote> especificou múltiplos pacotes)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"remover todos os pacotes iguais ao <pacote> (normalmente um erro é gerado se "
+"o <pacote> especificou múltiplos pacotes)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2053,7 @@ msgstr "atualizar o banco de dados, mas não modificar o sistema de arquivos"
 msgid "do not verify package dependencies"
 msgstr "não verificar as dependências do pacote"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "não verificar o digest dos arquivos"
 
@@ -1998,7 +2131,9 @@ msgstr "não executar nenhum scriptlet %%triggerpostun"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "atualizar para uma versão mais antiga do pacote (--force em atualizações faz isso automaticamente)"
+msgstr ""
+"atualizar para uma versão mais antiga do pacote (--force em atualizações faz "
+"isso automaticamente)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2175,182 @@ msgstr "atualizar pacote(s)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "consultar/verificar todos os pacotes"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "modo checksig do rpm"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "consultar/verificar pacote(s) que detém o arquivo"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "consultar/verificar pacote(s) em um grupo"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "consultar/verificar um arquivo de pacote"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "consultar/verificar pacote(s) com um identificador de pacotes"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "consultar/verificar pacote(s) com um identificador de cabeçalhos"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "modo de consulta do rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "consultar/verificar uma instância do cabeçalho"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "consultar/verificar pacote(s) da transação de instalação"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "consultar o(s) pacote(s) disparado pelo pacote"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "modo de verificação do rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "consultar/verificar pacotes que precisam de uma dependência"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "consultar/verificar pacote(s) que fornecem uma dependência"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "consultar/verificar pacotes que precisam de uma dependência"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "consultar/verificar pacotes que precisam de uma dependência"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "consultar/verificar pacotes que precisam de uma dependência"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "consultar/verificar pacotes que precisam de uma dependência"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "não fazer glob com os argumentos"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "não processar arquivos que não são de pacotes como manifestos"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "listar todos os arquivos de configuração"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "listar todos os arquivos de documentação"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "descarregar informações básicas do arquivo"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "listar arquivos do pacote"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "ignorar arquivos %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "exibir o estado dos arquivos listados"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "não verificar o tamanho dos arquivos"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "não verificar o caminho da ligação simbólica dos arquivos"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "não verificar o proprietário dos arquivos"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "não verificar o grupo dos arquivos"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "não verificar a hora de modificação dos arquivos"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "não verificar o modo dos arquivos"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "não verifica as capacidades dos arquivos"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "não verificar os contextos de segurança dos arquivos"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "não verificar os arquivos do pacote"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "não verificar as dependências do pacote"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "não executar script(s) de verificação"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Faltando recursos do rpmlib para %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "um pacote fonte era esperado, mas um binário foi encontrado\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "o pacote fonte não contém um arquivo .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "a descompactação do arquivo falhou %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " no arquivo "
 
@@ -2270,96 +2425,117 @@ msgstr "nenhum pacote corresponde com %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nenhum pacote requer %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "nenhum pacote requer %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "nenhum disparador de pacote %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "nenhum pacote requer %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "nenhum pacote requer %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nenhum pacote fornece %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "arquivo %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "o arquivo %s não pertence a nenhum pacote\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "o registro %u não pôde ser lido\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "o pacote %s não está instalado\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconhecida: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: a importação da chave %d falhou.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: %d não é uma chave pública blindada.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: leitura de importação falhou (%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: A região de cabeçalho imutável não pôde ser lida. Pacote corrompido?\n"
+msgstr ""
+"%s: A região de cabeçalho imutável não pôde ser lida. Pacote corrompido?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread falhou: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "Não está OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (CHAVES FALTANDO:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (CHAVES NÃO CONFIÁVEIS:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: falha ao abrir: %s\n"
@@ -2384,144 +2560,200 @@ msgstr "Não foi possível alterar o diretório raiz: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Não foi possível restaurar o diretório raiz: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NÃO "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "SIM"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "PreReq:, Capacidades: e Obsoletos: as dependências suportam as versões."
+msgstr ""
+"PreReq:, Capacidades: e Obsoletos: as dependências suportam as versões."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "Nome(s) de arquivo(s) armazenados como tuplas (dirName,baseName,dirIndex), não como um caminho."
+msgstr ""
+"Nome(s) de arquivo(s) armazenados como tuplas (dirName,baseName,dirIndex), "
+"não como um caminho."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "a carga útil do pacote pode ser compactada utilizando bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "a carga útil do pacote pode ser compactada utilizando o xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "a carga útil do pacote pode ser compactada utilizando lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "o(s) arquivo(s) da carga útil do pacote tem o prefixo \"./\"."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "o nome-versão-lançamento do pacote não está fornecido implicitamente."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
-msgstr "As etiquetas de cabeçalho sempre são classificadas após serem carregadas."
+msgstr ""
+"As etiquetas de cabeçalho sempre são classificadas após serem carregadas."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "o interpretador do scriptlet pode usar argumentos do cabeçalho."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
-msgstr "um conjunto de arquivos de ligação absoluta podem ser instalados sem estarem completos."
+msgstr ""
+"um conjunto de arquivos de ligação absoluta podem ser instalados sem estarem "
+"completos."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "scriptlets de pacotes podem acessar o banco de dados rpm durante a instalação."
+msgstr ""
+"scriptlets de pacotes podem acessar o banco de dados rpm durante a "
+"instalação."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "suporte interno para scripts lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "o algoritmo digest é configurável por pacote"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "suporte para as capacidades de arquivo do POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "scriptlets de pacotes podem ser expandidos durante a instalação."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "não verificar as dependências do pacote"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c incompleto: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "o usuário %s não existe - usando o root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "o grupo %s não existe - usando o root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Magic inválido"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Cabeçalho inválido/impossível de ler"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Tamanho do cabeçalho muito grande"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Tipo de arquivo desconhecido"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Digest incompatível"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Erro interno"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Arquivo de pacote não está no cabeçalho"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " falhou - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "falha ao abrir %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: não é um pacote rpm (ou um manifesto de pacote)\n"
@@ -2553,42 +2785,42 @@ msgstr "Dependências não satisfeitas:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: não é um pacote rpm (ou um manifesto de pacote): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s não pode ser instalado\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Obtendo %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "ignorando %s - a transferência falhou\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "o pacote %s não é realocável\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "erro ao ler o arquivo %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" especifica múltiplos pacotes:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instalando %s\n"
@@ -2614,12 +2846,12 @@ msgstr "falha na leitura: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "não é um pacote rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "não foi possível criar o bloqueio de transação %s em %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "esperando pelo bloqueio de transação %s em %s\n"
@@ -2686,12 +2918,15 @@ msgstr "o pacote %s (que é mais recente que o %s) já está instalado"
 #: lib/rpmprob.c:145
 #, c-format
 msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
-msgstr "a instalação do pacote %s precisa de %<PRIu64>%cB no sistema de arquivos %s"
+msgstr ""
+"a instalação do pacote %s precisa de %<PRIu64>%cB no sistema de arquivos %s"
 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "a instalação do pacote %s precisa de %<PRIu64> inodes no sistema de arquivos %s"
+msgstr ""
+"a instalação do pacote %s precisa de %<PRIu64> inodes no sistema de arquivos "
+"%s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2777,60 +3012,79 @@ msgstr "arquitetura faltando para %s em %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "opção inválida \"%s\" em %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Sistema desconhecido: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Por favor, contate %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Não foi possível abrir %s para leitura: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "suporte a scriptlet <lua> não embutido\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Não foi possível criar um arquivo temporário para %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Não foi possível duplicar o descritor do arquivo: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Não foi possível ler o ícone %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Não foi possível restaurar o diretório raiz: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite falhou: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "o scriptlet %s falhou, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "o scriptlet %s falhou, sinal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "o scriptlet %s falhou, status de saída %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Formato desconhecido"
 
@@ -2842,127 +3096,146 @@ msgstr "instalar"
 msgid "erase"
 msgstr "apagar"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "não foi possível abrir o banco de dados de pacotes em %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "\"(\" extra no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "\"(\" faltando no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "\")\" faltando no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: falha na leitura da chave pública.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transação"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(não é uma assinatura OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "Digest MD5:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Não foi possível recarregar o cabeçalho da assinatura.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Digest do cabeçalho SHA1:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Cabeçalho "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "Digest MD5:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Digest do cabeçalho SHA1:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "ignorado"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "falhou"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "%c %s faltando"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Dependências não satisfeitas para %s:\n"
@@ -3036,240 +3309,242 @@ msgstr "iterador da matriz utilizado com diferentes tamanhos de matrizes"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "nenhum dbpath foi definido\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: ignorando"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "erro (%d) ao armazenar o registro #%d em %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: o regexec falhou: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: o regcomp falhou: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: ignorando"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: cabeçalho danificado #%u recuperado -- ignorando.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: não foi possível ler o cabeçalho em 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "nenhum dbpath foi definido"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "falha ao criar o diretório %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "o cabeçalho #%u do banco de dados é inválido -- ignorando.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "não é possível adicionar o registro originalmente em %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "falha ao reconstruir o banco de dados: o banco de dados original permanece no lugar\n"
+msgstr ""
+"falha ao reconstruir o banco de dados: o banco de dados original permanece "
+"no lugar\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "falha ao substituir o banco de dados velho pela novo!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "substituir arquivos em %s com arquivos de %s para recuperação"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "falha ao remover o diretório %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "não foi possível obter o bloqueio %s em %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "compartilhado"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "exclusivo"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "erro (%d) ao armazenar o registro \"%s\" em %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "erro (%d) ao remover o registro \"%s\" a partir de %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "erro(%d) ao adicionar o registro de cabeçalho #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "erro(%d) ao remover o registro de cabeçalho #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "erro (%d) ao alocar nova instância do pacote\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "opção db não reconhecida: \"%s\" ignorado.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s tem um valor numérico inválido, ignorado\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s tem valor inteiro longo muito grande ou muito pequeno, ignorado\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s tem um valor inteiro muito grande ou muito pequeno, ignorado\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "não foi possível obter o bloqueio %s em %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "compartilhado"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "exclusivo"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "erro (%d) ao armazenar o registro \"%s\" em %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "erro (%d) ao remover o registro \"%s\" a partir de %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "erro(%d) ao adicionar o registro de cabeçalho #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "erro(%d) ao remover o registro de cabeçalho #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "erro (%d) ao alocar nova instância do pacote\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(vazio)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vazio)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "O macro %%%s tem opções incompletas\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "O macro %%%s tem um corpo incompleto\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "O macro %%%s tem um nome inválido (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "O macro %%%s tem um corpo vazio\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "O macro %%%s falhou ao expandir\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "O macro %%%s tem um nome inválido (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opção desconhecida %c em %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c incompleto: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Um %% é seguido por um macro não analisável\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d ativo %d vazio\n"
@@ -3289,31 +3564,31 @@ msgstr "Arquivo %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "O arquivo %s tem menos de %u bytes\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "falha ao criar o diretório"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxe inválida no scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxe inválida no script lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "falha no script lua: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxe inválida no arquivo lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "falha na conexão lua: %s\n"
@@ -3322,19 +3597,19 @@ msgstr "falha na conexão lua: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(sem erros)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "erro fatal: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "erro: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "aviso: "
 
@@ -3343,99 +3618,154 @@ msgstr "aviso: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "a alocação de memória (%u bytes) retornou NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID da chave %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(nada)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "erro ao criar o arquivo temporário %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "erro ao criar o arquivo temporário %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "erro ao criar o arquivo temporário %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "falha ao criar o diretório %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite falhou: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush falhou: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Não foi possível criar um canal para assinar: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Não foi possível executar %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: falha ao abrir: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "a execução do gpg falhou (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "o gpg falhou ao gravar a assinatura\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "não foi possível ler a assinatura\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature falhou: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature falhou: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "a execução falhou\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "o rpmMkTemp falhou\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "a execução falhou\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "a execução falhou\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature falhou: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature falhou: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "o rpmMkTemp falhou\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead falhou: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3778,18 @@ msgstr "%s: falha na leitura do manifesto: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "não verificar a assinatura do cabeçalho+carga útil"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Digite a senha: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Senha ok.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Proprietário/grupo inválido: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "linha %d: caractere inválido em: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Não foi possível criar um canal para assinar: %m"

--- a/po/rpm.pot
+++ b/po/rpm.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +100,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -505,29 +505,60 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+msgid "sign package(s) files"
+msgstr ""
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
+
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
+msgstr ""
+
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -778,79 +809,84 @@ msgstr ""
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1649
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2083
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -879,74 +915,71 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:441
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:510
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:565
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:618
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
@@ -1283,7 +1316,7 @@ msgstr ""
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:253 lib/rpmds.c:1438
 msgid "Version required"
 msgstr ""
 
@@ -1345,66 +1378,66 @@ msgstr ""
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:196
+#: build/parseSpec.c:209
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:300
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
+#: build/parseSpec.c:638
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:654
+#: build/parseSpec.c:667
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:799
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -2399,7 +2432,7 @@ msgstr ""
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
@@ -2409,7 +2442,7 @@ msgstr ""
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
@@ -2438,7 +2471,7 @@ msgstr ""
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2543,95 +2576,95 @@ msgstr ""
 msgid "support for rich dependencies."
 msgstr ""
 
-#: lib/rpmds.c:1385
+#: lib/rpmds.c:1384
 #, c-format
 msgid "Unknown rich dependency op '%.*s'"
 msgstr ""
 
-#: lib/rpmds.c:1422
+#: lib/rpmds.c:1419
 msgid "Name required"
 msgstr ""
 
-#: lib/rpmds.c:1459
+#: lib/rpmds.c:1456
 msgid "Rich dependency does not start with '('"
 msgstr ""
 
-#: lib/rpmds.c:1467
+#: lib/rpmds.c:1464
 msgid "Missing argument to rich dependency op"
 msgstr ""
 
-#: lib/rpmds.c:1469
+#: lib/rpmds.c:1466
 msgid "Empty rich dependency"
 msgstr ""
 
-#: lib/rpmds.c:1483
+#: lib/rpmds.c:1480
 #, c-format
 msgid "Unterminated rich dependency: %s"
 msgstr ""
 
-#: lib/rpmds.c:1495
+#: lib/rpmds.c:1492
 msgid "Cannot chain different ops"
 msgstr ""
 
-#: lib/rpmds.c:1500
+#: lib/rpmds.c:1497
 msgid "Can only chain AND and OR ops"
 msgstr ""
 
-#: lib/rpmds.c:1592
+#: lib/rpmds.c:1587
 msgid "Junk after rich dependency"
 msgstr ""
 
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr ""
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
@@ -2903,21 +2936,21 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
@@ -3016,77 +3049,81 @@ msgstr ""
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
+#: lib/signature.c:78
 #, c-format
 msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:83
+#: lib/signature.c:84
 #, c-format
 msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
-#: lib/signature.c:90
+#: lib/signature.c:91
 #, c-format
 msgid "%s tag %u: BAD, invalid OpenPGP signature"
 msgstr ""
 
-#: lib/signature.c:159
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr ""
+
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:377
+#: lib/signature.c:464
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:467
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
@@ -3238,39 +3275,39 @@ msgstr ""
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
@@ -3512,110 +3549,139 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
+#: sign/rpmgensig.c:58
 #, c-format
 msgid "error creating temp directory %s: %m\n"
 msgstr ""
 
-#: sign/rpmgensig.c:64
+#: sign/rpmgensig.c:66
 #, c-format
 msgid "error creating fifo %s: %m\n"
 msgstr ""
 
-#: sign/rpmgensig.c:85
+#: sign/rpmgensig.c:87
 #, c-format
 msgid "error delete fifo %s: %m\n"
 msgstr ""
 
-#: sign/rpmgensig.c:93
+#: sign/rpmgensig.c:95
 #, c-format
 msgid "error delete directory %s: %m\n"
 msgstr ""
 
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:278
 #, c-format
 msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:289
+#: sign/rpmgensig.c:288
 msgid "Fopen failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:304
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:311
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+msgid "headerReload failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+msgid "copyFile failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:622
+msgid "headerWrite failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,21 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Russian (http://www.transifex.com/rpm-team/rpm/language/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -79,7 +81,7 @@ msgstr "Параметры проверки (с -V или --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Параметры Установки/Обновления/Удаления:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Общие параметры для всех режимов и компонентов rpm:"
@@ -100,7 +102,7 @@ msgstr "неожиданный формат запроса"
 msgid "unexpected query source"
 msgstr "неожиданный источник запроса"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "может быть указан только один из основных режимов"
 
@@ -119,7 +121,9 @@ msgstr "--prefix нельзя использовать с --relocate или --ex
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "варианты --relocate и --excludepath можно использовать только при установке новых пакетов"
+msgstr ""
+"варианты --relocate и --excludepath можно использовать только при установке "
+"новых пакетов"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +139,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -153,7 +156,9 @@ msgstr "--includedocs может быть указан только при ус�
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
-msgstr "может быть использован только один из параметров --excludedocs или --includedocs"
+msgstr ""
+"может быть использован только один из параметров --excludedocs или --"
+"includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
@@ -183,13 +188,17 @@ msgstr "--justdb может быть указан только при устан
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "параметры запрета сценариев могут быть указаны только при установке или удалении пакета"
+msgstr ""
+"параметры запрета сценариев могут быть указаны только при установке или "
+"удалении пакета"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "параметры запрета триггеров могут быть указан только при установке или удалении пакета(ов)"
+msgstr ""
+"параметры запрета триггеров могут быть указан только при установке или "
+"удалении пакета(ов)"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +210,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументы для --root (-r) должны начинаться с /"
 
@@ -221,201 +230,261 @@ msgstr "не заданы аргументы запроса"
 msgid "no arguments given for verify"
 msgstr "не заданы аргументы для верификации"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot уже указан, %s игнорируется\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <файл спецификации>"
+msgstr ""
+"выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <файл "
+"спецификации>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<файл спецификации>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "выполнить по стадию %build (%prep, затем компиляция) из <файл спецификации>"
+msgstr ""
+"выполнить по стадию %build (%prep, затем компиляция) из <файл спецификации>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "выполнить по стадию %install (%prep, %build, затем установка) из <файл спецификации>"
+msgstr ""
+"выполнить по стадию %install (%prep, %build, затем установка) из <файл "
+"спецификации>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "проверить раздел %files из <файл спецификации>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "собрать исходный и двоичный пакеты по <файл спецификации>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "собрать двоичный пакет по <файл спецификации>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "собрать исходный пакет по <файлу спецификации>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <файл "
+"спецификации>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<исходный пакет>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"выполнить по стадию %build (%prep, затем компиляция) из <файл спецификации>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"выполнить по стадию %install (%prep, %build, затем установка)  из <исходный "
+"пакет>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "проверить раздел %files из <файл спецификации>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "собрать двоичный пакет из <исходный пакет>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "собрать двоичный пакет из <исходный пакет>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "собрать исходный пакет по <файлу спецификации>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <архив tar>"
+msgstr ""
+"выполнить по стадию %prep (развернуть исходники и наложить заплаты) из "
+"<архив tar>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<архив tar>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "выполнить по стадию %build (%prep, затем компиляция) из <архив tar>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "выполнить по стадию %install (%prep, %build, затем установка) из <архив tar>"
+msgstr ""
+"выполнить по стадию %install (%prep, %build, затем установка) из <архив tar>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "проверить секцию %files из <архив tar>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "собрать исходный и двоичный пакеты из <архив tar>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "собрать двоичный пакет из <архив tar>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "собрать исходный пакет из <архив tar>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "собрать двоичный пакет из <исходный пакет>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<исходный пакет>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "выполнить по стадию %install (%prep, %build, затем установка)  из <исходный пакет>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "переопределить build root"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "после завершения удалить дерево исходников"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "игнорировать ExcludeArch: в файле конфигурации"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "отладка машины состояния файлов"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "не выполнять никаких этапов сборки"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "не проверять зависимости пакета перед сборкой"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "не выполнять никаких этапов сборки"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "игнорировать строки i18N из файла спецификации"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "после завершения удалить исходники"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "после завершения удалить файл спецификации"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "перейти непосредственно к указанному этапу (только для c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "переопределить целевую платформу"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Параметры сборки с [ <файл спецификации> | <тар архив> | <исходный пакет> ]:"
+msgstr ""
+"Параметры сборки с [ <файл спецификации> | <тар архив> | <исходный пакет> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Неудовлетворенные зависимости сборки:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Ошибка открытия файла спецификации %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Ошибка открытия канала tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Ошибка открытия файла спецификации %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Ошибка чтения файла спецификации из %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Невозможно переименовать %s в %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "невозможно получить информацию о %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Не обычный файл: %s.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Файл %s не похож на файл спецификации.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Платформы для сборки: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Сборка для платформы %s\n"
@@ -426,7 +495,9 @@ msgstr "инициализировать базу данных"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "переиндексировать базу инвертированных списков из установленных заголовков пакетов"
+msgstr ""
+"переиндексировать базу инвертированных списков из установленных заголовков "
+"пакетов"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -464,49 +535,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "не заданы аргументы"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "подписать пакет(ы)"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "подписать пакет (то же самое что --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "удалить подписи пакета"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "подписать пакет(ы)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Параметры подписи:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Невозможно выполнить %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Вы должны установить \"%%_gpg_name\" в вашем макрофайле\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Введите ключевую фразу: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Ключевая фраза принята.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "вариант --prefix можно использовать только при установке новых пакетов"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches может быть указан только при удалении пакета"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +610,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "используйте следующий формат запроса"
 
@@ -571,68 +657,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nОшибки сборки пакетов:\n"
+msgstr ""
+"\n"
+"\n"
+"Ошибки сборки пакетов:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "синтаксическая ошибка при анализе ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "синтаксическая ошибка при анализе &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "синтаксическая ошибка при анализе ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "ошибка анализа выражения\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "незакрытая (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- только для чисел\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! только для чисел\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "типы должны совпадать\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / не поддерживается для строк\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- не поддерживается для строк\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& и || не поддерживаются для строк\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "синтаксическая ошибка в выражении\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Отсутствует '(' в %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "отсутствует ')' в %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Неверный токен %s: %s\n"
@@ -642,46 +731,46 @@ msgstr "Неверный токен %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Отсутствует %s в %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Не пробел следует после %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Неверный синтаксис: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Неверные права: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Неверные права на каталог %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Файл должен начинаться с \"/\": %s\n"
@@ -691,149 +780,151 @@ msgstr "Файл должен начинаться с \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Не удается проверить файл %u, возврат к MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Файл указан дважды: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Символическая ссылка указывает на BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Файл не найден: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: это не открытый ключ.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Файл должен начинаться с \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Файл не найден: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "строка: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Файл не найден: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Неверный файл %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Неверная пара владелец/группа: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Проверка на неупакованный(е) файл(ы): %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Обнаружен(ы) установленный(е) (но не упакованный(е)) файл(ы):\n%s"
+msgstr ""
+"Обнаружен(ы) установленный(е) (но не упакованный(е)) файл(ы):\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Двоичные данные с архитекутрой в пакете noarch\n"
 
@@ -862,79 +953,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Невозможно канонизировать имя компьютера: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Невозможно перезагрузить заголовок подписи.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Невозможно поместить заголовок в нерперывную область памяти.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Невозможно открыть %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Невозможно записать пакет: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Невозможно записать временный заголовок\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Неверные данные CSA\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записан: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Выполнение \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Выполнение \"%s\" не удалось.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Невозможно создать имя файла для пакета %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "невозможно создать %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "строка %d: второе %s\n"
@@ -985,19 +1073,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "строка %d: Ошибка анализа %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "строка %d: Неверный параметр %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "строка %d: Слишком много имен: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "строка %d: Пакет не существует: %s\n"
@@ -1104,90 +1192,94 @@ msgstr "строка %d: Ярлык требует только один арг�
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "строка %d: второе %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "строка %d: Неверный тэг: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "строка %d: Пустой тэг: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "строка %d: Префикс не может заканчиваться на \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "строка %d: Docdir должен начинаться с '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "строка %d: Неверное число %s: определяет: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "строка %d: Неверный формат BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Внутренняя ошибка: Неизвестный ярлык %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Неверная спецификация пакета: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Пакет уже существует: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "строка %d: Неизвестный тэг: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1289,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Неверный исходник: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Ошибка анализа %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "строка %d: Неверный аргумент для %%setup %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "строка %d: Неверный параметр %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "строка %d: второй %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "строка %d: триггеры должны содержать --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "строка %d: Ошибка анализа %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "строка %d: Программы в сценариях должны начинаться с '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "строка %d: Второе %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "строка %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Невозможно открыть %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Найден %%else без %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Найден %%endif без %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Не найдены совместимые архитектуры для сборки.\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Пакет не имеет %%description: %s\n"
@@ -1422,290 +1546,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Невозможно выполнить %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Сбой ветвления %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s не удалось: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "не удалось записать все данные в %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Идет поиск  %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Невозможно найти %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "запрос файла спецификации %s не удался, невозможно разобрать файл\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s является Delta RPM и не может быть установлен напрямую\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакет %s был уже добавлен, пропускаем %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакет %s уже был добавлен, заменяется %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(не число)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(не base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(неправильный тип)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(not a blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(неверный тип xml)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(не подпись формата OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Неверная дата %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "нормальный"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "перемещен"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "не установлен"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(неизвестный)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(не строка)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s сохранен как %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s создан как %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1949,18 @@ msgid "relocations must have a / following the ="
 msgstr "перемещения должны иметь / после ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "устанавливать все файлы, даже конфигурационные, которые могли бы быть пропущены"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"устанавливать все файлы, даже конфигурационные, которые могли бы быть "
+"пропущены"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "удалить все пакеты, совпадающие с <пакет> (обычно, если <пакет> соответствует нескольким пакетам, генерируется ошибка)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"удалить все пакеты, совпадающие с <пакет> (обычно, если <пакет> "
+"соответствует нескольким пакетам, генерируется ошибка)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2038,7 @@ msgstr "обновить базу данных, но не модифициров
 msgid "do not verify package dependencies"
 msgstr "не проверять зависимости пакета"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1998,7 +2116,9 @@ msgstr "не исполнять %%triggerpostun сценариев"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "откат на более старую версию пакета (--force при обновлении делает это автоматически)"
+msgstr ""
+"откат на более старую версию пакета (--force при обновлении делает это "
+"автоматически)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2160,182 @@ msgstr "обновить пакет(ы)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "запросить/проверить все пакеты"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "режим проверки подписи"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "запросить/проверить пакет, которому принадлежит файл"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "запросить/проверить пакеты в группе"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "запросить/проверить файл пакета"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "запросить/проверить пакет(ы) по идентификатору пакета"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "запросить/проверить пакет(ы), по идентификатору заголовка"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "режим запроса rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "запросить/проверить заголовок"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "запросить/проверить пакет(ы) из транзакции установки"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "запросить пакеты с триггер-сценариями на пакет"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "режим проверки rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "найти/проверить пакеты, требующие сервис"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "найти/проверить пакеты, предоставляющие сервис"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "найти/проверить пакеты, требующие сервис"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "найти/проверить пакеты, требующие сервис"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "найти/проверить пакеты, требующие сервис"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "найти/проверить пакеты, требующие сервис"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "показать все файлы конфигурации"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "показать все файлы документации"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "показать основную информацию о файле"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "показать список файлов пакета"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "пропустить файлы %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "показать состояние перечисленных файлов"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "не проверять размер файлов"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "не проверять путь символических ссылок"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "не проверять хозяина файлов"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "не проверять группу файлов"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "не проверять время модификации файлов"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "не проверять права доступа файлов пакета"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "не проверять файлы пакета"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "не проверять зависимости пакета"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "не исполнять сценарий(и) проверки"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "обнаружен двоичный пакет вместо ожидаемого исходного\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "исходный пакет не содержит файла спецификации\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "распаковка архива не удалась%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " на файле "
 
@@ -2270,96 +2410,116 @@ msgstr "ни один пакет не подходит к %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "ни один из пакетов не требует %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "ни один из пакетов не требует %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "ни один из пакетов не взводит триггер %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "ни один из пакетов не требует %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "ни один из пакетов не требует %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ни один из пакетов не предоставляет %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "файл %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "файл %s не принадлежит ни одному из пакетов\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "неверный номер пакета: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакет %s не установлен\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: ошибка Fread: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "НЕ ОК"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "ОК"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (ОТСУТСТВУЮТ КЛЮЧИ:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (НЕТ ДОВЕРИЯ К КЛЮЧАМ:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: ошибка открытия: %s\n"
@@ -2384,144 +2544,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "НЕT"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "ДА"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, и Obsoletes: зависимости поддерживают версии."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "имена файла(ов) хранятся в формате (dirName,baseName,dirIndex)."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "префикс \"./\" используется для фала(ов) содержимого пакета."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "имя-версия-выпуск пакета не предоставляется автоматически."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "ярлыки заголовков всегда сортируются после загрузки."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "интерпретатор сценариев может использовать аргументы из заголовка."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "поддерживается частичная установка набора жестких ссылок пакета."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "не проверять зависимости пакета"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Незакрытая %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "пользователь %s не существует - используется root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "группа %s не существует - используется root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Неверный magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Неверный/нечитаемый заголовок"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Заголовок слишком велик"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Неизвестный тип файла"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Внутренняя ошибка"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Файл архива не найден в заголовке пакета"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " не удалось - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "невозможно открыть %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2761,42 @@ msgstr "Неудовлетворенные зависимости:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: не пакет (или манифест пакета) rpm : %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s не может быть установлен\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Загружается %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "ошибка чтения из файла %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "невозможно открыть %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Устанавливается %s\n"
@@ -2614,12 +2822,12 @@ msgstr "ошибка чтения: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2676,7 +2884,8 @@ msgstr "конфликт файла %s при попытках установк�
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr "файл %s из устанавливаемого пакета %s конфликтует с файлом из пакета %s"
+msgstr ""
+"файл %s из устанавливаемого пакета %s конфликтует с файлом из пакета %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2777,60 +2986,79 @@ msgstr "отсутствует архитектура для %s в %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "неверный параметр '%s' в %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Неизвестная система: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Невозможно прочитать пиктограмму %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Невозможно прочитать пиктограмму %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: ошибка Fwrite: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Неизвестный формат"
 
@@ -2842,127 +3070,146 @@ msgstr "установить"
 msgid "erase"
 msgstr "стереть"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "не могу открыть базу данных Packages в %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "транзакция"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(не подпись формата OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr ""
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Невозможно перезагрузить заголовок подписи.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Заголовок "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "пропущено"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3283,242 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "параметер dbpath не установлен\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "ошибка (%d) сохранения записи #%d в %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: получен поврежденный заголовок #%u -- пропускается.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: невозможно прочесть заголовок в 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "параметер dbpath не установлен"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заголовок номер %u в базе данных неверный -- пропускается.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "невозможно добавить запись (первоначально в %u)\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "перестроение базы данных не удалось, старая база данных остается на месте\n"
+msgstr ""
+"перестроение базы данных не удалось, старая база данных остается на месте\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "невозможно заменить старую базу данных на новую!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "файлы в %s заменяются файлами из %s для восстановления"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "ошибка удаления каталога %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "невозможно получить блокировку %s на %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "разделяемый"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "исключительный"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "ошибка(%d) сохранения записи \"%s\" в %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "ошибка(%d) удаления записи %s из %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "ошибка(%d) резервирования памяти для образа нового пакета\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "неопознанный параметр базы данных: \"%s\" проигнорирован\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "неверное числовое значение %s, пропущено\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s имеет слишком малую или слишком большую величину long, пропущено\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s имеет слишком малую или слишком большую величину integer, пропущено\n"
+msgstr ""
+"%s имеет слишком малую или слишком большую величину integer, пропущено\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "невозможно получить блокировку %s на %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "разделяемый"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "исключительный"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "ошибка(%d) сохранения записи \"%s\" в %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "ошибка(%d) удаления записи %s из %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "ошибка(%d) резервирования памяти для образа нового пакета\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(пусто)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(пусто)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Незакрытые параметры в макросе %%%s\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Незакрытый макрос %%%s\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Недопустимое имя (%%define) макроса %%%s\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Макрос %%%s пуст\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Невозможно раскрыть макрос %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Недопустимое имя (%%undefine) макроса %%%s\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Неизвестный параметр %c в %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Незакрытая %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "непонятный макрос после %%\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "====================== активных %d пустых %d\n"
@@ -3289,31 +3538,31 @@ msgstr "Файл %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Длина файла %s меньше чем %u байт\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3571,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(нет ошибки)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "фатальная ошибка: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "ошибка: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "предупреждение: "
 
@@ -3343,99 +3592,154 @@ msgstr "предупреждение: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "memory alloc (%u bytes) returned NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "ошибка чтения из файла %s\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "ошибка чтения из файла %s\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "ошибка удаления каталога %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: ошибка Fwrite: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Неподдерживаемая подпись PGP\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr ""
+msgid "Could not exec %s: %s\n"
+msgstr "Невозможно выполнить %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: ошибка открытия: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "ошибка gpg при записи подписи\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "невозможно прочесть подпись\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: ошибка rpmWriteSignature: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: ошибка rpmWriteSignature: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "запуск не удался\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "запуск не удался\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "запуск не удался\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: ошибка rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: ошибка writeLead: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3752,12 @@ msgstr "%s: ошибка чтения списка файлов: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "не проверять подпись заголовока и содержимого"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Введите ключевую фразу: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Ключевая фраза принята.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Неверная пара владелец/группа: %s\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,23 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Russian (http://www.transifex.com/projects/p/rpm/language/"
-"ru/)\n"
-"Language: ru\n"
+"Language-Team: Russian (http://www.transifex.com/rpm-team/rpm/language/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: ru\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -81,7 +79,7 @@ msgstr "Параметры проверки (с -V или --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Параметры Установки/Обновления/Удаления:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Общие параметры для всех режимов и компонентов rpm:"
@@ -102,7 +100,7 @@ msgstr "неожиданный формат запроса"
 msgid "unexpected query source"
 msgstr "неожиданный источник запроса"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "может быть указан только один из основных режимов"
 
@@ -121,9 +119,7 @@ msgstr "--prefix нельзя использовать с --relocate или --ex
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"варианты --relocate и --excludepath можно использовать только при установке "
-"новых пакетов"
+msgstr "варианты --relocate и --excludepath можно использовать только при установке новых пакетов"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -156,9 +153,7 @@ msgstr "--includedocs может быть указан только при ус�
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
-msgstr ""
-"может быть использован только один из параметров --excludedocs или --"
-"includedocs"
+msgstr "может быть использован только один из параметров --excludedocs или --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
@@ -188,17 +183,13 @@ msgstr "--justdb может быть указан только при устан
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"параметры запрета сценариев могут быть указаны только при установке или "
-"удалении пакета"
+msgstr "параметры запрета сценариев могут быть указаны только при установке или удалении пакета"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"параметры запрета триггеров могут быть указан только при установке или "
-"удалении пакета(ов)"
+msgstr "параметры запрета триггеров могут быть указан только при установке или удалении пакета(ов)"
 
 #: rpmqv.c:231
 msgid ""
@@ -210,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументы для --root (-r) должны начинаться с /"
 
@@ -230,261 +221,201 @@ msgstr "не заданы аргументы запроса"
 msgid "no arguments given for verify"
 msgstr "не заданы аргументы для верификации"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot уже указан, %s игнорируется\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <файл "
-"спецификации>"
+msgstr "выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <файл спецификации>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<файл спецификации>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"выполнить по стадию %build (%prep, затем компиляция) из <файл спецификации>"
+msgstr "выполнить по стадию %build (%prep, затем компиляция) из <файл спецификации>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"выполнить по стадию %install (%prep, %build, затем установка) из <файл "
-"спецификации>"
+msgstr "выполнить по стадию %install (%prep, %build, затем установка) из <файл спецификации>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "проверить раздел %files из <файл спецификации>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "собрать исходный и двоичный пакеты по <файл спецификации>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "собрать двоичный пакет по <файл спецификации>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "собрать исходный пакет по <файлу спецификации>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <файл "
-"спецификации>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<исходный пакет>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"выполнить по стадию %build (%prep, затем компиляция) из <файл спецификации>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"выполнить по стадию %install (%prep, %build, затем установка)  из <исходный "
-"пакет>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "проверить раздел %files из <файл спецификации>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "собрать двоичный пакет из <исходный пакет>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "собрать двоичный пакет из <исходный пакет>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "собрать исходный пакет по <файлу спецификации>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"выполнить по стадию %prep (развернуть исходники и наложить заплаты) из "
-"<архив tar>"
+msgstr "выполнить по стадию %prep (развернуть исходники и наложить заплаты) из <архив tar>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<архив tar>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "выполнить по стадию %build (%prep, затем компиляция) из <архив tar>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"выполнить по стадию %install (%prep, %build, затем установка) из <архив tar>"
+msgstr "выполнить по стадию %install (%prep, %build, затем установка) из <архив tar>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "проверить секцию %files из <архив tar>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "собрать исходный и двоичный пакеты из <архив tar>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "собрать двоичный пакет из <архив tar>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "собрать исходный пакет из <архив tar>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "собрать двоичный пакет из <исходный пакет>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<исходный пакет>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "выполнить по стадию %install (%prep, %build, затем установка)  из <исходный пакет>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "переопределить build root"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "после завершения удалить дерево исходников"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "игнорировать ExcludeArch: в файле конфигурации"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "отладка машины состояния файлов"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "не выполнять никаких этапов сборки"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "не проверять зависимости пакета перед сборкой"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "не выполнять никаких этапов сборки"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "игнорировать строки i18N из файла спецификации"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "после завершения удалить исходники"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "после завершения удалить файл спецификации"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "перейти непосредственно к указанному этапу (только для c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "переопределить целевую платформу"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Параметры сборки с [ <файл спецификации> | <тар архив> | <исходный пакет> ]:"
+msgstr "Параметры сборки с [ <файл спецификации> | <тар архив> | <исходный пакет> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Неудовлетворенные зависимости сборки:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Ошибка открытия файла спецификации %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Ошибка открытия канала tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Ошибка открытия файла спецификации %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Ошибка чтения файла спецификации из %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Невозможно переименовать %s в %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "невозможно получить информацию о %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Не обычный файл: %s.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Файл %s не похож на файл спецификации.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Платформы для сборки: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Сборка для платформы %s\n"
@@ -495,9 +426,7 @@ msgstr "инициализировать базу данных"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"переиндексировать базу инвертированных списков из установленных заголовков "
-"пакетов"
+msgstr "переиндексировать базу инвертированных списков из установленных заголовков пакетов"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -535,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "не заданы аргументы"
 
@@ -555,10 +484,29 @@ msgstr "удалить подписи пакета"
 msgid "Signature options:"
 msgstr "Параметры подписи:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Невозможно выполнить %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Вы должны установить \"%%_gpg_name\" в вашем макрофайле\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Введите ключевую фразу: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Ключевая фраза принята.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -576,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "используйте следующий формат запроса"
 
@@ -623,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Ошибки сборки пакетов:\n"
+msgstr "\n\nОшибки сборки пакетов:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "синтаксическая ошибка при анализе ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "синтаксическая ошибка при анализе &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "синтаксическая ошибка при анализе ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "ошибка анализа выражения\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "незакрытая (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- только для чисел\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! только для чисел\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "типы должны совпадать\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / не поддерживается для строк\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- не поддерживается для строк\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& и || не поддерживаются для строк\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "синтаксическая ошибка в выражении\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Отсутствует '(' в %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "отсутствует ')' в %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Неверный токен %s: %s\n"
@@ -697,46 +642,46 @@ msgstr "Неверный токен %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Отсутствует %s в %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Не пробел следует после %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Неверный синтаксис: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Неверные права: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Неверные права на каталог %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Файл должен начинаться с \"/\": %s\n"
@@ -746,146 +691,149 @@ msgstr "Файл должен начинаться с \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Не удается проверить файл %u, возврат к MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Файл указан дважды: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Символическая ссылка указывает на BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Файл не найден: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: это не открытый ключ.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Файл должен начинаться с \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Файл не найден: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "строка: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Неверный файл %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Неверная пара владелец/группа: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Проверка на неупакованный(е) файл(ы): %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Обнаружен(ы) установленный(е) (но не упакованный(е)) файл(ы):\n"
-"%s"
+msgstr "Обнаружен(ы) установленный(е) (но не упакованный(е)) файл(ы):\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Двоичные данные с архитекутрой в пакете noarch\n"
 
@@ -914,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Невозможно канонизировать имя компьютера: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Невозможно перезагрузить заголовок подписи.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Невозможно поместить заголовок в нерперывную область памяти.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Невозможно открыть %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Невозможно записать пакет: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Невозможно записать временный заголовок\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Неверные данные CSA\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Невозможно выполнить %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: ошибка Fread: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записан: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Выполнение \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Выполнение \"%s\" не удалось.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Невозможно создать имя файла для пакета %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "невозможно создать %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "строка %d: второе %s\n"
@@ -1037,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "строка %d: Ошибка анализа %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "строка %d: Неверный параметр %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "строка %d: Слишком много имен: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "строка %d: Пакет не существует: %s\n"
@@ -1156,94 +1104,90 @@ msgstr "строка %d: Ярлык требует только один арг�
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "строка %d: второе %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "строка %d: Неверный тэг: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "строка %d: Пустой тэг: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "строка %d: Префикс не может заканчиваться на \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "строка %d: Docdir должен начинаться с '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "строка %d: Неверное число %s: определяет: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "строка %d: Неверный формат BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Внутренняя ошибка: Неизвестный ярлык %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Неверная спецификация пакета: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Пакет уже существует: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "строка %d: Неизвестный тэг: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1253,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Неверный исходник: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Ошибка анализа %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "строка %d: Неверный аргумент для %%setup %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "строка %d: Неверный параметр %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "строка %d: второй %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "строка %d: триггеры должны содержать --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "строка %d: Ошибка анализа %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "строка %d: Программы в сценариях должны начинаться с '/': %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "строка %d: Второе %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "строка %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Невозможно открыть %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Найден %%else без %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Найден %%endif без %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Не найдены совместимые архитектуры для сборки.\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Пакет не имеет %%description: %s\n"
@@ -1510,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Невозможно выполнить %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Сбой ветвления %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s не удалось: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "не удалось записать все данные в %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Идет поиск  %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Невозможно найти %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "запрос файла спецификации %s не удался, невозможно разобрать файл\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s является Delta RPM и не может быть установлен напрямую\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакет %s был уже добавлен, пропускаем %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакет %s уже был добавлен, заменяется %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(не число)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(не base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(неправильный тип)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(not a blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(неверный тип xml)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(не подпись формата OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Неверная дата %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "нормальный"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "перемещен"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "не установлен"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(неизвестный)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(не строка)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s сохранен как %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s создан как %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1913,18 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "перемещения должны иметь / после ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"устанавливать все файлы, даже конфигурационные, которые могли бы быть "
-"пропущены"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "устанавливать все файлы, даже конфигурационные, которые могли бы быть пропущены"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"удалить все пакеты, совпадающие с <пакет> (обычно, если <пакет> "
-"соответствует нескольким пакетам, генерируется ошибка)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "удалить все пакеты, совпадающие с <пакет> (обычно, если <пакет> соответствует нескольким пакетам, генерируется ошибка)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2002,7 +1920,7 @@ msgstr "обновить базу данных, но не модифициров
 msgid "do not verify package dependencies"
 msgstr "не проверять зависимости пакета"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2080,9 +1998,7 @@ msgstr "не исполнять %%triggerpostun сценариев"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"откат на более старую версию пакета (--force при обновлении делает это "
-"автоматически)"
+msgstr "откат на более старую версию пакета (--force при обновлении делает это автоматически)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2124,182 +2040,162 @@ msgstr "обновить пакет(ы)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "запросить/проверить все пакеты"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "режим проверки подписи"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "запросить/проверить пакет, которому принадлежит файл"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "запросить/проверить пакеты в группе"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "запросить/проверить файл пакета"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "запросить/проверить пакет(ы) по идентификатору пакета"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "запросить/проверить пакет(ы), по идентификатору заголовка"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "режим запроса rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "запросить/проверить заголовок"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "запросить/проверить пакет(ы) из транзакции установки"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "запросить пакеты с триггер-сценариями на пакет"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "режим проверки rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "найти/проверить пакеты, требующие сервис"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "найти/проверить пакеты, предоставляющие сервис"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "найти/проверить пакеты, требующие сервис"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "найти/проверить пакеты, требующие сервис"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "найти/проверить пакеты, требующие сервис"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "найти/проверить пакеты, требующие сервис"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "показать все файлы конфигурации"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "показать все файлы документации"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "показать основную информацию о файле"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "показать список файлов пакета"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "пропустить файлы %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "показать состояние перечисленных файлов"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "не проверять размер файлов"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "не проверять путь символических ссылок"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "не проверять хозяина файлов"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "не проверять группу файлов"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "не проверять время модификации файлов"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "не проверять права доступа файлов пакета"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "не проверять файлы пакета"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "не проверять зависимости пакета"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "не исполнять сценарий(и) проверки"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "обнаружен двоичный пакет вместо ожидаемого исходного\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "исходный пакет не содержит файла спецификации\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "распаковка архива не удалась%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " на файле "
 
@@ -2374,116 +2270,96 @@ msgstr "ни один пакет не подходит к %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "ни один из пакетов не требует %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "ни один из пакетов не требует %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "ни один из пакетов не взводит триггер %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "ни один из пакетов не требует %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "ни один из пакетов не требует %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ни один из пакетов не предоставляет %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "файл %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "файл %s не принадлежит ни одному из пакетов\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "неверный номер пакета: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакет %s не установлен\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: ошибка Fread: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "НЕ ОК"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "ОК"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (ОТСУТСТВУЮТ КЛЮЧИ:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (НЕТ ДОВЕРИЯ К КЛЮЧАМ:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: ошибка открытия: %s\n"
@@ -2508,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "НЕT"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "ДА"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, и Obsoletes: зависимости поддерживают версии."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "имена файла(ов) хранятся в формате (dirName,baseName,dirIndex)."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "префикс \"./\" используется для фала(ов) содержимого пакета."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "имя-версия-выпуск пакета не предоставляется автоматически."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "ярлыки заголовков всегда сортируются после загрузки."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "интерпретатор сценариев может использовать аргументы из заголовка."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "поддерживается частичная установка набора жестких ссылок пакета."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "не проверять зависимости пакета"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Незакрытая %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "пользователь %s не существует - используется root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "группа %s не существует - используется root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Неверный magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Неверный/нечитаемый заголовок"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Заголовок слишком велик"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Неизвестный тип файла"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Внутренняя ошибка"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Файл архива не найден в заголовке пакета"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " не удалось - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "невозможно открыть %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2725,42 +2553,42 @@ msgstr "Неудовлетворенные зависимости:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: не пакет (или манифест пакета) rpm : %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s не может быть установлен\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Загружается %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "ошибка чтения из файла %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "невозможно открыть %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Устанавливается %s\n"
@@ -2786,12 +2614,12 @@ msgstr "ошибка чтения: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2848,8 +2676,7 @@ msgstr "конфликт файла %s при попытках установк�
 #: lib/rpmprob.c:135
 #, c-format
 msgid "file %s from install of %s conflicts with file from package %s"
-msgstr ""
-"файл %s из устанавливаемого пакета %s конфликтует с файлом из пакета %s"
+msgstr "файл %s из устанавливаемого пакета %s конфликтует с файлом из пакета %s"
 
 #: lib/rpmprob.c:140
 #, c-format
@@ -2954,75 +2781,56 @@ msgstr "неверный параметр '%s' в %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Неизвестная система: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Невозможно прочитать пиктограмму %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Невозможно прочитать пиктограмму %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: ошибка Fwrite: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Неизвестный формат"
 
@@ -3034,142 +2842,127 @@ msgstr "установить"
 msgid "erase"
 msgstr "стереть"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "не могу открыть базу данных Packages в %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "транзакция"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(не подпись формата OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Заголовок "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Заголовок "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "пропущено"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3243,242 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "параметер dbpath не установлен\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "ошибка (%d) сохранения записи #%d в %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: получен поврежденный заголовок #%u -- пропускается.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: невозможно прочесть заголовок в 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "параметер dbpath не установлен"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заголовок номер %u в базе данных неверный -- пропускается.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "невозможно добавить запись (первоначально в %u)\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"перестроение базы данных не удалось, старая база данных остается на месте\n"
+msgstr "перестроение базы данных не удалось, старая база данных остается на месте\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "невозможно заменить старую базу данных на новую!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "файлы в %s заменяются файлами из %s для восстановления"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "ошибка удаления каталога %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "неопознанный параметр базы данных: \"%s\" проигнорирован\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "неверное числовое значение %s, пропущено\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s имеет слишком малую или слишком большую величину long, пропущено\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-"%s имеет слишком малую или слишком большую величину integer, пропущено\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "невозможно получить блокировку %s на %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "разделяемый"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "исключительный"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "ошибка(%d) сохранения записи \"%s\" в %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "ошибка(%d) удаления записи %s из %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "ошибка(%d) резервирования памяти для образа нового пакета\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "неопознанный параметр базы данных: \"%s\" проигнорирован\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "неверное числовое значение %s, пропущено\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s имеет слишком малую или слишком большую величину long, пропущено\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s имеет слишком малую или слишком большую величину integer, пропущено\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(пусто)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(пусто)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Незакрытые параметры в макросе %%%s\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Незакрытый макрос %%%s\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Недопустимое имя (%%define) макроса %%%s\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Макрос %%%s пуст\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Невозможно раскрыть макрос %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Недопустимое имя (%%undefine) макроса %%%s\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Неизвестный параметр %c в %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Незакрытая %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "непонятный макрос после %%\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "====================== активных %d пустых %d\n"
@@ -3498,31 +3289,31 @@ msgstr "Файл %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Длина файла %s меньше чем %u байт\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3531,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(нет ошибки)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "фатальная ошибка: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "ошибка: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "предупреждение: "
 
@@ -3552,121 +3343,99 @@ msgstr "предупреждение: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "memory alloc (%u bytes) returned NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "ошибка чтения из файла %s\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "ошибка чтения из файла %s\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "ошибка удаления каталога %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: ошибка Fwrite: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Неподдерживаемая подпись PGP\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Невозможно выполнить %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: ошибка открытия: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Невозможно выполнить %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Невозможно выполнить %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "ошибка gpg при записи подписи\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "невозможно прочесть подпись\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: ошибка rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: ошибка writeLead: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3679,30 +3448,3 @@ msgstr "%s: ошибка чтения списка файлов: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "не проверять подпись заголовока и содержимого"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Введите ключевую фразу: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Ключевая фраза принята.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Неверная пара владелец/группа: %s\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Невозможно записать содержимое в %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Невозможно прочитать содержимое из %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Невозможно открыть временный файл.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Невозможно открыть цель подписи %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Невозможно прочитать заголовок из %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Невозможно записать заголовок в %s: %s\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Lubos Kardos <kardos.lubos@gmail.com>, 2015
 # Tomáš Vadina <tomasvadina+transifex@cryptolab.net>, 2011
@@ -10,14 +10,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-13 10:17+0000\n"
 "Last-Translator: Lubos Kardos <kardos.lubos@gmail.com>\n"
 "Language-Team: Slovak (http://www.transifex.com/rpm-team/rpm/language/sk/)\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sk\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -82,7 +82,7 @@ msgstr "Možnosti kontroly (s -V alebo --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Možnosti pre Inštaláciu/Upgrade/Mazanie:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Spoočné možnosti pre všetky režimy rpm a spustiteľné súbory:"
@@ -103,7 +103,7 @@ msgstr "neočakávaný formát požiadavky"
 msgid "unexpected query source"
 msgstr "neočakávaný zdroj pre otázku"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "môže byť použitý iba jeden hlavný režim"
 
@@ -122,7 +122,9 @@ msgstr "nie je možné použiť --prefix s --relocate alebo --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate a --excludepath môžu byť použité iba počas inštalácie nových balíkov"
+msgstr ""
+"--relocate a --excludepath môžu byť použité iba počas inštalácie nových "
+"balíkov"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -138,8 +140,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -186,25 +187,31 @@ msgstr "--justdb môže byť použité iba počas inštalácie a odstránenia ba
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "možnosť pre potlačenie skriptov môže byť použitá len pri inštalácii alebo pri odstraňovaní balíčkov"
+msgstr ""
+"možnosť pre potlačenie skriptov môže byť použitá len pri inštalácii alebo "
+"pri odstraňovaní balíčkov"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "možnosť pre potlačenie triggerov môže byť použitá len pri inštalácii alebo odstraňovaní balíčkov"
+msgstr ""
+"možnosť pre potlačenie triggerov môže byť použitá len pri inštalácii alebo "
+"odstraňovaní balíčkov"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps môže byť špecifikovaný iba počas inštalácie, mazania a overovania balíčka"
+msgstr ""
+"--nodeps môže byť špecifikovaný iba počas inštalácie, mazania a overovania "
+"balíčka"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "-- test môže byť špecifikovaný iba počas inštalácie a mazania balíčka"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenty pre --root (-r) musia začínať znakom /"
 
@@ -224,201 +231,259 @@ msgstr "neboli zadané žiadne argumenty pre otázku"
 msgid "no arguments given for verify"
 msgstr "neboli zadané žiadne argumenty pre overenie"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot už bol nastavený, ignoruje sa %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z <spec_subor>"
+msgstr ""
+"zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z "
+"<spec_subor>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<spec_subor>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "zostavenie podľa %build (%prep, potom kompilácia) z <spec_subor>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "zostavenie podľa %install (%prep, %build, potom install) z <spec_subor>"
+msgstr ""
+"zostavenie podľa %install (%prep, %build, potom install) z <spec_subor>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "kontrola častí %files z <spec_subor>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "vytvorenie zdrojového kódu a binárnych balíčkov z <spec_subor>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "vytvorenie iba binárneho balíčka z <spec_subor>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z "
+"<spec_subor>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<zdrojovy balicek>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "zostavenie podľa %build (%prep, potom kompilácia) z <spec_subor>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"zostavenie podľa %install (%prep, %build, potom inštalácia) z <zdrojovy "
+"balicek>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "kontrola častí %files z <spec_subor>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "vytvorenie binárneho balíčka z <zdrojovy balicek>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "vytvorenie binárneho balíčka z <zdrojovy balicek>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z <tar_subor>"
+msgstr ""
+"zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z "
+"<tar_subor>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tar_subor>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "zostavenie podľa %build (%prep, potom kompilácia) z <tar_subor>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "zostavenie podľa %install (%prep, %build, potom inštalácia) z <tar_subor>"
+msgstr ""
+"zostavenie podľa %install (%prep, %build, potom inštalácia) z <tar_subor>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "kontrola častí %files z <tar_subor>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "vytvorenie zdrojového kódu a binárneho balíčka z <tar_subor>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "vytvorenie iba binárneho balíčka z <tar_subor>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "vytvorenie iba zdrojového balíčka z <tar_subor>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "vytvorenie binárneho balíčka z <zdrojovy balicek>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<zdrojovy balicek>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "zostavenie podľa %install (%prep, %build, potom inštalácia) z <zdrojovy balicek>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "predefinovať adresár pre zostavenie balíka"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Nie je možné otvoriť aktuálny priečinok: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "po ukončení odstrániť adresár, v ktorom sa balík zostavoval"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorovať ExcludeArch: direktívy z spec súboru"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "ladiť nástroj stavu súborov"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "nevykonať žiadne etapy zostavenia"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "nekontrolovať závislosti balíčkov"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "generovanie hlavičiek balíčka kompatibilné s (legacy) rpm v3 packaging"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "nevykonať %clean fázu zostavenia"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "nevykonať %clean fázu zostavenia"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "nevykonať %check fázu zostavenia"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "neakceptovať i18N popisy z spec súboru"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "po dokončení odstrániť zdrojové kódy"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "po dokončení odstrániť spec súbor"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preskočiť priamo k určenej etape (iba pre c, i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "predefinovať cieľovú platformu"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Zostavovacie možnosti s [ <spec_subor> | <tar_subor> | <zdrojovy balicek> ]:"
+msgstr ""
+"Zostavovacie možnosti s [ <spec_subor> | <tar_subor> | <zdrojovy balicek> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Chybné závislosti pri zostavovaní:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Nie je možné otvoriť spec súbor %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Nie je možné otvoriť rúru pre tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Viac než jeden súbor na riadku: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Nie je možné čítať spec súbor z %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Nie je možné premenovať %s na %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "nie je možné zistiť stav %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Súbor %s nie je obyčajný súbor.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Súbor %s nevyzerá ako spec súbor.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Zostavujú sa cieľové platformy: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Zostavuje sa pre cieľ %s\n"
@@ -467,49 +532,64 @@ msgstr "zobraziť kľúče z kľúčového zväzku RPM"
 msgid "Keyring options:"
 msgstr "Možnosti zväzku kľúčov:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "nezadané žiadne parametre"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "podpísať balíčky"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "podpísať balíčky (identické s --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "vymazať podpis balíčka"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "podpísať balíčky"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Možnosti podpisu:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Nie je možné spustiť %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Je potrebné nastaviť \"%%_gpg_name\" v makro súbore\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Zadajte helo:"
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Heslo je v poriadku.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Chybne zadané heslo, alebo expirovaný kľúč gpg\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix môže byť použitý iba počas inštalácie nových balíkov"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches môže byť použité iba počas odstránenia balíkov"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -527,7 +607,7 @@ msgstr "pôsobenie v binárke rpm generovanej spec (predvolené)"
 msgid "operate on source rpm generated by spec"
 msgstr "pôsobenie v zdroji rpm generovaného spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "použiť nasledovný formát otázky"
 
@@ -574,68 +654,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nChyby zostavenia RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Chyby zostavenia RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "chyba syntaxe pri spracovaní ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "chyba syntaxe pri spracovaní &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "chyba syntaxe pri spracovaní ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "chyba spracovania vo výraze\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "nedoplnená (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- len na číslach\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! len na číslach\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "typy musia súhlasiť\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / nie sú podporované pre reťazce\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- nie je podporované pre reťazce\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& a || nie sú podporované pre reťazce\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "chyba syntaxe vo výraze\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Chýba '(' v %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Chýba ')' v %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Neplatný %s token: %s\n"
@@ -645,46 +728,46 @@ msgstr "Neplatný %s token: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Chýba %s v %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Nasleduje nie prázdny znak %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Zlá syntax: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Zlý režim spec: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Zlý režim adresára spec: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Nepoužiteľná dĺžka lokalizácie: \"%s\" v %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Dvojitá lokalizácia %s v %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Neplatná možnosť: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Podpora možností súboru nie je zabudovaná\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Súbor musí začínať na \"/\": %s\n"
@@ -694,149 +777,151 @@ msgstr "Súbor musí začínať na \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Neznámy prehľad súborového algoritmu %u, návrat späť k MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Súbor uvedený dvakrát: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "čítanie symlinku %s zlyhalo: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolický link ukazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Cesta sa nachádza mimo buildroot: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Priečinok nenájdený: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Súbor nenájdený: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Toto nie je adresár: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nie je možné načítať neznámu značku (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: čítanie verejného kľúča zlyhalo.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: nie je obrnený verejný kľúč.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: zlyhalo kódovanie\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Súbor potrebuje úvodný \"/\": %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob nie je povolený: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Priečinok nebol nájdený globom: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Súbor nenájdený globom: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Nie je možné otvoriť %%files súbor %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "riadok: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Chyba čítania %%files súboru %s: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Súbor nenájdený globom: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Viac než jeden súbor na riadku: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Zlý súbor: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Chybný vlastník/skupina: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontrolujú sa nezabalené súbory: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Nájdené nainštalované (ale nezabalené) súbory:\n%s"
+msgstr ""
+"Nájdené nainštalované (ale nezabalené) súbory:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Spracovávajú sa súbory: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binárky závislé na architektúre v bezarchitektúrnom balíčku\n"
 
@@ -865,79 +950,76 @@ msgstr "%s: riadok: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nie je možné kanonizovať názov počítača: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Nie je možné znova načítať hlavičku podpisu.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Neznáma kompresia payloadu: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Nie je možné vytvoriť nezmeniteľný region hlavičky.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nie je možné otvoriť %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nie je možné zapísať balíček: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Nie je možné zapísať dočasnú hlavičku\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Zlé CSA dáta\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapísané: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Spúšťa sa \"%s\":\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Spustenie \"%s\" zlyhalo.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Kontrola balíčka \"%s\" zlyhala.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nie je možné vytvoriť meno výstupného súboru pre balík %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nie je možné vytvoriť %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "riadok %d: druhý %s\n"
@@ -988,19 +1070,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "riadok %d: Chyba pri parsovaní %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "riadok %d: zlá možnosť %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "riadok %d: Príliš veľa názvov: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "riadok %d: Balíček neexistuje: %s\n"
@@ -1106,91 +1188,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "riadok %d: Značka má len jeden token: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "riadok %d: Neplatný znak '%c' v: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "riadok %d: Neplatný znak v: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "riadok %d: Neplatná sekvencia \"..\" v: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "riadok %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: riadok: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "riadok %d: Poškodená značka: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "riadok %d: Prázdna značka: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "riadok %d: Prefixy nemôžu končiť \"/\": %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "riadok %d: Docdir musí začínať '/': %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "riadok %d: Súbor epochy musí byť nepodpísané číslo: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "riadok %d: Zlé určenie %s: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "riadok %d: Zlý formát BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "riadok %d: Podporované sú iba subbalíčky typu noarch: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interná chyba: Chybná značka %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "riadok %d: %s je zastaralý: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Zlá špecifikácia balíčka: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Balíček už existuje: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "riadok %d: neznáma značka: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} nemôže byť prázdne\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} nemôže byť \"/\"\n"
@@ -1200,161 +1287,193 @@ msgstr "%%{buildroot} nemôže byť \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Zlý zdroj: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Bez čísla záplaty %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch bez zodpovedajúcej značky \"Patch:\"\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Bez čísla zdroja %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Bez značky \"Source:\" v spec súbore\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Chyba pri parsovaní %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "riadok %d: Zlý parameter v %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "riadok %d: Zlá možnosť v %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neplatné číslo záplaty %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "riadok %d: druhý %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "Tokeny závislosti musia začínať alfa-numerickými znakmi, '_' alebo '/'"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Názov súboru s verziou nie je povolený"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Vyžadovaná verzia"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "Neplatná závislosť"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Vyžadovaná verzia"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "riadok %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "riadok %d: triggery musia obsahovať --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "riadok %d: Chyba parsovania %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "riadok %d: interné skripty musia končiť s '>': %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "riadok %d: skriptovací program musí začínať s '/': %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "riadok %d: argumenty interpretera nie sú v triggeroch povolené: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "riadok %d: Druhý %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "riadok %d: nepodporovaný interný skript: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "riadok %d: argumenty interpretera nie sú v triggeroch povolené: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "riadok %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nie je možné otvoriť %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Očakávaný argument pre %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "riadok %d: neuzatvorené makro alebo zlá náväznosť riadka\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: zlá kondícia %%if\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else bez počiatočného %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif bez počiatočného %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Nenájdené žiadne kompatibilné architektúry pre zostavenie\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Balíček neobsahuje %%description: %s\n"
@@ -1398,7 +1517,8 @@ msgstr "Zlyhalo získanie názvu politiky: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "'%s' typ dodaný s ostatnými typmi v %%semodule %s. Úprava typov na '%s'.\n"
+msgstr ""
+"'%s' typ dodaný s ostatnými typmi v %%semodule %s. Úprava typov na '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1425,290 +1545,281 @@ msgstr "Príliž veľa argumentov v riadku: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Vykonávaná politika: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorovanie neplatného regexu %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nie je možné vytvoriť rúru pre %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Nie je možné spustiť %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nie je možné vykonať fork %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s zlyhalo: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "nie je možné zapísať všetky dáta do %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konverzia %s na dlhý integer zlyhala.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Klasifikátor prázdneho súboru\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Nenastavené žiadne atribúty\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) zlyhalo: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load zlyhal: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rozpoznávanie súboru \"%s\" zlyhalo: režim %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Hľadá sa  %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Zlyhalo vyhľadávanie %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "otázka na spec-súbor %s zlyhala, nie je možné analyzovať\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s je Delta RPM a nemôže byž priamo inštalovaný\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodporovaný payload (%s) v balíčku %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "balíček %s už bol pridaný, %s sa preskakuje\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "balíček %s už bol pridaný, nahradzuje sa s %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(nie je číslo)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(nie je base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(neplatný typ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(nie je blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(neplatný typ xml)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(nie je OpenPGP podpis)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normálny"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "nahradený"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "nenainštalovaný"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "zdieľaný sieťou"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "zlá farba"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "chýbajúci"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(neznámy)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(nie je reťazec)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s uložený ako %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s vytvorený ako %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1837,15 +1948,18 @@ msgid "relocations must have a / following the ="
 msgstr "presunutia musia mať za znakom = znak /"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "inštalovať všetky súbory vrátane konfiguračných súborov, ktoré by inak mohli byť vynechané"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"inštalovať všetky súbory vrátane konfiguračných súborov, ktoré by inak mohli "
+"byť vynechané"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "odinštalovať všetky balíky určené <balíkom> (inak je chybou, pokiaľ <balík> špecifikuje viac ako jeden balík)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"odinštalovať všetky balíky určené <balíkom> (inak je chybou, pokiaľ <balík> "
+"špecifikuje viac ako jeden balík)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1923,7 +2037,7 @@ msgstr "aktualizovať databázu bez zmeny súborového systému"
 msgid "do not verify package dependencies"
 msgstr "neoverovať závislosti balíka"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "neoverovať prehľad súborov"
 
@@ -2001,7 +2115,9 @@ msgstr "nespúšťať žiadne %%triggerpostun skripty"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "aktualizovať na staršiu verziu balíka (--force to pri aktualizácii urobí automaticky)"
+msgstr ""
+"aktualizovať na staršiu verziu balíka (--force to pri aktualizácii urobí "
+"automaticky)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2043,162 +2159,182 @@ msgstr "upgradovať balíčky"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "vyžiadať/overiť všetky balíčky"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "režim rpm checksig"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "požiadavka/overenie balíčkov vlastniacich súbor"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "požiadavka/overenie balíčkov v skupine"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "požiadavka/overenie súboru balíčka"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "požiadavka/overenie balíčkov s identifikátorom balíčka"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "požiadavka/overenie balíčkov identifikátorom hlavičky"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "režim požiadavok"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "požiadavka/overenie inštancie hlavičky"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "požiadavka/overenie balíčkov z inštalačnej transakcie"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "požiadavka pre balíčky aktivované balíčkom"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "režim kontroly"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "požiadavka/overenie balíčkov poskytujúcich závislosť"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "neseparovať argumenty"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "nespracovávať nebalíčkové súbory ako zoznamy"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "zobraziť všetky konfiguračné súbory"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "zobraziť všetky súbory s dokumentáciou"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "zobraziť základné informácie o balíku"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "zobraziť súbory v balíku"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "vynechať %%ghost súbory"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "zobraziiť stav daných súborov"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "nekontrolovať veľkosť súborov"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "nekontrolovať cesty symbolických linkov"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "nekontrolovať vlastníka súborov"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "nekontrolovať skupinu súborov"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "nekontrolovať čas zmeny súborov"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "nekontrolovať režim súborov"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "nekontrolovať možnosti súborov"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "nekontrolovať bezpečnostné kontexty súboru"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "nekontorlovať súbory v balíčku"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "nekontrolovať závislosti balíčka"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "nespúšťať kontrolné skripty"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Chýbajúce funkcie rpmlib pre %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "očakáva sa balíček so zdrojovým kódom, nájdený bol binárny\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "balíček so zdrojovými kódmi neobsahuje .spec súbor\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozbaľovanie archívu zlyhalo %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " pre súbor "
 
@@ -2273,96 +2409,117 @@ msgstr "žiadny z balíčkov sa nezhoduje s %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "žiadny z balíkov nevyžaduje %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "žiadny z balíkov nevyžaduje %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "žiadny z balíkov nespúšťa %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "žiadny z balíkov nevyžaduje %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "žiadny z balíkov nevyžaduje %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "žiadny z balíkov neposkytuje %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "súbor %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "súbor %s nie je vlastnený žiadnym balíkom\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "chybné číslo balíku: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "záznam %u nie je možné čítať\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "balík %s nie je nainštalovaný\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "neznáma značka: \"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: kľúč %d import zlyhal.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: kľúč %d nie je verejný obrnený kľúč.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importné čítanie zlyhalo(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: Nezmeniteľná oblasť hlavičky nemôže byť čítaná. Poškodený balíček?\n"
+msgstr ""
+"%s: Nezmeniteľná oblasť hlavičky nemôže byť čítaná. Poškodený balíček?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread zlyhalo: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NIE JE V PORIADKU"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "V PORIADKU"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (CHÝBAJÚCE KĽÚČE):"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NEDÔVERUJE SA KĽÚČOM: "
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otvorenie zlyhalo: %s\n"
@@ -2387,144 +2544,195 @@ msgstr "Nie je možné zmeniť koreňový adresár: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Nie je možné obnoviť koreňový adresár: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NIE"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "ÁNO"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, a Obsoletes: verzie pre podporu závislostí."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "názvy súborov uložené ako (dirName,baseName,dirIndex), nie ako cesta."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "payload balíčka môže byť komprimovaný pomocou bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "payload balíčka môže byť komprimovaný pomocou xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "payload balíčka môže byť komprimovaný pomocou lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "súbory payloadu balíčka majú predponu \"./\"."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "názov-verzia-vydanie balíčka nie je implicitne sprostredkované."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "značky hlavičky sú vždy zoradené po nahratí."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "interpreter skriptletov môže použiť argumenty z hlavičky."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "hardlinkovaný súbor môže byť inštalovaný bez toho, aby bol kompletný."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "skriptlety balíčka môžu pristupovať k databáze rpm pri inštalácii."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "interná podpora pre lua skripty."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "prehľad algoritmu súboru je nastaviteľný v každom balíčku"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "podpora pre schopnosti súboru POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "skriptlety balíčka môžu byť rozbalené počas inštalácie."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "neoverovať závislosti balíka"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Vyžadovaná verzia"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "Neplatná závislosť"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Neukončené %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "Neplatná závislosť"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "používateľ %s neexistuje - použije sa root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "skupina %s neexistuje - použije sa root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Chybné magické číslo"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Chybná/nečitateľná hlavička"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Priveľká hlavička"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Neznámy typ súboru"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Prehľad sa nezhoduje"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Interná chyba"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Súbor z archívu nie je v hlavičke"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " zlyhalo - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otvorenie %s zlyhalo: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: nie je balíček rpm (alebo balíček manifestu)\n"
@@ -2556,42 +2764,42 @@ msgstr "Zlyhané závislosti:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: nie je balíček rpm (alebo balíček manifestu): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s nie je možné nainštalovať\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Prenáša sa %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "preskakuje sa %s - transfer zlyhal\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "balíček %s nie je premiestniteľný\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "chyba pri čítaní zo súboru %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" špecifikuje viacero balíčkov:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "nie je možné otvoriť %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Inštaluje sa %s\n"
@@ -2617,12 +2825,12 @@ msgstr "čítanie zlyhalo: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "nie je balíček rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "nie je možné vytvoriť %s zámok na %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "čaká sa na %s zámok na %s\n"
@@ -2694,7 +2902,8 @@ msgstr "inštalovaný balíček %s vyžaduje %<PRIu64>%cB v súborovom systéme 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "inštalovaný balíček %s vyžaduje %<PRIu64> inody na súborovom systéme %s"
+msgstr ""
+"inštalovaný balíček %s vyžaduje %<PRIu64> inody na súborovom systéme %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2780,60 +2989,79 @@ msgstr "chýba architektúra pre %s na %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "zlá možnosť '%s' na %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Neznámy systém: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Prosím kontaktujte %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Nie je možné otvoriť %s pre čítanie: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Nie je možné obnoviť aktuálny priečinok: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "nie je zabudovaná podpora pre skriptlety <lua>\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Nie je možné vytvoriť dočasný súbor pre %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Nie je možné duplikovať popisovač súboru: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Nie je možné prečítať ikonu %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Nie je možné obnoviť koreňový adresár: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite zlyhalo: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s skriptlet zlyhal, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skriplet zlahal, signál %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s skriplet zlyhal, návratový kód: %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Neznámy formát"
 
@@ -2845,127 +3073,146 @@ msgstr "inštalovať"
 msgid "erase"
 msgstr "zmazať"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "nie je možné otvoriť databázu balíčkov v %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "nadbytočná '(' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "chýbajúca '(' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "chýbajúca ')' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: čítanie verejného kľúča zlyhalo.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transakcia"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(nie je OpenPGP podpis)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Nie je možné znova načítať hlavičku podpisu.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "SHA1 digest v hlavičke:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Hlavička"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 digest:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "SHA1 digest v hlavičke:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "preskočené"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "zlyhané"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "chýba   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Nesplené závislosti pre %s:\n"
@@ -3039,240 +3286,242 @@ msgstr "iterátor poľa použitý s poľami inej veľkosti"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generuje sa %d chýbajúcich indexov, prosím čakajte...\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "nenastavená dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preskakuje sa"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "chyba(%d) ukladania záznamu #%d do %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec zlyhal: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp zlyhal: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preskakuje sa"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: poškodená hlavička #%u získaná -- preskakuje sa.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nie je možné čítať hlavičku na 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "nebola nastavená žiadna dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "zlyhanie pri vytváraní priečinka %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "hlavička #%u v databázy je zlá -- preskakuje sa.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nie je možné pridať záznam pôvodne na %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "zlyhalo znovuzostavenie databázy: pôvodná databáza zostáva na mieste\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "nepodarilo sa nahradiť starú databázu novou!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "nahradiť súbory v %s súbormi z %s pre obnovenie"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "nepodarilo sa odstrániť adresár %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "nie je možné získaž zámok %s na %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "zdieľaný"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "výhradný"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "neplatný typ indexu %x v %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "chyba(%d) získaných \"%s\" záznamov z %s indexu: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "chyba(%d) pri ukladaní záznamu \"%s\" do %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "chyba(%d) v odstraňovaní záznamu \"%s\" z %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "chyba(%d) pridania hlavičky #%d záznamu\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "chyba(%d) odstránenia hlavičky #%d záznamu\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "chyba(%d) pri alokácii novej inštancii balíčka\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "nerozpoznaný db parameter: \"%s\" ignorovaný.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s má neplatnú číselnú hodnotu, preskakuje sa\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s má príliš veľkú alebo príliš malú long hodnotu, preskakuje sa\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s má príliš veľkú alebo príliš malú int hodnotu, preskakuje sa\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "nie je možné získaž zámok %s na %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "zdieľaný"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "výhradný"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "neplatný typ indexu %x v %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "chyba(%d) získaných \"%s\" záznamov z %s indexu: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "chyba(%d) pri ukladaní záznamu \"%s\" do %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "chyba(%d) v odstraňovaní záznamu \"%s\" z %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "chyba(%d) pridania hlavičky #%d záznamu\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "chyba(%d) odstránenia hlavičky #%d záznamu\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "chyba(%d) pri alokácii novej inštancii balíčka\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prázdne)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prázdne)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s má neukončené parametre\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s má neukončené telo\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s má neprípustné meno (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s má prázdné telo\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Zlyhalo vyhodnotenie makra %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s má nedovolené meno (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Neznáma možnosť %c v %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Príliž veľa úrovní rekurzie v rozbaľovaní makra. Zrejme je to spôsobené vyhlásením rekurzívneho makra.\n"
+msgstr ""
+"Príliž veľa úrovní rekurzie v rozbaľovaní makra. Zrejme je to spôsobené "
+"vyhlásením rekurzívneho makra.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neukončené %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Po %% nasleduje nespracovateľné makro\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktívnych %d prázdnych %d\n"
@@ -3292,31 +3541,31 @@ msgstr "Súbor %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Súbor %s je menší než %u bytov\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "vytvorenie priečinka zlyhalo"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "neplatná syntax v lua skriptlete: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nesprávna syntax v lua skripte: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skript zlyhal: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "neplatná syntax v súbore lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "obslúženie lua zlyhalo: %s\n"
@@ -3325,19 +3574,19 @@ msgstr "obslúženie lua zlyhalo: %s\n"
 msgid "[none]"
 msgstr "[žiadne]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(žiadna chyba)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "fatálna chyba: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "chyba: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "varovanie: "
 
@@ -3346,99 +3595,154 @@ msgstr "varovanie: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokácia pamäti (%u bajtov) vrátila NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID kľúča %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(žiadne)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "chyba pri vytvárané dočasného súboru %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "chyba pri vytvárané dočasného súboru %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "chyba pri vytvárané dočasného súboru %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "zlyhanie pri vytváraní priečinka %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush zlyhal: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Nie je možné vytvoriť rúru pre podpísanie: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Nie je možné spustiť %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: otvorenie zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "spustenie gpg zlyhalo (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg zlyhal pri zápise podpisu\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "nie je možné prečítať podpis\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature zlyhalo: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature zlyhalo: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "vykonanie zlyhalo\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp zlyhal\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "vykonanie zlyhalo\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "vykonanie zlyhalo\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s už obsahuje rovnaký podpis, preskakuje sa\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature zlyhalo: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s už obsahuje rovnaký podpis, preskakuje sa\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp zlyhal\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "nahradenie %s zlyhalo: %s\n"
@@ -3451,3 +3755,21 @@ msgstr "%s: čítanie zoznamu zlyhalo: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "neoverovať podpis hlavičky a payloadu"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Zadajte helo:"
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Heslo je v poriadku.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "Chybne zadané heslo, alebo expirovaný kľúč gpg\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Chybný vlastník/skupina: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "riadok %d: Neplatný znak v: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Nie je možné vytvoriť rúru pre podpísanie: %m"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,22 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
+# Lubos Kardos <kardos.lubos@gmail.com>, 2015
+# Tomáš Vadina <tomasvadina+transifex@cryptolab.net>, 2011
 # Tomáš Vadina <tomasvadina+transifex@cryptolab.net>, 2011
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
-"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Slovak (http://www.transifex.com/projects/p/rpm/language/"
-"sk/)\n"
-"Language: sk\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-13 10:17+0000\n"
+"Last-Translator: Lubos Kardos <kardos.lubos@gmail.com>\n"
+"Language-Team: Slovak (http://www.transifex.com/rpm-team/rpm/language/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: sk\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +82,7 @@ msgstr "Možnosti kontroly (s -V alebo --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Možnosti pre Inštaláciu/Upgrade/Mazanie:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Spoočné možnosti pre všetky režimy rpm a spustiteľné súbory:"
@@ -102,7 +103,7 @@ msgstr "neočakávaný formát požiadavky"
 msgid "unexpected query source"
 msgstr "neočakávaný zdroj pre otázku"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "môže byť použitý iba jeden hlavný režim"
 
@@ -121,9 +122,7 @@ msgstr "nie je možné použiť --prefix s --relocate alebo --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate a --excludepath môžu byť použité iba počas inštalácie nových "
-"balíkov"
+msgstr "--relocate a --excludepath môžu byť použité iba počas inštalácie nových balíkov"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,7 +138,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -186,31 +186,25 @@ msgstr "--justdb môže byť použité iba počas inštalácie a odstránenia ba
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"možnosť pre potlačenie skriptov môže byť použitá len pri inštalácii alebo "
-"pri odstraňovaní balíčkov"
+msgstr "možnosť pre potlačenie skriptov môže byť použitá len pri inštalácii alebo pri odstraňovaní balíčkov"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"možnosť pre potlačenie triggerov môže byť použitá len pri inštalácii alebo "
-"odstraňovaní balíčkov"
+msgstr "možnosť pre potlačenie triggerov môže byť použitá len pri inštalácii alebo odstraňovaní balíčkov"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps môže byť špecifikovaný iba počas inštalácie, mazania a overovania "
-"balíčka"
+msgstr "--nodeps môže byť špecifikovaný iba počas inštalácie, mazania a overovania balíčka"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "-- test môže byť špecifikovaný iba počas inštalácie a mazania balíčka"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenty pre --root (-r) musia začínať znakom /"
 
@@ -230,259 +224,201 @@ msgstr "neboli zadané žiadne argumenty pre otázku"
 msgid "no arguments given for verify"
 msgstr "neboli zadané žiadne argumenty pre overenie"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot už bol nastavený, ignoruje sa %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z "
-"<spec_subor>"
+msgstr "zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z <spec_subor>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<spec_subor>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "zostavenie podľa %build (%prep, potom kompilácia) z <spec_subor>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"zostavenie podľa %install (%prep, %build, potom install) z <spec_subor>"
+msgstr "zostavenie podľa %install (%prep, %build, potom install) z <spec_subor>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "kontrola častí %files z <spec_subor>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "vytvorenie zdrojového kódu a binárnych balíčkov z <spec_subor>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "vytvorenie iba binárneho balíčka z <spec_subor>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z "
-"<spec_subor>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<zdrojovy balicek>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "zostavenie podľa %build (%prep, potom kompilácia) z <spec_subor>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"zostavenie podľa %install (%prep, %build, potom inštalácia) z <zdrojovy "
-"balicek>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "kontrola častí %files z <spec_subor>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "vytvorenie binárneho balíčka z <zdrojovy balicek>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "vytvorenie binárneho balíčka z <zdrojovy balicek>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z "
-"<tar_subor>"
+msgstr "zostavenie podľa %prep (rozbalenie zdrojových kódov a aplikácia patchov) z <tar_subor>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tar_subor>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "zostavenie podľa %build (%prep, potom kompilácia) z <tar_subor>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"zostavenie podľa %install (%prep, %build, potom inštalácia) z <tar_subor>"
+msgstr "zostavenie podľa %install (%prep, %build, potom inštalácia) z <tar_subor>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "kontrola častí %files z <tar_subor>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "vytvorenie zdrojového kódu a binárneho balíčka z <tar_subor>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "vytvorenie iba binárneho balíčka z <tar_subor>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "vytvorenie iba zdrojového balíčka z <tar_subor>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "vytvorenie binárneho balíčka z <zdrojovy balicek>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<zdrojovy balicek>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "zostavenie podľa %install (%prep, %build, potom inštalácia) z <zdrojovy balicek>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "predefinovať adresár pre zostavenie balíka"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Nie je možné otvoriť aktuálny priečinok: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "po ukončení odstrániť adresár, v ktorom sa balík zostavoval"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorovať ExcludeArch: direktívy z spec súboru"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "ladiť nástroj stavu súborov"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "nevykonať žiadne etapy zostavenia"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "nekontrolovať závislosti balíčkov"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "generovanie hlavičiek balíčka kompatibilné s (legacy) rpm v3 packaging"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
-msgstr ""
+msgstr "nevykonať %clean fázu zostavenia"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "nevykonať žiadne etapy zostavenia"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
-msgstr ""
+msgstr "nevykonať %check fázu zostavenia"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "neakceptovať i18N popisy z spec súboru"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "po dokončení odstrániť zdrojové kódy"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "po dokončení odstrániť spec súbor"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preskočiť priamo k určenej etape (iba pre c, i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "predefinovať cieľovú platformu"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Zostavovacie možnosti s [ <spec_subor> | <tar_subor> | <zdrojovy balicek> ]:"
+msgstr "Zostavovacie možnosti s [ <spec_subor> | <tar_subor> | <zdrojovy balicek> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Chybné závislosti pri zostavovaní:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Nie je možné otvoriť spec súbor %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Nie je možné otvoriť rúru pre tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Nie je možné otvoriť spec súbor %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Nie je možné čítať spec súbor z %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Nie je možné premenovať %s na %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "nie je možné zistiť stav %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Súbor %s nie je obyčajný súbor.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Súbor %s nevyzerá ako spec súbor.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Zostavujú sa cieľové platformy: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Zostavuje sa pre cieľ %s\n"
@@ -501,11 +437,11 @@ msgstr "skontrolovať databázové súbory"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr ""
+msgstr "exportuj databázu na stdout ako postupnosť hlavičiek"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr ""
+msgstr "importuj databázu z stdin postupnosti hlavičiek"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -531,7 +467,7 @@ msgstr "zobraziť kľúče z kľúčového zväzku RPM"
 msgid "Keyring options:"
 msgstr "Možnosti zväzku kľúčov:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "nezadané žiadne parametre"
 
@@ -551,10 +487,29 @@ msgstr "vymazať podpis balíčka"
 msgid "Signature options:"
 msgstr "Možnosti podpisu:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Nie je možné spustiť %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Je potrebné nastaviť \"%%_gpg_name\" v makro súbore\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Zadajte helo:"
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Heslo je v poriadku.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Chybne zadané heslo, alebo expirovaný kľúč gpg\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -572,7 +527,7 @@ msgstr "pôsobenie v binárke rpm generovanej spec (predvolené)"
 msgid "operate on source rpm generated by spec"
 msgstr "pôsobenie v zdroji rpm generovaného spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "použiť nasledovný formát otázky"
 
@@ -619,71 +574,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Chyby zostavenia RPM:\n"
+msgstr "\n\nChyby zostavenia RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "chyba syntaxe pri spracovaní ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "chyba syntaxe pri spracovaní &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "chyba syntaxe pri spracovaní ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "chyba spracovania vo výraze\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "nedoplnená (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- len na číslach\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! len na číslach\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "typy musia súhlasiť\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / nie sú podporované pre reťazce\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- nie je podporované pre reťazce\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& a || nie sú podporované pre reťazce\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "chyba syntaxe vo výraze\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Chýba '(' v %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Chýba ')' v %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Neplatný %s token: %s\n"
@@ -693,46 +645,46 @@ msgstr "Neplatný %s token: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Chýba %s v %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Nasleduje nie prázdny znak %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Zlá syntax: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Zlý režim spec: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Zlý režim adresára spec: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Nepoužiteľná dĺžka lokalizácie: \"%s\" v %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Dvojitá lokalizácia %s v %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Neplatná možnosť: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Podpora možností súboru nie je zabudovaná\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Súbor musí začínať na \"/\": %s\n"
@@ -742,158 +694,161 @@ msgstr "Súbor musí začínať na \"/\": %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Neznámy prehľad súborového algoritmu %u, návrat späť k MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Súbor uvedený dvakrát: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "čítanie symlinku %s zlyhalo: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolický link ukazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
-msgstr ""
+msgstr "Cesta sa nachádza mimo buildroot: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Priečinok nenájdený: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Súbor nenájdený: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
-msgstr ""
+msgstr "Toto nie je adresár: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nie je možné načítať neznámu značku (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: čítanie verejného kľúča zlyhalo.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: nie je obrnený verejný kľúč.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: zlyhalo kódovanie\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Súbor potrebuje úvodný \"/\": %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob nie je povolený: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Priečinok nebol nájdený globom: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Súbor nenájdený globom: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Nie je možné otvoriť %%files súbor %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "riadok: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Chyba čítania %%files súboru %s: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
-msgstr ""
+msgstr "Viac než jeden súbor na riadku: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Zlý súbor: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Chybný vlastník/skupina: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontrolujú sa nezabalené súbory: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Nájdené nainštalované (ale nezabalené) súbory:\n"
-"%s"
+msgstr "Nájdené nainštalované (ale nezabalené) súbory:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Spracovávajú sa súbory: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binárky závislé na architektúre v bezarchitektúrnom balíčku\n"
 
 #: build/pack.c:90
 #, c-format
 msgid "create archive failed on file %s: %s\n"
-msgstr ""
+msgstr "vytvorenie archívu zlyhalo na súbore %s: %s\n"
 
 #: build/pack.c:93
 #, c-format
 msgid "create archive failed: %s\n"
-msgstr ""
+msgstr "vytvorenie archívu zlyhalo: %s\n"
 
 #: build/pack.c:120
 #, c-format
@@ -910,79 +865,79 @@ msgstr "%s: riadok: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nie je možné kanonizovať názov počítača: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Nie je možné znova načítať hlavičku podpisu.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Neznáma kompresia payloadu: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Nie je možné vytvoriť nezmeniteľný region hlavičky.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nie je možné otvoriť %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nie je možné zapísať balíček: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Nie je možné zapísať dočasnú hlavičku\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Zlé CSA dáta\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Nie je možné otvoriť súbor %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread zlyhalo: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapísané: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Spúšťa sa \"%s\":\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Spustenie \"%s\" zlyhalo.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Kontrola balíčka \"%s\" zlyhala.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nie je možné vytvoriť meno výstupného súboru pre balík %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nie je možné vytvoriť %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "riadok %d: druhý %s\n"
@@ -1033,19 +988,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "riadok %d: Chyba pri parsovaní %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "riadok %d: zlá možnosť %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "riadok %d: Príliš veľa názvov: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "riadok %d: Balíček neexistuje: %s\n"
@@ -1151,96 +1106,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "riadok %d: Značka má len jeden token: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "riadok %d: Neplatný znak '%c' v: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "riadok %d: Neplatná sekvencia \"..\" v: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "riadok %d: Neplatný znak v: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "riadok %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "riadok %d: Neplatná sekvencia \"..\" v: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: riadok: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "riadok %d: Poškodená značka: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "riadok %d: Prázdna značka: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "riadok %d: Prefixy nemôžu končiť \"/\": %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "riadok %d: Docdir musí začínať '/': %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "riadok %d: Súbor epochy musí byť nepodpísané číslo: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "riadok %d: Zlé určenie %s: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "riadok %d: Zlý formát BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "riadok %d: Podporované sú iba subbalíčky typu noarch: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interná chyba: Chybná značka %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "riadok %d: %s je zastaralý: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Zlá špecifikácia balíčka: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Balíček už existuje: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "riadok %d: neznáma značka: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} nemôže byť prázdne\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} nemôže byť \"/\"\n"
@@ -1250,193 +1200,161 @@ msgstr "%%{buildroot} nemôže byť \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Zlý zdroj: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Bez čísla záplaty %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch bez zodpovedajúcej značky \"Patch:\"\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Bez čísla zdroja %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Bez značky \"Source:\" v spec súbore\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Chyba pri parsovaní %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "riadok %d: Zlý parameter v %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "riadok %d: Zlá možnosť v %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neplatné číslo záplaty %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "riadok %d: druhý %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "Tokeny závislosti musia začínať alfa-numerickými znakmi, '_' alebo '/'"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Názov súboru s verziou nie je povolený"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "Neplatná závislosť"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Vyžadovaná verzia"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "Neplatná závislosť"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "riadok %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "riadok %d: triggery musia obsahovať --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "riadok %d: Chyba parsovania %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "riadok %d: interné skripty musia končiť s '>': %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "riadok %d: skriptovací program musí začínať s '/': %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr "riadok %d: argumenty interpretera nie sú v triggeroch povolené: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "riadok %d: Druhý %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "riadok %d: nepodporovaný interný skript: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "riadok %d: argumenty interpretera nie sú v triggeroch povolené: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "riadok %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nie je možné otvoriť %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Očakávaný argument pre %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "riadok %d: neuzatvorené makro alebo zlá náväznosť riadka\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: zlá kondícia %%if\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%else bez počiatočného %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%endif bez počiatočného %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Nenájdené žiadne kompatibilné architektúry pre zostavenie\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Balíček neobsahuje %%description: %s\n"
@@ -1480,8 +1398,7 @@ msgstr "Zlyhalo získanie názvu politiky: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"'%s' typ dodaný s ostatnými typmi v %%semodule %s. Úprava typov na '%s'.\n"
+msgstr "'%s' typ dodaný s ostatnými typmi v %%semodule %s. Úprava typov na '%s'.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1508,281 +1425,290 @@ msgstr "Príliž veľa argumentov v riadku: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Vykonávaná politika: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorovanie neplatného regexu %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nie je možné vytvoriť rúru pre %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Nie je možné spustiť %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nie je možné vykonať fork %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s zlyhalo: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "nie je možné zapísať všetky dáta do %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konverzia %s na dlhý integer zlyhala.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Klasifikátor prázdneho súboru\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Nenastavené žiadne atribúty\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) zlyhalo: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load zlyhal: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rozpoznávanie súboru \"%s\" zlyhalo: režim %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Hľadá sa  %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Zlyhalo vyhľadávanie %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "otázka na spec-súbor %s zlyhala, nie je možné analyzovať\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s je Delta RPM a nemôže byž priamo inštalovaný\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodporovaný payload (%s) v balíčku %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "balíček %s už bol pridaný, %s sa preskakuje\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "balíček %s už bol pridaný, nahradzuje sa s %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(nie je číslo)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(nie je base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(neplatný typ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(nie je blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(neplatný typ xml)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(nie je OpenPGP podpis)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normálny"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "nahradený"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "nenainštalovaný"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "zdieľaný sieťou"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "zlá farba"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "chýbajúci"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(neznámy)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(nie je reťazec)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s uložený ako %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s vytvorený ako %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1911,18 +1837,15 @@ msgid "relocations must have a / following the ="
 msgstr "presunutia musia mať za znakom = znak /"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"inštalovať všetky súbory vrátane konfiguračných súborov, ktoré by inak mohli "
-"byť vynechané"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "inštalovať všetky súbory vrátane konfiguračných súborov, ktoré by inak mohli byť vynechané"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"odinštalovať všetky balíky určené <balíkom> (inak je chybou, pokiaľ <balík> "
-"špecifikuje viac ako jeden balík)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "odinštalovať všetky balíky určené <balíkom> (inak je chybou, pokiaľ <balík> špecifikuje viac ako jeden balík)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2000,7 +1923,7 @@ msgstr "aktualizovať databázu bez zmeny súborového systému"
 msgid "do not verify package dependencies"
 msgstr "neoverovať závislosti balíka"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "neoverovať prehľad súborov"
 
@@ -2078,9 +2001,7 @@ msgstr "nespúšťať žiadne %%triggerpostun skripty"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"aktualizovať na staršiu verziu balíka (--force to pri aktualizácii urobí "
-"automaticky)"
+msgstr "aktualizovať na staršiu verziu balíka (--force to pri aktualizácii urobí automaticky)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2122,182 +2043,162 @@ msgstr "upgradovať balíčky"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "vyžiadať/overiť všetky balíčky"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "režim rpm checksig"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "požiadavka/overenie balíčkov vlastniacich súbor"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "požiadavka/overenie balíčkov v skupine"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "požiadavka/overenie súboru balíčka"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "požiadavka/overenie balíčkov s identifikátorom balíčka"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "požiadavka/overenie balíčkov identifikátorom hlavičky"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "režim požiadavok"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "požiadavka/overenie inštancie hlavičky"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "požiadavka/overenie balíčkov z inštalačnej transakcie"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "požiadavka pre balíčky aktivované balíčkom"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "režim kontroly"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "požiadavka/overenie balíčkov poskytujúcich závislosť"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "požiadavka/overenie balíčkov vyžadujúcich závislosť"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "neseparovať argumenty"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "nespracovávať nebalíčkové súbory ako zoznamy"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "zobraziť všetky konfiguračné súbory"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "zobraziť všetky súbory s dokumentáciou"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "zobraziť základné informácie o balíku"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "zobraziť súbory v balíku"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "vynechať %%ghost súbory"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "zobraziiť stav daných súborov"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "nekontrolovať veľkosť súborov"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "nekontrolovať cesty symbolických linkov"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "nekontrolovať vlastníka súborov"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "nekontrolovať skupinu súborov"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "nekontrolovať čas zmeny súborov"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "nekontrolovať režim súborov"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "nekontrolovať možnosti súborov"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "nekontrolovať bezpečnostné kontexty súboru"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "nekontorlovať súbory v balíčku"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "nekontrolovať závislosti balíčka"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "nespúšťať kontrolné skripty"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Chýbajúce funkcie rpmlib pre %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "očakáva sa balíček so zdrojovým kódom, nájdený bol binárny\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "balíček so zdrojovými kódmi neobsahuje .spec súbor\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozbaľovanie archívu zlyhalo %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " pre súbor "
 
@@ -2372,117 +2273,96 @@ msgstr "žiadny z balíčkov sa nezhoduje s %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "žiadny z balíkov nevyžaduje %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "žiadny z balíkov nevyžaduje %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "žiadny z balíkov nespúšťa %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "žiadny z balíkov nevyžaduje %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "žiadny z balíkov nevyžaduje %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "žiadny z balíkov neposkytuje %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "súbor %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "súbor %s nie je vlastnený žiadnym balíkom\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "chybné číslo balíku: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "záznam %u nie je možné čítať\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "balík %s nie je nainštalovaný\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "neznáma značka: \"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: kľúč %d import zlyhal.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: kľúč %d nie je verejný obrnený kľúč.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importné čítanie zlyhalo(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: Nezmeniteľná oblasť hlavičky nemôže byť čítaná. Poškodený balíček?\n"
+msgstr "%s: Nezmeniteľná oblasť hlavičky nemôže byť čítaná. Poškodený balíček?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread zlyhalo: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NIE JE V PORIADKU"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "V PORIADKU"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (CHÝBAJÚCE KĽÚČE):"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NEDÔVERUJE SA KĽÚČOM: "
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otvorenie zlyhalo: %s\n"
@@ -2507,195 +2387,144 @@ msgstr "Nie je možné zmeniť koreňový adresár: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Nie je možné obnoviť koreňový adresár: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NIE"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "ÁNO"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, a Obsoletes: verzie pre podporu závislostí."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "názvy súborov uložené ako (dirName,baseName,dirIndex), nie ako cesta."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "payload balíčka môže byť komprimovaný pomocou bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "payload balíčka môže byť komprimovaný pomocou xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "payload balíčka môže byť komprimovaný pomocou lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "súbory payloadu balíčka majú predponu \"./\"."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "názov-verzia-vydanie balíčka nie je implicitne sprostredkované."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "značky hlavičky sú vždy zoradené po nahratí."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "interpreter skriptletov môže použiť argumenty z hlavičky."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "hardlinkovaný súbor môže byť inštalovaný bez toho, aby bol kompletný."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "skriptlety balíčka môžu pristupovať k databáze rpm pri inštalácii."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "interná podpora pre lua skripty."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "prehľad algoritmu súboru je nastaviteľný v každom balíčku"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "podpora pre schopnosti súboru POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "skriptlety balíčka môžu byť rozbalené počas inštalácie."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "neoverovať závislosti balíka"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Vyžadovaná verzia"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "Neplatná závislosť"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Neukončené %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "Neplatná závislosť"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "používateľ %s neexistuje - použije sa root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "skupina %s neexistuje - použije sa root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Chybné magické číslo"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Chybná/nečitateľná hlavička"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Priveľká hlavička"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Neznámy typ súboru"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Prehľad sa nezhoduje"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Interná chyba"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Súbor z archívu nie je v hlavičke"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " zlyhalo - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otvorenie %s zlyhalo: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: nie je balíček rpm (alebo balíček manifestu)\n"
@@ -2727,42 +2556,42 @@ msgstr "Zlyhané závislosti:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: nie je balíček rpm (alebo balíček manifestu): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s nie je možné nainštalovať\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Prenáša sa %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "preskakuje sa %s - transfer zlyhal\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "balíček %s nie je premiestniteľný\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "chyba pri čítaní zo súboru %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" špecifikuje viacero balíčkov:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "nie je možné otvoriť %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Inštaluje sa %s\n"
@@ -2788,12 +2617,12 @@ msgstr "čítanie zlyhalo: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "nie je balíček rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "nie je možné vytvoriť %s zámok na %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "čaká sa na %s zámok na %s\n"
@@ -2809,9 +2638,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Zlyhalo vyriešenie symbolu %s: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Zásuvný modul %s nenačítaný\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2865,8 +2694,7 @@ msgstr "inštalovaný balíček %s vyžaduje %<PRIu64>%cB v súborovom systéme 
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"inštalovaný balíček %s vyžaduje %<PRIu64> inody na súborovom systéme %s"
+msgstr "inštalovaný balíček %s vyžaduje %<PRIu64> inody na súborovom systéme %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2956,75 +2784,56 @@ msgstr "zlá možnosť '%s' na %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Neznámy systém: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Prosím kontaktujte %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Nie je možné otvoriť %s pre čítanie: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Nie je možné obnoviť aktuálny priečinok: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "nie je zabudovaná podpora pre skriptlety <lua>\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Nie je možné vytvoriť dočasný súbor pre %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Nie je možné duplikovať popisovač súboru: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Nie je možné prečítať ikonu %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Nie je možné obnoviť koreňový adresár: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite zlyhalo: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s skriptlet zlyhal, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skriplet zlahal, signál %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s skriplet zlyhal, návratový kód: %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Neznámy formát"
 
@@ -3036,142 +2845,127 @@ msgstr "inštalovať"
 msgid "erase"
 msgstr "zmazať"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "nie je možné otvoriť databázu balíčkov v %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "nadbytočná '(' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "chýbajúca '(' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "chýbajúca ')' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: čítanie verejného kľúča zlyhalo.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transakcia"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(nie je OpenPGP podpis)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Hlavička"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 digest:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "SHA1 digest v hlavičke:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Hlavička"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "preskočené"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "zlyhané"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "chýba   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Nesplené závislosti pre %s:\n"
@@ -3245,242 +3039,240 @@ msgstr "iterátor poľa použitý s poľami inej veľkosti"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generuje sa %d chýbajúcich indexov, prosím čakajte...\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "nenastavená dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preskakuje sa"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "chyba(%d) ukladania záznamu #%d do %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec zlyhal: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp zlyhal: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preskakuje sa"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: poškodená hlavička #%u získaná -- preskakuje sa.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nie je možné čítať hlavičku na 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "nebola nastavená žiadna dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "zlyhanie pri vytváraní priečinka %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "hlavička #%u v databázy je zlá -- preskakuje sa.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nie je možné pridať záznam pôvodne na %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "zlyhalo znovuzostavenie databázy: pôvodná databáza zostáva na mieste\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "nepodarilo sa nahradiť starú databázu novou!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "nahradiť súbory v %s súbormi z %s pre obnovenie"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "nepodarilo sa odstrániť adresár %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "nerozpoznaný db parameter: \"%s\" ignorovaný.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s má neplatnú číselnú hodnotu, preskakuje sa\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s má príliš veľkú alebo príliš malú long hodnotu, preskakuje sa\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s má príliš veľkú alebo príliš malú int hodnotu, preskakuje sa\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "nie je možné získaž zámok %s na %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "zdieľaný"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "výhradný"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "neplatný typ indexu %x v %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "chyba(%d) získaných \"%s\" záznamov z %s indexu: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "chyba(%d) pri ukladaní záznamu \"%s\" do %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "chyba(%d) v odstraňovaní záznamu \"%s\" z %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "chyba(%d) pridania hlavičky #%d záznamu\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "chyba(%d) odstránenia hlavičky #%d záznamu\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "chyba(%d) pri alokácii novej inštancii balíčka\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "nerozpoznaný db parameter: \"%s\" ignorovaný.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s má neplatnú číselnú hodnotu, preskakuje sa\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s má príliš veľkú alebo príliš malú long hodnotu, preskakuje sa\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s má príliš veľkú alebo príliš malú int hodnotu, preskakuje sa\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prázdne)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prázdne)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s má neukončené parametre\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s má neukončené telo\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s má neprípustné meno (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s má prázdné telo\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Zlyhalo vyhodnotenie makra %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s má nedovolené meno (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Neznáma možnosť %c v %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Príliž veľa úrovní rekurzie v rozbaľovaní makra. Zrejme je to spôsobené "
-"vyhlásením rekurzívneho makra.\n"
+msgstr "Príliž veľa úrovní rekurzie v rozbaľovaní makra. Zrejme je to spôsobené vyhlásením rekurzívneho makra.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neukončené %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Po %% nasleduje nespracovateľné makro\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktívnych %d prázdnych %d\n"
@@ -3500,31 +3292,31 @@ msgstr "Súbor %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Súbor %s je menší než %u bytov\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "vytvorenie priečinka zlyhalo"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "neplatná syntax v lua skriptlete: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nesprávna syntax v lua skripte: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skript zlyhal: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "neplatná syntax v súbore lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "obslúženie lua zlyhalo: %s\n"
@@ -3533,19 +3325,19 @@ msgstr "obslúženie lua zlyhalo: %s\n"
 msgid "[none]"
 msgstr "[žiadne]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(žiadna chyba)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "fatálna chyba: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "chyba: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "varovanie: "
 
@@ -3554,121 +3346,99 @@ msgstr "varovanie: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokácia pamäti (%u bajtov) vrátila NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID kľúča %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(žiadne)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "chyba pri vytvárané dočasného súboru %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "chyba pri vytvárané dočasného súboru %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "chyba pri vytvárané dočasného súboru %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "zlyhanie pri vytváraní priečinka %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush zlyhal: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Nie je možné spustiť %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Nie je možné vytvoriť rúru pre podpísanie: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: otvorenie zlyhalo: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Nie je možné otvoriť súbor %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Nie je možné otvoriť %%files súbor %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "spustenie gpg zlyhalo (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg zlyhal pri zápise podpisu\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "nie je možné prečítať podpis\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature zlyhalo: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s už obsahuje rovnaký podpis, preskakuje sa\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp zlyhal\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "nahradenie %s zlyhalo: %s\n"
@@ -3681,103 +3451,3 @@ msgstr "%s: čítanie zoznamu zlyhalo: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "neoverovať podpis hlavičky a payloadu"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Zadajte helo:"
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Heslo je v poriadku.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "Chybne zadané heslo, alebo expirovaný kľúč gpg\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Chybný vlastník/skupina: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "riadok %d: Neplatný znak v: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Nie je možné vytvoriť rúru pre podpísanie: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Nie je možné zapísať payload do %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Nie je možné čítať payload z %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Nie je možné otvoriť dočasný súbor.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Nie je možné otvoriť cieľ pre podpísanie %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Nie je možné prečítať hlavičku z %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Nie je možné zapísať hlavičku do %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "nevykonať žiadne kolekcie akcií"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "Nezmeniteľná oblasť hlavičky nemôže byť čítaná. Poškodený balíček?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Zlyhalo dekódovanie politiky pre %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Zlyhalo vytvorenie dočasného súboru pre %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Zlyhalo zapísanie %s politiky do súboru %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Zlyhalo vytvorenie obsluhy semanage\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Zlyhalo pripojenie k politike obsluhy\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Zlyhalo začatie transakcie politiky: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Zlyhalo odstránenie dočasnej politky súboru %s: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Zlyhala inštalácia modulu politiky: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Zlyhalo odstránenie modulu politiky: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Zlyhal proces forku: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Zlyhalo spustenie %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s nebol ukončený v poriadku\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s zlyhal s exit kódom %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Zlyhalo odoslanie zmien politiky\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Zlyhalo rozbalenie cesty restorecon"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Zlyhalo preznačkovanie súborového systému. Súbory môžu mať nesprávne "
-#~ "značky\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Zlyhalo znovunačítanie kontextu súboru. Súbory môžu mať nesprávne značky\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Zlyhalo rozbalenie politiky z %s\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -1,21 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Slovenian (http://www.transifex.com/rpm-team/rpm/language/sl/)\n"
+"Language-Team: Slovenian (http://www.transifex.com/rpm-team/rpm/language/"
+"sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -79,7 +81,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -100,7 +102,7 @@ msgstr "nepričakovana oblika poizvedbe"
 msgid "unexpected query source"
 msgstr "nepričakovan izvor poizvedbe"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "izbran sme biti le en glavni način"
 
@@ -135,8 +137,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -201,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenti izbire --root (-r) se morajo začeti z /"
 
@@ -221,201 +222,243 @@ msgstr "argumenti za poizvedbo niso podani"
 msgid "no arguments given for verify"
 msgstr "argumenti za preverjanje niso podani"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
-msgstr "brez upoštevanja vrhnjega imenika izgradnje"
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "brez preverjanja datotek v paketu"
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr "po zaključku drevo imenikov v katerih smo pakete gradili odstrani"
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
-msgstr "brez izvajanja katerekoli od stopenj izgradnje"
-
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr "brez upoštevanja vrhnjega imenika izgradnje"
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr "po zaključku drevo imenikov v katerih smo pakete gradili odstrani"
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr "brez izvajanja katerekoli od stopenj izgradnje"
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "brez izvajanja katerekoli od stopenj izgradnje"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "po zaključku naj se izvorna koda izbriše"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "po zaključku odstrani datoteko s specifikacijami"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preskok naravnost na določeno stopnjo (samo za c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "brez upoštevanja strojnega okolja ciljnega sistema"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Izgradnja za ciljna strojna okolja: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Izgradnja za ciljni sistem %s\n"
@@ -464,49 +507,63 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr ""
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+msgid "sign package(s) files"
+msgstr ""
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Vnesite pristopno geslo: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Pristopno geslo je pravo.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix se sme uporabiti le pri namestitvi"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches sme biti podan le ob odstranitvi paketa"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +581,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "uporabi naslednjo obliko poizvedbe"
 
@@ -573,66 +630,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -642,46 +699,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -691,149 +748,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Neobstoječ lastnik/skupina: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -862,79 +919,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Iskanje kanoničnega imena gostitelja je bilo neuspešno: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ni možno odpreti %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Neuspešno ustvarjanje izhodne datoteke za paket %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ni možno ustvariti %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -985,19 +1039,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1104,90 +1158,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "vrstica %d: Napačno število %s: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "datoteka %s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1197,161 +1255,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ni možno odpreti %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1422,290 +1512,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "poizvedba po datoteki spec. %s je bila neuspešna, razčlemba ni možna\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(ni število)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1915,17 @@ msgid "relocations must have a / following the ="
 msgstr "premikanja morajo imeti /, ki mu sledi ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "namestitev vseh datotek, vključno z nastavitvenimi, ki so sicer izpuščene"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"namestitev vseh datotek, vključno z nastavitvenimi, ki so sicer izpuščene"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "odstrani vse pakete, ki vsebujejo vzorec <paket> (sicer program izide z napako, če paket <paket> določa več paketov)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"odstrani vse pakete, ki vsebujejo vzorec <paket> (sicer program izide z "
+"napako, če paket <paket> določa več paketov)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2003,7 @@ msgstr "obnovi podatkovno zbirko, a ne spreminjaj datotečnega sistema"
 msgid "do not verify package dependencies"
 msgstr "brez preverjanja soodvisnosti paketa"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1934,7 +2017,8 @@ msgstr ""
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "brez spreminjanja vrstnega reda paketov z namenom zadovoljevanja soodvisnosti"
+msgstr ""
+"brez spreminjanja vrstnega reda paketov z namenom zadovoljevanja soodvisnosti"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1998,7 +2082,9 @@ msgstr ""
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "nadgraditev na starejšo različico paketa (--force pri nadgradnjah avtomatično vključi to izbiro)"
+msgstr ""
+"nadgraditev na starejšo različico paketa (--force pri nadgradnjah "
+"avtomatično vključi to izbiro)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2126,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "izpis vseh nastavitvene datoteke"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "izpis vseh dokumentacijske datoteke"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "iznos osnovnih podatkov o datoteki"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "izpis seznama datotek v paketu"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "izpis stanja seznama datotek"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "brez preverjanja datotek v paketu"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " za datoteko "
 
@@ -2270,96 +2372,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "noben paket ne potrebuje %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "noben paket ne potrebuje %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "noben paket ne proži %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "noben paket ne potrebuje %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "noben paket ne potrebuje %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "noben paket ne nudi %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "datoteka %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "datoteka %s ni del nobenega paketa\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neveljavna številka paketa: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s ni nameščen\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: branje Fread je bilo neuspešno: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NI DOBRO"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "V REDU"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (MANJKAJOČI KLJUČI:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NEPREVERJENI KLJUČI:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: odpiranje je bilo neuspešno: %s\n"
@@ -2384,144 +2506,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "brez preverjanja soodvisnosti paketa"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Napačno magično število"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Poškodovana/neberljiva glava"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Glava je predolga"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Neznan tip datoteke"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Notranja napaka"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " neuspešno - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "odpiranje %s je bilo neuspešno: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2553,42 +2723,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s ni možno namestiti\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Prenašanje %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "napaka pri branju iz datoteke %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "ni možno odpreti %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Nameščanje %s\n"
@@ -2614,12 +2784,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2777,60 +2947,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Neznan sistem: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
+
+#: lib/rpmscript.c:354
+#, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr ""
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: pisanje Fwrite je bilo neuspešno: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2842,127 +3031,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3036,240 +3244,242 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "dbpath ni nastavljena"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "zamenjava stare podatkovne zbirke z novo je bila neuspešna!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "neuspešna odstranitev imenika %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "skupno"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "izključujoče"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s ima neveljavno številčno vrednost, prezrto\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s ima preveliko ali premajhno dolgo (long) vrednost, prezrto\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s ima preveliko ali premajhno vrednost malega (small) celega\nštevila, prezrto\n"
+msgstr ""
+"%s ima preveliko ali premajhno vrednost malega (small) celega\n"
+"števila, prezrto\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "skupno"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "izključujoče"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prazni)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prazni)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivni %d prazni %d\n"
@@ -3289,31 +3499,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3322,19 +3532,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "usodna napaka: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "napaka: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "opozorilo: "
 
@@ -3343,99 +3553,154 @@ msgstr "opozorilo: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokacija pomnilnika (%u bajtov) vrnjeno NIČ.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "napaka pri branju iz datoteke %s\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "napaka pri branju iz datoteke %s\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "neuspešna odstranitev imenika %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: pisanje Fwrite je bilo neuspešno: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: odpiranje je bilo neuspešno: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature je bilo neuspešno: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmWriteSignature je bilo neuspešno: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "izvajanje je bilo neuspešno\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "izvajanje je bilo neuspešno\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "izvajanje je bilo neuspešno\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature je bilo neuspešno: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead je bil neuspešen: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3713,12 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Vnesite pristopno geslo: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Pristopno geslo je pravo.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Neobstoječ lastnik/skupina: %s\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -1,23 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Slovenian (http://www.transifex.com/projects/p/rpm/language/"
-"sl/)\n"
-"Language: sl\n"
+"Language-Team: Slovenian (http://www.transifex.com/rpm-team/rpm/language/sl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -81,7 +79,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -102,7 +100,7 @@ msgstr "nepričakovana oblika poizvedbe"
 msgid "unexpected query source"
 msgstr "nepričakovan izvor poizvedbe"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "izbran sme biti le en glavni način"
 
@@ -137,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -202,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenti izbire --root (-r) se morajo začeti z /"
 
@@ -222,243 +221,201 @@ msgstr "argumenti za poizvedbo niso podani"
 msgid "no arguments given for verify"
 msgstr "argumenti za preverjanje niso podani"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr ""
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "brez preverjanja datotek v paketu"
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "brez upoštevanja vrhnjega imenika izgradnje"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "po zaključku drevo imenikov v katerih smo pakete gradili odstrani"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "brez izvajanja katerekoli od stopenj izgradnje"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "brez izvajanja katerekoli od stopenj izgradnje"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "po zaključku naj se izvorna koda izbriše"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "po zaključku odstrani datoteko s specifikacijami"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preskok naravnost na določeno stopnjo (samo za c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "brez upoštevanja strojnega okolja ciljnega sistema"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Izgradnja za ciljna strojna okolja: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Izgradnja za ciljni sistem %s\n"
@@ -507,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -527,9 +484,28 @@ msgstr ""
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Vnesite pristopno geslo: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Pristopno geslo je pravo.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -548,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "uporabi naslednjo obliko poizvedbe"
 
@@ -597,66 +573,66 @@ msgid ""
 "RPM build errors:\n"
 msgstr ""
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -666,46 +642,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -715,144 +691,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr ""
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Neobstoječ lastnik/skupina: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -881,79 +862,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Iskanje kanoničnega imena gostitelja je bilo neuspešno: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ni možno odpreti %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Ni možno odpreti %s: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: branje Fread je bilo neuspešno: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Neuspešno ustvarjanje izhodne datoteke za paket %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ni možno ustvariti %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1004,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1123,94 +1104,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "vrstica %d: Napačno število %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "datoteka %s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1220,193 +1197,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ni možno odpreti %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1477,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "poizvedba po datoteki spec. %s je bila neuspešna, razčlemba ni možna\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(ni število)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1880,17 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "premikanja morajo imeti /, ki mu sledi ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"namestitev vseh datotek, vključno z nastavitvenimi, ki so sicer izpuščene"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "namestitev vseh datotek, vključno z nastavitvenimi, ki so sicer izpuščene"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"odstrani vse pakete, ki vsebujejo vzorec <paket> (sicer program izide z "
-"napako, če paket <paket> določa več paketov)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "odstrani vse pakete, ki vsebujejo vzorec <paket> (sicer program izide z napako, če paket <paket> določa več paketov)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1968,7 +1920,7 @@ msgstr "obnovi podatkovno zbirko, a ne spreminjaj datotečnega sistema"
 msgid "do not verify package dependencies"
 msgstr "brez preverjanja soodvisnosti paketa"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1982,8 +1934,7 @@ msgstr ""
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"brez spreminjanja vrstnega reda paketov z namenom zadovoljevanja soodvisnosti"
+msgstr "brez spreminjanja vrstnega reda paketov z namenom zadovoljevanja soodvisnosti"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2047,9 +1998,7 @@ msgstr ""
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"nadgraditev na starejšo različico paketa (--force pri nadgradnjah "
-"avtomatično vključi to izbiro)"
+msgstr "nadgraditev na starejšo različico paketa (--force pri nadgradnjah avtomatično vključi to izbiro)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2091,178 +2040,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "izpis vseh nastavitvene datoteke"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "izpis vseh dokumentacijske datoteke"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "iznos osnovnih podatkov o datoteki"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "izpis seznama datotek v paketu"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "izpis stanja seznama datotek"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "brez preverjanja datotek v paketu"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " za datoteko "
 
@@ -2337,116 +2270,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "noben paket ne potrebuje %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "noben paket ne potrebuje %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "noben paket ne proži %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "noben paket ne potrebuje %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "noben paket ne potrebuje %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "noben paket ne nudi %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "datoteka %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "datoteka %s ni del nobenega paketa\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neveljavna številka paketa: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s ni nameščen\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: branje Fread je bilo neuspešno: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NI DOBRO"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "V REDU"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (MANJKAJOČI KLJUČI:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NEPREVERJENI KLJUČI:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: odpiranje je bilo neuspešno: %s\n"
@@ -2471,192 +2384,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "brez preverjanja soodvisnosti paketa"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Napačno magično število"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Poškodovana/neberljiva glava"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Glava je predolga"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Neznan tip datoteke"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Notranja napaka"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " neuspešno - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "odpiranje %s je bilo neuspešno: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2688,42 +2553,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s ni možno namestiti\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Prenašanje %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "napaka pri branju iz datoteke %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "ni možno odpreti %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Nameščanje %s\n"
@@ -2749,12 +2614,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2916,75 +2781,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Neznan sistem: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
-
-#: lib/rpmscript.c:354
-#, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr ""
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: pisanje Fwrite je bilo neuspešno: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -2996,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3205,242 +3036,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "dbpath ni nastavljena"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "zamenjava stare podatkovne zbirke z novo je bila neuspešna!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "neuspešna odstranitev imenika %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s ima neveljavno številčno vrednost, prezrto\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s ima preveliko ali premajhno dolgo (long) vrednost, prezrto\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-"%s ima preveliko ali premajhno vrednost malega (small) celega\n"
-"števila, prezrto\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "skupno"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "izključujoče"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s ima neveljavno številčno vrednost, prezrto\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s ima preveliko ali premajhno dolgo (long) vrednost, prezrto\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s ima preveliko ali premajhno vrednost malega (small) celega\nštevila, prezrto\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prazni)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prazni)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivni %d prazni %d\n"
@@ -3460,31 +3289,31 @@ msgstr ""
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3493,19 +3322,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "usodna napaka: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "napaka: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "opozorilo: "
 
@@ -3514,121 +3343,99 @@ msgstr "opozorilo: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokacija pomnilnika (%u bajtov) vrnjeno NIČ.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "napaka pri branju iz datoteke %s\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "napaka pri branju iz datoteke %s\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "neuspešna odstranitev imenika %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: pisanje Fwrite je bilo neuspešno: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: odpiranje je bilo neuspešno: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Ni možno odpreti %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Ni možno odpreti %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature je bilo neuspešno: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead je bil neuspešen: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3641,12 +3448,3 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Vnesite pristopno geslo: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Pristopno geslo je pravo.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Neobstoječ lastnik/skupina: %s\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,21 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Serbian (http://www.transifex.com/rpm-team/rpm/language/sr/)\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -79,7 +80,7 @@ msgstr "Опције провере (са -V или --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Опције инсталације/надградње/брисања:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Заједничке опције за све rpm режиме и извршне програме:"
@@ -100,7 +101,7 @@ msgstr "неочекиван облик упита"
 msgid "unexpected query source"
 msgstr "неочекивани извор упита"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "само један главни режим сме бити наведен"
 
@@ -119,7 +120,9 @@ msgstr "не може се користити --prefix уз --relocate или --
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate и --excludepath могу бити употребљене само при инсталацији нових пакета"
+msgstr ""
+"--relocate и --excludepath могу бити употребљене само при инсталацији нових "
+"пакета"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +138,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -183,13 +185,17 @@ msgstr "--justdb може бити наведена само током инст
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "опције искључивања скрипте могу бити наведене само током инсталације и брисања пакета"
+msgstr ""
+"опције искључивања скрипте могу бити наведене само током инсталације и "
+"брисања пакета"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "опције искључивања окидача могу бити наведене само током инсталације и брисања пакета"
+msgstr ""
+"опције искључивања окидача могу бити наведене само током инсталације и "
+"брисања пакета"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +207,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументи за --root (-r) морају почети знаком /"
 
@@ -221,201 +227,252 @@ msgstr "нема задатих аргумената за упит"
 msgid "no arguments given for verify"
 msgstr "нема задатих аргумената за проверу"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot је већ наведен, занемарујем %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "направи кроз %prep (распаковани извори и примењене закрпе) из <specfile>"
+msgstr ""
+"направи кроз %prep (распаковани извори и примењене закрпе) из <specfile>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "направи кроз %build (%prep, онда компилирај) из <specfile>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "направи кроз %install (%prep, %build, затим инсталирај) из <specfile>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "провери %files одељак из <specfile>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "направи изворне и бинарне пакете из <specfile>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "направи бинарне пакете само из <specfile>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "направи изворне пакете само из <specfile>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"направи кроз %prep (распаковани извори и примењене закрпе) из <specfile>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<source package>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "направи кроз %build (%prep, онда компилирај) из <specfile>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"направи кроз %install (%prep, %build, затим инсталирај) из <source package>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "провери %files одељак из <specfile>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "направи бинарни пакет из <source package>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "направи бинарни пакет из <source package>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "направи изворне пакете само из <specfile>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "направи кроз %prep (распаковани извори и примењене закрпе) из <tarball>"
+msgstr ""
+"направи кроз %prep (распаковани извори и примењене закрпе) из <tarball>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "направи кроз %build (%prep, онда компилирај) из <tarball>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "направи кроз %install (%prep, %build, онда инсталирај) из <tarball>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "провери %files одељак из <tarball>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "направи изворне и бинарне пакете из <tarball>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "направи бинарне пакете само из <tarball>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "направи изворне пакете само из <tarball>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "направи бинарни пакет из <source package>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<source package>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "направи кроз %install (%prep, %build, затим инсталирај) из <source package>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "премости корен прављења"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "неуспело креирање директоријума"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "уклони стабло прављења по завршетку"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "занемари ExcludeArch: упутства из датотеке спецификације"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "отклони грешке у машини стања датотека"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "немој извршити ниједну фазу прављења"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "немој проверавати зависности прављења"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "немој извршити ниједну фазу прављења"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "не прихватај i18N msgstr ниске из датотеке спецификације"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "уклони изворе по завршетку"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "уклони датотеку спецификације по завршетку"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "прескочи право до одређене фазе (само за c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "премости циљну платформу"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Опције прављења уз [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Неуспело прављење зависности:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Не могу да отворим датотеку спецификације %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Неуспело отварање tar цеви: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Не могу да отворим датотеку спецификације %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Неуспело читање датотеке спецификације из %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Неуспела промена имена %s у %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat није успео %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Датотека %s није обична датотека.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Датотека %s не личи на датотеку спецификације.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Правим циљне платформе: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Правим за циљ %s\n"
@@ -426,7 +483,8 @@ msgstr "иницијализуј базу података"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "поново направи обрнуте спискове базе података из заглавља инсталираних пакета"
+msgstr ""
+"поново направи обрнуте спискове базе података из заглавља инсталираних пакета"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -464,49 +522,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "нема задатих аргумената"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "потпиши пакет(е) (истоветно са --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "обриши потписе пакета"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "инсталирај пакет(е)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Опције потписа:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Не могу да извршим %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Морате поставити „%%_gpg_name“ у макро датотеци\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Унесите лозинку: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Лозинка је добра.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix може бити употребљена само при инсталацији нових пакета"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches може бити наведена само током брисања пакета"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +597,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "користи следећи облик упита"
 
@@ -571,68 +644,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nГрешке RPM прављења:\n"
+msgstr ""
+"\n"
+"\n"
+"Грешке RPM прављења:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "синтаксна грешка при рашчлањивању ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "синтаксна грешка при рашчлањивању &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "синтаксна грешка при рашчлањивању ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "грешка рашчлањивања у изразу\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "неупарена (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- само код бројева\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! само код бројева\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "врсте се морају поклапати\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / није подржано за стрингове\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- није подржано за стрингове\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& и || нису подржани за стрингове\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "синтаксна грешка у изразу\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Недостаје „(“ у %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Недостаје „)“ у %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Неисправан %s знак: %s\n"
@@ -642,46 +718,46 @@ msgstr "Неисправан %s знак: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Недостаје %s у %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Размак који није празан следи %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Лоша синтакса: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Лоша спецификација режима: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Лоша спецификација режима директоријума: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Неисправна могућност: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Није уграђена подршка за могућност датотеке\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Датотека мора почети са „/“: %s\n"
@@ -691,149 +767,151 @@ msgstr "Датотека мора почети са „/“: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Непознат алгоритам %u за сажимање датотека, враћам се на MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Датотека наведена двапут: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symlink тачке за BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Датотека није пронађена: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: не могу да учитам непознату ознаку (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: неуспело читање јавног кључа.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: јавни кључ није ојачан.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Испред датотеке је потребно да стоји „/“: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Датотека није пронађена поклапањем: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Не могу да отворим %%files датотеку %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "ред: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Датотека није пронађена поклапањем: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Лоша датотека: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Лош власник/група: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Проверавам за незапаковане датотеке: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Пронађене су инсталиране (али незапаковане) датотеке:\n%s"
+msgstr ""
+"Пронађене су инсталиране (али незапаковане) датотеке:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Бинарне датотеке зависне од архитектуре у noarch пакету\n"
 
@@ -862,79 +940,76 @@ msgstr "%s: ред: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Није могуће утврдити назив домаћина: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Не могу да поново учитам заглавље потписа.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Непозната компресија товара: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Не могу да направим непроменљиву област заглавља.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Не могу да отворим %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Не могу да запишем пакет: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Не могу да упишем привремено заглавље\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Лоши CSA подаци\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записано: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Извршавам „%s“:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Извршавање „%s“ није успело.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Неуспела провера пакета „%s“.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Не могу да направим име излазне датотеке за пакет %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "не могу да направим %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "ред %d: други %s\n"
@@ -985,19 +1060,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "ред %d: Грешка при тумачењу %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "ред %d: Лоша опција %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "ред %d: Превише имена: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "ред %d: Пакет не постоји: %s\n"
@@ -1104,90 +1179,94 @@ msgstr "ред %d: Ознака прихвата само један жетон:
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "ред %d: други %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: ред: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "ред %d: Лоше обликована ознака: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "ред %d: Празна ознака: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "ред %d: Префикси се не смеју завршавати са „/“: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "ред %d: Docdir мора почети са „/“: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "ред %d: Поље епохе мора бити број без предзнака: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "ред %d: Лоши %s: квалификатори: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "ред %d: Лош облик за BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "ред %d: Само noarch подпакети су подржани: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Интерна грешка: Лажна ознака %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Лоша спецификација пакета: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Пакет већ постоји: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "ред %d: Непозната ознака: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не може бити празно\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не може бити „/“\n"
@@ -1197,161 +1276,193 @@ msgstr "%%{buildroot} не може бити „/“\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Лош извор: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Нема закрпе број %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch без одговарајуће „Patch:“ ознаке\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Нема извора број %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Нема ознаке „Source:“ у датотеци спецификације\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Грешка у тумачењу %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "ред %d: Лош аргумент за %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "ред %d: Лоша %%setup опција %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Неисправан број закрпе %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "ред %d: други %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "ред %d: окидачи морају имати --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "ред %d: Грешка при тумачењу %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "ред %d: интерна скрипта се мора завршити са „>“: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "ред %d: скрипта програма мора почети са „/“: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "ред %d: Други %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "ред %d: неподржана интерна скрипта: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "ред %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Не могу да отворим %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Добио %%else без %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Добио %%endif без %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Нису пронађене усаглашене архитектуре за прављење\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Пакет нема %%description: %s\n"
@@ -1422,290 +1533,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Не могу да направим цев за %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Не могу да извршим %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Не могу да одвојим %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Пребацивање %s у дуги цео број није успело.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) није успело: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load није успело: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Препознавање датотеке „%s“ није успело: режим %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Проналазак %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Неуспело тражење %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "упит на датотеком спецификације %s није успео, не могу да протумачим\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s је Делта RPM и не може се директно инсталирати\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Неподржан терет (%s) у пакету %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакет %s је већ додат, прескачем %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакет %s је већ додат, замењујем са %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(није број)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(није base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(неисправна врста)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(није blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(неисправна xml врста)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(није OpenPGP потпис)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s сачувано као %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s направљено као %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1936,17 @@ msgid "relocations must have a / following the ="
 msgstr "премештања морају имати / након ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "инсталирај све датотеке, чак и подешавања која би иначе могла бити прескочена"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"инсталирај све датотеке, чак и подешавања која би иначе могла бити прескочена"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "уклони све пакете који одговарају <package> (обично се пријављује грешка ако <package> одређује више пакета)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"уклони све пакете који одговарају <package> (обично се пријављује грешка ако "
+"<package> одређује више пакета)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2024,7 @@ msgstr "ажурирај базу података, али немој мењат
 msgid "do not verify package dependencies"
 msgstr "немој проверавати зависности пакета"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1934,7 +2038,8 @@ msgstr "немој инсталирати безбедносне контекс�
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "немој преуређивати редослед инсталације пакета ради задовољавања зависности"
+msgstr ""
+"немој преуређивати редослед инсталације пакета ради задовољавања зависности"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1998,7 +2103,8 @@ msgstr "немој извршити ниједну %%triggerpostun скрипт�
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "надгради на стару верзију пакета (--force код надградње ово ради самостално)"
+msgstr ""
+"надгради на стару верзију пакета (--force код надградње ово ради самостално)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2146,182 @@ msgstr "надгради пакет(е)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "испитај/провери све пакете"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm checksig режим"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "испитај/провери пакет(е) које поседују датотеку"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "испитај/провери пакет(е) у групи"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "испитај/провери датотеку пакета"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "испитај/провери пакет(е) са идентификатором пакета"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "испитај/провери пакет(е) са идентификатором заглавља"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "режим rpm упита"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "испитај/провери инстанцу заглавља"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "испитај/провери пакет(е) из трансакције инсталације"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "испитај пакет(е) које је активирао овај пакет"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "режим rpm провере"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "испитај/провери пакет(е) који захтевају зависности"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "испитај/провери пакет(е) који пружају зависности"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "испитај/провери пакет(е) који захтевају зависности"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "испитај/провери пакет(е) који захтевају зависности"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "испитај/провери пакет(е) који захтевају зависности"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "испитај/провери пакет(е) који захтевају зависности"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "немој преклапати аргументе"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "немој обрађивати датотеке које нису пакети као манифесте"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "испиши све датотеке подешавања"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "испиши све датотеке документације"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "избаци основне податке о датотеци"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "испиши датотеке у пакету"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "прескочи %%ghost датотеке"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "прикажи стања наведених датотека"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "немој проверавати величину датотека"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "немој проверавати путање симболичких веза датотека"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "немој проверавати власника датотека"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "немој проверавати групу датотека"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "немој проверавати време мењања датотека"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "немој проверавати режим приступа датотека"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "немој проверавати могућности датотека"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "немој проверавати безбедносне контексте датотека"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "немој проверавати датотеке у пакету"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "немој проверавати зависности пакета"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "немој извршити скрипту(е) провере"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "очекиван је изворни пакет, пронађен је бинарни\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "изворни пакет не садржи .spec датотеку\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "распакивање архиве није успело %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " на датотеци "
 
@@ -2270,96 +2396,116 @@ msgstr "ниједан пакет не одговара %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "ниједан пакет не захтева %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "ниједан пакет не захтева %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "ниједан пакет не активира %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "ниједан пакет не захтева %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "ниједан пакет не захтева %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ниједан пакет не пружа %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "датотека %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "датотека %s не припада ниједном пакету\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "неисправан број пакета: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакет %s није инсталиран\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "непозната ознака: „%s“\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: увозно читање није успело(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Непромењива регија заглавља се не може ишчитати. Оштећен пакет?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread није успело: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "НИЈЕ УРЕДУ"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "УРЕДУ"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (НЕДОСТАЈУЋИ КЉУЧЕВИ:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (НЕПОУЗДАНИ КЉУЧЕВИ:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: отварање није успело: %s\n"
@@ -2384,144 +2530,194 @@ msgstr "Не могу да променим коренски директори�
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "НЕ "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "ДА"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Неопходне:, Обезбеђене:, и Застареле: верзије подршке зависности."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "име(на) датотеке сачувано као (називДиректоријума,основноИме,индексДиректоријума) пар, не као путања."
+msgstr ""
+"име(на) датотеке сачувано као (називДиректоријума,основноИме,"
+"индексДиректоријума) пар, не као путања."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "товар пакета може бити компримован користећи bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "товар пакета може бити компримован користећи lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "датотека(е) товара пакета има префикс „./“."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "назив пакета-верзија-издање није имплицитно наведено."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "ознаке заглавља се увек сортирају након учитавања."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "преводилац скриптице може користити аргументе заглавља."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "датотека чврсте везе може бити инсталирана иако није потпуна."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "скриптица пакета може приступити rpm бази података током инсталације."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "унутрашња подршка за скрипте lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "подршка за POSIX.1e могућности датотека"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "немој проверавати зависности пакета"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Неограничено %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "корисник %s не постоји - користим root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "група %s не постоји - користим root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Лош magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Лоше/нечитљиво  заглавље"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Превелика величина заглавља"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Непозната врста датотеке"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Интерна грешка"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Датотека архиве није у заглављу"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " неуспело - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "отварање %s није успело: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: није rpm пакет (или манифест пакета)\n"
@@ -2553,42 +2749,42 @@ msgstr "Неуспеле зависности:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: није rpm пакет (или манифест пакета): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s се не може инсталирати\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Прибављам %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "прескачем %s - неуспео пренос\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "пакет %s се не може премештати\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "грешка при читању из датотеке %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "„%s“ одређује више пакета:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "не могу да отворим %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Инсталирам %s\n"
@@ -2614,12 +2810,12 @@ msgstr "неуспело читање: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2691,7 +2887,8 @@ msgstr "пакет %s који се инсталира захтева %<PRIu64>%
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "пакет %s који се инсталира захтева %<PRIu64> и-чворова на %s систему датотека"
+msgstr ""
+"пакет %s који се инсталира захтева %<PRIu64> и-чворова на %s систему датотека"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2777,60 +2974,79 @@ msgstr "недостаје архитектура за %s на %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "лоша опција „%s“ код %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Непознати систем: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Молим вас контактирајте %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Не могу да отворим %s за читање: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "није уграђена подршка <lua> скриптица\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Не могу да направим привремену датотеку за %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Не могу да удвојим описника датотеке: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Не могу да прочитам икону %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Не могу да прочитам икону %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite није успело: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s скриптица није успела, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s скриптица није успела, сигнал %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s скриптица није успела, излазни статус %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Непознат облик"
 
@@ -2842,127 +3058,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "не могу да отворим Packages базу података у %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "сувишна „(“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "недостаје „(“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "недостаје „)“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: неуспело читање јавног кључа.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(није OpenPGP потпис)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 сажетак:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Не могу да поново учитам заглавље потписа.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "SHA1 сажетак заглавља:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Заглавље "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 сажетак:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "SHA1 сажетак заглавља:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "недостаје   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Незадовољене зависности за %s:\n"
@@ -3036,240 +3271,242 @@ msgstr "показивач низа коришћен са низовима ра�
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "није постављен dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: прескачем"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "грешка(%d) при записивању слога #%d у %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec није успео: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp није успео: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: прескачем"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: оштећено заглавље #%u враћено -- прескачем.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: не могу да прочитам заглавље на 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "није постављен dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "неуспело креирање директоријума %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заглавље #%u у бази податак је лоше -- прескачем.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "не могу да додам слог првобитно на %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "неуспело поновно прављење базе података: основна база података је остала на месту\n"
+msgstr ""
+"неуспело поновно прављење базе података: основна база података је остала на "
+"месту\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "неуспела замена старе базе података са новом базом података!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "замени датотеке у %s са датотекама из %s да вратиш у претходно стање"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "неуспело уклањање директоријума %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "не могу да добијем %s катанац на %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "дељено"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "ексклузивно"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "грешка(%d) при складиштењу слога „%s“ у %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "грешка(%d) при уклањању слога „%s“ из %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "грешка(%d) при заузимању новог примерка пакета\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "није препозната опција базе података: „%s“ занемарено.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s има неправилну бројчану вредност, прескочено\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s има превелику или премалу long вредност, прескочено\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s има превелику или премалу целобројну вредност, прескочено\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "не могу да добијем %s катанац на %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "дељено"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "ексклузивно"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "грешка(%d) при складиштењу слога „%s“ у %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "грешка(%d) при уклањању слога „%s“ из %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "грешка(%d) при заузимању новог примерка пакета\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(празно)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(празно)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Макро %%%s има незавршене опције\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Макро %%%s има незавршено тело\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Макро %%%s има неправилно име (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Макро %%%s има празно тело\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Макро %%%s није могао да се прошири\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Макро %%%s има неправилно име (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Непозната опција %c у %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Неограничено %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% је праћена са макроом кога није могуће рашчланити\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== активно %d празно %d\n"
@@ -3289,31 +3526,31 @@ msgstr "Датотека %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Датотека %s је мања од %u бајтова\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "неуспело креирање директоријума"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "неправилна синтакса у lua скриптици: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "неправилна синтакса у lua скрипти: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua скрипта није успела: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "неправилна синтакса у lua датотеци: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua удица није успела: %s\n"
@@ -3322,19 +3559,19 @@ msgstr "lua удица није успела: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(без грешке)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "кобна грешка: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "грешка: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "упозорење: "
 
@@ -3343,99 +3580,154 @@ msgstr "упозорење: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "алокација меморије (%u бајта) је вратила НАЛ.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "грешка при прављењу привремене датотеке %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "грешка при прављењу привремене датотеке %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "грешка при прављењу привремене датотеке %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "неуспело креирање директоријума %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite није успело: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush није успело: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Не могу да направим цев за потписивање: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Не могу да извршим %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: отварање није успело: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "неуспело gpg извршавање (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg није успео да запише потпис\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "не могу да прочитам потпис\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature није успело: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature није успело: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "неуспело извршавање\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp није успело\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "неуспело извршавање\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "неуспело извршавање\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature није успело: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature није успело: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp није успело\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead није успело: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3740,15 @@ msgstr "%s: неуспело читање манифеста: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "немој проверавати потпис заглавља+товара"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Унесите лозинку: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Лозинка је добра.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Лош власник/група: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Не могу да направим цев за потписивање: %m"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,23 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Serbian (http://www.transifex.com/projects/p/rpm/language/"
-"sr/)\n"
-"Language: sr\n"
+"Language-Team: Serbian (http://www.transifex.com/rpm-team/rpm/language/sr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: sr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -81,7 +79,7 @@ msgstr "Опције провере (са -V или --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Опције инсталације/надградње/брисања:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Заједничке опције за све rpm режиме и извршне програме:"
@@ -102,7 +100,7 @@ msgstr "неочекиван облик упита"
 msgid "unexpected query source"
 msgstr "неочекивани извор упита"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "само један главни режим сме бити наведен"
 
@@ -121,9 +119,7 @@ msgstr "не може се користити --prefix уз --relocate или --
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate и --excludepath могу бити употребљене само при инсталацији нових "
-"пакета"
+msgstr "--relocate и --excludepath могу бити употребљене само при инсталацији нових пакета"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -186,17 +183,13 @@ msgstr "--justdb може бити наведена само током инст
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"опције искључивања скрипте могу бити наведене само током инсталације и "
-"брисања пакета"
+msgstr "опције искључивања скрипте могу бити наведене само током инсталације и брисања пакета"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"опције искључивања окидача могу бити наведене само током инсталације и "
-"брисања пакета"
+msgstr "опције искључивања окидача могу бити наведене само током инсталације и брисања пакета"
 
 #: rpmqv.c:231
 msgid ""
@@ -208,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументи за --root (-r) морају почети знаком /"
 
@@ -228,252 +221,201 @@ msgstr "нема задатих аргумената за упит"
 msgid "no arguments given for verify"
 msgstr "нема задатих аргумената за проверу"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot је већ наведен, занемарујем %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"направи кроз %prep (распаковани извори и примењене закрпе) из <specfile>"
+msgstr "направи кроз %prep (распаковани извори и примењене закрпе) из <specfile>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "направи кроз %build (%prep, онда компилирај) из <specfile>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "направи кроз %install (%prep, %build, затим инсталирај) из <specfile>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "провери %files одељак из <specfile>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "направи изворне и бинарне пакете из <specfile>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "направи бинарне пакете само из <specfile>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "направи изворне пакете само из <specfile>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"направи кроз %prep (распаковани извори и примењене закрпе) из <specfile>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<source package>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "направи кроз %build (%prep, онда компилирај) из <specfile>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"направи кроз %install (%prep, %build, затим инсталирај) из <source package>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "провери %files одељак из <specfile>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "направи бинарни пакет из <source package>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "направи бинарни пакет из <source package>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "направи изворне пакете само из <specfile>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"направи кроз %prep (распаковани извори и примењене закрпе) из <tarball>"
+msgstr "направи кроз %prep (распаковани извори и примењене закрпе) из <tarball>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "направи кроз %build (%prep, онда компилирај) из <tarball>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "направи кроз %install (%prep, %build, онда инсталирај) из <tarball>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "провери %files одељак из <tarball>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "направи изворне и бинарне пакете из <tarball>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "направи бинарне пакете само из <tarball>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "направи изворне пакете само из <tarball>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "направи бинарни пакет из <source package>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<source package>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "направи кроз %install (%prep, %build, затим инсталирај) из <source package>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "премости корен прављења"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "неуспело креирање директоријума"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "уклони стабло прављења по завршетку"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "занемари ExcludeArch: упутства из датотеке спецификације"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "отклони грешке у машини стања датотека"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "немој извршити ниједну фазу прављења"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "немој проверавати зависности прављења"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "немој извршити ниједну фазу прављења"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "не прихватај i18N msgstr ниске из датотеке спецификације"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "уклони изворе по завршетку"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "уклони датотеку спецификације по завршетку"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "прескочи право до одређене фазе (само за c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "премости циљну платформу"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Опције прављења уз [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Неуспело прављење зависности:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Не могу да отворим датотеку спецификације %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Неуспело отварање tar цеви: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Не могу да отворим датотеку спецификације %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Неуспело читање датотеке спецификације из %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Неуспела промена имена %s у %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat није успео %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Датотека %s није обична датотека.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Датотека %s не личи на датотеку спецификације.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Правим циљне платформе: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Правим за циљ %s\n"
@@ -484,8 +426,7 @@ msgstr "иницијализуј базу података"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"поново направи обрнуте спискове базе података из заглавља инсталираних пакета"
+msgstr "поново направи обрнуте спискове базе података из заглавља инсталираних пакета"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -523,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "нема задатих аргумената"
 
@@ -543,10 +484,29 @@ msgstr "обриши потписе пакета"
 msgid "Signature options:"
 msgstr "Опције потписа:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Не могу да извршим %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Морате поставити „%%_gpg_name“ у макро датотеци\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Унесите лозинку: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Лозинка је добра.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -564,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "користи следећи облик упита"
 
@@ -611,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Грешке RPM прављења:\n"
+msgstr "\n\nГрешке RPM прављења:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "синтаксна грешка при рашчлањивању ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "синтаксна грешка при рашчлањивању &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "синтаксна грешка при рашчлањивању ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "грешка рашчлањивања у изразу\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "неупарена (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- само код бројева\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! само код бројева\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "врсте се морају поклапати\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / није подржано за стрингове\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- није подржано за стрингове\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& и || нису подржани за стрингове\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "синтаксна грешка у изразу\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Недостаје „(“ у %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Недостаје „)“ у %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Неисправан %s знак: %s\n"
@@ -685,46 +642,46 @@ msgstr "Неисправан %s знак: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Недостаје %s у %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Размак који није празан следи %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Лоша синтакса: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Лоша спецификација режима: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Лоша спецификација режима директоријума: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Неисправна могућност: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Није уграђена подршка за могућност датотеке\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Датотека мора почети са „/“: %s\n"
@@ -734,146 +691,149 @@ msgstr "Датотека мора почети са „/“: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Непознат алгоритам %u за сажимање датотека, враћам се на MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Датотека наведена двапут: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symlink тачке за BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Датотека није пронађена: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: не могу да учитам непознату ознаку (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: неуспело читање јавног кључа.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: јавни кључ није ојачан.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Испред датотеке је потребно да стоји „/“: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Датотека није пронађена поклапањем: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Не могу да отворим %%files датотеку %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "ред: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Лоша датотека: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Лош власник/група: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Проверавам за незапаковане датотеке: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Пронађене су инсталиране (али незапаковане) датотеке:\n"
-"%s"
+msgstr "Пронађене су инсталиране (али незапаковане) датотеке:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Бинарне датотеке зависне од архитектуре у noarch пакету\n"
 
@@ -902,79 +862,79 @@ msgstr "%s: ред: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Није могуће утврдити назив домаћина: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Не могу да поново учитам заглавље потписа.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Непозната компресија товара: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Не могу да направим непроменљиву област заглавља.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Не могу да отворим %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Не могу да запишем пакет: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Не могу да упишем привремено заглавље\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Лоши CSA подаци\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Не могу да отворим %%files датотеку %s: %m\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread није успело: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записано: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Извршавам „%s“:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Извршавање „%s“ није успело.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Неуспела провера пакета „%s“.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Не могу да направим име излазне датотеке за пакет %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "не могу да направим %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "ред %d: други %s\n"
@@ -1025,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "ред %d: Грешка при тумачењу %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "ред %d: Лоша опција %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "ред %d: Превише имена: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "ред %d: Пакет не постоји: %s\n"
@@ -1144,94 +1104,90 @@ msgstr "ред %d: Ознака прихвата само један жетон:
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "ред %d: други %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: ред: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "ред %d: Лоше обликована ознака: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "ред %d: Празна ознака: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "ред %d: Префикси се не смеју завршавати са „/“: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "ред %d: Docdir мора почети са „/“: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "ред %d: Поље епохе мора бити број без предзнака: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "ред %d: Лоши %s: квалификатори: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "ред %d: Лош облик за BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "ред %d: Само noarch подпакети су подржани: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Интерна грешка: Лажна ознака %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Лоша спецификација пакета: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Пакет већ постоји: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "ред %d: Непозната ознака: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не може бити празно\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не може бити „/“\n"
@@ -1241,193 +1197,161 @@ msgstr "%%{buildroot} не може бити „/“\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Лош извор: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Нема закрпе број %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch без одговарајуће „Patch:“ ознаке\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Нема извора број %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Нема ознаке „Source:“ у датотеци спецификације\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Грешка у тумачењу %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "ред %d: Лош аргумент за %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "ред %d: Лоша %%setup опција %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Неисправан број закрпе %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "ред %d: други %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "ред %d: окидачи морају имати --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "ред %d: Грешка при тумачењу %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "ред %d: интерна скрипта се мора завршити са „>“: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "ред %d: скрипта програма мора почети са „/“: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "ред %d: Други %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "ред %d: неподржана интерна скрипта: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "ред %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Не могу да отворим %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Добио %%else без %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Добио %%endif без %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Нису пронађене усаглашене архитектуре за прављење\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Пакет нема %%description: %s\n"
@@ -1498,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Не могу да направим цев за %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Не могу да извршим %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Не могу да одвојим %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Пребацивање %s у дуги цео број није успело.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) није успело: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load није успело: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Препознавање датотеке „%s“ није успело: режим %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Проналазак %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Неуспело тражење %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "упит на датотеком спецификације %s није успео, не могу да протумачим\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s је Делта RPM и не може се директно инсталирати\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Неподржан терет (%s) у пакету %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакет %s је већ додат, прескачем %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакет %s је већ додат, замењујем са %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(није број)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(није base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(неисправна врста)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(није blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(неисправна xml врста)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(није OpenPGP потпис)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s сачувано као %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s направљено као %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1901,17 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "премештања морају имати / након ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"инсталирај све датотеке, чак и подешавања која би иначе могла бити прескочена"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "инсталирај све датотеке, чак и подешавања која би иначе могла бити прескочена"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"уклони све пакете који одговарају <package> (обично се пријављује грешка ако "
-"<package> одређује више пакета)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "уклони све пакете који одговарају <package> (обично се пријављује грешка ако <package> одређује више пакета)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1989,7 +1920,7 @@ msgstr "ажурирај базу података, али немој мењат
 msgid "do not verify package dependencies"
 msgstr "немој проверавати зависности пакета"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2003,8 +1934,7 @@ msgstr "немој инсталирати безбедносне контекс�
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"немој преуређивати редослед инсталације пакета ради задовољавања зависности"
+msgstr "немој преуређивати редослед инсталације пакета ради задовољавања зависности"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2068,8 +1998,7 @@ msgstr "немој извршити ниједну %%triggerpostun скрипт�
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"надгради на стару верзију пакета (--force код надградње ово ради самостално)"
+msgstr "надгради на стару верзију пакета (--force код надградње ово ради самостално)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2111,182 +2040,162 @@ msgstr "надгради пакет(е)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "испитај/провери све пакете"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm checksig режим"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "испитај/провери пакет(е) које поседују датотеку"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "испитај/провери пакет(е) у групи"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "испитај/провери датотеку пакета"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "испитај/провери пакет(е) са идентификатором пакета"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "испитај/провери пакет(е) са идентификатором заглавља"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "режим rpm упита"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "испитај/провери инстанцу заглавља"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "испитај/провери пакет(е) из трансакције инсталације"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "испитај пакет(е) које је активирао овај пакет"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "режим rpm провере"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "испитај/провери пакет(е) који захтевају зависности"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "испитај/провери пакет(е) који пружају зависности"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "испитај/провери пакет(е) који захтевају зависности"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "испитај/провери пакет(е) који захтевају зависности"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "испитај/провери пакет(е) који захтевају зависности"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "испитај/провери пакет(е) који захтевају зависности"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "немој преклапати аргументе"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "немој обрађивати датотеке које нису пакети као манифесте"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "испиши све датотеке подешавања"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "испиши све датотеке документације"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "избаци основне податке о датотеци"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "испиши датотеке у пакету"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "прескочи %%ghost датотеке"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "прикажи стања наведених датотека"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "немој проверавати величину датотека"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "немој проверавати путање симболичких веза датотека"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "немој проверавати власника датотека"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "немој проверавати групу датотека"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "немој проверавати време мењања датотека"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "немој проверавати режим приступа датотека"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "немој проверавати могућности датотека"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "немој проверавати безбедносне контексте датотека"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "немој проверавати датотеке у пакету"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "немој проверавати зависности пакета"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "немој извршити скрипту(е) провере"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "очекиван је изворни пакет, пронађен је бинарни\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "изворни пакет не садржи .spec датотеку\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "распакивање архиве није успело %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " на датотеци "
 
@@ -2361,116 +2270,96 @@ msgstr "ниједан пакет не одговара %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "ниједан пакет не захтева %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "ниједан пакет не захтева %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "ниједан пакет не активира %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "ниједан пакет не захтева %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "ниједан пакет не захтева %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ниједан пакет не пружа %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "датотека %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "датотека %s не припада ниједном пакету\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "неисправан број пакета: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакет %s није инсталиран\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "непозната ознака: „%s“\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: увозно читање није успело(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Непромењива регија заглавља се не може ишчитати. Оштећен пакет?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread није успело: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "НИЈЕ УРЕДУ"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "УРЕДУ"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (НЕДОСТАЈУЋИ КЉУЧЕВИ:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (НЕПОУЗДАНИ КЉУЧЕВИ:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: отварање није успело: %s\n"
@@ -2495,194 +2384,144 @@ msgstr "Не могу да променим коренски директори�
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "НЕ "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "ДА"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Неопходне:, Обезбеђене:, и Застареле: верзије подршке зависности."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"име(на) датотеке сачувано као (називДиректоријума,основноИме,"
-"индексДиректоријума) пар, не као путања."
+msgstr "име(на) датотеке сачувано као (називДиректоријума,основноИме,индексДиректоријума) пар, не као путања."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "товар пакета може бити компримован користећи bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "товар пакета може бити компримован користећи lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "датотека(е) товара пакета има префикс „./“."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "назив пакета-верзија-издање није имплицитно наведено."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "ознаке заглавља се увек сортирају након учитавања."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "преводилац скриптице може користити аргументе заглавља."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "датотека чврсте везе може бити инсталирана иако није потпуна."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "скриптица пакета може приступити rpm бази података током инсталације."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "унутрашња подршка за скрипте lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "подршка за POSIX.1e могућности датотека"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "немој проверавати зависности пакета"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Неограничено %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "корисник %s не постоји - користим root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "група %s не постоји - користим root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Лош magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Лоше/нечитљиво  заглавље"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Превелика величина заглавља"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Непозната врста датотеке"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Интерна грешка"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Датотека архиве није у заглављу"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " неуспело - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "отварање %s није успело: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: није rpm пакет (или манифест пакета)\n"
@@ -2714,42 +2553,42 @@ msgstr "Неуспеле зависности:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: није rpm пакет (или манифест пакета): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s се не може инсталирати\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Прибављам %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "прескачем %s - неуспео пренос\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "пакет %s се не може премештати\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "грешка при читању из датотеке %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "„%s“ одређује више пакета:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "не могу да отворим %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Инсталирам %s\n"
@@ -2775,12 +2614,12 @@ msgstr "неуспело читање: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2852,8 +2691,7 @@ msgstr "пакет %s који се инсталира захтева %<PRIu64>%
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"пакет %s који се инсталира захтева %<PRIu64> и-чворова на %s систему датотека"
+msgstr "пакет %s који се инсталира захтева %<PRIu64> и-чворова на %s систему датотека"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2943,75 +2781,56 @@ msgstr "лоша опција „%s“ код %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Непознати систем: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Молим вас контактирајте %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Не могу да отворим %s за читање: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "није уграђена подршка <lua> скриптица\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Не могу да направим привремену датотеку за %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Не могу да удвојим описника датотеке: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Не могу да прочитам икону %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Не могу да прочитам икону %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite није успело: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s скриптица није успела, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s скриптица није успела, сигнал %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s скриптица није успела, излазни статус %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Непознат облик"
 
@@ -3023,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "не могу да отворим Packages базу података у %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "сувишна „(“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "недостаје „(“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "недостаје „)“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: неуспело читање јавног кључа.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(није OpenPGP потпис)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Заглавље "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 сажетак:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "SHA1 сажетак заглавља:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Заглавље "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "недостаје   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Незадовољене зависности за %s:\n"
@@ -3232,242 +3036,240 @@ msgstr "показивач низа коришћен са низовима ра�
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "није постављен dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: прескачем"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "грешка(%d) при записивању слога #%d у %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec није успео: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp није успео: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: прескачем"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: оштећено заглавље #%u враћено -- прескачем.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: не могу да прочитам заглавље на 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "није постављен dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "неуспело креирање директоријума %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заглавље #%u у бази податак је лоше -- прескачем.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "не могу да додам слог првобитно на %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"неуспело поновно прављење базе података: основна база података је остала на "
-"месту\n"
+msgstr "неуспело поновно прављење базе података: основна база података је остала на месту\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "неуспела замена старе базе података са новом базом података!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "замени датотеке у %s са датотекама из %s да вратиш у претходно стање"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "неуспело уклањање директоријума %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "није препозната опција базе података: „%s“ занемарено.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s има неправилну бројчану вредност, прескочено\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s има превелику или премалу long вредност, прескочено\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s има превелику или премалу целобројну вредност, прескочено\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "не могу да добијем %s катанац на %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "дељено"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "ексклузивно"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "грешка(%d) при складиштењу слога „%s“ у %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "грешка(%d) при уклањању слога „%s“ из %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "грешка(%d) при заузимању новог примерка пакета\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "није препозната опција базе података: „%s“ занемарено.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s има неправилну бројчану вредност, прескочено\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s има превелику или премалу long вредност, прескочено\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s има превелику или премалу целобројну вредност, прескочено\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(празно)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(празно)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Макро %%%s има незавршене опције\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Макро %%%s има незавршено тело\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Макро %%%s има неправилно име (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Макро %%%s има празно тело\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Макро %%%s није могао да се прошири\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Макро %%%s има неправилно име (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Непозната опција %c у %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Неограничено %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% је праћена са макроом кога није могуће рашчланити\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== активно %d празно %d\n"
@@ -3487,31 +3289,31 @@ msgstr "Датотека %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Датотека %s је мања од %u бајтова\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "неуспело креирање директоријума"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "неправилна синтакса у lua скриптици: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "неправилна синтакса у lua скрипти: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua скрипта није успела: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "неправилна синтакса у lua датотеци: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua удица није успела: %s\n"
@@ -3520,19 +3322,19 @@ msgstr "lua удица није успела: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(без грешке)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "кобна грешка: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "грешка: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "упозорење: "
 
@@ -3541,121 +3343,99 @@ msgstr "упозорење: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "алокација меморије (%u бајта) је вратила НАЛ.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "грешка при прављењу привремене датотеке %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "грешка при прављењу привремене датотеке %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "грешка при прављењу привремене датотеке %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "неуспело креирање директоријума %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite није успело: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush није успело: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Не могу да извршим %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Не могу да направим цев за потписивање: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: отварање није успело: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Не могу да извршим %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Не могу да отворим %%files датотеку %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "неуспело gpg извршавање (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg није успео да запише потпис\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "не могу да прочитам потпис\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature није успело: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature није успело: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp није успело\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead није успело: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3668,36 +3448,3 @@ msgstr "%s: неуспело читање манифеста: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "немој проверавати потпис заглавља+товара"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Унесите лозинку: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Лозинка је добра.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Лош власник/група: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Не могу да направим цев за потписивање: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Не могу да упишем товар у %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Не могу да прочитам товар из %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Не могу да отворим temp датотеку.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Не могу да отворим sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Не могу да прочитам заглавље из %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Не могу да упишем заглавље у %s: %s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "Непромењива регија заглавља се не може ишчитати. Оштећен пакет?\n"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,23 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Serbian (Latin) (http://www.transifex.com/projects/p/rpm/"
-"language/sr@latin/)\n"
-"Language: sr@latin\n"
+"Language-Team: Serbian (Latin) (http://www.transifex.com/rpm-team/rpm/language/sr@latin/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: sr@latin\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -81,7 +79,7 @@ msgstr "Opcije provere (sa -V ili --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opcije instalacije/nadgradnje/brisanja:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Zajedničke opcije za sve rpm režime i izvršne programe:"
@@ -102,7 +100,7 @@ msgstr "neočekivan oblik upita"
 msgid "unexpected query source"
 msgstr "neočekivani izvor upita"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "samo jedan glavni režim sme biti naveden"
 
@@ -121,9 +119,7 @@ msgstr "ne može se koristiti --prefix uz --relocate ili --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate i --excludepath mogu biti upotrebljene samo pri instalaciji novih "
-"paketa"
+msgstr "--relocate i --excludepath mogu biti upotrebljene samo pri instalaciji novih paketa"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,7 +135,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -186,17 +183,13 @@ msgstr "--justdb može biti navedena samo tokom instalacije i brisanja paketa"
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"opcije isključivanja skripte mogu biti navedene samo tokom instalacije i "
-"brisanja paketa"
+msgstr "opcije isključivanja skripte mogu biti navedene samo tokom instalacije i brisanja paketa"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"opcije isključivanja okidača mogu biti navedene samo tokom instalacije i "
-"brisanja paketa"
+msgstr "opcije isključivanja okidača mogu biti navedene samo tokom instalacije i brisanja paketa"
 
 #: rpmqv.c:231
 msgid ""
@@ -208,7 +201,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenti za --root (-r) moraju početi znakom /"
 
@@ -228,252 +221,201 @@ msgstr "nema zadatih argumenata za upit"
 msgid "no arguments given for verify"
 msgstr "nema zadatih argumenata za proveru"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot je već naveden, zanemarujem %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <specfile>"
+msgstr "napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <specfile>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "napravi kroz %build (%prep, onda kompiliraj) iz <specfile>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "napravi kroz %install (%prep, %build, zatim instaliraj) iz <specfile>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "proveri %files odeljak iz <specfile>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "napravi izvorne i binarne pakete iz <specfile>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "napravi binarne pakete samo iz <specfile>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "napravi izvorne pakete samo iz <specfile>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <specfile>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<source package>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "napravi kroz %build (%prep, onda kompiliraj) iz <specfile>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"napravi kroz %install (%prep, %build, zatim instaliraj) iz <source package>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "proveri %files odeljak iz <specfile>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "napravi binarni paket iz <source package>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "napravi binarni paket iz <source package>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "napravi izvorne pakete samo iz <specfile>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <tarball>"
+msgstr "napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <tarball>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "napravi kroz %build (%prep, onda kompiliraj) iz <tarball>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "napravi kroz %install (%prep, %build, onda instaliraj) iz <tarball>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "proveri %files odeljak iz <tarball>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "napravi izvorne i binarne pakete iz <tarball>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "napravi binarne pakete samo iz <tarball>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "napravi izvorne pakete samo iz <tarball>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "napravi binarni paket iz <source package>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<source package>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "napravi kroz %install (%prep, %build, zatim instaliraj) iz <source package>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "premosti koren pravljenja"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "neuspelo kreiranje direktorijuma"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "ukloni stablo pravljenja po završetku"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "zanemari ExcludeArch: uputstva iz datoteke specifikacije"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "otkloni greške u mašini stanja datoteka"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "nemoj izvršiti nijednu fazu pravljenja"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "nemoj proveravati zavisnosti pravljenja"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "nemoj izvršiti nijednu fazu pravljenja"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "ne prihvataj i18N msgstr niske iz datoteke specifikacije"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "ukloni izvore po završetku"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "ukloni datoteku specifikacije po završetku"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preskoči pravo do određene faze (samo za c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "premosti ciljnu platformu"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opcije pravljenja uz [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Neuspelo pravljenje zavisnosti:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Ne mogu da otvorim datoteku specifikacije %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Neuspelo otvaranje tar cevi: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Ne mogu da otvorim datoteku specifikacije %s: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Neuspelo čitanje datoteke specifikacije iz %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Neuspela promena imena %s u %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat nije uspeo %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Datoteka %s nije obična datoteka.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Datoteka %s ne liči na datoteku specifikacije.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Pravim ciljne platforme: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Pravim za cilj %s\n"
@@ -484,9 +426,7 @@ msgstr "inicijalizuj bazu podataka"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"ponovo napravi obrnute spiskove baze podataka iz zaglavlja instaliranih "
-"paketa"
+msgstr "ponovo napravi obrnute spiskove baze podataka iz zaglavlja instaliranih paketa"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -524,7 +464,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "nema zadatih argumenata"
 
@@ -544,10 +484,29 @@ msgstr "obriši potpise paketa"
 msgid "Signature options:"
 msgstr "Opcije potpisa:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Ne mogu da izvršim %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Morate postaviti „%%_gpg_name“ u makro datoteci\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Unesite lozinku: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Lozinka je dobra.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -565,7 +524,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "koristi sledeći oblik upita"
 
@@ -612,71 +571,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Greške RPM pravljenja:\n"
+msgstr "\n\nGreške RPM pravljenja:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "sintaksna greška pri raščlanjivanju ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "sintaksna greška pri raščlanjivanju &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "sintaksna greška pri raščlanjivanju ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "greška raščlanjivanja u izrazu\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "neuparena (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- samo kod brojeva\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! samo kod brojeva\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "vrste se moraju poklapati\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / nije podržano za stringove\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- nije podržano za stringove\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& i || nisu podržani za stringove\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "sintaksna greška u izrazu\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Nedostaje „(“ u %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Nedostaje „)“ u %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Neispravan %s znak: %s\n"
@@ -686,46 +642,46 @@ msgstr "Neispravan %s znak: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Nedostaje %s u %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Razmak koji nije prazan sledi %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Loša sintaksa: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Loša specifikacija režima: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Loša specifikacija režima direktorijuma: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Neispravna mogućnost: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Nije ugrađena podrška za mogućnost datoteke\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Datoteka mora početi sa „/“: %s\n"
@@ -735,146 +691,149 @@ msgstr "Datoteka mora početi sa „/“: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Nepoznat algoritam %u za sažimanje datoteka, vraćam se na MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Datoteka navedena dvaput: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symlink tačke za BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Datoteka nije pronađena: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: ne mogu da učitam nepoznatu oznaku (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: neuspelo čitanje javnog ključa.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: javni ključ nije ojačan.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Ispred datoteke je potrebno da stoji „/“: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Datoteka nije pronađena poklapanjem: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Ne mogu da otvorim %%files datoteku %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "red: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Loša datoteka: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Loš vlasnik/grupa: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Proveravam za nezapakovane datoteke: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Pronađene su instalirane (ali nezapakovane) datoteke:\n"
-"%s"
+msgstr "Pronađene su instalirane (ali nezapakovane) datoteke:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binarne datoteke zavisne od arhitekture u noarch paketu\n"
 
@@ -903,79 +862,79 @@ msgstr "%s: red: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nije moguće utvrditi naziv domaćina: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Ne mogu da ponovo učitam zaglavlje potpisa.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nepoznata kompresija tovara: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Ne mogu da napravim nepromenljivu oblast zaglavlja.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ne mogu da otvorim %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Ne mogu da zapišem paket: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Ne mogu da upišem privremeno zaglavlje\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Loši CSA podaci\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Ne mogu da otvorim %%files datoteku %s: %m\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread nije uspelo: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Izvršavam „%s“:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Izvršavanje „%s“ nije uspelo.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Neuspela provera paketa „%s“.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne mogu da napravim ime izlazne datoteke za paket %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ne mogu da napravim %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "red %d: drugi %s\n"
@@ -1026,19 +985,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "red %d: Greška pri tumačenju %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "red %d: Loša opcija %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "red %d: Previše imena: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "red %d: Paket ne postoji: %s\n"
@@ -1145,94 +1104,90 @@ msgstr "red %d: Oznaka prihvata samo jedan žeton: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "red %d: drugi %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: red: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "red %d: Loše oblikovana oznaka: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "red %d: Prazna oznaka: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "red %d: Prefiksi se ne smeju završavati sa „/“: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "red %d: Docdir mora početi sa „/“: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "red %d: Polje epohe mora biti broj bez predznaka: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "red %d: Loši %s: kvalifikatori: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "red %d: Loš oblik za BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "red %d: Samo noarch podpaketi su podržani: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interna greška: Lažna oznaka %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Loša specifikacija paketa: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paket već postoji: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "red %d: Nepoznata oznaka: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ne može biti prazno\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ne može biti „/“\n"
@@ -1242,193 +1197,161 @@ msgstr "%%{buildroot} ne može biti „/“\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Loš izvor: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nema zakrpe broj %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch bez odgovarajuće „Patch:“ oznake\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nema izvora broj %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Nema oznake „Source:“ u datoteci specifikacije\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Greška u tumačenju %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "red %d: Loš argument za %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "red %d: Loša %%setup opcija %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neispravan broj zakrpe %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "red %d: drugi %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "red %d: okidači moraju imati --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "red %d: Greška pri tumačenju %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "red %d: interna skripta se mora završiti sa „>“: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "red %d: skripta programa mora početi sa „/“: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "red %d: Drugi %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "red %d: nepodržana interna skripta: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "red %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ne mogu da otvorim %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Dobio %%else bez %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Dobio %%endif bez %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Nisu pronađene usaglašene arhitekture za pravljenje\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket nema %%description: %s\n"
@@ -1499,281 +1422,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ne mogu da napravim cev za %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Ne mogu da izvršim %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ne mogu da odvojim %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Prebacivanje %s u dugi ceo broj nije uspelo.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) nije uspelo: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load nije uspelo: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Prepoznavanje datoteke „%s“ nije uspelo: režim %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Pronalazak %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Neuspelo traženje %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "upit na datotekom specifikacije %s nije uspeo, ne mogu da protumačim\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s je Delta RPM i ne može se direktno instalirati\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodržan teret (%s) u paketu %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paket %s je već dodat, preskačem %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paket %s je već dodat, zamenjujem sa %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(nije broj)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(nije base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(neispravna vrsta)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(nije blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(neispravna xml vrsta)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(nije OpenPGP potpis)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sačuvano kao %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s napravljeno kao %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1902,18 +1834,15 @@ msgid "relocations must have a / following the ="
 msgstr "premeštanja moraju imati / nakon ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"instaliraj sve datoteke, čak i podešavanja koja bi inače mogla biti "
-"preskočena"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "instaliraj sve datoteke, čak i podešavanja koja bi inače mogla biti preskočena"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"ukloni sve pakete koji odgovaraju <package> (obično se prijavljuje greška "
-"ako <package> određuje više paketa)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "ukloni sve pakete koji odgovaraju <package> (obično se prijavljuje greška ako <package> određuje više paketa)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1991,7 +1920,7 @@ msgstr "ažuriraj bazu podataka, ali nemoj menjati sistem datoteka"
 msgid "do not verify package dependencies"
 msgstr "nemoj proveravati zavisnosti paketa"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2005,8 +1934,7 @@ msgstr "nemoj instalirati bezbednosne kontekste datoteka"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr ""
-"nemoj preuređivati redosled instalacije paketa radi zadovoljavanja zavisnosti"
+msgstr "nemoj preuređivati redosled instalacije paketa radi zadovoljavanja zavisnosti"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -2070,8 +1998,7 @@ msgstr "nemoj izvršiti nijednu %%triggerpostun skripticu(e)"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"nadgradi na staru verziju paketa (--force kod nadgradnje ovo radi samostalno)"
+msgstr "nadgradi na staru verziju paketa (--force kod nadgradnje ovo radi samostalno)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2113,182 +2040,162 @@ msgstr "nadgradi paket(e)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "ispitaj/proveri sve pakete"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm checksig režim"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "ispitaj/proveri paket(e) koje poseduju datoteku"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "ispitaj/proveri paket(e) u grupi"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "ispitaj/proveri datoteku paketa"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "ispitaj/proveri paket(e) sa identifikatorom paketa"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "ispitaj/proveri paket(e) sa identifikatorom zaglavlja"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "režim rpm upita"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "ispitaj/proveri instancu zaglavlja"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "ispitaj/proveri paket(e) iz transakcije instalacije"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "ispitaj paket(e) koje je aktivirao ovaj paket"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "režim rpm provere"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "ispitaj/proveri paket(e) koji pružaju zavisnosti"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "nemoj preklapati argumente"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "nemoj obrađivati datoteke koje nisu paketi kao manifeste"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "ispiši sve datoteke podešavanja"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "ispiši sve datoteke dokumentacije"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "izbaci osnovne podatke o datoteci"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "ispiši datoteke u paketu"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "preskoči %%ghost datoteke"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "prikaži stanja navedenih datoteka"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "nemoj proveravati veličinu datoteka"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "nemoj proveravati putanje simboličkih veza datoteka"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "nemoj proveravati vlasnika datoteka"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "nemoj proveravati grupu datoteka"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "nemoj proveravati vreme menjanja datoteka"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "nemoj proveravati režim pristupa datoteka"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "nemoj proveravati mogućnosti datoteka"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "nemoj proveravati bezbednosne kontekste datoteka"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "nemoj proveravati datoteke u paketu"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "nemoj proveravati zavisnosti paketa"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "nemoj izvršiti skriptu(e) provere"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "očekivan je izvorni paket, pronađen je binarni\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "izvorni paket ne sadrži .spec datoteku\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "raspakivanje arhive nije uspelo %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " na datoteci "
 
@@ -2363,117 +2270,96 @@ msgstr "nijedan paket ne odgovara %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nijedan paket ne zahteva %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "nijedan paket ne zahteva %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "nijedan paket ne aktivira %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "nijedan paket ne zahteva %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "nijedan paket ne zahteva %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nijedan paket ne pruža %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "datoteka %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "datoteka %s ne pripada nijednom paketu\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neispravan broj paketa: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s nije instaliran\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nepoznata oznaka: „%s“\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: uvozno čitanje nije uspelo(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: Nepromenjiva regija zaglavlja se ne može iščitati. Oštećen paket?\n"
+msgstr "%s: Nepromenjiva regija zaglavlja se ne može iščitati. Oštećen paket?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread nije uspelo: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "NIJE UREDU"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "UREDU"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (NEDOSTAJUĆI KLJUČEVI:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NEPOUZDANI KLJUČEVI:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otvaranje nije uspelo: %s\n"
@@ -2498,194 +2384,144 @@ msgstr "Ne mogu da promenim korenski direktorijum: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NE "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "DA"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Neophodne:, Obezbeđene:, i Zastarele: verzije podrške zavisnosti."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"ime(na) datoteke sačuvano kao (nazivDirektorijuma,osnovnoIme,"
-"indeksDirektorijuma) par, ne kao putanja."
+msgstr "ime(na) datoteke sačuvano kao (nazivDirektorijuma,osnovnoIme,indeksDirektorijuma) par, ne kao putanja."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "tovar paketa može biti komprimovan koristeći bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "tovar paketa može biti komprimovan koristeći lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "datoteka(e) tovara paketa ima prefiks „./“."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "naziv paketa-verzija-izdanje nije implicitno navedeno."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "oznake zaglavlja se uvek sortiraju nakon učitavanja."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "prevodilac skriptice može koristiti argumente zaglavlja."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "datoteka čvrste veze može biti instalirana iako nije potpuna."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "skriptica paketa može pristupiti rpm bazi podataka tokom instalacije."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "unutrašnja podrška za skripte lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "podrška za POSIX.1e mogućnosti datoteka"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "nemoj proveravati zavisnosti paketa"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Neograničeno %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "korisnik %s ne postoji - koristim root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupa %s ne postoji - koristim root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Loš magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Loše/nečitljivo  zaglavlje"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Prevelika veličina zaglavlja"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Nepoznata vrsta datoteke"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Interna greška"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Datoteka arhive nije u zaglavlju"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " neuspelo - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otvaranje %s nije uspelo: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: nije rpm paket (ili manifest paketa)\n"
@@ -2717,42 +2553,42 @@ msgstr "Neuspele zavisnosti:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: nije rpm paket (ili manifest paketa): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s se ne može instalirati\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Pribavljam %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "preskačem %s - neuspeo prenos\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paket %s se ne može premeštati\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "greška pri čitanju iz datoteke %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "„%s“ određuje više paketa:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "ne mogu da otvorim %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instaliram %s\n"
@@ -2778,12 +2614,12 @@ msgstr "neuspelo čitanje: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2855,8 +2691,7 @@ msgstr "paket %s koji se instalira zahteva %<PRIu64>%cB na %s sistemu datoteka"
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"paket %s koji se instalira zahteva %<PRIu64> i-čvorova na %s sistemu datoteka"
+msgstr "paket %s koji se instalira zahteva %<PRIu64> i-čvorova na %s sistemu datoteka"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2946,75 +2781,56 @@ msgstr "loša opcija „%s“ kod %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Nepoznati sistem: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Molim vas kontaktirajte %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Ne mogu da otvorim %s za čitanje: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "nije ugrađena podrška <lua> skriptica\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Ne mogu da napravim privremenu datoteku za %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Ne mogu da udvojim opisnika datoteke: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Ne mogu da pročitam ikonu %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Ne mogu da pročitam ikonu %s: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite nije uspelo: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s skriptica nije uspela, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skriptica nije uspela, signal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s skriptica nije uspela, izlazni status %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Nepoznat oblik"
 
@@ -3026,142 +2842,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "ne mogu da otvorim Packages bazu podataka u %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "suvišna „(“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "nedostaje „(“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "nedostaje „)“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: neuspelo čitanje javnog ključa.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(nije OpenPGP potpis)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Zaglavlje "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 sažetak:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "SHA1 sažetak zaglavlja:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Zaglavlje "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "nedostaje   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Nezadovoljene zavisnosti za %s:\n"
@@ -3235,242 +3036,240 @@ msgstr "pokazivač niza korišćen sa nizovima različitih veličina"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "nije postavljen dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preskačem"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "greška(%d) pri zapisivanju sloga #%d u %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec nije uspeo: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp nije uspeo: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preskačem"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: oštećeno zaglavlje #%u vraćeno -- preskačem.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ne mogu da pročitam zaglavlje na 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "nije postavljen dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "neuspelo kreiranje direktorijuma %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "zaglavlje #%u u bazi podatak je loše -- preskačem.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "ne mogu da dodam slog prvobitno na %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"neuspelo ponovno pravljenje baze podataka: osnovna baza podataka je ostala "
-"na mestu\n"
+msgstr "neuspelo ponovno pravljenje baze podataka: osnovna baza podataka je ostala na mestu\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "neuspela zamena stare baze podataka sa novom bazom podataka!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "zameni datoteke u %s sa datotekama iz %s da vratiš u prethodno stanje"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "neuspelo uklanjanje direktorijuma %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "nije prepoznata opcija baze podataka: „%s“ zanemareno.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s ima nepravilnu brojčanu vrednost, preskočeno\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s ima preveliku ili premalu long vrednost, preskočeno\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s ima preveliku ili premalu celobrojnu vrednost, preskočeno\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "ne mogu da dobijem %s katanac na %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "deljeno"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "ekskluzivno"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "greška(%d) pri skladištenju sloga „%s“ u %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "greška(%d) pri uklanjanju sloga „%s“ iz %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "greška(%d) pri zauzimanju novog primerka paketa\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "nije prepoznata opcija baze podataka: „%s“ zanemareno.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s ima nepravilnu brojčanu vrednost, preskočeno\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s ima preveliku ili premalu long vrednost, preskočeno\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s ima preveliku ili premalu celobrojnu vrednost, preskočeno\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prazno)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prazno)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s ima nezavršene opcije\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s ima nezavršeno telo\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s ima nepravilno ime (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s ima prazno telo\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s nije mogao da se proširi\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s ima nepravilno ime (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nepoznata opcija %c u %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neograničeno %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% je praćena sa makroom koga nije moguće raščlaniti\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivno %d prazno %d\n"
@@ -3490,31 +3289,31 @@ msgstr "Datoteka %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Datoteka %s je manja od %u bajtova\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "neuspelo kreiranje direktorijuma"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nepravilna sintaksa u lua skriptici: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nepravilna sintaksa u lua skripti: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skripta nije uspela: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nepravilna sintaksa u lua datoteci: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua udica nije uspela: %s\n"
@@ -3523,19 +3322,19 @@ msgstr "lua udica nije uspela: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(bez greške)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "kobna greška: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "greška: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "upozorenje: "
 
@@ -3544,121 +3343,99 @@ msgstr "upozorenje: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokacija memorije (%u bajta) je vratila NAL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "greška pri pravljenju privremene datoteke %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "greška pri pravljenju privremene datoteke %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "greška pri pravljenju privremene datoteke %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "neuspelo kreiranje direktorijuma %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Ne mogu da izvršim %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Ne mogu da napravim cev za potpisivanje: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: otvaranje nije uspelo: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Ne mogu da izvršim %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Ne mogu da otvorim %%files datoteku %s: %m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "neuspelo gpg izvršavanje (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg nije uspeo da zapiše potpis\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "ne mogu da pročitam potpis\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature nije uspelo: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp nije uspelo\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3671,36 +3448,3 @@ msgstr "%s: neuspelo čitanje manifesta: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "nemoj proveravati potpis zaglavlja+tovara"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Unesite lozinku: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Lozinka je dobra.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Loš vlasnik/grupa: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Ne mogu da napravim cev za potpisivanje: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Ne mogu da upišem tovar u %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Ne mogu da pročitam tovar iz %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Ne mogu da otvorim temp datoteku.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Ne mogu da otvorim sigtarget %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Ne mogu da pročitam zaglavlje iz %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Ne mogu da upišem zaglavlje u %s: %s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "Nepromenjiva regija zaglavlja se ne može iščitati. Oštećen paket?\n"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,21 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Serbian (Latin) (http://www.transifex.com/rpm-team/rpm/language/sr@latin/)\n"
+"Language-Team: Serbian (Latin) (http://www.transifex.com/rpm-team/rpm/"
+"language/sr@latin/)\n"
+"Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr@latin\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -79,7 +81,7 @@ msgstr "Opcije provere (sa -V ili --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Opcije instalacije/nadgradnje/brisanja:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Zajedničke opcije za sve rpm režime i izvršne programe:"
@@ -100,7 +102,7 @@ msgstr "neočekivan oblik upita"
 msgid "unexpected query source"
 msgstr "neočekivani izvor upita"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "samo jedan glavni režim sme biti naveden"
 
@@ -119,7 +121,9 @@ msgstr "ne može se koristiti --prefix uz --relocate ili --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate i --excludepath mogu biti upotrebljene samo pri instalaciji novih paketa"
+msgstr ""
+"--relocate i --excludepath mogu biti upotrebljene samo pri instalaciji novih "
+"paketa"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -135,8 +139,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -183,13 +186,17 @@ msgstr "--justdb može biti navedena samo tokom instalacije i brisanja paketa"
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "opcije isključivanja skripte mogu biti navedene samo tokom instalacije i brisanja paketa"
+msgstr ""
+"opcije isključivanja skripte mogu biti navedene samo tokom instalacije i "
+"brisanja paketa"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "opcije isključivanja okidača mogu biti navedene samo tokom instalacije i brisanja paketa"
+msgstr ""
+"opcije isključivanja okidača mogu biti navedene samo tokom instalacije i "
+"brisanja paketa"
 
 #: rpmqv.c:231
 msgid ""
@@ -201,7 +208,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenti za --root (-r) moraju početi znakom /"
 
@@ -221,201 +228,252 @@ msgstr "nema zadatih argumenata za upit"
 msgid "no arguments given for verify"
 msgstr "nema zadatih argumenata za proveru"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot je već naveden, zanemarujem %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <specfile>"
+msgstr ""
+"napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <specfile>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "napravi kroz %build (%prep, onda kompiliraj) iz <specfile>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "napravi kroz %install (%prep, %build, zatim instaliraj) iz <specfile>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "proveri %files odeljak iz <specfile>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "napravi izvorne i binarne pakete iz <specfile>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "napravi binarne pakete samo iz <specfile>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "napravi izvorne pakete samo iz <specfile>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <specfile>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<source package>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "napravi kroz %build (%prep, onda kompiliraj) iz <specfile>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"napravi kroz %install (%prep, %build, zatim instaliraj) iz <source package>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "proveri %files odeljak iz <specfile>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "napravi binarni paket iz <source package>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "napravi binarni paket iz <source package>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "napravi izvorne pakete samo iz <specfile>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <tarball>"
+msgstr ""
+"napravi kroz %prep (raspakovani izvori i primenjene zakrpe) iz <tarball>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarball>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "napravi kroz %build (%prep, onda kompiliraj) iz <tarball>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
 msgstr "napravi kroz %install (%prep, %build, onda instaliraj) iz <tarball>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "proveri %files odeljak iz <tarball>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "napravi izvorne i binarne pakete iz <tarball>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "napravi binarne pakete samo iz <tarball>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "napravi izvorne pakete samo iz <tarball>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "napravi binarni paket iz <source package>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<source package>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "napravi kroz %install (%prep, %build, zatim instaliraj) iz <source package>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "premosti koren pravljenja"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "neuspelo kreiranje direktorijuma"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "ukloni stablo pravljenja po završetku"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "zanemari ExcludeArch: uputstva iz datoteke specifikacije"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "otkloni greške u mašini stanja datoteka"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "nemoj izvršiti nijednu fazu pravljenja"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "nemoj proveravati zavisnosti pravljenja"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "nemoj izvršiti nijednu fazu pravljenja"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "ne prihvataj i18N msgstr niske iz datoteke specifikacije"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "ukloni izvore po završetku"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "ukloni datoteku specifikacije po završetku"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "preskoči pravo do određene faze (samo za c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "premosti ciljnu platformu"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opcije pravljenja uz [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Neuspelo pravljenje zavisnosti:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Ne mogu da otvorim datoteku specifikacije %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Neuspelo otvaranje tar cevi: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Ne mogu da otvorim datoteku specifikacije %s: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Neuspelo čitanje datoteke specifikacije iz %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Neuspela promena imena %s u %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat nije uspeo %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Datoteka %s nije obična datoteka.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Datoteka %s ne liči na datoteku specifikacije.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Pravim ciljne platforme: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Pravim za cilj %s\n"
@@ -426,7 +484,9 @@ msgstr "inicijalizuj bazu podataka"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "ponovo napravi obrnute spiskove baze podataka iz zaglavlja instaliranih paketa"
+msgstr ""
+"ponovo napravi obrnute spiskove baze podataka iz zaglavlja instaliranih "
+"paketa"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -464,49 +524,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "nema zadatih argumenata"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "potpiši paket(e) (istovetno sa --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "obriši potpise paketa"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "instaliraj paket(e)"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Opcije potpisa:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Ne mogu da izvršim %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Morate postaviti „%%_gpg_name“ u makro datoteci\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Unesite lozinku: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Lozinka je dobra.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix može biti upotrebljena samo pri instalaciji novih paketa"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches može biti navedena samo tokom brisanja paketa"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -524,7 +599,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "koristi sledeći oblik upita"
 
@@ -571,68 +646,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nGreške RPM pravljenja:\n"
+msgstr ""
+"\n"
+"\n"
+"Greške RPM pravljenja:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "sintaksna greška pri raščlanjivanju ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "sintaksna greška pri raščlanjivanju &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "sintaksna greška pri raščlanjivanju ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "greška raščlanjivanja u izrazu\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "neuparena (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- samo kod brojeva\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! samo kod brojeva\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "vrste se moraju poklapati\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / nije podržano za stringove\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- nije podržano za stringove\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& i || nisu podržani za stringove\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "sintaksna greška u izrazu\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Nedostaje „(“ u %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Nedostaje „)“ u %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Neispravan %s znak: %s\n"
@@ -642,46 +720,46 @@ msgstr "Neispravan %s znak: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Nedostaje %s u %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Razmak koji nije prazan sledi %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Loša sintaksa: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Loša specifikacija režima: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Loša specifikacija režima direktorijuma: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Neispravna mogućnost: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Nije ugrađena podrška za mogućnost datoteke\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Datoteka mora početi sa „/“: %s\n"
@@ -691,149 +769,151 @@ msgstr "Datoteka mora početi sa „/“: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Nepoznat algoritam %u za sažimanje datoteka, vraćam se na MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Datoteka navedena dvaput: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symlink tačke za BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Datoteka nije pronađena: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: ne mogu da učitam nepoznatu oznaku (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: neuspelo čitanje javnog ključa.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: javni ključ nije ojačan.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Ispred datoteke je potrebno da stoji „/“: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Datoteka nije pronađena poklapanjem: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Ne mogu da otvorim %%files datoteku %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "red: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Datoteka nije pronađena poklapanjem: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Loša datoteka: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Loš vlasnik/grupa: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Proveravam za nezapakovane datoteke: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Pronađene su instalirane (ali nezapakovane) datoteke:\n%s"
+msgstr ""
+"Pronađene su instalirane (ali nezapakovane) datoteke:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binarne datoteke zavisne od arhitekture u noarch paketu\n"
 
@@ -862,79 +942,76 @@ msgstr "%s: red: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Nije moguće utvrditi naziv domaćina: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Ne mogu da ponovo učitam zaglavlje potpisa.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nepoznata kompresija tovara: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Ne mogu da napravim nepromenljivu oblast zaglavlja.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ne mogu da otvorim %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Ne mogu da zapišem paket: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Ne mogu da upišem privremeno zaglavlje\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Loši CSA podaci\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Izvršavam „%s“:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Izvršavanje „%s“ nije uspelo.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Neuspela provera paketa „%s“.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne mogu da napravim ime izlazne datoteke za paket %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ne mogu da napravim %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "red %d: drugi %s\n"
@@ -985,19 +1062,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "red %d: Greška pri tumačenju %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "red %d: Loša opcija %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "red %d: Previše imena: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "red %d: Paket ne postoji: %s\n"
@@ -1104,90 +1181,94 @@ msgstr "red %d: Oznaka prihvata samo jedan žeton: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "red %d: drugi %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: red: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "red %d: Loše oblikovana oznaka: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "red %d: Prazna oznaka: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "red %d: Prefiksi se ne smeju završavati sa „/“: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "red %d: Docdir mora početi sa „/“: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "red %d: Polje epohe mora biti broj bez predznaka: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "red %d: Loši %s: kvalifikatori: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "red %d: Loš oblik za BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "red %d: Samo noarch podpaketi su podržani: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interna greška: Lažna oznaka %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Loša specifikacija paketa: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paket već postoji: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "red %d: Nepoznata oznaka: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ne može biti prazno\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ne može biti „/“\n"
@@ -1197,161 +1278,193 @@ msgstr "%%{buildroot} ne može biti „/“\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Loš izvor: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nema zakrpe broj %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch bez odgovarajuće „Patch:“ oznake\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nema izvora broj %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Nema oznake „Source:“ u datoteci specifikacije\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Greška u tumačenju %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "red %d: Loš argument za %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "red %d: Loša %%setup opcija %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neispravan broj zakrpe %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "red %d: drugi %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "red %d: okidači moraju imati --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "red %d: Greška pri tumačenju %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "red %d: interna skripta se mora završiti sa „>“: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "red %d: skripta programa mora početi sa „/“: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "red %d: Drugi %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "red %d: nepodržana interna skripta: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "red %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ne mogu da otvorim %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Dobio %%else bez %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Dobio %%endif bez %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Nisu pronađene usaglašene arhitekture za pravljenje\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket nema %%description: %s\n"
@@ -1422,290 +1535,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ne mogu da napravim cev za %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Ne mogu da izvršim %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ne mogu da odvojim %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Prebacivanje %s u dugi ceo broj nije uspelo.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) nije uspelo: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load nije uspelo: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Prepoznavanje datoteke „%s“ nije uspelo: režim %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Pronalazak %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Neuspelo traženje %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "upit na datotekom specifikacije %s nije uspeo, ne mogu da protumačim\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s je Delta RPM i ne može se direktno instalirati\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodržan teret (%s) u paketu %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paket %s je već dodat, preskačem %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paket %s je već dodat, zamenjujem sa %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(nije broj)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(nije base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(neispravna vrsta)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(nije blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(neispravna xml vrsta)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(nije OpenPGP potpis)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sačuvano kao %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s napravljeno kao %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1834,15 +1938,18 @@ msgid "relocations must have a / following the ="
 msgstr "premeštanja moraju imati / nakon ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "instaliraj sve datoteke, čak i podešavanja koja bi inače mogla biti preskočena"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"instaliraj sve datoteke, čak i podešavanja koja bi inače mogla biti "
+"preskočena"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "ukloni sve pakete koji odgovaraju <package> (obično se prijavljuje greška ako <package> određuje više paketa)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"ukloni sve pakete koji odgovaraju <package> (obično se prijavljuje greška "
+"ako <package> određuje više paketa)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1920,7 +2027,7 @@ msgstr "ažuriraj bazu podataka, ali nemoj menjati sistem datoteka"
 msgid "do not verify package dependencies"
 msgstr "nemoj proveravati zavisnosti paketa"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -1934,7 +2041,8 @@ msgstr "nemoj instalirati bezbednosne kontekste datoteka"
 
 #: lib/poptI.c:187
 msgid "do not reorder package installation to satisfy dependencies"
-msgstr "nemoj preuređivati redosled instalacije paketa radi zadovoljavanja zavisnosti"
+msgstr ""
+"nemoj preuređivati redosled instalacije paketa radi zadovoljavanja zavisnosti"
 
 #: lib/poptI.c:191
 msgid "do not execute package scriptlet(s)"
@@ -1998,7 +2106,8 @@ msgstr "nemoj izvršiti nijednu %%triggerpostun skripticu(e)"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "nadgradi na staru verziju paketa (--force kod nadgradnje ovo radi samostalno)"
+msgstr ""
+"nadgradi na staru verziju paketa (--force kod nadgradnje ovo radi samostalno)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2040,162 +2149,182 @@ msgstr "nadgradi paket(e)"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "ispitaj/proveri sve pakete"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm checksig režim"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "ispitaj/proveri paket(e) koje poseduju datoteku"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "ispitaj/proveri paket(e) u grupi"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "ispitaj/proveri datoteku paketa"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "ispitaj/proveri paket(e) sa identifikatorom paketa"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "ispitaj/proveri paket(e) sa identifikatorom zaglavlja"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "režim rpm upita"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "ispitaj/proveri instancu zaglavlja"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "ispitaj/proveri paket(e) iz transakcije instalacije"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "ispitaj paket(e) koje je aktivirao ovaj paket"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "režim rpm provere"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "ispitaj/proveri paket(e) koji pružaju zavisnosti"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "ispitaj/proveri paket(e) koji zahtevaju zavisnosti"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "nemoj preklapati argumente"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "nemoj obrađivati datoteke koje nisu paketi kao manifeste"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "ispiši sve datoteke podešavanja"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "ispiši sve datoteke dokumentacije"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "izbaci osnovne podatke o datoteci"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "ispiši datoteke u paketu"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "preskoči %%ghost datoteke"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "prikaži stanja navedenih datoteka"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "nemoj proveravati veličinu datoteka"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "nemoj proveravati putanje simboličkih veza datoteka"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "nemoj proveravati vlasnika datoteka"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "nemoj proveravati grupu datoteka"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "nemoj proveravati vreme menjanja datoteka"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "nemoj proveravati režim pristupa datoteka"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "nemoj proveravati mogućnosti datoteka"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "nemoj proveravati bezbednosne kontekste datoteka"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "nemoj proveravati datoteke u paketu"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "nemoj proveravati zavisnosti paketa"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "nemoj izvršiti skriptu(e) provere"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "očekivan je izvorni paket, pronađen je binarni\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "izvorni paket ne sadrži .spec datoteku\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "raspakivanje arhive nije uspelo %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " na datoteci "
 
@@ -2270,96 +2399,117 @@ msgstr "nijedan paket ne odgovara %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "nijedan paket ne zahteva %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "nijedan paket ne zahteva %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "nijedan paket ne aktivira %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "nijedan paket ne zahteva %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "nijedan paket ne zahteva %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nijedan paket ne pruža %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "datoteka %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "datoteka %s ne pripada nijednom paketu\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neispravan broj paketa: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s nije instaliran\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nepoznata oznaka: „%s“\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: uvozno čitanje nije uspelo(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: Nepromenjiva regija zaglavlja se ne može iščitati. Oštećen paket?\n"
+msgstr ""
+"%s: Nepromenjiva regija zaglavlja se ne može iščitati. Oštećen paket?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread nije uspelo: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "NIJE UREDU"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "UREDU"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (NEDOSTAJUĆI KLJUČEVI:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (NEPOUZDANI KLJUČEVI:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: otvaranje nije uspelo: %s\n"
@@ -2384,144 +2534,194 @@ msgstr "Ne mogu da promenim korenski direktorijum: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NE "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "DA"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "Neophodne:, Obezbeđene:, i Zastarele: verzije podrške zavisnosti."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "ime(na) datoteke sačuvano kao (nazivDirektorijuma,osnovnoIme,indeksDirektorijuma) par, ne kao putanja."
+msgstr ""
+"ime(na) datoteke sačuvano kao (nazivDirektorijuma,osnovnoIme,"
+"indeksDirektorijuma) par, ne kao putanja."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "tovar paketa može biti komprimovan koristeći bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "tovar paketa može biti komprimovan koristeći lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "datoteka(e) tovara paketa ima prefiks „./“."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "naziv paketa-verzija-izdanje nije implicitno navedeno."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "oznake zaglavlja se uvek sortiraju nakon učitavanja."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "prevodilac skriptice može koristiti argumente zaglavlja."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "datoteka čvrste veze može biti instalirana iako nije potpuna."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "skriptica paketa može pristupiti rpm bazi podataka tokom instalacije."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "unutrašnja podrška za skripte lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "podrška za POSIX.1e mogućnosti datoteka"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "nemoj proveravati zavisnosti paketa"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Neograničeno %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "korisnik %s ne postoji - koristim root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupa %s ne postoji - koristim root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Loš magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Loše/nečitljivo  zaglavlje"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Prevelika veličina zaglavlja"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Nepoznata vrsta datoteke"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Interna greška"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Datoteka arhive nije u zaglavlju"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " neuspelo - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "otvaranje %s nije uspelo: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: nije rpm paket (ili manifest paketa)\n"
@@ -2553,42 +2753,42 @@ msgstr "Neuspele zavisnosti:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: nije rpm paket (ili manifest paketa): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s se ne može instalirati\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Pribavljam %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "preskačem %s - neuspeo prenos\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paket %s se ne može premeštati\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "greška pri čitanju iz datoteke %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "„%s“ određuje više paketa:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "ne mogu da otvorim %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Instaliram %s\n"
@@ -2614,12 +2814,12 @@ msgstr "neuspelo čitanje: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr ""
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2691,7 +2891,8 @@ msgstr "paket %s koji se instalira zahteva %<PRIu64>%cB na %s sistemu datoteka"
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "paket %s koji se instalira zahteva %<PRIu64> i-čvorova na %s sistemu datoteka"
+msgstr ""
+"paket %s koji se instalira zahteva %<PRIu64> i-čvorova na %s sistemu datoteka"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2777,60 +2978,79 @@ msgstr "nedostaje arhitektura za %s na %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "loša opcija „%s“ kod %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Nepoznati sistem: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Molim vas kontaktirajte %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Ne mogu da otvorim %s za čitanje: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "nije ugrađena podrška <lua> skriptica\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Ne mogu da napravim privremenu datoteku za %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Ne mogu da udvojim opisnika datoteke: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Ne mogu da pročitam ikonu %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Ne mogu da pročitam ikonu %s: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite nije uspelo: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s skriptica nije uspela, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s skriptica nije uspela, signal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s skriptica nije uspela, izlazni status %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Nepoznat oblik"
 
@@ -2842,127 +3062,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "ne mogu da otvorim Packages bazu podataka u %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "suvišna „(“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "nedostaje „(“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "nedostaje „)“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: neuspelo čitanje javnog ključa.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(nije OpenPGP potpis)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 sažetak:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Ne mogu da ponovo učitam zaglavlje potpisa.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "SHA1 sažetak zaglavlja:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Zaglavlje "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 sažetak:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "SHA1 sažetak zaglavlja:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "nedostaje   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Nezadovoljene zavisnosti za %s:\n"
@@ -3036,240 +3275,242 @@ msgstr "pokazivač niza korišćen sa nizovima različitih veličina"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "nije postavljen dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preskačem"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "greška(%d) pri zapisivanju sloga #%d u %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec nije uspeo: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp nije uspeo: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preskačem"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: oštećeno zaglavlje #%u vraćeno -- preskačem.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ne mogu da pročitam zaglavlje na 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "nije postavljen dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "neuspelo kreiranje direktorijuma %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "zaglavlje #%u u bazi podatak je loše -- preskačem.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "ne mogu da dodam slog prvobitno na %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "neuspelo ponovno pravljenje baze podataka: osnovna baza podataka je ostala na mestu\n"
+msgstr ""
+"neuspelo ponovno pravljenje baze podataka: osnovna baza podataka je ostala "
+"na mestu\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "neuspela zamena stare baze podataka sa novom bazom podataka!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "zameni datoteke u %s sa datotekama iz %s da vratiš u prethodno stanje"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "neuspelo uklanjanje direktorijuma %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "ne mogu da dobijem %s katanac na %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "deljeno"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "ekskluzivno"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "greška(%d) pri skladištenju sloga „%s“ u %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "greška(%d) pri uklanjanju sloga „%s“ iz %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "greška(%d) pri zauzimanju novog primerka paketa\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "nije prepoznata opcija baze podataka: „%s“ zanemareno.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s ima nepravilnu brojčanu vrednost, preskočeno\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s ima preveliku ili premalu long vrednost, preskočeno\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s ima preveliku ili premalu celobrojnu vrednost, preskočeno\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "ne mogu da dobijem %s katanac na %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "deljeno"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "ekskluzivno"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "greška(%d) pri skladištenju sloga „%s“ u %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "greška(%d) pri uklanjanju sloga „%s“ iz %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "greška(%d) pri zauzimanju novog primerka paketa\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(prazno)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prazno)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s ima nezavršene opcije\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s ima nezavršeno telo\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makro %%%s ima nepravilno ime (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s ima prazno telo\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s nije mogao da se proširi\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makro %%%s ima nepravilno ime (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nepoznata opcija %c u %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neograničeno %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% je praćena sa makroom koga nije moguće raščlaniti\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivno %d prazno %d\n"
@@ -3289,31 +3530,31 @@ msgstr "Datoteka %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Datoteka %s je manja od %u bajtova\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "neuspelo kreiranje direktorijuma"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nepravilna sintaksa u lua skriptici: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nepravilna sintaksa u lua skripti: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skripta nije uspela: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nepravilna sintaksa u lua datoteci: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua udica nije uspela: %s\n"
@@ -3322,19 +3563,19 @@ msgstr "lua udica nije uspela: %s\n"
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(bez greške)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "kobna greška: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "greška: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "upozorenje: "
 
@@ -3343,99 +3584,154 @@ msgstr "upozorenje: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokacija memorije (%u bajta) je vratila NAL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "greška pri pravljenju privremene datoteke %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "greška pri pravljenju privremene datoteke %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "greška pri pravljenju privremene datoteke %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "neuspelo kreiranje direktorijuma %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Ne mogu da napravim cev za potpisivanje: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Ne mogu da izvršim %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: otvaranje nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "neuspelo gpg izvršavanje (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg nije uspeo da zapiše potpis\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "ne mogu da pročitam potpis\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature nije uspelo: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature nije uspelo: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "neuspelo izvršavanje\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp nije uspelo\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "neuspelo izvršavanje\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "neuspelo izvršavanje\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature nije uspelo: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp nije uspelo\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3448,3 +3744,15 @@ msgstr "%s: neuspelo čitanje manifesta: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "nemoj proveravati potpis zaglavlja+tovara"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Unesite lozinku: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Lozinka je dobra.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Loš vlasnik/grupa: %s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Ne mogu da napravim cev za potpisivanje: %m"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,23 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
-# Göran Uddeborg <goeran@uddeborg.se>, 2011
 # Göran Uddeborg <goeran@uddeborg.se>, 2011,2013
+# Göran Uddeborg <goeran@uddeborg.se>, 2011,2013,2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
-"Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Swedish (http://www.transifex.com/projects/p/rpm/language/"
-"sv/)\n"
-"Language: sv\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-13 10:40+0000\n"
+"Last-Translator: Lubos Kardos <kardos.lubos@gmail.com>\n"
+"Language-Team: Swedish (http://www.transifex.com/rpm-team/rpm/language/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -80,9 +79,9 @@ msgstr "Verifieringsflaggor (med -V eller --verify):"
 
 #: rpmqv.c:57
 msgid "Install/Upgrade/Erase options:"
-msgstr "Installations-/Uppdaterings-/Raderingsflaggor"
+msgstr "Installations-/Uppdaterings-/Raderingsflaggor:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Gemensamma flaggor för alla rpm-lägen och binärer:"
@@ -103,7 +102,7 @@ msgstr "oväntat frågeformat"
 msgid "unexpected query source"
 msgstr "oväntad frågekälla"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "enbart ett huvudläge kan anges"
 
@@ -122,8 +121,7 @@ msgstr "kan inte använda --prefix med --relocate eller --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate och --excludepath kan endast användas när nya paket installeras"
+msgstr "--relocate och --excludepath kan endast användas när nya paket installeras"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -139,7 +137,8 @@ msgid ""
 msgstr "--hash (-h) kan enbart användas vid paketinstallation och -radering"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr "--percent kan enbart användas vid paketinstallation och -radering"
 
 #: rpmqv.c:179
@@ -186,31 +185,25 @@ msgstr "--justdb kan enbart användas när paket installeras eller raderas"
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"skriptinaktiveringsflaggor kan enbart användas när paket installeras eller "
-"raderas"
+msgstr "skriptinaktiveringsflaggor kan enbart användas när paket installeras eller raderas"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"utlösarinaktiveringsflaggor kan enbart användas när paket installeras eller "
-"raderas"
+msgstr "utlösarinaktiveringsflaggor kan enbart användas när paket installeras eller raderas"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps kan enbart användas vid paketinstallation, -radering och -"
-"verifikation"
+msgstr "--nodeps kan enbart användas vid paketinstallation, -radering och -verifikation"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test kan enbart användas vid paketinstallation och -radering"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argument till --root (-r) måste börja med /"
 
@@ -230,255 +223,201 @@ msgstr "inga parametrar angivna för fråga"
 msgid "no arguments given for verify"
 msgstr "inga parametrar angivna för verifiering"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot redan angivet, ignorerar %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"bygg till %prep (packa upp källkod samt applicera patchar) från <specfil>"
+msgstr "bygg till %prep (packa upp källkod samt applicera patchar) från <specfil>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfil>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "bygg till och med %build (%prep, kompilera sedan) från <specfil>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"bygg till och med %install (%prep, %build, installera sedan) från <specfil>"
+msgstr "bygg till och med %install (%prep, %build, installera sedan) från <specfil>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verifiera %files-sektionen i <specfil>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "bygg käll- och binärpaket från <specfil>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "bygg endast binärpaket från <specfil>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "bygg endast källpaket från <specfil>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"bygg till %prep (packa upp källkod samt applicera patchar) från <specfil>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<källpaket>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "bygg till och med %build (%prep, kompilera sedan) från <specfil>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"bygg till och med %install (%prep, %build, installera sedan) från <källpaket>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "verifiera %files-sektionen i <specfil>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "bygg binärpaket från <källpaket>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "bygg binärpaket från <källpaket>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "bygg endast källpaket från <specfil>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"bygg till och med %prep (packa upp källkod samt applicera patchar) från <tar-"
-"arkiv>"
+msgstr "bygg till och med %prep (packa upp källkod samt applicera patchar) från <tar-arkiv>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tar-arkiv>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "bygg till och med %build (%prep, kompilera sedan) från <tar-arkiv>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"bygg till och med %install (%prep, %build, installera sedan) från <tar-arkiv>"
+msgstr "bygg till och med %install (%prep, %build, installera sedan) från <tar-arkiv>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verifiera %files-sektionen från <tar-arkiv>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "bygg käll- och binärpaket från <tar-arkiv>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "bygg endast binärpaket från <tar-arkiv>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "bygg endast källpaket från <tar-arkiv>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "bygg binärpaket från <källpaket>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<källpaket>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "bygg till och med %install (%prep, %build, installera sedan) från <källpaket>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "åsidosätt byggrot"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Det går inte öppna aktuell katalog: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "ta bort byggträd efteråt"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorera ExcludeArch:-direktiv från specfil"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "felsök filtillståndsmaskin"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "utför inga steg i byggnationen"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "verifiera inte byggberoenden"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "generera pakethuvd(en) kompatibla med (äldre) rpm-v3-paketering"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "utför inte %clean-steget i byggnationen"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "utför inte %clean-steget i byggnationen"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "utför inte %check-steget i byggnationen"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
-msgstr "acceptera inte översatta ”msgstr” från specfilen"
+msgstr "acceptera inte i18N-msgstr:er från specfilen"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "ta bort källkod efteråt"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "ta bort specfil efteråt"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "gå direkt till angivet steg (endast för c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "åsidosätt målplattform"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Byggflaggor med [ <specfil> | <tar-arkiv> | <källpaket> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Ouppfyllda byggberoenden:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Kan inte öppna specfilen %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Kunde inte öppna ”tar”-rör: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Mer än en fil på en rad: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Kunde inte läsa specfil från %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Kunde inte byta namn på %s till %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "kunde inte ta status på %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Filen %s är inte en vanlig fil.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Filen %s tycks inte vara en specfil.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Bygger målplattformar: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Bygger för målet %s\n"
@@ -497,11 +436,11 @@ msgstr "verifiera databasfiler"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr ""
+msgstr "exportera databasen till standard ut huvudlista"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr ""
+msgstr "importera databasen från standard in huvudlista"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -527,7 +466,7 @@ msgstr "lista nycklar från RPM-nyckelringen"
 msgid "Keyring options:"
 msgstr "Nyckelringsflaggor:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "inga argument angivna"
 
@@ -547,10 +486,29 @@ msgstr "tag bort paketsignaturer"
 msgid "Signature options:"
 msgstr "Signaturflaggor:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Kunde inte köra %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Du måste sätta ”%%_gpg_name” i din makrofil\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Ange lösenfras: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Lösenfrasen är ok.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Kontrollen av lösenfrasen misslyckades eller gpg-nyckeln har gått ut\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -568,7 +526,7 @@ msgstr "arbeta på binära rpm:er som genereras av spec (standard)"
 msgid "operate on source rpm generated by spec"
 msgstr "arbeta på käll-rpm genererad av spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "använd följande frågeformat"
 
@@ -615,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM-byggfel:\n"
+msgstr "\n\nRPM-byggfel:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "syntaxfel vid tolkning av ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "syntaxfel vid tolkning av &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "syntaxfel vid tolkning av ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "tolkningsfel i uttryck\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "ensam (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- endast i tal\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! endast på tal\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "typer måste passa ihop\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / stöds inte för strängar\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- stöds inte för strängar\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& och || stöds inte för strängar\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "syntaxfel i uttryck\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "”(” saknas i %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "”)” saknas i %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ogiltigt %s-element: %s\n"
@@ -689,46 +644,46 @@ msgstr "Ogiltigt %s-element: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s saknas i %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Annat än blanktecken följer på %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Felaktig syntax: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Felaktig rättighetsspecifikation: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Felaktig specifikation av katalogrättigheter: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Ovanlig lokallängd: ”%s” i %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Duplicerad lokal %s i %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Ogiltig förmåga (capability): %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Stöd för filförmågor (capability) är inte inbyggt\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Filnamn måste börja med ”/”: %s\n"
@@ -738,146 +693,149 @@ msgstr "Filnamn måste börja med ”/”: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Okänd filkontrollsummealgoritm %u, faller tillbaka på MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Filen uppräknad två gånger: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "läsning av symlänk %s misslyckades: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolisk länk pekar på BuildRoot: %s → %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
-msgstr ""
+msgstr "Sökvägen är utanför buildroot: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Katalogen hittades inte: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Filen hittades inte: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
-msgstr ""
+msgstr "Inte en katalog: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: kan inte läsa okänd tagg (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: läsning av publik nyckel misslyckades.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: inte en publik nyckel med skal.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: misslyckades att koda\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Filen behöver inledande ”/”: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev-matchning inte tillåten: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Hittade ingen katalog vid matchningen: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Hittade ingen fil vid matchningen: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Kunde inte öppna %%files-fil %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "rad: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
-msgstr ""
+msgstr "Tom %%files-fil %s\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Fel vid läsning av %%files-fil %s: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "ogiltigt _docdir_fmt: %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Kan inte blanda special %s med andra former: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Mer än en fil på en rad: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Felaktig fil: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Felaktig ägare/grupp: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Letar efter opackade fil(er): %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Installerade (men opaketerade) filer funna:\n"
-"%s"
+msgstr "Installerade (men opaketerade) filer funna:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Bearberar filer: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "Binärers arkitektur (%d) matchar inte paketarkitekturen (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Arkitekturberoende binärfiler i noarch-paket\n"
 
@@ -906,79 +864,79 @@ msgstr "%s: rad: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Kunde inte kanonisera värdnamn: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Kan inte läsa om signaturhuvud.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Okänd lastkomprimering: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Kan inte skapa oföränderlig huvudregion.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunde inte öppna %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunde inte skriva paket: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Kan inte skriva temporärhuvud\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Felaktig CSA-data\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Kunde inte öppna %s-fil: %s\n"
+msgstr "Kunde inte söka i filen %s: %s\n"
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "misslyckades skapa arkiv vid filen %s: %s\n"
+msgstr "Fread misslyckades på filen %s: %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Kör ”%s”:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Körning av ”%s” misslyckades.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paketkontroll ”%s” misslyckades.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Kunde inte generera utfilnamn för paketet %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "kan inte skapa %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "rad %d: andra %s\n"
@@ -1021,7 +979,7 @@ msgstr "ingen beskrivning i %%changelog\n"
 #: build/parseChangelog.c:237
 #, c-format
 msgid "line %d: second %%changelog\n"
-msgstr ""
+msgstr "rad %d: andra %%changelog\n"
 
 #: build/parseDescription.c:32
 #, c-format
@@ -1029,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "rad %d: Fel i tolkning av %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "rad %d: otillåten flagga %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "rad %d: För många namn: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "rad %d: Paketet existerar inte: %s\n"
@@ -1054,7 +1012,7 @@ msgstr "rad %d: Fel i tolkning av %%files: %s\n"
 #: build/parseFiles.c:76
 #, c-format
 msgid "line %d: second %%files\n"
-msgstr ""
+msgstr "rad %d: andra %%files\n"
 
 #: build/parsePolicies.c:32
 #, c-format
@@ -1147,96 +1105,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "rad %d: Taggen tar endast ett värde: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "rad %d: Otillåtet tecken ”%c” i: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "rad %d: Otillåten sekvens ”..” i: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "rad %d: Otillåtet tecken i: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "rad %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "rad %d: Otillåten sekvens ”..” i: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: rad: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "rad %d: Felaktig tagg: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "rad %d: Tom tagg: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "rad %d: Prefix får inte sluta med ”/”: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "rad %d: Docdir måste börja med ”/”: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "rad %d: Epoch-fält måste vara ett teckenlöst tal: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "rad %d: Felaktigt %s: bestämningar: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "rad %d: Felaktigt BuildArchitecture-format: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "rad %d: Endast noarch-underpaket stöds: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Internt fel: felaktig tagg %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "rad %d: %s är föråldrad: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Felaktig paketangivelse %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paketet existerar redan: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "rad %d: Okänd tagg: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} fick inte vara tom\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} kan inte vara ”/”\n"
@@ -1246,193 +1199,161 @@ msgstr "%%{buildroot} kan inte vara ”/”\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Dålig källa: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Inget patch-nummer %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch utan motsvarande ”Patch:”-tagg\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Inget källkodsnummer %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Ingen ”Source:”-tagg i spec-filen\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fel i tolkning av %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "rad %d: Felaktigt argument till %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "rad %d: Felaktig %%setup-flagga %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Felaktigt patch-nummer %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "rad %d: andra %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "Beroenden måste börja alfanumeriskt, med ”_” eller med ”/”"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Filnamn med version inte tillåtet"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "ogiltigt beroende"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Version krävs"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "ogiltigt beroende"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "rad %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "rad %d: utlösare måste ha --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "rad %d: Fel vid tolkning av %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "rad %d: internt skript måste sluta med ”>”: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "rad %d: skriptprogram måste börja med ”/”: %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr "rad %d: argument till tolken tillåts inte i utlösare: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "rad %d: En andra %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "rad %d: ej stött internt skript: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "rad %d: argument till tolken tillåts inte i utlösare: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "rad %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Kan inte öppna %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argument förväntades för %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "rad %d: Oavslutat %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "rad %d: oavslutat makro eller felaktig fortsättning på rad\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: felaktigt %%if-villkor\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Fick ett %%else utan något %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Fick ett %%endif utan något %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: felformaterad %%include-sats\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Hittade inga kompatibla arkitekturer att bygga\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paketet har ingen %%description: %s\n"
@@ -1476,8 +1397,7 @@ msgstr "Det gick inte att bestämma ett policynamn: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"”%s”-typ ges med andra typer i %%semodule %s.  Komprimerar typer till ”%s”.\n"
+msgstr "”%s”-typ ges med andra typer i %%semodule %s.  Komprimerar typer till ”%s”.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1504,282 +1424,291 @@ msgstr "För många argument på rad: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Bearbetning policyer: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorerar ogiltigt reguttr %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Kunde inte öppna rör för %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Kunde inte köra %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Kunde inte grena (fork) %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s misslyckades: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "misslyckades med att skriva all data till %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
-msgstr ""
+msgstr "felaktig operator"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
-msgstr ""
+msgstr "felaktigt format"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
-msgstr ""
+msgstr "felaktigt beroende (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konvertering av %s till långt heltal misslyckades.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Tom filklassificerare\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Inga filattribut konfigurerade\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) misslyckades: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load misslyckades: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Igenkänning av filen ”%s” misslyckades: läge %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Letar efter %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Misslyckades med att hitta %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "fråga av specfil %s misslyckades, kan inte tolka\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s är en delta-RPM och kan inte installeras direkt\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Ej stödd last (%s) i paket %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paket %s var redan tillagt, hoppar över %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paket %s är redan tillagt, ersätter med %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(inte ett tal)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(inte base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(felaktig typ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(inte en klick)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(felaktig xml-typ)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(inte en OpenPGP-signatur)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ogiltig tidpunkt %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "ersatt"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "inte installerad"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "nätdelad"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "fel färg"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "saknas"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(okänd)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(inte en sträng)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sparades som %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s skapades som %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: borttagande misslyckades: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "katalog"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "fil"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "%s har en okontrollerbar signatur"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
-msgstr ""
+msgstr "tagg[%d]: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
-msgstr ""
-
-#: lib/package.c:204
-msgid "hdr RSA: BAD, not binary"
-msgstr ""
+msgstr "hvd SHA1: FEL, ej hex"
 
 #: lib/package.c:214
-msgid "hdr DSA: BAD, not binary"
-msgstr ""
+msgid "hdr RSA: BAD, not binary"
+msgstr "hvd RSA: FEL, ej binär"
 
-#: lib/package.c:292
+#: lib/package.c:224
+msgid "hdr DSA: BAD, not binary"
+msgstr "hvd DSA: FEL, ej binär"
+
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
-msgstr ""
+msgstr "regiontagg: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
-msgstr ""
+msgstr "regionposition: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
-msgstr ""
+msgstr "regionavslutning: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
-msgstr ""
+msgstr "regionstorlek: FEL, ril(%d) > il(%d)"
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
-msgstr ""
+msgstr "klickstorlek(%d): FEL, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
-msgstr ""
-
-#: lib/package.c:441
-msgid "hdr magic: BAD"
-msgstr ""
-
-#: lib/package.c:446
-#, c-format
-msgid "hdr tags: BAD, no. of tags(%d) out of range"
-msgstr ""
-
-#: lib/package.c:452
-#, c-format
-msgid "hdr data: BAD, no. of bytes(%d) out of range"
-msgstr ""
+msgstr "hvdstorlek(%d): FEL, läsning returnerade %d"
 
 #: lib/package.c:462
+msgid "hdr magic: BAD"
+msgstr "hvdmagi: FEL"
+
+#: lib/package.c:467
+#, c-format
+msgid "hdr tags: BAD, no. of tags(%d) out of range"
+msgstr "hvdtaggar: FEL, antal taggar(%d) utanför intervall"
+
+#: lib/package.c:473
+#, c-format
+msgid "hdr data: BAD, no. of bytes(%d) out of range"
+msgstr "hvddata: FEL, antal byte(%d) utanför intervall"
+
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
-msgstr ""
+msgstr "hvdklick(%zd): FEL, läsning returnerade %d"
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
-msgstr ""
+msgstr "hvdlast: FEL"
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "Fread misslyckades: %s"
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr ""
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr "%s: fel: mer än en --pipe angiven (inkompatibla popt-alias?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1795,11 +1724,11 @@ msgstr "definiera MAKRO till värdet UTTR"
 
 #: lib/poptALL.c:181
 msgid "undefine MACRO"
-msgstr ""
+msgstr "odefinierat MAKRO"
 
 #: lib/poptALL.c:182
 msgid "MACRO"
-msgstr ""
+msgstr "MAKRO"
 
 #: lib/poptALL.c:184
 msgid "print macro expansion of EXPR"
@@ -1819,7 +1748,7 @@ msgstr "<FIL:...>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "aktivera inga insticksmoduler"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
@@ -1907,17 +1836,15 @@ msgid "relocations must have a / following the ="
 msgstr "omflyttningar måste ha ett / efter ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"installera alla filer, även konfigurationer som annars kunde hoppats över"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "installera alla filer, även konfigurationer som annars kunde hoppats över"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"ta bort alla paket som matchar <paket> (normalt ger det ett fel om <paket> "
-"anger flera paket)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "ta bort alla paket som matchar <paket> (normalt ger det ett fel om <paket> anger flera paket)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1965,8 +1892,7 @@ msgstr "<paketfil>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr ""
-"skriv ut brädgårdar allteftersom paketet installeras (bra tillsammans med -v)"
+msgstr "skriv ut brädgårdar allteftersom paketet installeras (bra tillsammans med -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1996,7 +1922,7 @@ msgstr "uppdatera databasen, men ändra inte filsystemet"
 msgid "do not verify package dependencies"
 msgstr "verifiera inte paketberoenden"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "verifiera inte kontrollsummor av filer"
 
@@ -2039,12 +1965,12 @@ msgstr "utför inte (eventuellt) %%postun-skript"
 #: lib/poptI.c:207
 #, c-format
 msgid "do not execute %%pretrans scriptlet (if any)"
-msgstr ""
+msgstr "utför inte (eventuellt) %%pretrans-skript"
 
 #: lib/poptI.c:210
 #, c-format
 msgid "do not execute %%posttrans scriptlet (if any)"
-msgstr ""
+msgstr "utför inte (eventuellt) %%posttrans-skript"
 
 #: lib/poptI.c:213
 msgid "do not execute any scriptlet(s) triggered by this package"
@@ -2074,9 +2000,7 @@ msgstr "kör inte %%triggerpostun-skript"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"uppgradera till en gammal version av paketet (--force vid uppgraderingar gör "
-"detta automatiskt)"
+msgstr "uppgradera till en gammal version av paketet (--force vid uppgraderingar gör detta automatiskt)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2116,184 +2040,164 @@ msgstr "uppgradera paket"
 
 #: lib/poptI.c:254
 msgid "reinstall package(s)"
-msgstr ""
+msgstr "ominstallera paket"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "fråga/verifiera alla paket"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm signaturkontrolläge"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "fråga/verifiera paket som äger fil"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "fråga/verifiera paket i grupp"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "fråga/verifiera en paketfil"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "fråga/verifiera paket som med paketidentifierare"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "fråga/verifiera paket med huvudidentifierare"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm frågeläge"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "fråga/verifiera en huvudinstans"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "fråga/verifiera paket från installationstransaktion"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "fråga paket utlösta av paketet"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm verifieringsläge"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "fråga/verifiera paket som behöver ett beroende"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "fråga/verifiera paket som tillhandahåller ett beroende"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "fråga/verifiera paket som behöver ett beroende"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "fråga/verifiera paket som behöver ett beroende"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "fråga/verifiera paket som behöver ett beroende"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "fråga/verifiera paket som behöver ett beroende"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "mönstermatcha inte argument"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "behandla inte icke-paket-filer som förteckningar"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "lista alla konfigurationsfiler"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "lista alla dokumentationsfiler"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
-msgstr ""
+msgstr "lista alla licensfiler"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "visa filinformation"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "lista filer i paketet"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "hoppa över %%ghost-filer"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "visa tillstånd för de listade filerna"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "verifiera inte storlekar på filer"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "verifiera inte sökvägen i symboliska länkar"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "verifiera inte ägare till filer"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "verifiera inte grupper till filer"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "verifiera inte modifikationstiden för filer"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "verifiera inte rättigheter för filer"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "verifiera inte förmågor (capabilities) på filer"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "verifiera inte filsäkerhetskontexter"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "verifiera inte filerna i paketet"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "verifiera inte paketberoenden"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "utför inte verifieringsskript"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Saknade rpmlib-funktioner för %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "källpaket förväntades, fann binärpaket\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "källpaket innehåller ingen .spec-fil\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "uppackning av arkiv misslyckades%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " vid fil "
 
@@ -2368,116 +2272,96 @@ msgstr "inga paket matchar %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "inget paket behöver %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "inget paket behöver %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "inga paketutlösare %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "inget paket behöver %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "inget paket behöver %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "inget paket tillhandahåller %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s tillhör inget paket\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "felaktigt paketnummer: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "post %u kunde inte läsas\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s är inte installerat\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "okänd tagg: ”%s”\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: import av nyckeln %d misslyckades.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: nyckeln %d är inte en bepansrad publik nyckel.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importläsning misslyckades(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead misslyckades: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Oföränderlig huvudregion kunde inte läsas.  Trasigt paket?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread misslyckades: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "EJ OK"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (SAKNADE NYCKLAR:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (EJ BETRODDA NYCKLAR:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: open misslyckades: %s\n"
@@ -2502,195 +2386,144 @@ msgstr "Kunde inte ändra rotkatalog: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Det går inte att återställa root-katalogen: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "NEJ "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, and Obsoletes:-beroenden stödjer versioner."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "filnamn lagrade som (katNamn,basNam,katIndex)-tupel, inte som sökväg."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "paketlasten kan komprimeras med bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "paketets nyttolast kan komprimeras med xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "paketlasten kan komprimeras med lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "paketlastfiler har ”./”-prefix."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "paketets namn-version-utgåva tillhandahålls inte implicit."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "huvudtaggar sorteras alltid efter att ha lästs in."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "skriptinterpretatorn kan använda argument från huvudet."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "en hårdlänkad filuppsättning får installeras utan att vara komplett."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "paketskript kan komma åt rpm-databasen under installation."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "internt stöd för lua-skript."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "kontrollsummealgoritm för filer kan konfigureras per paket"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "stöd för filförmågor (capabilities) enligt POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "paketskript kan utökas vid installationstillfället."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "beroendejämförelser stödjer versioner med tilde."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
-msgstr ""
+msgstr "stöd filer större än 4 GB"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "verifiera inte paketberoenden"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Version krävs"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "ogiltigt beroende"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Oavslutad %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "ogiltigt beroende"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "användare %s finns inte - använder root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupp %s finns inte - använder root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Felaktigt magiskt tal"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Felaktigt/oläsbart huvud"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Huvudstorleken för stor"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Filen är för stor att arkivera"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Okänd filtyp"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
-msgstr ""
+msgstr "Saknade filer"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Kontrollsumman stämmer inte"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Internt fel"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Ingen arkivfilen i huvud"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " misslyckades - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
-msgstr ""
+msgstr "%s: (fel 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "misslyckades med att öppna %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: inte ett rpm-paket (eller paketspecifikation)\n"
@@ -2722,42 +2555,42 @@ msgstr "Ouppfyllda beroenden:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: inte ett rpm-paket (eller paketspecifikation): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s kan inte installeras\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Hämtar %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "hoppar över %s - överföring misslyckades\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paket %s är inte relokerbart\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "fel vid läsning från fil %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "”%s” anger flera paket:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "kan inte öppna %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installerar %s\n"
@@ -2783,12 +2616,12 @@ msgstr "läsning misslyckades: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "inte ett rpm-paket\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "det går inte att skapa %s-lås på %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "väntar på %s-lås på %s\n"
@@ -2804,9 +2637,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Misslyckades med att lösa upp symbolen %s: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Insticksmodulen %s är inte inläst\n"
+msgstr "Insticksmodulen %%__%s_%s är inte konfigurerad\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2950,75 +2783,56 @@ msgstr "okänd flagga ”%s” vid %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Misslyckades att läsa extra vektor, /proc inte monterat?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Okänt system: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Var god kontakta %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Kan inte öppna %s för läsning: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Det går inte att återställa aktuell katalog: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua>-skriptstöd är inte inbyggt\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Kunde inte skapa temporärfil för %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Kunde inte duplicera filidentifierare: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Kan inte läsa ikon %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Det går inte att återställa root-katalogen: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite misslyckades: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s-skript misslyckades, waitpid(%d) rk %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s-skript misslyckades, signal %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s-skript misslyckades, slutstatus %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Okänt format"
 
@@ -3030,142 +2844,127 @@ msgstr "installera"
 msgid "erase"
 msgstr "radera"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "kan inte öppna paketdatabas i %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "överflödigt ”(” i paketetikett: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "”(” saknas i etikett: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "”)” saknas i paketetikett: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: misslyckades att läsa publik nyckel.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "transaktion"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(inte en OpenPGP-signatur)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
-msgstr ""
+msgstr "sighstorlek(%d): FEL, läsning returnerade %d"
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
-msgstr ""
+msgstr "sighmagi: FEL"
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
-msgstr ""
+msgstr "sightaggar: FEL, antal taggar(%d) utanför intervall"
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
-msgstr ""
+msgstr "sighdata: FEL, antal byte(%d) itanför intevall"
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
-msgstr ""
+msgstr "sighklick(%d): FEL, läsning returnerade %d"
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
-msgstr ""
+msgstr "sightagg[%d]: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
-msgstr ""
+msgstr "sighlast: FEL"
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
-msgstr ""
+msgstr "sighutfyllnad(%zd): FEL, läste %zd byte"
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
-msgstr ""
+msgstr "sigh sigSize(%zd): FEL, fstat(2) misslyckades"
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Huvud "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5-summa:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Huvudets SHA1-summa:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Huvud "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
-msgstr ""
+msgstr "Verifiera signatur: FELAKTIGA PARAMETRAR (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "hoppade över"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "misslyckades"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
-msgstr ""
+msgstr "Dubblerat användarnamn eller UID för användaren %s\n"
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
-msgstr ""
+msgstr "Dubblerat gruppnamn eller GID för gruppen %s\n"
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
-msgstr ""
+msgstr "inget tillstånd"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
-msgstr ""
+msgstr "okänt tillstånd"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "saknas    %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Ouppfyllda beroenden för %s:\n"
@@ -3239,242 +3038,240 @@ msgstr "vektoriterator använd med vektor av annan storlek"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Genererar %d saknade index, vänta …\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
-msgstr ""
+msgstr "kan inte öppna %s-indexet med %s - %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "ingen dbpath har satts\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: hoppar över"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "fel(%d) när post nr. %d sparades i %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec misslyckades: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp misslyckades: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: hoppar över"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: skadat huvud nr. %u hämtat -- hoppar över.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: kan inte läsa huvud vid 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "ingen dbpath har satts"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "misslyckades att skapa katalogen %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "huvud nr. %u i databasen är felaktigt -- hoppar över.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "kan inte lägga till post ursprungligen vid %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "kunde inte bygga om databasen: orginaldatabasen finns kvar\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "kunde inte ersätta gammal databas med ny databas!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "byt ut filer i %s med filer från %s för att återställa"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "kunde inte ta bort katalogen %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
-msgstr ""
+msgstr "%s-fel(%d) från %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
-msgstr ""
+msgstr "%s-fel(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "okänd db-flagga: ”%s” ignorerad\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s har ogiltigt ogiltigt numeriskt värde, hoppar över\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s har för stort eller för litet ”long”-värde, hoppar över\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s har för stort eller för litet heltalsvärde, hoppar över\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "kan inte få %s lås på %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "delat"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "uteslutande"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "ogiltig indextyp %x på %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "fel(%d) när ”%s”-poster hämtades från %s-indexet: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "fel(%d) när post ”%s” sparades i %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "fel(%d) när post ”%s” togs bort från %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "fel(%d) vid tillägg av post för huvud nr. %d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "fel(%d) tar bort post för huvud nr. %d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "fel(%d) vid allokering av ny paketinstans\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "okänd db-flagga: ”%s” ignorerad\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s har ett ogiltigt numeriskt värde, hoppar över\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s har för stort eller för litet ”long”-värde, hoppar över\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s har för stort eller för litet heltalsvärde, hoppar över\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tom)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tom)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
-msgstr "Makro %%%s har oavslutade flaggor\n"
+msgstr "Makrot %%%s har oavslutade flaggor\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
-msgstr "Makro %%%s har oavslutad kropp\n"
+msgstr "Makrot %%%s har oavslutad kropp\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
-msgstr "Makro %%%s har otillåtet namn (%%define)\n"
+msgstr "Makrot %%%s har otillåtet namn (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
-msgstr "makro %%%s har tom kropp\n"
+msgstr "Makrot %%%s har tom kropp\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
-msgstr ""
+msgstr "Makrot %%%s måste ha blanksteg före kroppen\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s misslyckades att expandera\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
-msgstr "Makro %%%s har otillåtet namn (%%undefine)\n"
+msgstr "Makrot %%%s har ett otillåtet namn (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
-msgstr ""
+msgstr "Makrot %%%s definierat men inte använt i sin räckvidd\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Okänd flagga %c i %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Alltför många nivåer av rekursion i en makroexpansion.  Det beror sannolikt "
-"på en rekursiv makrodeklaration.\n"
+msgstr "Alltför många nivåer av rekursion i en makroexpansion.  Det beror sannolikt på en rekursiv makrodeklaration.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Oavslutad %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Ett %% följs av ett makro som inte kan tolkas\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
-msgstr ""
+msgstr "misslyckades med att läsa in makrofilen %s"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiva %d tomma %d\n"
@@ -3494,31 +3291,31 @@ msgstr "Fil %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Filen %s är mindre än %u byte\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "misslyckades att skapa katalog"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "felaktig syntax i lua-skript: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "felaktig syntax i lua-skript: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skript misslyckades: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "felaktig syntax i lua-fil: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua-hake misslyckades: %s\n"
@@ -3527,19 +3324,19 @@ msgstr "lua-hake misslyckades: %s\n"
 msgid "[none]"
 msgstr "[ingen]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(inget fel)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "ödesdigert fel: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "fel: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "varning: "
 
@@ -3548,121 +3345,99 @@ msgstr "varning: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "minnesallokering (%u byte) returnerade NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, nyckel-ID %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(ingen)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "fel när tämporärfil %s skapades: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "fel när tämporärfil %s skapades: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "fel när tämporärfil %s skapades: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "misslyckades att skapa katalogen %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite misslyckades: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush misslyckades: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "PGP-signaturen stödjs inte\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "PGP-hash-algoritm %u stödjs inte\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "PGP-publik nyckelalgoritm %u stödjs inte\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Kunde inte köra %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Det gick inte att skapa ett rör för signering: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: open misslyckades: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "fdopen misslyckades\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Kunde inte öppna %s-fil: %s\n"
+msgstr "Kunde inte skriva till ett rör\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Kunde inte öppna %%files-fil %s: %m\n"
+msgstr "Kunde inte läsa från filen %s: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg exec misslyckades (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg kunde inte skriva signatur\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "kan inte läsa signaturen\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature misslyckades: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Kan inte signera RPM-v3-paket\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s innehåller redan en identisk signatur, hoppar över\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature misslyckades: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp misslyckades\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead misslyckades: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "misslyckades med att ersätta %s: %s\n"
@@ -3675,102 +3450,3 @@ msgstr "%s: läsning av paketlista misslyckades: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "verifiera inte huvud+lastsignatur"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Ange lösenfras: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Lösenfrasen är ok.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr ""
-#~ "Kontrollen av lösenfrasen misslyckades eller gpg-nyckeln har gått ut\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Felaktig ägare/grupp: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "rad %d: Otillåtet tecken i: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Det gick inte att skapa ett rör för signering: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Kan inte skriva last till %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Kan inte läsa last från %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Kan inte öppna temporär fil.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Kan inte läsa signaturen %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Kan inte läsa huvud från %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Kan inte skriva huvud till %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "utför inte några samlingsåtgärder"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "Oföränderlig huvudregion kunde inte läsas.  Trasigt paket?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Misslyckades med att avkoda policy för %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Misslyckades med att skapa temporär fil för %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Misslyckades med att skriva %s-policy för att filen %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Misslyckades med att skapa semanage-handtag\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Misslyckades att ansluta till policyhanterare\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Misslyckades med att börja policytransaktion: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Misslyckades att ta bort den tillfälliga policyfilen %s: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Misslyckades att installera policymodul: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Misslyckades att ta bort policymodul: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Misslyckades med att grena process: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Misslyckades med att köra %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s avslutades onormalt\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s misslyckades med slutstatus %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Misslyckades med att fastställa policyförändringar\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Misslyckades med att expandera restorecon-sökväg"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Misslyckades med etikettera om filsystemet.  Filer kan vara felmärkta\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Misslyckades med att ladda om filkontexter.  Filer kan vara felmärkta\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Misslyckades att extrahera policy från %s\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Göran Uddeborg <goeran@uddeborg.se>, 2011,2013
 # Göran Uddeborg <goeran@uddeborg.se>, 2011,2013,2015
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-13 10:40+0000\n"
 "Last-Translator: Lubos Kardos <kardos.lubos@gmail.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/rpm-team/rpm/language/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +81,7 @@ msgstr "Verifieringsflaggor (med -V eller --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Installations-/Uppdaterings-/Raderingsflaggor:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Gemensamma flaggor för alla rpm-lägen och binärer:"
@@ -102,7 +102,7 @@ msgstr "oväntat frågeformat"
 msgid "unexpected query source"
 msgstr "oväntad frågekälla"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "enbart ett huvudläge kan anges"
 
@@ -121,7 +121,8 @@ msgstr "kan inte använda --prefix med --relocate eller --excludepath"
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate och --excludepath kan endast användas när nya paket installeras"
+msgstr ""
+"--relocate och --excludepath kan endast användas när nya paket installeras"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -137,8 +138,7 @@ msgid ""
 msgstr "--hash (-h) kan enbart användas vid paketinstallation och -radering"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr "--percent kan enbart användas vid paketinstallation och -radering"
 
 #: rpmqv.c:179
@@ -185,25 +185,31 @@ msgstr "--justdb kan enbart användas när paket installeras eller raderas"
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "skriptinaktiveringsflaggor kan enbart användas när paket installeras eller raderas"
+msgstr ""
+"skriptinaktiveringsflaggor kan enbart användas när paket installeras eller "
+"raderas"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "utlösarinaktiveringsflaggor kan enbart användas när paket installeras eller raderas"
+msgstr ""
+"utlösarinaktiveringsflaggor kan enbart användas när paket installeras eller "
+"raderas"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps kan enbart användas vid paketinstallation, -radering och -verifikation"
+msgstr ""
+"--nodeps kan enbart användas vid paketinstallation, -radering och -"
+"verifikation"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test kan enbart användas vid paketinstallation och -radering"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argument till --root (-r) måste börja med /"
 
@@ -223,201 +229,255 @@ msgstr "inga parametrar angivna för fråga"
 msgid "no arguments given for verify"
 msgstr "inga parametrar angivna för verifiering"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot redan angivet, ignorerar %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "bygg till %prep (packa upp källkod samt applicera patchar) från <specfil>"
+msgstr ""
+"bygg till %prep (packa upp källkod samt applicera patchar) från <specfil>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfil>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "bygg till och med %build (%prep, kompilera sedan) från <specfil>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "bygg till och med %install (%prep, %build, installera sedan) från <specfil>"
+msgstr ""
+"bygg till och med %install (%prep, %build, installera sedan) från <specfil>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "verifiera %files-sektionen i <specfil>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "bygg käll- och binärpaket från <specfil>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "bygg endast binärpaket från <specfil>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "bygg endast källpaket från <specfil>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"bygg till %prep (packa upp källkod samt applicera patchar) från <specfil>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<källpaket>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "bygg till och med %build (%prep, kompilera sedan) från <specfil>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"bygg till och med %install (%prep, %build, installera sedan) från <källpaket>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "verifiera %files-sektionen i <specfil>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "bygg binärpaket från <källpaket>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "bygg binärpaket från <källpaket>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "bygg endast källpaket från <specfil>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "bygg till och med %prep (packa upp källkod samt applicera patchar) från <tar-arkiv>"
+msgstr ""
+"bygg till och med %prep (packa upp källkod samt applicera patchar) från <tar-"
+"arkiv>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tar-arkiv>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "bygg till och med %build (%prep, kompilera sedan) från <tar-arkiv>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "bygg till och med %install (%prep, %build, installera sedan) från <tar-arkiv>"
+msgstr ""
+"bygg till och med %install (%prep, %build, installera sedan) från <tar-arkiv>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "verifiera %files-sektionen från <tar-arkiv>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "bygg käll- och binärpaket från <tar-arkiv>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "bygg endast binärpaket från <tar-arkiv>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "bygg endast källpaket från <tar-arkiv>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "bygg binärpaket från <källpaket>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<källpaket>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "bygg till och med %install (%prep, %build, installera sedan) från <källpaket>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "åsidosätt byggrot"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Det går inte öppna aktuell katalog: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "ta bort byggträd efteråt"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ignorera ExcludeArch:-direktiv från specfil"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "felsök filtillståndsmaskin"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "utför inga steg i byggnationen"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "verifiera inte byggberoenden"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "generera pakethuvd(en) kompatibla med (äldre) rpm-v3-paketering"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "utför inte %clean-steget i byggnationen"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "utför inte %clean-steget i byggnationen"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "utför inte %check-steget i byggnationen"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "acceptera inte i18N-msgstr:er från specfilen"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "ta bort källkod efteråt"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "ta bort specfil efteråt"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "gå direkt till angivet steg (endast för c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "åsidosätt målplattform"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Byggflaggor med [ <specfil> | <tar-arkiv> | <källpaket> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Ouppfyllda byggberoenden:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Kan inte öppna specfilen %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Kunde inte öppna ”tar”-rör: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Mer än en fil på en rad: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Kunde inte läsa specfil från %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Kunde inte byta namn på %s till %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "kunde inte ta status på %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Filen %s är inte en vanlig fil.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Filen %s tycks inte vara en specfil.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Bygger målplattformar: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Bygger för målet %s\n"
@@ -466,49 +526,64 @@ msgstr "lista nycklar från RPM-nyckelringen"
 msgid "Keyring options:"
 msgstr "Nyckelringsflaggor:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "inga argument angivna"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "signera paket"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "signera paket (detsamma som --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "tag bort paketsignaturer"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "signera paket"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Signaturflaggor:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Kunde inte köra %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Du måste sätta ”%%_gpg_name” i din makrofil\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Ange lösenfras: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Lösenfrasen är ok.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Kontrollen av lösenfrasen misslyckades eller gpg-nyckeln har gått ut\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix kan endast användas när nya paket installeras"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches kan enbart användas när paket raderas"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -526,7 +601,7 @@ msgstr "arbeta på binära rpm:er som genereras av spec (standard)"
 msgid "operate on source rpm generated by spec"
 msgstr "arbeta på käll-rpm genererad av spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "använd följande frågeformat"
 
@@ -573,68 +648,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM-byggfel:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM-byggfel:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "syntaxfel vid tolkning av ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "syntaxfel vid tolkning av &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "syntaxfel vid tolkning av ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "tolkningsfel i uttryck\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "ensam (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- endast i tal\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! endast på tal\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "typer måste passa ihop\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / stöds inte för strängar\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- stöds inte för strängar\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& och || stöds inte för strängar\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "syntaxfel i uttryck\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "”(” saknas i %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "”)” saknas i %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Ogiltigt %s-element: %s\n"
@@ -644,46 +722,46 @@ msgstr "Ogiltigt %s-element: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%s saknas i %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Annat än blanktecken följer på %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Felaktig syntax: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Felaktig rättighetsspecifikation: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Felaktig specifikation av katalogrättigheter: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Ovanlig lokallängd: ”%s” i %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Duplicerad lokal %s i %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Ogiltig förmåga (capability): %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Stöd för filförmågor (capability) är inte inbyggt\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Filnamn måste börja med ”/”: %s\n"
@@ -693,149 +771,151 @@ msgstr "Filnamn måste börja med ”/”: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Okänd filkontrollsummealgoritm %u, faller tillbaka på MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Filen uppräknad två gånger: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "läsning av symlänk %s misslyckades: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolisk länk pekar på BuildRoot: %s → %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Sökvägen är utanför buildroot: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Katalogen hittades inte: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Filen hittades inte: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Inte en katalog: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: kan inte läsa okänd tagg (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: läsning av publik nyckel misslyckades.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: inte en publik nyckel med skal.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: misslyckades att koda\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Filen behöver inledande ”/”: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev-matchning inte tillåten: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Hittade ingen katalog vid matchningen: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Hittade ingen fil vid matchningen: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Kunde inte öppna %%files-fil %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "rad: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Tom %%files-fil %s\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Fel vid läsning av %%files-fil %s: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "ogiltigt _docdir_fmt: %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Hittade ingen fil vid matchningen: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Kan inte blanda special %s med andra former: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Mer än en fil på en rad: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Felaktig fil: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Felaktig ägare/grupp: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Letar efter opackade fil(er): %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Installerade (men opaketerade) filer funna:\n%s"
+msgstr ""
+"Installerade (men opaketerade) filer funna:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Bearberar filer: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "Binärers arkitektur (%d) matchar inte paketarkitekturen (%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Arkitekturberoende binärfiler i noarch-paket\n"
 
@@ -864,79 +944,76 @@ msgstr "%s: rad: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Kunde inte kanonisera värdnamn: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Kan inte läsa om signaturhuvud.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Okänd lastkomprimering: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Kan inte skapa oföränderlig huvudregion.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunde inte öppna %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunde inte skriva paket: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Kan inte skriva temporärhuvud\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Felaktig CSA-data\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Kunde inte söka i filen %s: %s\n"
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "Fread misslyckades på filen %s: %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Kör ”%s”:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Körning av ”%s” misslyckades.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paketkontroll ”%s” misslyckades.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Kunde inte generera utfilnamn för paketet %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "kan inte skapa %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "rad %d: andra %s\n"
@@ -987,19 +1064,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "rad %d: Fel i tolkning av %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "rad %d: otillåten flagga %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "rad %d: För många namn: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "rad %d: Paketet existerar inte: %s\n"
@@ -1105,91 +1182,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "rad %d: Taggen tar endast ett värde: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "rad %d: Otillåtet tecken ”%c” i: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "rad %d: Otillåtet tecken i: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "rad %d: Otillåten sekvens ”..” i: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "rad %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: rad: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "rad %d: Felaktig tagg: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "rad %d: Tom tagg: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "rad %d: Prefix får inte sluta med ”/”: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "rad %d: Docdir måste börja med ”/”: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "rad %d: Epoch-fält måste vara ett teckenlöst tal: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "rad %d: Felaktigt %s: bestämningar: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "rad %d: Felaktigt BuildArchitecture-format: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "rad %d: Endast noarch-underpaket stöds: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Internt fel: felaktig tagg %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "rad %d: %s är föråldrad: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Felaktig paketangivelse %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paketet existerar redan: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "rad %d: Okänd tagg: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} fick inte vara tom\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} kan inte vara ”/”\n"
@@ -1199,161 +1281,193 @@ msgstr "%%{buildroot} kan inte vara ”/”\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Dålig källa: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Inget patch-nummer %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch utan motsvarande ”Patch:”-tagg\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Inget källkodsnummer %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Ingen ”Source:”-tagg i spec-filen\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fel i tolkning av %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "rad %d: Felaktigt argument till %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "rad %d: Felaktig %%setup-flagga %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Felaktigt patch-nummer %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "rad %d: andra %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "Beroenden måste börja alfanumeriskt, med ”_” eller med ”/”"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Filnamn med version inte tillåtet"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Version krävs"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "ogiltigt beroende"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Version krävs"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "rad %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "rad %d: utlösare måste ha --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "rad %d: Fel vid tolkning av %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "rad %d: internt skript måste sluta med ”>”: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "rad %d: skriptprogram måste börja med ”/”: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "rad %d: argument till tolken tillåts inte i utlösare: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "rad %d: En andra %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "rad %d: ej stött internt skript: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "rad %d: argument till tolken tillåts inte i utlösare: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "rad %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Kan inte öppna %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argument förväntades för %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "rad %d: Oavslutat %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "rad %d: oavslutat makro eller felaktig fortsättning på rad\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: felaktigt %%if-villkor\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Fick ett %%else utan något %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Fick ett %%endif utan något %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: felformaterad %%include-sats\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Hittade inga kompatibla arkitekturer att bygga\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paketet har ingen %%description: %s\n"
@@ -1397,7 +1511,8 @@ msgstr "Det gick inte att bestämma ett policynamn: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "”%s”-typ ges med andra typer i %%semodule %s.  Komprimerar typer till ”%s”.\n"
+msgstr ""
+"”%s”-typ ges med andra typer i %%semodule %s.  Komprimerar typer till ”%s”.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1424,290 +1539,281 @@ msgstr "För många argument på rad: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Bearbetning policyer: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorerar ogiltigt reguttr %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Kunde inte öppna rör för %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Kunde inte köra %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Kunde inte grena (fork) %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s misslyckades: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "misslyckades med att skriva all data till %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "felaktig operator"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "felaktigt format"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "felaktigt beroende (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Konvertering av %s till långt heltal misslyckades.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Tom filklassificerare\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Inga filattribut konfigurerade\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) misslyckades: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load misslyckades: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Igenkänning av filen ”%s” misslyckades: läge %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Letar efter %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Misslyckades med att hitta %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "fråga av specfil %s misslyckades, kan inte tolka\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s är en delta-RPM och kan inte installeras direkt\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Ej stödd last (%s) i paket %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paket %s var redan tillagt, hoppar över %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paket %s är redan tillagt, ersätter med %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(inte ett tal)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(inte base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(felaktig typ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(inte en klick)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(felaktig xml-typ)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(inte en OpenPGP-signatur)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ogiltig tidpunkt %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "ersatt"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "inte installerad"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "nätdelad"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "fel färg"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "saknas"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(okänd)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(inte en sträng)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sparades som %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s skapades som %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: borttagande misslyckades: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "katalog"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "fil"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "%s har en okontrollerbar signatur"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "tagg[%d]: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr "hvd SHA1: FEL, ej hex"
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr "hvd RSA: FEL, ej binär"
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr "hvd DSA: FEL, ej binär"
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "regiontagg: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "regionposition: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "regionavslutning: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr "regionstorlek: FEL, ril(%d) > il(%d)"
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "klickstorlek(%d): FEL, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "hvdstorlek(%d): FEL, läsning returnerade %d"
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr "hvdmagi: FEL"
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "hvdtaggar: FEL, antal taggar(%d) utanför intervall"
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "hvddata: FEL, antal byte(%d) utanför intervall"
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "hvdklick(%zd): FEL, läsning returnerade %d"
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr "hvdlast: FEL"
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "Fread misslyckades: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr "%s: fel: mer än en --pipe angiven (inkompatibla popt-alias?)\n"
 
 #: lib/poptALL.c:175
@@ -1836,15 +1942,17 @@ msgid "relocations must have a / following the ="
 msgstr "omflyttningar måste ha ett / efter ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "installera alla filer, även konfigurationer som annars kunde hoppats över"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"installera alla filer, även konfigurationer som annars kunde hoppats över"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "ta bort alla paket som matchar <paket> (normalt ger det ett fel om <paket> anger flera paket)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"ta bort alla paket som matchar <paket> (normalt ger det ett fel om <paket> "
+"anger flera paket)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1892,7 +2000,8 @@ msgstr "<paketfil>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "skriv ut brädgårdar allteftersom paketet installeras (bra tillsammans med -v)"
+msgstr ""
+"skriv ut brädgårdar allteftersom paketet installeras (bra tillsammans med -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1922,7 +2031,7 @@ msgstr "uppdatera databasen, men ändra inte filsystemet"
 msgid "do not verify package dependencies"
 msgstr "verifiera inte paketberoenden"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "verifiera inte kontrollsummor av filer"
 
@@ -2000,7 +2109,9 @@ msgstr "kör inte %%triggerpostun-skript"
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "uppgradera till en gammal version av paketet (--force vid uppgraderingar gör detta automatiskt)"
+msgstr ""
+"uppgradera till en gammal version av paketet (--force vid uppgraderingar gör "
+"detta automatiskt)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2042,162 +2153,182 @@ msgstr "uppgradera paket"
 msgid "reinstall package(s)"
 msgstr "ominstallera paket"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "fråga/verifiera alla paket"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm signaturkontrolläge"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "fråga/verifiera paket som äger fil"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "fråga/verifiera paket i grupp"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "fråga/verifiera en paketfil"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "fråga/verifiera paket som med paketidentifierare"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "fråga/verifiera paket med huvudidentifierare"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm frågeläge"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "fråga/verifiera en huvudinstans"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "fråga/verifiera paket från installationstransaktion"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "fråga paket utlösta av paketet"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm verifieringsläge"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "fråga/verifiera paket som behöver ett beroende"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "fråga/verifiera paket som tillhandahåller ett beroende"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "fråga/verifiera paket som behöver ett beroende"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "fråga/verifiera paket som behöver ett beroende"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "fråga/verifiera paket som behöver ett beroende"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "fråga/verifiera paket som behöver ett beroende"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "mönstermatcha inte argument"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "behandla inte icke-paket-filer som förteckningar"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "lista alla konfigurationsfiler"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "lista alla dokumentationsfiler"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "lista alla licensfiler"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "visa filinformation"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "lista filer i paketet"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "hoppa över %%ghost-filer"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "visa tillstånd för de listade filerna"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "verifiera inte storlekar på filer"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "verifiera inte sökvägen i symboliska länkar"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "verifiera inte ägare till filer"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "verifiera inte grupper till filer"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "verifiera inte modifikationstiden för filer"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "verifiera inte rättigheter för filer"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "verifiera inte förmågor (capabilities) på filer"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "verifiera inte filsäkerhetskontexter"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "verifiera inte filerna i paketet"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "verifiera inte paketberoenden"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "utför inte verifieringsskript"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Saknade rpmlib-funktioner för %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "källpaket förväntades, fann binärpaket\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "källpaket innehåller ingen .spec-fil\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "uppackning av arkiv misslyckades%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " vid fil "
 
@@ -2272,96 +2403,116 @@ msgstr "inga paket matchar %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "inget paket behöver %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "inget paket behöver %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "inga paketutlösare %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "inget paket behöver %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "inget paket behöver %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "inget paket tillhandahåller %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s tillhör inget paket\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "felaktigt paketnummer: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "post %u kunde inte läsas\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s är inte installerat\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "okänd tagg: ”%s”\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: import av nyckeln %d misslyckades.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: nyckeln %d är inte en bepansrad publik nyckel.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importläsning misslyckades(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead misslyckades: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Oföränderlig huvudregion kunde inte läsas.  Trasigt paket?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread misslyckades: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "EJ OK"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (SAKNADE NYCKLAR:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (EJ BETRODDA NYCKLAR:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: open misslyckades: %s\n"
@@ -2386,144 +2537,195 @@ msgstr "Kunde inte ändra rotkatalog: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Det går inte att återställa root-katalogen: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "NEJ "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "JA"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides:, and Obsoletes:-beroenden stödjer versioner."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "filnamn lagrade som (katNamn,basNam,katIndex)-tupel, inte som sökväg."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "paketlasten kan komprimeras med bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "paketets nyttolast kan komprimeras med xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "paketlasten kan komprimeras med lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "paketlastfiler har ”./”-prefix."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "paketets namn-version-utgåva tillhandahålls inte implicit."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "huvudtaggar sorteras alltid efter att ha lästs in."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "skriptinterpretatorn kan använda argument från huvudet."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "en hårdlänkad filuppsättning får installeras utan att vara komplett."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "paketskript kan komma åt rpm-databasen under installation."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "internt stöd för lua-skript."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "kontrollsummealgoritm för filer kan konfigureras per paket"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "stöd för filförmågor (capabilities) enligt POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "paketskript kan utökas vid installationstillfället."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "beroendejämförelser stödjer versioner med tilde."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "stöd filer större än 4 GB"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "verifiera inte paketberoenden"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Version krävs"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "ogiltigt beroende"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Oavslutad %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "ogiltigt beroende"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "användare %s finns inte - använder root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grupp %s finns inte - använder root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Felaktigt magiskt tal"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Felaktigt/oläsbart huvud"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Huvudstorleken för stor"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Filen är för stor att arkivera"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Okänd filtyp"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Saknade filer"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Kontrollsumman stämmer inte"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Internt fel"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Ingen arkivfilen i huvud"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " misslyckades - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (fel 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "misslyckades med att öppna %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: inte ett rpm-paket (eller paketspecifikation)\n"
@@ -2555,42 +2757,42 @@ msgstr "Ouppfyllda beroenden:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: inte ett rpm-paket (eller paketspecifikation): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s kan inte installeras\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Hämtar %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "hoppar över %s - överföring misslyckades\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "paket %s är inte relokerbart\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "fel vid läsning från fil %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "”%s” anger flera paket:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "kan inte öppna %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Installerar %s\n"
@@ -2616,12 +2818,12 @@ msgstr "läsning misslyckades: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "inte ett rpm-paket\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "det går inte att skapa %s-lås på %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "väntar på %s-lås på %s\n"
@@ -2779,60 +2981,79 @@ msgstr "arkitektur saknas för %s vid %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "okänd flagga ”%s” vid %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Misslyckades att läsa extra vektor, /proc inte monterat?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Okänt system: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Var god kontakta %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Kan inte öppna %s för läsning: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Det går inte att återställa aktuell katalog: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua>-skriptstöd är inte inbyggt\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Kunde inte skapa temporärfil för %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Kunde inte duplicera filidentifierare: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Kan inte läsa ikon %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Det går inte att återställa root-katalogen: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite misslyckades: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s-skript misslyckades, waitpid(%d) rk %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s-skript misslyckades, signal %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s-skript misslyckades, slutstatus %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Okänt format"
 
@@ -2844,127 +3065,146 @@ msgstr "installera"
 msgid "erase"
 msgstr "radera"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "kan inte öppna paketdatabas i %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "överflödigt ”(” i paketetikett: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "”(” saknas i etikett: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "”)” saknas i paketetikett: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: misslyckades att läsa publik nyckel.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "transaktion"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(inte en OpenPGP-signatur)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr "sighstorlek(%d): FEL, läsning returnerade %d"
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr "sighmagi: FEL"
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr "sightaggar: FEL, antal taggar(%d) utanför intervall"
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr "sighdata: FEL, antal byte(%d) itanför intevall"
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr "sighklick(%d): FEL, läsning returnerade %d"
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "sightagg[%d]: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr "sighlast: FEL"
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "sighutfyllnad(%zd): FEL, läste %zd byte"
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigh sigSize(%zd): FEL, fstat(2) misslyckades"
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5-summa:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Kan inte läsa om signaturhuvud.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Huvudets SHA1-summa:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Huvud "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5-summa:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Huvudets SHA1-summa:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Verifiera signatur: FELAKTIGA PARAMETRAR (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "hoppade över"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "misslyckades"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr "Dubblerat användarnamn eller UID för användaren %s\n"
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr "Dubblerat gruppnamn eller GID för gruppen %s\n"
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "inget tillstånd"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "okänt tillstånd"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "saknas    %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Ouppfyllda beroenden för %s:\n"
@@ -3038,240 +3278,242 @@ msgstr "vektoriterator använd med vektor av annan storlek"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Genererar %d saknade index, vänta …\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "kan inte öppna %s-indexet med %s - %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "ingen dbpath har satts\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: hoppar över"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "fel(%d) när post nr. %d sparades i %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec misslyckades: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp misslyckades: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: hoppar över"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: skadat huvud nr. %u hämtat -- hoppar över.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: kan inte läsa huvud vid 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "ingen dbpath har satts"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "misslyckades att skapa katalogen %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "huvud nr. %u i databasen är felaktigt -- hoppar över.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "kan inte lägga till post ursprungligen vid %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "kunde inte bygga om databasen: orginaldatabasen finns kvar\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "kunde inte ersätta gammal databas med ny databas!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "byt ut filer i %s med filer från %s för att återställa"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "kunde inte ta bort katalogen %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s-fel(%d) från %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s-fel(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "kan inte få %s lås på %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "delat"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "uteslutande"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "ogiltig indextyp %x på %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "fel(%d) när ”%s”-poster hämtades från %s-indexet: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "fel(%d) när post ”%s” sparades i %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "fel(%d) när post ”%s” togs bort från %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "fel(%d) vid tillägg av post för huvud nr. %d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "fel(%d) tar bort post för huvud nr. %d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "fel(%d) vid allokering av ny paketinstans\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "okänd db-flagga: ”%s” ignorerad\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s har ett ogiltigt numeriskt värde, hoppar över\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s har för stort eller för litet ”long”-värde, hoppar över\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s har för stort eller för litet heltalsvärde, hoppar över\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "kan inte få %s lås på %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "delat"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "uteslutande"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "ogiltig indextyp %x på %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "fel(%d) när ”%s”-poster hämtades från %s-indexet: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "fel(%d) när post ”%s” sparades i %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "fel(%d) när post ”%s” togs bort från %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "fel(%d) vid tillägg av post för huvud nr. %d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "fel(%d) tar bort post för huvud nr. %d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "fel(%d) vid allokering av ny paketinstans\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(tom)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tom)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makrot %%%s har oavslutade flaggor\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makrot %%%s har oavslutad kropp\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Makrot %%%s har otillåtet namn (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makrot %%%s har tom kropp\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makrot %%%s måste ha blanksteg före kroppen\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s misslyckades att expandera\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Makrot %%%s har ett otillåtet namn (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Makrot %%%s definierat men inte använt i sin räckvidd\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Okänd flagga %c i %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Alltför många nivåer av rekursion i en makroexpansion.  Det beror sannolikt på en rekursiv makrodeklaration.\n"
+msgstr ""
+"Alltför många nivåer av rekursion i en makroexpansion.  Det beror sannolikt "
+"på en rekursiv makrodeklaration.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Oavslutad %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Ett %% följs av ett makro som inte kan tolkas\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "misslyckades med att läsa in makrofilen %s"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiva %d tomma %d\n"
@@ -3291,31 +3533,31 @@ msgstr "Fil %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Filen %s är mindre än %u byte\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "misslyckades att skapa katalog"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "felaktig syntax i lua-skript: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "felaktig syntax i lua-skript: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skript misslyckades: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "felaktig syntax i lua-fil: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua-hake misslyckades: %s\n"
@@ -3324,19 +3566,19 @@ msgstr "lua-hake misslyckades: %s\n"
 msgid "[none]"
 msgstr "[ingen]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(inget fel)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "ödesdigert fel: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "fel: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "varning: "
 
@@ -3345,99 +3587,154 @@ msgstr "varning: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "minnesallokering (%u byte) returnerade NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, nyckel-ID %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(ingen)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "fel när tämporärfil %s skapades: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "fel när tämporärfil %s skapades: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "fel när tämporärfil %s skapades: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "misslyckades att skapa katalogen %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite misslyckades: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush misslyckades: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "PGP-signaturen stödjs inte\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "PGP-hash-algoritm %u stödjs inte\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "PGP-publik nyckelalgoritm %u stödjs inte\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Det gick inte att skapa ett rör för signering: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Kunde inte köra %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "fdopen misslyckades\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "Kunde inte skriva till ett rör\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "Kunde inte läsa från filen %s: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg exec misslyckades (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg kunde inte skriva signatur\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "kan inte läsa signaturen\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature misslyckades: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature misslyckades: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: headerRead misslyckades: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp misslyckades\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "fdopen misslyckades\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: headerRead misslyckades: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s innehåller redan en identisk signatur, hoppar över\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature misslyckades: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Kan inte signera RPM-v3-paket\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s innehåller redan en identisk signatur, hoppar över\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature misslyckades: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp misslyckades\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead misslyckades: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "misslyckades med att ersätta %s: %s\n"
@@ -3450,3 +3747,28 @@ msgstr "%s: läsning av paketlista misslyckades: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "verifiera inte huvud+lastsignatur"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Ange lösenfras: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Lösenfrasen är ok.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr ""
+#~ "Kontrollen av lösenfrasen misslyckades eller gpg-nyckeln har gått ut\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Felaktig ägare/grupp: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "rad %d: Otillåtet tecken i: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "%s har en okontrollerbar signatur"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "Fread misslyckades: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Det gick inte att skapa ett rör för signering: %m"

--- a/po/te.po
+++ b/po/te.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # ప్రవీణ్ ఇళ్ళ <mail2ipn@gmail.com>, 2011
 # ప్రవీణ్ ఇళ్ళ <mail2ipn@gmail.com>, 2011
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Telugu (http://www.transifex.com/rpm-team/rpm/language/te/)\n"
+"Language: te\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: te\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +81,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -102,7 +102,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -137,8 +137,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -203,7 +202,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -223,201 +222,243 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
 #, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
 msgstr ""
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<వనరు ప్యాకేజీ>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-msgid "override build root"
+#, c-format
+msgid "verify %files section from <source package>"
 msgstr ""
 
-#: rpmbuild.c:173
-msgid "remove build tree when done"
-msgstr ""
-
-#: rpmbuild.c:175
-msgid "ignore ExcludeArch: directives from spec file"
+#: rpmbuild.c:174
+msgid "build source and binary packages from <source package>"
 msgstr ""
 
 #: rpmbuild.c:177
-msgid "debug file state machine"
+msgid "build binary package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:179
-msgid "do not execute any stages of the build"
+#: rpmbuild.c:180
+msgid "build source package only from <source package>"
 msgstr ""
 
-#: rpmbuild.c:181
-msgid "do not verify build dependencies"
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:183
-msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
 msgstr ""
 
 #: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:213
+msgid "override build root"
+msgstr ""
+
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
+msgid "remove build tree when done"
+msgstr ""
+
+#: rpmbuild.c:219
+msgid "ignore ExcludeArch: directives from spec file"
+msgstr ""
+
+#: rpmbuild.c:221
+msgid "debug file state machine"
+msgstr ""
+
+#: rpmbuild.c:223
+msgid "do not execute any stages of the build"
+msgstr ""
+
+#: rpmbuild.c:225
+msgid "do not verify build dependencies"
+msgstr ""
+
+#: rpmbuild.c:227
+msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
+msgstr ""
+
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, c-format
+msgid "do not execute %prep stage of the build"
+msgstr ""
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "అయిన తరువాత వనరులను తీసివేయి"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr ""
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -466,48 +507,60 @@ msgstr ""
 msgid "Keyring options:"
 msgstr "కీరింగ్ ఐచ్ఛికాలు:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr ""
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "ప్యాకేజీ సంతకాలను తొలగించు"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+msgid "sign package(s) files"
+msgstr ""
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "సంతకం ఐచ్ఛికాలు:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
+#: rpmsign.c:76
+#, c-format
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:127
-#, c-format
-msgid "Pass phrase is good.\n"
+#: rpmsign.c:82
+msgid "--fskpass may only be specified when signing files"
 msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+#: rpmsign.c:126
+msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
 #: rpmspec.c:26
@@ -526,7 +579,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr ""
 
@@ -573,68 +626,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM నిర్మాణ దోషాలు:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM నిర్మాణ దోషాలు:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -644,46 +700,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -693,149 +749,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "ఫైలు కనపడలేదు: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
+#: build/files.c:1590
 #, c-format
-msgid "File not found by glob: %s\n"
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "వరుస: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr ""
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "చెడ్డ ఫైలు: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr ""
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -864,79 +920,76 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr ""
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -987,19 +1040,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1106,90 +1159,94 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "ఫైల్ %s: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1199,161 +1256,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "చెడ్డ వనరు: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1424,290 +1513,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1836,14 +1916,13 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1922,7 +2001,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2042,162 +2121,178 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr ""
+
+#: lib/poptQV.c:107
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr ""
+
+#: lib/poptQV.c:109
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr ""
+
+#: lib/poptQV.c:111
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr ""
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "అన్ని స్వరూపణం ఫైళ్ళను జాబితాగా చూపు"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr ""
 
@@ -2272,96 +2367,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, c-format
+msgid "no package recommends %s\n"
+msgstr ""
+
+#: lib/query.c:397
+#, c-format
+msgid "no package suggests %s\n"
+msgstr ""
+
+#: lib/query.c:404
+#, c-format
+msgid "no package supplements %s\n"
+msgstr ""
+
+#: lib/query.c:411
+#, c-format
+msgid "no package enhances %s\n"
+msgstr ""
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ఫైల్ %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2386,144 +2501,191 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+msgid "support for rich dependencies."
+msgstr ""
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr ""
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "తెలియని ఫైల్ రకం"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2555,42 +2717,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2616,12 +2778,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr "rpm ప్యాకేజీ కాదు\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2779,60 +2941,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr ""
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, c-format
+msgid "Unable to reset nice value: %s"
+msgstr ""
+
+#: lib/rpmscript.c:354
+#, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr ""
+
+#: lib/rpmscript.c:382
+#, c-format
+msgid "Fwrite failed: %s"
+msgstr ""
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr ""
 
@@ -2844,127 +3025,146 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
 #, c-format
-msgid "sigh size(%d): BAD, read returned %d"
+msgid "%s tag %u: BAD, invalid size %u"
 msgstr ""
 
-#: lib/signature.c:79
-msgid "sigh magic: BAD"
-msgstr ""
-
-#: lib/signature.c:85
+#: lib/signature.c:84
 #, c-format
-msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgid "%s tag %u: BAD, invalid type %u"
 msgstr ""
 
 #: lib/signature.c:91
 #, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr ""
+
+#: lib/signature.c:160
+#, c-format
+msgid "sigh size(%d): BAD, read returned %d"
+msgstr ""
+
+#: lib/signature.c:165
+msgid "sigh magic: BAD"
+msgstr ""
+
+#: lib/signature.c:171
+#, c-format
+msgid "sigh tags: BAD, no. of tags(%d) out of range"
+msgstr ""
+
+#: lib/signature.c:177
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr ""
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3038,240 +3238,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr ""
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr ""
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr ""
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr ""
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr ""
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr ""
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr ""
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3291,31 +3491,31 @@ msgstr "ఫైల్ %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3324,19 +3524,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr ""
 
@@ -3345,99 +3545,148 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:66
+#, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, c-format
+msgid "error delete directory %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+msgid "Fopen failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+msgid "generateSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:544
+msgid "rpmReadSignature failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+msgid "headerReload failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+msgid "copyFile failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:622
+msgid "headerWrite failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # ప్రవీణ్ ఇళ్ళ <mail2ipn@gmail.com>, 2011
 # ప్రవీణ్ ఇళ్ళ <mail2ipn@gmail.com>, 2011
@@ -9,15 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Telugu (http://www.transifex.com/projects/p/rpm/language/"
-"te/)\n"
-"Language: te\n"
+"Language-Team: Telugu (http://www.transifex.com/rpm-team/rpm/language/te/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: te\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -82,7 +81,7 @@ msgstr ""
 msgid "Install/Upgrade/Erase options:"
 msgstr ""
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -103,7 +102,7 @@ msgstr ""
 msgid "unexpected query source"
 msgstr ""
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -138,7 +137,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -203,7 +203,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
@@ -223,243 +223,201 @@ msgstr ""
 msgid "no arguments given for verify"
 msgstr ""
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr ""
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr ""
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr ""
 
-#: rpmbuild.c:162
+#: rpmbuild.c:142
 #, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
 msgstr ""
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr ""
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr ""
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr ""
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<వనరు ప్యాకేజీ>"
 
-#: rpmbuild.c:165
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
 
 #: rpmbuild.c:171
-#, c-format
-msgid "verify %files section from <source package>"
-msgstr ""
-
-#: rpmbuild.c:174
-msgid "build source and binary packages from <source package>"
-msgstr ""
-
-#: rpmbuild.c:177
-msgid "build binary package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:180
-msgid "build source package only from <source package>"
-msgstr ""
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr ""
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr ""
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr ""
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr ""
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr ""
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr ""
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr ""
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr ""
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, c-format
-msgid "do not execute %prep stage of the build"
-msgstr ""
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr ""
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "అయిన తరువాత వనరులను తీసివేయి"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr ""
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr ""
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr ""
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr ""
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr ""
 
-#: rpmbuild.c:379
-#, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr ""
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr ""
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr ""
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr ""
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr ""
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr ""
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr ""
@@ -508,7 +466,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr "కీరింగ్ ఐచ్ఛికాలు:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -528,9 +486,28 @@ msgstr "ప్యాకేజీ సంతకాలను తొలగించ�
 msgid "Signature options:"
 msgstr "సంతకం ఐచ్ఛికాలు:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
+msgstr ""
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr ""
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr ""
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
 msgstr ""
 
 #: rpmspec.c:26
@@ -549,7 +526,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr ""
 
@@ -596,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM నిర్మాణ దోషాలు:\n"
+msgstr "\n\nRPM నిర్మాణ దోషాలు:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr ""
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr ""
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr ""
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr ""
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr ""
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr ""
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr ""
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr ""
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr ""
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr ""
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr ""
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr ""
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr ""
@@ -670,46 +644,46 @@ msgstr ""
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr ""
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr ""
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr ""
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr ""
@@ -719,144 +693,149 @@ msgstr ""
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr ""
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "ఫైలు కనపడలేదు: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "వరుస: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "చెడ్డ ఫైలు: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr ""
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -885,79 +864,79 @@ msgstr ""
 msgid "Could not canonicalize hostname: %s\n"
 msgstr ""
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr ""
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "చెడ్డ ఫైలు: %s: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1008,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr ""
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr ""
@@ -1127,94 +1106,90 @@ msgstr ""
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "ఫైల్ %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1224,193 +1199,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "చెడ్డ వనరు: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr ""
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr ""
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr ""
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1481,281 +1424,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr ""
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr ""
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr ""
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr ""
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1884,13 +1836,14 @@ msgid "relocations must have a / following the ="
 msgstr ""
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr ""
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
 msgstr ""
 
 #: lib/poptI.c:123
@@ -1969,7 +1922,7 @@ msgstr ""
 msgid "do not verify package dependencies"
 msgstr ""
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2089,178 +2042,162 @@ msgstr ""
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr ""
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr ""
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr ""
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr ""
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr ""
 
-#: lib/poptQV.c:105
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr ""
-
-#: lib/poptQV.c:107
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr ""
-
-#: lib/poptQV.c:109
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr ""
-
-#: lib/poptQV.c:111
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr ""
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "అన్ని స్వరూపణం ఫైళ్ళను జాబితాగా చూపు"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr ""
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr ""
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr ""
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr ""
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr ""
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr ""
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr ""
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr ""
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr ""
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr ""
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr ""
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr ""
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr ""
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr ""
 
@@ -2335,116 +2272,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:390
-#, c-format
-msgid "no package recommends %s\n"
-msgstr ""
-
-#: lib/query.c:397
-#, c-format
-msgid "no package suggests %s\n"
-msgstr ""
-
-#: lib/query.c:404
-#, c-format
-msgid "no package supplements %s\n"
-msgstr ""
-
-#: lib/query.c:411
-#, c-format
-msgid "no package enhances %s\n"
-msgstr ""
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ఫైల్ %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ""
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr ""
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ""
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr ""
@@ -2469,191 +2386,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr ""
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr ""
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-msgid "support for rich dependencies."
-msgstr ""
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr ""
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr ""
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr ""
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr ""
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr ""
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "తెలియని ఫైల్ రకం"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr ""
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr ""
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr ""
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2685,42 +2555,42 @@ msgstr ""
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr ""
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr ""
@@ -2746,12 +2616,12 @@ msgstr ""
 msgid "not an rpm package\n"
 msgstr "rpm ప్యాకేజీ కాదు\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2913,75 +2783,56 @@ msgstr ""
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, c-format
-msgid "Unable to reset nice value: %s"
-msgstr ""
-
-#: lib/rpmscript.c:354
-#, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr ""
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "చెడ్డ ఫైలు: %s: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr ""
 
@@ -2993,142 +2844,127 @@ msgstr ""
 msgid "erase"
 msgstr ""
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr ""
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr ""
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr ""
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr ""
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr ""
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3202,240 +3038,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr ""
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr ""
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr ""
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr ""
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr ""
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr ""
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr ""
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr ""
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3455,31 +3291,31 @@ msgstr "ఫైల్ %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr ""
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3488,19 +3324,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr ""
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr ""
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr ""
 
@@ -3509,119 +3345,99 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:64
-#, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, c-format
-msgid "error delete directory %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-msgid "Fopen failed\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:304
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "చెడ్డ ఫైలు: %s: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Muhammet Kara <muhammetk@gmail.com>, 2011-2012,2014
 # Muhammet Kara <muhammetk@gmail.com>, 2014
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-12-10 15:08+0000\n"
 "Last-Translator: Muhammet Kara <muhammetk@gmail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/rpm-team/rpm/language/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -38,7 +38,8 @@ msgstr "Telif Hakkı (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Bu program, GNU GPL koşulları altında serbestçe yeniden dağıtılabilir\n"
+msgstr ""
+"Bu program, GNU GPL koşulları altında serbestçe yeniden dağıtılabilir\n"
 
 #: cliutils.c:53
 #, c-format
@@ -81,7 +82,7 @@ msgstr "Denetleme seçenekleri (-V ya da --verify ile)"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Kurma/Güncelleme/Kaldırma seçenekleri:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Tüm rpm kipleri ve yürütülebilir dosyaları için ortak seçenekler:"
@@ -102,7 +103,7 @@ msgstr "beklenmeyen sorgulama biçemi"
 msgid "unexpected query source"
 msgstr "beklenmeyen sorgulama kaynağı"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "sadece bir ana kip belirtilebilir"
 
@@ -112,7 +113,8 @@ msgstr ""
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "dosyalar sadece paket kurulumu sırasında yeni yerlerine yerleştirilebilir"
+msgstr ""
+"dosyalar sadece paket kurulumu sırasında yeni yerlerine yerleştirilebilir"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -121,7 +123,8 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate ve --excludepath sadece yeni paket kurulumunda kullanılabilir"
+msgstr ""
+"--relocate ve --excludepath sadece yeni paket kurulumunda kullanılabilir"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -137,8 +140,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -179,19 +181,24 @@ msgstr "--allfiles sadece paket kurulumu sırasında kullanılabilir"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb sadece paket kurulumu ve kaldırılması sırasında kullanılabilir"
+msgstr ""
+"--justdb sadece paket kurulumu ve kaldırılması sırasında kullanılabilir"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "betik iptal etme seçenekleri sadece paketin kurulması ve silinmesi sırasında kullanılabilir"
+msgstr ""
+"betik iptal etme seçenekleri sadece paketin kurulması ve silinmesi sırasında "
+"kullanılabilir"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "tetikleme iptal seçenekleri sadece paketin kurulması ve silinmesi sırasında kullanılabilir"
+msgstr ""
+"tetikleme iptal seçenekleri sadece paketin kurulması ve silinmesi sırasında "
+"kullanılabilir"
 
 #: rpmqv.c:231
 msgid ""
@@ -203,7 +210,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) ile verilenler '/' ile başlamalı"
 
@@ -223,201 +230,265 @@ msgstr "sorgulama için hiç argüman belirtilmedi"
 msgid "no arguments given for verify"
 msgstr "denetleme için hiç argüman belirtilmedi"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot zaten belirtilmiş, %s yoksayılıyor\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "<specDosyası>ndan  %prep adımı sayesinde oluşturulur (kaynak paketi açılır ve yamalar uygulanır)"
+msgstr ""
+"<specDosyası>ndan  %prep adımı sayesinde oluşturulur (kaynak paketi açılır "
+"ve yamalar uygulanır)"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specDosyası>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "<specDosyası>ndan %build adımı sayesinde oluşturulur (%prep, sonra da derlenir)"
+msgstr ""
+"<specDosyası>ndan %build adımı sayesinde oluşturulur (%prep, sonra da "
+"derlenir)"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "<specDosyası>ndan %install adımı sayesinde oluşturulur (%prep, %build, sonra da kurulum)"
+msgstr ""
+"<specDosyası>ndan %install adımı sayesinde oluşturulur (%prep, %build, sonra "
+"da kurulum)"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "<specDosyası>ndan %files bölümünü denetler"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "kaynak ve çalıştırılabilir paketleri <specDosyası>ndan oluşturur"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "çalıştırılabilir paketi sadece <specDosyası>ndan oluşturur"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"<specDosyası>ndan  %prep adımı sayesinde oluşturulur (kaynak paketi açılır "
+"ve yamalar uygulanır)"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<kaynak paketi>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"<specDosyası>ndan %build adımı sayesinde oluşturulur (%prep, sonra da "
+"derlenir)"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"<kaynak paketi>nden %install adımı sayesinde oluşturulur (%prep, %build, "
+"sonra da kurulur)"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "<specDosyası>ndan %files bölümünü denetler"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "çalıştırılabilir paketi <kaynak paketi>nden oluşturur"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "çalıştırılabilir paketi <kaynak paketi>nden oluşturur"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "<tarpaketi>nden %prep adımı sayesinde oluşturulur (kaynak paketi açılır ve yamalar uygulanır)"
+msgstr ""
+"<tarpaketi>nden %prep adımı sayesinde oluşturulur (kaynak paketi açılır ve "
+"yamalar uygulanır)"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<tarPaketi>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "<tarPaketi>nden %build adımı sayesinde oluşturulur (%prep, sonra da derleme)"
+msgstr ""
+"<tarPaketi>nden %build adımı sayesinde oluşturulur (%prep, sonra da derleme)"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "<tarpaketi>nden %install adımı sayesinde oluşturulur (%prep, %build, sonra da kurulur)"
+msgstr ""
+"<tarpaketi>nden %install adımı sayesinde oluşturulur (%prep, %build, sonra "
+"da kurulur)"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "<tarpaketi>nden %files bölümünü denetler"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "kaynak ve çalıştırılabilir paketleri <tarpaketi>nden oluşturur"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "çalıştırılabilir paketi sadece <tarpaketi>nden oluşturur"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "kaynak paketi sadece <tarpaketi>nden oluşturur"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "çalıştırılabilir paketi <kaynak paketi>nden oluşturur"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<kaynak paketi>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "<kaynak paketi>nden %install adımı sayesinde oluşturulur (%prep, %build, sonra da kurulur)"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "build root'a zorlar"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+msgid "run build in current directory"
+msgstr ""
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "işlem sonunda paket oluşturma ağacını siler"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "spec dosyasındaki ExcludeArch: yönergeleri yoksayılıyor"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "hata ayıklama dosyası durum motoru"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "oluşumun herhangi bir adımı icra edilmez"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "oluşumun herhangi bir adımı icra edilmez"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "spec dosyası içindeki i18n msgstr'leri kabul edilmez"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "işlem sonunda kaynakları siler"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "işlem sonunda spec dosyasını siler"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "doğrudan belirtilen adıma atlar (sadece c ve i için)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "hedef platforma zorlar"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "[ <specDosyası> | <tarPaketi> | <kaynakPaketi> ] ile paketleme seçenekleri:"
+msgstr ""
+"[ <specDosyası> | <tarPaketi> | <kaynakPaketi> ] ile paketleme seçenekleri:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "%s spec dosyası açılamadı: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar veriyolu açılamadı: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "%s spec dosyası açılamadı: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "%s paketinden spec dosyası okunamadı\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s %s olarak değiştirilemedi: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "%s durum bilgileri alınamadı: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s bir normal bir dosya değil.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s bir spec dosyası gibi görünmüyor.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Hedef platformlar derleniyor: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "%s için derleniyor\n"
@@ -466,49 +537,64 @@ msgstr ""
 msgid "Keyring options:"
 msgstr "Anahtarlık seçenekleri:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr ""
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "paket(ler)i imzala"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr ""
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "paket imzalarını sil"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "paket(ler)i imzala"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "İmza seçenekleri:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr ""
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Makro dosyanızda \"%%_pgp_name\" tanımlanmış olmalı\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Anahtar parolasını girin: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Anahtar parolası doğru.\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix sadece yeni paketlerin kurulması sırasında kullanılabilir"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches sadece paket kurulumu sırasında kullanılabilir"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -526,7 +612,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "izleyen sorgulama biçimini kullanır"
 
@@ -573,68 +659,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM derleme hataları:\n"
+msgstr ""
+"\n"
+"\n"
+"RPM derleme hataları:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "== çözümlenirken sözdizimi hatası bulundu\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "&& çözümlenirken sözdizimi hatası bulundu\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "|| çözümlenirken sözdizimi hatası bulundu\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "ifadede çözümleme hatası\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "uyumsuz (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- sadece sayılarda\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! sadece sayılarda\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "türler eşleşmeli\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / dizgelerde desteklenmez\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- dizgelerde desteklenmez\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& ve || dizgelerde desteklenmez\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "ifadede sözdizimi hatası\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s içinde '(' yok: %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s içinde ')' yok: (%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Andaç %s geçersiz: %s\n"
@@ -644,46 +733,46 @@ msgstr "Andaç %s geçersiz: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() boşluksuz yazılmış: %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sözdizimi hatası: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "mode spec hatalı: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "dirmode spec hatalı: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Geçersiz yeterlilik: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Dosya \"/\" ile başlamalı: %s\n"
@@ -693,149 +782,149 @@ msgstr "Dosya \"/\" ile başlamalı: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Dosya iki kere gösterildi: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Sembolik bağ BuildRoot gösteriyor: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Dosya bulunamadı: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Dizin değil: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: genel anahtar okuması başarısız oldu.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: kodlama başarısız oldu\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Dosya \"/\" ile içermeli: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Dosya glob tarafından bulunamadı: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "satır: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Dosya glob tarafından bulunamadı: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Dosya hatalı: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Kullanıcı/grup hatalı: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Dosyalar işleniyor: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -864,79 +953,76 @@ msgstr "%s: satır: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Böyle bir makina yok: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "İmza başlığı yeniden yüklenemedi.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "paket yazılamadı: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "CSA verisi geçersiz\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Yazıldı: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "\"%s\" yürütülüyor:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "\"%s\"in yürütülmesi başarısız oldu.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "%s paket dosyası için çıktı dosya adı üretilemedi: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s dosyası oluşturulamıyor: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d satır: %s saniye\n"
@@ -987,19 +1073,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "satır %d: %%description ayrıştırılırken hata: %s \n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "satır %d: %s seçeneği hatalı: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "satır %d: İsim sayısı fazla: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "satır %d: Paket yok: %s\n"
@@ -1106,90 +1192,94 @@ msgstr "satır %d: Etiket sadece tek dizgecik alır: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "%d satır: %s saniye\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: satır: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "satır %d: Etiket bozuk: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "satır %d: Etiket boş: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "satır %d: Önekler \"/\" ile bitemez: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "satır %d: Docdir '/' ile başlamalı: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "satır %d: %s hatalı: niteleyiciler: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "satır %d: BuildArchitecture biçimi hatalı: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "İçsel hata: %d etiketi sahte\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Paket özellikleri hatalı: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paket zaten var: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "satır %d: Bilinmeyen etiket: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1199,161 +1289,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Kaynak hatalı: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup çözümlenirken hata: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "satır %d: %%setup argumanı hatalı: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "satır %d: %%setup seçeneği %s hatalı: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Geçersiz yama numarası %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "satır %d: %%prep saniye\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "satır %d: tetikleyiciler -- içermeli: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "satır %d: %s çözümlenirken hata oluştu: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "satır %d: içsel betik '>' ile bitmeli: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "satır %d: betik programı '/' ile başlamalı: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "satır %d: %s saniye\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "satır %d: desteklenmeyen içsel betik: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "satır %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%if'siz bir  %%else alındı\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%if'siz bir %%endif alındı\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Kurgulamak için uyumlu mimari yok\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket %%description içermiyor: %s\n"
@@ -1424,290 +1546,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s icra edilemedi: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s ayrılamadı: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s bulunamadı:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s spec dosyasının sorgulanması başarısız, çözümlenemiyor\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(bir sayı değil)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(base64 değil)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(geçersiz tür)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(geçersiz xml türü)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(OpenPGP imzası değil)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "kurulmamış"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "yanlış renk"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "eksik"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(bilinmiyor)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(dizge değil)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s %s olarak kaydedildi\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s %s olarak oluşturuldu\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "dizin"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "dosya"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1836,15 +1949,16 @@ msgid "relocations must have a / following the ="
 msgstr "yeniden konumlandırma için = den sonra bir / gerekir"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr "yapılandırmalarda atlanmış bile olsa tüm dosyaları kurar"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "<paket> ile eşlenen tüm paketleri kaldırır(<paket> ile çok sayıda paket belirtilmişse normalde bir hata oluşur)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"<paket> ile eşlenen tüm paketleri kaldırır(<paket> ile çok sayıda paket "
+"belirtilmişse normalde bir hata oluşur)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1922,7 +2036,7 @@ msgstr "veri tabanını günceller, ama dosya sistemini değiştirmez"
 msgid "do not verify package dependencies"
 msgstr "paket bağımlılıklarını denetlemez"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2000,7 +2114,9 @@ msgstr "hiçbir %%triggerpostun betiği çalıştırılmaz."
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "paketin eski bir sürüme güncellenmesini sağlar (--force aynı işi otomatik yapar)"
+msgstr ""
+"paketin eski bir sürüme güncellenmesini sağlar (--force aynı işi otomatik "
+"yapar)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2042,162 +2158,182 @@ msgstr "paket günceller"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "tüm paketleri sorgular/doğrular"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "dosyayı içeren paketleri sorgular/denetler"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "gruptaki paketleri sorgular/denetler"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm sorgulama kipi"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "paket tarafından tetiklenen paketleri sorgular"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm denetleme kipi"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "bir bağımlılığı sağlayan  paketleri sorgular/denetler"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "tüm yapılandırma dosyalarını listeler"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "tüm belgeleme dosyalarını gösterir"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "temel dosya bilgilerini gösterir"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "paketteki dosyaları gösterir"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost dosyaları atlanır"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "listelenmiş dosyaların durumunu gösterir"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "dosyaların uzunlukları doğrulanmaz"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "dosyaların sembolik bağ dosya yolları doğrulanmaz"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "dosyaların sahipleri doğrulanmaz"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "dosyaların grupları doğrulanmaz"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "dosyaların değişiklik zamanları doğrulanmaz"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "dosyaların kipleri doğrulanmaz"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "paketteki dosyalar doğrulanamaz"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "paket bağımlılıkları doğrulanmaz"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "kaynak paketi gerekirken çalıştırılabilir paketi bulundu\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "kaynak paketi .spec dosyası içermiyor\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "arşiv paketi açılırken başarısız%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " dosyada "
 
@@ -2272,96 +2408,116 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "%s gerektiren paket yok\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "%s gerektiren paket yok\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "%s tetikleyen paket yok\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "%s gerektiren paket yok\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "%s gerektiren paket yok\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s sağlayan paket yok\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "dosya %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "%s dosyası, hiç bir pakete ait değil\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "geçersiz paket numarası: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "%s paketi kurulu değil\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread başarısız: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "TAMAM DEĞİL"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "Tamam"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (EKSİK ANAHTARLAR:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (GÜVENCESİZ ANAHTARLAR:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: açılamadı: %s\n"
@@ -2386,144 +2542,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "HAYIR "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "EVET"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "lua betikleri için dahili destek."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "paket bağımlılıklarını denetlemez"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c sonlandırılmamış: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "kullanıcı %s yok - root kullanılacak\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grup %s yok - root kullanılacak\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Magic hatalı"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Hatalı/okunamayan başlık"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Başlık çok uzun"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Dosya arşiv için çok büyük"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Bilinmeyen dosya türü"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "İç hata"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " başarısız - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2555,42 +2759,42 @@ msgstr "Sağlanamayan bağımlılıklar:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s yüklenemedi\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s alınıyor\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s atlanıyor - aktarım başarısız\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "%s dosyasından okuma hatalı\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s kuruluyor\n"
@@ -2616,12 +2820,12 @@ msgstr "okuma başarısız: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "rpm paketi değil\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2779,60 +2983,79 @@ msgstr "%s için %s:%d'de eksik mimari\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "seçenek '%s' (%s:%d) de hatalı\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Bilinmeyen sistem: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "%s kısayol simgesi okunamadı: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "%s kısayol simgesi okunamadı: %s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite başarısız: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Bilinmeyen biçim"
 
@@ -2844,127 +3067,146 @@ msgstr "kur"
 msgid "erase"
 msgstr "sil"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "%s de Paket veritabanı açılamadı\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(OpenPGP imzası değil)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr ""
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "İmza başlığı yeniden yüklenemedi.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr ""
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Başlık"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr ""
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr ""
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "atlandı"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "başarısız oldu"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "bilinmeyen durum"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "eksik   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3038,240 +3280,242 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "belirtilmiş bir dbpath değeri yok\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: 0x%x de başlık okunamadı\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "belirtilmiş bir dbpath yok"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "kayıt özgün olarak %u e eklenemedi\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "veritabanı yeniden oluşturulamadı: mevcut veritabanı değişmeden\nyerinde bırakıldı\n"
+msgstr ""
+"veritabanı yeniden oluşturulamadı: mevcut veritabanı değişmeden\n"
+"yerinde bırakıldı\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "eski veritabanının yenisiyle değiştirilirmesi başarısız!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "kurtarmak için %s içindeki dosyalar %s deki dosyalarla değiştiriliyor"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "%s dizininin silinmesi başarısız: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "%s kilit  %s/%s'den alınamadı\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "paylaşımlı"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "bağdaşık"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "yeni paket örneğini tutma hatası(%d)\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "tanınmayan db seçeneği: \"%s\" yoksayıldı\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s geçersiz sayısal değer içeriyor, atlandı\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s ya çok büyük ya da çok küçük 'long' değer içeriyor, atlandı\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s ya çok büyük ya da çok küçük 'integer' değer içeriyor, atlandı\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "%s kilit  %s/%s'den alınamadı\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "paylaşımlı"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "bağdaşık"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "yeni paket örneğini tutma hatası(%d)\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(boş)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(boş)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "%%%s makrosunu seçenekleri sonlandırılmamış\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "%%%s makrosunun gövdesi sonlandırılmamış\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "%%%s makrosunun ismi kuraldışı (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "%%%s makrosu boş\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "%%%s makrosu genişletmede başarısız\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "%%%s makrosunun ismi kuraldışı (%%define)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "%c seçeneği %s(%s) de anlaşılamadı\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c sonlandırılmamış: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Bir ayrıştırılamayan makro tarafından bir %% izlendi\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "makro dosyası %s'in yüklenmesi başarısız oldu"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d etkin %d boş\n"
@@ -3291,31 +3535,31 @@ msgstr "%s dosyası: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "%s dosyası %u bayttan küçük\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3324,19 +3568,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(hata yok)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "ölümcül hata: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "hata: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "uyarı: "
 
@@ -3345,99 +3589,154 @@ msgstr "uyarı: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "bellek ayrılırken (%u bayt) NULL döndü.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "%s dosyasından okuma hatalı\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "%s dosyasından okuma hatalı\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "%s dizininin silinmesi başarısız: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite başarısız: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Desteklenmeyen PGP imzası\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
+msgid "Could not exec %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s: açılamadı: %s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "imzanın yazılması sırasında gpg hata verdi\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "imza okunamadı\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: rpmWriteSignature başarısız: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmWriteSignature başarısız: %s\n"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "icra başarısız\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr ""
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "icra başarısız\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "icra başarısız\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM v3 paketleri imzalanamıyor\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature başarısız: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr ""
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead başarısız: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3450,3 +3749,12 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Anahtar parolasını girin: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Anahtar parolası doğru.\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Kullanıcı/grup hatalı: %s\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,22 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
-# Muhammet Kara <muhammet.k@gmail.com>, 2011-2012,2014
+# Muhammet Kara <muhammetk@gmail.com>, 2011-2012,2014
+# Muhammet Kara <muhammetk@gmail.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-05-28 17:29+0000\n"
-"Last-Translator: Muhammet Kara <muhammet.k@gmail.com>\n"
-"Language-Team: Turkish (http://www.transifex.com/projects/p/rpm/language/"
-"tr/)\n"
-"Language: tr\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-12-10 15:08+0000\n"
+"Last-Translator: Muhammet Kara <muhammetk@gmail.com>\n"
+"Language-Team: Turkish (http://www.transifex.com/rpm-team/rpm/language/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -38,8 +38,7 @@ msgstr "Telif Hakkı (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Bu program, GNU GPL koşulları altında serbestçe yeniden dağıtılabilir\n"
+msgstr "Bu program, GNU GPL koşulları altında serbestçe yeniden dağıtılabilir\n"
 
 #: cliutils.c:53
 #, c-format
@@ -82,7 +81,7 @@ msgstr "Denetleme seçenekleri (-V ya da --verify ile)"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Kurma/Güncelleme/Kaldırma seçenekleri:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Tüm rpm kipleri ve yürütülebilir dosyaları için ortak seçenekler:"
@@ -103,7 +102,7 @@ msgstr "beklenmeyen sorgulama biçemi"
 msgid "unexpected query source"
 msgstr "beklenmeyen sorgulama kaynağı"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "sadece bir ana kip belirtilebilir"
 
@@ -113,8 +112,7 @@ msgstr ""
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr ""
-"dosyalar sadece paket kurulumu sırasında yeni yerlerine yerleştirilebilir"
+msgstr "dosyalar sadece paket kurulumu sırasında yeni yerlerine yerleştirilebilir"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
@@ -123,8 +121,7 @@ msgstr ""
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate ve --excludepath sadece yeni paket kurulumunda kullanılabilir"
+msgstr "--relocate ve --excludepath sadece yeni paket kurulumunda kullanılabilir"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -140,7 +137,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -181,24 +179,19 @@ msgstr "--allfiles sadece paket kurulumu sırasında kullanılabilir"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb sadece paket kurulumu ve kaldırılması sırasında kullanılabilir"
+msgstr "--justdb sadece paket kurulumu ve kaldırılması sırasında kullanılabilir"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"betik iptal etme seçenekleri sadece paketin kurulması ve silinmesi sırasında "
-"kullanılabilir"
+msgstr "betik iptal etme seçenekleri sadece paketin kurulması ve silinmesi sırasında kullanılabilir"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"tetikleme iptal seçenekleri sadece paketin kurulması ve silinmesi sırasında "
-"kullanılabilir"
+msgstr "tetikleme iptal seçenekleri sadece paketin kurulması ve silinmesi sırasında kullanılabilir"
 
 #: rpmqv.c:231
 msgid ""
@@ -210,7 +203,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) ile verilenler '/' ile başlamalı"
 
@@ -230,265 +223,201 @@ msgstr "sorgulama için hiç argüman belirtilmedi"
 msgid "no arguments given for verify"
 msgstr "denetleme için hiç argüman belirtilmedi"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot zaten belirtilmiş, %s yoksayılıyor\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"<specDosyası>ndan  %prep adımı sayesinde oluşturulur (kaynak paketi açılır "
-"ve yamalar uygulanır)"
+msgstr "<specDosyası>ndan  %prep adımı sayesinde oluşturulur (kaynak paketi açılır ve yamalar uygulanır)"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specDosyası>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"<specDosyası>ndan %build adımı sayesinde oluşturulur (%prep, sonra da "
-"derlenir)"
+msgstr "<specDosyası>ndan %build adımı sayesinde oluşturulur (%prep, sonra da derlenir)"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"<specDosyası>ndan %install adımı sayesinde oluşturulur (%prep, %build, sonra "
-"da kurulum)"
+msgstr "<specDosyası>ndan %install adımı sayesinde oluşturulur (%prep, %build, sonra da kurulum)"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "<specDosyası>ndan %files bölümünü denetler"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "kaynak ve çalıştırılabilir paketleri <specDosyası>ndan oluşturur"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "çalıştırılabilir paketi sadece <specDosyası>ndan oluşturur"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"<specDosyası>ndan  %prep adımı sayesinde oluşturulur (kaynak paketi açılır "
-"ve yamalar uygulanır)"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<kaynak paketi>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"<specDosyası>ndan %build adımı sayesinde oluşturulur (%prep, sonra da "
-"derlenir)"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"<kaynak paketi>nden %install adımı sayesinde oluşturulur (%prep, %build, "
-"sonra da kurulur)"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "<specDosyası>ndan %files bölümünü denetler"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "çalıştırılabilir paketi <kaynak paketi>nden oluşturur"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "çalıştırılabilir paketi <kaynak paketi>nden oluşturur"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"<tarpaketi>nden %prep adımı sayesinde oluşturulur (kaynak paketi açılır ve "
-"yamalar uygulanır)"
+msgstr "<tarpaketi>nden %prep adımı sayesinde oluşturulur (kaynak paketi açılır ve yamalar uygulanır)"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<tarPaketi>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-"<tarPaketi>nden %build adımı sayesinde oluşturulur (%prep, sonra da derleme)"
+msgstr "<tarPaketi>nden %build adımı sayesinde oluşturulur (%prep, sonra da derleme)"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"<tarpaketi>nden %install adımı sayesinde oluşturulur (%prep, %build, sonra "
-"da kurulur)"
+msgstr "<tarpaketi>nden %install adımı sayesinde oluşturulur (%prep, %build, sonra da kurulur)"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "<tarpaketi>nden %files bölümünü denetler"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "kaynak ve çalıştırılabilir paketleri <tarpaketi>nden oluşturur"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "çalıştırılabilir paketi sadece <tarpaketi>nden oluşturur"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "kaynak paketi sadece <tarpaketi>nden oluşturur"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "çalıştırılabilir paketi <kaynak paketi>nden oluşturur"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<kaynak paketi>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "<kaynak paketi>nden %install adımı sayesinde oluşturulur (%prep, %build, sonra da kurulur)"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "build root'a zorlar"
 
-#: rpmbuild.c:215
-msgid "run build in current directory"
-msgstr ""
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "işlem sonunda paket oluşturma ağacını siler"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "spec dosyasındaki ExcludeArch: yönergeleri yoksayılıyor"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "hata ayıklama dosyası durum motoru"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "oluşumun herhangi bir adımı icra edilmez"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr ""
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "oluşumun herhangi bir adımı icra edilmez"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "spec dosyası içindeki i18n msgstr'leri kabul edilmez"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "işlem sonunda kaynakları siler"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "işlem sonunda spec dosyasını siler"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "doğrudan belirtilen adıma atlar (sadece c ve i için)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "hedef platforma zorlar"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"[ <specDosyası> | <tarPaketi> | <kaynakPaketi> ] ile paketleme seçenekleri:"
+msgstr "[ <specDosyası> | <tarPaketi> | <kaynakPaketi> ] ile paketleme seçenekleri:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "%s spec dosyası açılamadı: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "tar veriyolu açılamadı: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "%s spec dosyası açılamadı: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "%s paketinden spec dosyası okunamadı\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "%s %s olarak değiştirilemedi: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "%s durum bilgileri alınamadı: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s bir normal bir dosya değil.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s bir spec dosyası gibi görünmüyor.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Hedef platformlar derleniyor: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "%s için derleniyor\n"
@@ -537,7 +466,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr "Anahtarlık seçenekleri:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr ""
 
@@ -557,10 +486,29 @@ msgstr "paket imzalarını sil"
 msgid "Signature options:"
 msgstr "İmza seçenekleri:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr ""
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Makro dosyanızda \"%%_pgp_name\" tanımlanmış olmalı\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Anahtar parolasını girin: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Anahtar parolası doğru.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -578,7 +526,7 @@ msgstr ""
 msgid "operate on source rpm generated by spec"
 msgstr ""
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "izleyen sorgulama biçimini kullanır"
 
@@ -625,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM derleme hataları:\n"
+msgstr "\n\nRPM derleme hataları:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "== çözümlenirken sözdizimi hatası bulundu\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "&& çözümlenirken sözdizimi hatası bulundu\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "|| çözümlenirken sözdizimi hatası bulundu\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "ifadede çözümleme hatası\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "uyumsuz (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- sadece sayılarda\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! sadece sayılarda\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "türler eşleşmeli\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / dizgelerde desteklenmez\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- dizgelerde desteklenmez\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& ve || dizgelerde desteklenmez\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "ifadede sözdizimi hatası\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s içinde '(' yok: %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s içinde ')' yok: (%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Andaç %s geçersiz: %s\n"
@@ -699,46 +644,46 @@ msgstr "Andaç %s geçersiz: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr ""
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() boşluksuz yazılmış: %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Sözdizimi hatası: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "mode spec hatalı: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "dirmode spec hatalı: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Geçersiz yeterlilik: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr ""
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Dosya \"/\" ile başlamalı: %s\n"
@@ -748,144 +693,149 @@ msgstr "Dosya \"/\" ile başlamalı: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Dosya iki kere gösterildi: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Sembolik bağ BuildRoot gösteriyor: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Dosya bulunamadı: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Dizin değil: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: genel anahtar okuması başarısız oldu.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: kodlama başarısız oldu\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Dosya \"/\" ile içermeli: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Dosya glob tarafından bulunamadı: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "satır: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Dosya hatalı: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Kullanıcı/grup hatalı: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Dosyalar işleniyor: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
@@ -914,79 +864,79 @@ msgstr "%s: satır: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Böyle bir makina yok: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "İmza başlığı yeniden yüklenemedi.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr ""
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "paket yazılamadı: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr ""
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "CSA verisi geçersiz\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "%s açılamadı: %s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s: Fread başarısız: %s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Yazıldı: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "\"%s\" yürütülüyor:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "\"%s\"in yürütülmesi başarısız oldu.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "%s paket dosyası için çıktı dosya adı üretilemedi: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s dosyası oluşturulamıyor: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d satır: %s saniye\n"
@@ -1037,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "satır %d: %%description ayrıştırılırken hata: %s \n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "satır %d: %s seçeneği hatalı: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "satır %d: İsim sayısı fazla: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "satır %d: Paket yok: %s\n"
@@ -1156,94 +1106,90 @@ msgstr "satır %d: Etiket sadece tek dizgecik alır: %s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "%d satır: %s saniye\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: satır: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "satır %d: Etiket bozuk: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "satır %d: Etiket boş: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "satır %d: Önekler \"/\" ile bitemez: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "satır %d: Docdir '/' ile başlamalı: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "satır %d: %s hatalı: niteleyiciler: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "satır %d: BuildArchitecture biçimi hatalı: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "İçsel hata: %d etiketi sahte\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Paket özellikleri hatalı: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Paket zaten var: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "satır %d: Bilinmeyen etiket: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1253,193 +1199,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Kaynak hatalı: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr ""
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup çözümlenirken hata: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "satır %d: %%setup argumanı hatalı: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "satır %d: %%setup seçeneği %s hatalı: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Geçersiz yama numarası %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "satır %d: %%prep saniye\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "satır %d: tetikleyiciler -- içermeli: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "satır %d: %s çözümlenirken hata oluştu: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "satır %d: içsel betik '>' ile bitmeli: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "satır %d: betik programı '/' ile başlamalı: %s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "satır %d: %s saniye\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "satır %d: desteklenmeyen içsel betik: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "satır %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: %%if'siz bir  %%else alındı\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: %%if'siz bir %%endif alındı\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Kurgulamak için uyumlu mimari yok\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket %%description içermiyor: %s\n"
@@ -1510,281 +1424,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "%s icra edilemedi: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s ayrılamadı: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr ""
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s bulunamadı:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s spec dosyasının sorgulanması başarısız, çözümlenemiyor\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(bir sayı değil)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(base64 değil)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(geçersiz tür)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr ""
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(geçersiz xml türü)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(OpenPGP imzası değil)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "kurulmamış"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "yanlış renk"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "eksik"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(bilinmiyor)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(dizge değil)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s %s olarak kaydedildi\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s %s olarak oluşturuldu\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "dizin"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "dosya"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1913,16 +1836,15 @@ msgid "relocations must have a / following the ="
 msgstr "yeniden konumlandırma için = den sonra bir / gerekir"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr "yapılandırmalarda atlanmış bile olsa tüm dosyaları kurar"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"<paket> ile eşlenen tüm paketleri kaldırır(<paket> ile çok sayıda paket "
-"belirtilmişse normalde bir hata oluşur)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "<paket> ile eşlenen tüm paketleri kaldırır(<paket> ile çok sayıda paket belirtilmişse normalde bir hata oluşur)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -2000,7 +1922,7 @@ msgstr "veri tabanını günceller, ama dosya sistemini değiştirmez"
 msgid "do not verify package dependencies"
 msgstr "paket bağımlılıklarını denetlemez"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr ""
 
@@ -2078,9 +2000,7 @@ msgstr "hiçbir %%triggerpostun betiği çalıştırılmaz."
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"paketin eski bir sürüme güncellenmesini sağlar (--force aynı işi otomatik "
-"yapar)"
+msgstr "paketin eski bir sürüme güncellenmesini sağlar (--force aynı işi otomatik yapar)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2122,182 +2042,162 @@ msgstr "paket günceller"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "tüm paketleri sorgular/doğrular"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr ""
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "dosyayı içeren paketleri sorgular/denetler"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "gruptaki paketleri sorgular/denetler"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr ""
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm sorgulama kipi"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "paket tarafından tetiklenen paketleri sorgular"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm denetleme kipi"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "bir bağımlılığı sağlayan  paketleri sorgular/denetler"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "bir bağımlılık gerektiren paketleri sorgular/denetler"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr ""
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr ""
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "tüm yapılandırma dosyalarını listeler"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "tüm belgeleme dosyalarını gösterir"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "temel dosya bilgilerini gösterir"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "paketteki dosyaları gösterir"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "%%ghost dosyaları atlanır"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "listelenmiş dosyaların durumunu gösterir"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "dosyaların uzunlukları doğrulanmaz"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "dosyaların sembolik bağ dosya yolları doğrulanmaz"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "dosyaların sahipleri doğrulanmaz"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "dosyaların grupları doğrulanmaz"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "dosyaların değişiklik zamanları doğrulanmaz"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "dosyaların kipleri doğrulanmaz"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr ""
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "paketteki dosyalar doğrulanamaz"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "paket bağımlılıkları doğrulanmaz"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "kaynak paketi gerekirken çalıştırılabilir paketi bulundu\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "kaynak paketi .spec dosyası içermiyor\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "arşiv paketi açılırken başarısız%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " dosyada "
 
@@ -2372,116 +2272,96 @@ msgstr ""
 msgid "no package requires %s\n"
 msgstr "%s gerektiren paket yok\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "%s gerektiren paket yok\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "%s tetikleyen paket yok\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "%s gerektiren paket yok\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "%s gerektiren paket yok\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s sağlayan paket yok\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "dosya %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "%s dosyası, hiç bir pakete ait değil\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "geçersiz paket numarası: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "%s paketi kurulu değil\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread başarısız: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "TAMAM DEĞİL"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "Tamam"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (EKSİK ANAHTARLAR:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (GÜVENCESİZ ANAHTARLAR:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: açılamadı: %s\n"
@@ -2506,192 +2386,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "HAYIR "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "EVET"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr ""
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr ""
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr ""
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr ""
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr ""
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr ""
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "lua betikleri için dahili destek."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "paket bağımlılıklarını denetlemez"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c sonlandırılmamış: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "kullanıcı %s yok - root kullanılacak\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "grup %s yok - root kullanılacak\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Magic hatalı"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Hatalı/okunamayan başlık"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Başlık çok uzun"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
-msgstr ""
+msgstr "Dosya arşiv için çok büyük"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Bilinmeyen dosya türü"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr ""
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "İç hata"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr ""
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " başarısız - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2723,42 +2555,42 @@ msgstr "Sağlanamayan bağımlılıklar:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr ""
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s yüklenemedi\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "%s alınıyor\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "%s atlanıyor - aktarım başarısız\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr ""
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "%s dosyasından okuma hatalı\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr ""
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "%s kuruluyor\n"
@@ -2784,12 +2616,12 @@ msgstr "okuma başarısız: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "rpm paketi değil\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2951,75 +2783,56 @@ msgstr "seçenek '%s' (%s:%d) de hatalı\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Bilinmeyen sistem: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr ""
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr ""
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "%s kısayol simgesi okunamadı: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "%s kısayol simgesi okunamadı: %s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite başarısız: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Bilinmeyen biçim"
 
@@ -3031,142 +2844,127 @@ msgstr "kur"
 msgid "erase"
 msgstr "sil"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "%s de Paket veritabanı açılamadı\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr ""
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(OpenPGP imzası değil)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Başlık"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr ""
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr ""
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Başlık"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "atlandı"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "başarısız oldu"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr "bilinmeyen durum"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "eksik   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3240,242 +3038,240 @@ msgstr ""
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "belirtilmiş bir dbpath değeri yok\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: 0x%x de başlık okunamadı\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "belirtilmiş bir dbpath yok"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "kayıt özgün olarak %u e eklenemedi\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"veritabanı yeniden oluşturulamadı: mevcut veritabanı değişmeden\n"
-"yerinde bırakıldı\n"
+msgstr "veritabanı yeniden oluşturulamadı: mevcut veritabanı değişmeden\nyerinde bırakıldı\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "eski veritabanının yenisiyle değiştirilirmesi başarısız!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "kurtarmak için %s içindeki dosyalar %s deki dosyalarla değiştiriliyor"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "%s dizininin silinmesi başarısız: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "tanınmayan db seçeneği: \"%s\" yoksayıldı\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s geçersiz sayısal değer içeriyor, atlandı\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s ya çok büyük ya da çok küçük 'long' değer içeriyor, atlandı\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s ya çok büyük ya da çok küçük 'integer' değer içeriyor, atlandı\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "%s kilit  %s/%s'den alınamadı\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "paylaşımlı"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "bağdaşık"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "yeni paket örneğini tutma hatası(%d)\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "tanınmayan db seçeneği: \"%s\" yoksayıldı\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s geçersiz sayısal değer içeriyor, atlandı\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s ya çok büyük ya da çok küçük 'long' değer içeriyor, atlandı\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s ya çok büyük ya da çok küçük 'integer' değer içeriyor, atlandı\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(boş)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(boş)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "%%%s makrosunu seçenekleri sonlandırılmamış\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "%%%s makrosunun gövdesi sonlandırılmamış\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "%%%s makrosunun ismi kuraldışı (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "%%%s makrosu boş\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "%%%s makrosu genişletmede başarısız\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "%%%s makrosunun ismi kuraldışı (%%define)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "%c seçeneği %s(%s) de anlaşılamadı\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c sonlandırılmamış: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Bir ayrıştırılamayan makro tarafından bir %% izlendi\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "makro dosyası %s'in yüklenmesi başarısız oldu"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d etkin %d boş\n"
@@ -3495,31 +3291,31 @@ msgstr "%s dosyası: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "%s dosyası %u bayttan küçük\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr ""
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3528,19 +3324,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(hata yok)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "ölümcül hata: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "hata: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "uyarı: "
 
@@ -3549,121 +3345,99 @@ msgstr "uyarı: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "bellek ayrılırken (%u bayt) NULL döndü.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr ""
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "%s dosyasından okuma hatalı\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "%s dosyasından okuma hatalı\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "%s dizininin silinmesi başarısız: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite başarısız: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Desteklenmeyen PGP imzası\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
 msgstr ""
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: açılamadı: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "%s açılamadı: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "%s açılamadı: %s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr ""
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "imzanın yazılması sırasında gpg hata verdi\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "imza okunamadı\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM v3 paketleri imzalanamıyor\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature başarısız: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead başarısız: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3676,30 +3450,3 @@ msgstr ""
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Anahtar parolasını girin: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Anahtar parolası doğru.\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Kullanıcı/grup hatalı: %s\n"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "%s'e payload yazılamadı: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "%s'den payload okunamadı: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Geçici dosya açılamadı.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "sigtarget %s açılamadı: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "%s'den başlık okunamadı: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "%s'e başlık yazılamadı: %s\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,22 +1,24 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Yuri Chornoivan <yurchor@ukr.net>, 2011-2012,2014
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 12:23+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
-"Language-Team: Ukrainian (http://www.transifex.com/rpm-team/rpm/language/uk/)\n"
+"Language-Team: Ukrainian (http://www.transifex.com/rpm-team/rpm/language/"
+"uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -80,7 +82,7 @@ msgstr "Перевірити параметри (за допомогою -V аб
 msgid "Install/Upgrade/Erase options:"
 msgstr "Параметри встановлення/оновлення/вилучення:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Загальні параметри для всіх режимів та виконуваних файлів rpm:"
@@ -101,7 +103,7 @@ msgstr "неочікуваний формат запитів"
 msgid "unexpected query source"
 msgstr "неочікуване джерело запиту"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "можна визначати лише один основний режим"
 
@@ -120,11 +122,14 @@ msgstr "не можна використовувати --prefix разом з --
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "--relocate і --excludepath можна використовувати лише під час встановлення нових пакунків"
+msgstr ""
+"--relocate і --excludepath можна використовувати лише під час встановлення "
+"нових пакунків"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
-msgstr "--prefix можна використовувати, лише під час встановлення нових пакунків"
+msgstr ""
+"--prefix можна використовувати, лише під час встановлення нових пакунків"
 
 #: rpmqv.c:168
 msgid "arguments to --prefix must begin with a /"
@@ -133,12 +138,13 @@ msgstr "аргументи параметра --prefix мають починат
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr "--hash (-h) можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr ""
+"--hash (-h) можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
-msgstr "--percent можна вказувати лише під час встановлення або вилучення пакунків"
+msgid "--percent may only be specified during package installation and erasure"
+msgstr ""
+"--percent можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
@@ -154,7 +160,8 @@ msgstr "--includedocs можна вказувати лише під час вс�
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
-msgstr "можна вказувати лише один з параметрів, --excludedocs або --includedocs"
+msgstr ""
+"можна вказувати лише один з параметрів, --excludedocs або --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
@@ -178,31 +185,39 @@ msgstr "--allfiles можна вказувати лише під час вста
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "--justdb можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr ""
+"--justdb можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "параметри вимикання скриптів можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr ""
+"параметри вимикання скриптів можна вказувати лише під час встановлення або "
+"вилучення пакунків"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "параметри вимикання перемикачів можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr ""
+"параметри вимикання перемикачів можна вказувати лише під час встановлення "
+"або вилучення пакунків"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr "--nodeps можна вказувати лише під час встановлення, вилучення або перевірки пакунків"
+msgstr ""
+"--nodeps можна вказувати лише під час встановлення, вилучення або перевірки "
+"пакунків"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "--test можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr ""
+"--test можна вказувати лише під час встановлення або вилучення пакунків"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументи параметра --root (-r) мають починатися символом /"
 
@@ -222,201 +237,264 @@ msgstr "не вказано аргументів запиту"
 msgid "no arguments given for verify"
 msgstr "не вказано аргументів перевірки"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot вже вказано, ігноруємо %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "виконати команди аж до %prep (розпакувати коди і накласти латки) з <файла специфікації>"
+msgstr ""
+"виконати команди аж до %prep (розпакувати коди і накласти латки) з <файла "
+"специфікації>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<файл специфікації>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "виконати аж до команди %build (%prep, потім збирання) з <файла специфікації>"
+msgstr ""
+"виконати аж до команди %build (%prep, потім збирання) з <файла специфікації>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "виконати аж до команди %install (%prep, %build, потім встановити) з <файла специфікації>"
+msgstr ""
+"виконати аж до команди %install (%prep, %build, потім встановити) з <файла "
+"специфікації>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "перевірити розділ %files з <файла специфікації>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "зібрати пакунки з кодами та бінарними файлами за <файлом специфікації>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "зібрати за <файлом специфікації> лише пакунок з бінарними файлами"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "зібрати за <файлом специфікації> лише пакунок з кодами"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"виконати команди аж до %prep (розпакувати коди і накласти латки) з <файла "
+"специфікації>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<пакунок з кодами>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"виконати аж до команди %build (%prep, потім збирання) з <файла специфікації>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"виконати аж до команди %install (%prep, %build, потім встановити) з <пакунка "
+"з кодами>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "перевірити розділ %files з <файла специфікації>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "зібрати за <пакунком з кодами> пакунок з бінарними файлами"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "зібрати за <пакунком з кодами> пакунок з бінарними файлами"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "зібрати за <файлом специфікації> лише пакунок з кодами"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "виконати команди аж до %prep (розпакувати коди і накласти латки) з <архіву tar>"
+msgstr ""
+"виконати команди аж до %prep (розпакувати коди і накласти латки) з <архіву "
+"tar>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<архів tar>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "виконати аж до команди %build (%prep, потім збирання) з <архіву tar>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "виконати аж до команди %install (%prep, %build, потім встановити) з <архіву tar>"
+msgstr ""
+"виконати аж до команди %install (%prep, %build, потім встановити) з <архіву "
+"tar>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "перевірити розділ %files з <архіву tar>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "зібрати пакунки з кодами та бінарними файлами за <архівом tar>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "зібрати за <архівом tar> лише пакунок з бінарними файлами"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "зібрати за <архівом tar> лише пакунок з кодами"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "зібрати за <пакунком з кодами> пакунок з бінарними файлами"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<пакунок з кодами>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "виконати аж до команди %install (%prep, %build, потім встановити) з <пакунка з кодами>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "перевизначити кореневий каталог збирання"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Не вдалося відкрити поточний каталог: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "вилучити ієрархію каталогу збирання після завершення збирання"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ігнорування ExcludeArch: настанови з файла специфікації"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "зневаджування кінцевого автомата файлів"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "не виконувати жодного з кроків збирання"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "не перевіряти залежності збирання"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr "створити заголовки пакунків, сумісні з (застарілим) пакуванням версій rpm 3"
+msgstr ""
+"створити заголовки пакунків, сумісні з (застарілим) пакуванням версій rpm 3"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "не виконувати етапу %clean збирання"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "не виконувати етапу %clean збирання"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "не виконувати етапу %check збирання"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "не приймати рядки перекладів з файла специфікації"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "вилучити коди після збирання"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "вилучити файл специфікації після збирання"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "перейти одразу до вказаного кроку (лише для c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "перевизначити платформу призначення"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr "Параметри збирання з [ <файл spec> | <архів tar> | <пакунок з кодами> ]:"
+msgstr ""
+"Параметри збирання з [ <файл spec> | <архів tar> | <пакунок з кодами> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Не вдалося зібрати залежності:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Не вдалося відкрити файл spec %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Не вдалося відкрити канал tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Декілька файлів у одному рядку: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Не вдалося прочитати файл spec з %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Не вдалося перейменувати %s на %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "не вдалося отримати дані за допомогою stat з %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Файл %s не є звичайним файлом.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Здається, файл %s не є файлом spec.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Збирання для таких платформ: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Збирання для %s\n"
@@ -427,7 +505,9 @@ msgstr "ініціалізувати базу даних"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "перебудувати зворотні списки бази даних на основі заголовків встановлених пакунків"
+msgstr ""
+"перебудувати зворотні списки бази даних на основі заголовків встановлених "
+"пакунків"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -465,49 +545,65 @@ msgstr "показати список ключів зі сховища ключ�
 msgid "Keyring options:"
 msgstr "Параметри сховища ключів:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "не вказано жодних параметрів"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "підписати пакунки"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "підписати пакунки (тотожне до --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "вилучити підписи пакунка"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "підписати пакунки"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Параметри підписування:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Не вдалося виконати %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Вам слід встановити значення \"%%_gpg_name\" у вашому файлі макросу\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Введіть пароль: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Пароль підтверджено.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Не вдалося пройти перевірку паролем або строк дії ключа gpg вичерпано\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr ""
+"--prefix можна використовувати, лише під час встановлення нових пакунків"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches можна вказувати лише під час встановлення пакунків"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -525,7 +621,7 @@ msgstr "обробити бінарні rpm, створені на основі 
 msgid "operate on source rpm generated by spec"
 msgstr "обробити srpm, створені на основі spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "використовувати вказаний нижче формат запиту"
 
@@ -572,68 +668,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nПомилки збирання RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Помилки збирання RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "синтаксична помилка під час обробки ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "синтаксична помилка під час обробки &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "синтаксична помилка під час обробки ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "помилка обробки у виразі\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "незакрита дужка (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- лише для чисел\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! лише для чисел\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "типи мають збігатися\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / не підтримується для рядків\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- не підтримується для рядків\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& і || не підтримуються для рядків\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "синтаксична помилка у виразі\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Не вистачає «(» у %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Не вистачає «)» у %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Некоректний елемент %s: %s\n"
@@ -643,46 +742,46 @@ msgstr "Некоректний елемент %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Не вистачає %s у %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "За %s() вказано непробільне значення: %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Помилковий синтаксис: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Помилкові права доступу: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Помилкові права доступу до каталогу: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Незвичайна довжина locale: «%s» у %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Дублювання locale %s у %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Некоректний мандат: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Підтримку мандатів на файли не було зібрано\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Назва файла має починатися з «/»: %s\n"
@@ -690,151 +789,157 @@ msgstr "Назва файла має починатися з «/»: %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr "Невідомий алгоритм обчислення контрольної суми файла %u, буде використано MD5\n"
+msgstr ""
+"Невідомий алгоритм обчислення контрольної суми файла %u, буде використано "
+"MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Файл вказано двічі: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "під час спроби читання символічного посилання %s сталася помилка: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Символічне посилання вказує на BuildRoot: %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Шлях поза межами кореневої теки збирання: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Не знайдено каталогу: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Файл не знайдено: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Не є каталогом: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: не вдалося завантажити невідомий теґ (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: невдала спроба читання відкритого ключа.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: не є захищеним відкритим ключем.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: не вдалося закодувати\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Назва файла має починатися з «/»: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Не можна використовувати glob %%dev: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Каталог не знайдено glob: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "У glob файла не виявлено: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Не вдалося відкрити файл %%files %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "рядок: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Порожній файл %%files %s\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Помилка під час спроби читання файла %%files %s: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "некоректний формат каталогу документації %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "У glob файла не виявлено: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Не можна змішувати спеціальний %s з іншими формами: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Декілька файлів у одному рядку: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Помилковий файл: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Помилкові дані щодо власника/групи: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Пошук незапакованих файлів: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Виявлено встановлені (але не запаковані) файли:\n%s"
+msgstr ""
+"Виявлено встановлені (але не запаковані) файли:\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Обробка файлів: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr "Архітектура виконуваних файлів (%d) не збігається з архітектурою пакунка (%d).\n"
+msgstr ""
+"Архітектура виконуваних файлів (%d) не збігається з архітектурою пакунка "
+"(%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Виявлено залежні від архітектури бінарні файли у пакунку noarch\n"
 
@@ -863,79 +968,76 @@ msgstr "%s: рядок: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Не вдалося привести до канонічної форми назву вузла: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Не вдалося перезавантажити заголовок підпису.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Невідомий спосіб стиснення вмісту: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Не вдалося створити незмінну область заголовка.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Не вдалося відкрити %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Не вдалося записати пакунок: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Не вдалося записати тимчасовий заголовок\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Помилкові дані CSA\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Не вдалося виконати позиціювання у файлі %s: %s\n"
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "Помилка fread у файлі %s: %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записано: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Виконання «%s»:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Спроба виконання «%s» зазнала невдачі.\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Спроба перевірки пакунка «%s» зазнала невдачі.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Не вдалося створити назву файла виведених даних для пакунка %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "не вдалося створити %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "рядок %d: друге %s\n"
@@ -986,19 +1088,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "рядок %d: помилка під час обробки %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "рядок %d: помилковий параметр %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "рядок %d: забагато назв: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "рядок %d: пакунка не існує: %s\n"
@@ -1104,91 +1206,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "рядок %d: у тезі має бути лише один елемент: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "рядок %d: некоректний символ «%c» у: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "рядок %d: некоректний символ у: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "рядок %d: некоректна послідовність «..» у: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "рядок %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: рядок: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "рядок %d: помилковий теґ: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "рядок %d: порожній теґ: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "рядок %d: префікси не повинні завершуватися на «/»: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "рядок %d: запис Docdir має починатися з «/»: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "рядок %d: у полі Epoch має бути вказано ціле невід’ємне число: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "рядок %d: помилкове значення %s: специфікатори: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "рядок %d: помилковий формат BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "рядок %d: передбачено підтримку лише підпакунків типу noarch: %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Внутрішня помилка: зайвий теґ %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "рядок %d: %s вважається застарілим: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Помилкова специфікація пакунка: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Пакунок вже існує: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "рядок %d: невідомий теґ: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не може бути порожнім\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не може приймати значення «/»\n"
@@ -1198,161 +1305,198 @@ msgstr "%%{buildroot} не може приймати значення «/»\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Помилкове джерело: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Латки з номером %u не існує\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch без відповідного теґу \"Patch:\"\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Джерела з номером %u не існує\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "У файлі spec немає теґу \"Source:\"\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Помилка під час обробки %%setup: %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "рядок %d: помилковий аргумент %%setup: %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "рядок %d: помилковий параметр %%setup %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Некоректний номер латки %s: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "рядок %d: друге %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "записи залежностей мають починатися з букви, числа, «_» або «/»"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "не можна використовувати версії у назвах файлів"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Слід вказати версію"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "некоректна залежність"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Слід вказати версію"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "рядок %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "рядок %d: у записах перемикачів має бути --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "рядок %d: помилка під час обробки %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
-msgstr "рядок %d: запис вбудованого скрипту має завершуватися символом «>»: %s\n"
+msgstr ""
+"рядок %d: запис вбудованого скрипту має завершуватися символом «>»: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "рядок %d: програма скрипту має починатися з  символу «/»: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+"рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: "
+"%s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "рядок %d: друге %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "рядок %d: непідтримуваний вбудований скрипт: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr "рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: %s\n"
+msgstr ""
+"рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: "
+"%s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "рядок %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Не вдалося відкрити %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: мало бути вказано аргумент для %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "рядок %d: незавершена команда %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "рядок %d: незавершений макрос або помилкове продовження рядка\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: помилкова умова %%if\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: вказано %%else без %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: вказано %%endif без %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: помилкове форматування інструкції %%include\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Не знайдено сумісних архітектур для збирання\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "У пакунка немає поля %%description: %s\n"
@@ -1396,7 +1540,9 @@ msgstr "Не вдалося визначити назву правил: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "Тип «%s» вказано з іншими типами у %%semodule %s. Стискання запису типів до «%s».\n"
+msgstr ""
+"Тип «%s» вказано з іншими типами у %%semodule %s. Стискання запису типів до "
+"«%s».\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1423,291 +1569,287 @@ msgstr "Забагато аргументів у рядку: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Обробка правил: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ігноруємо некоректний формальний вираз %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Не вдалося створити канал для %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Не вдалося виконати %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Не вдалося розгалуження %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "Помилка %s: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "Не вдалося записати всі дані до %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "помилковий оператор"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "помилковий формат"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "некоректна залежність (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Невдала спроба перетворення %s у формат long integer.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Порожній класифікатор файла\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Не вказано атрибутів файла\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "помилка magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "помилка magic_load: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Спроба розпізнавання файла «%s» зазнала невдачі: режим %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Пошук %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Не вдалося знайти %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr "спроба опитування файла специфікації %s зазнала невдачі, не вдалося обробити\n"
+msgstr ""
+"спроба опитування файла специфікації %s зазнала невдачі, не вдалося "
+"обробити\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
-msgstr "%s належить до типу Delta RPM, його не можна встановлювати безпосередньо\n"
+msgstr ""
+"%s належить до типу Delta RPM, його не можна встановлювати безпосередньо\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Непідтримуваний вміст (%s) у пакунку %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакунок %s вже було додано, пропускаємо %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакунок %s вже було додано, замінюємо на %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(не є числом)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(не є base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(некоректний тип)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(не є бінарним об’єктом)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(некоректний тип xml)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(не є підписом OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Некоректна дата %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "звичайний"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "замінено"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "не встановлено"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "мережевий"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "помилковий колір"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "немає"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(невідомо)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(не є рядком)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s збережено як %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s створено як %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: спроба вилучення зазнала невдачі: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "каталог"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "файл"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "%s підписано непридатним до перевірки підписом"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "теґ[%d]: ПОМИЛКА, теґ %d тип %d зміщення %d лічильник %d"
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr "SHA1 заголовка: ПОМИЛКА, не є шістнадцятковою"
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr "RSA заголовка: ПОМИЛКА, не є двійковою"
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr "DSA заголовка: ПОМИЛКА, не є двійковою"
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "мітка області: BAD, мітка %d тип %d відступ %d кількість %d"
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "зміщення ділянки: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "залишок ділянки: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr "розмір ділянки: ПОМИЛКА, ril(%d) > il(%d)"
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "розмір бінарного об’єкта (%d): ПОМИЛКА, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "розмір заголовка(%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr "magic заголовка: ПОМИЛКА"
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "теґи заголовка: ПОМИЛКА, кількість теґів(%d) перевищує максимальну"
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "дані заголовка: ПОМИЛКА, кількість байтів(%d) перевищує максимальну"
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "бінарний елемент заголовка(%zd): ПОМИЛКА, read повернуто %d"
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr "завантаження заголовка: ПОМИЛКА"
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "Помилка fread: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr "%s: помилка: вказано декілька параметрів --pipe (несумісні альтернативні назви popt?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr ""
+"%s: помилка: вказано декілька параметрів --pipe (несумісні альтернативні "
+"назви popt?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1835,15 +1977,18 @@ msgid "relocations must have a / following the ="
 msgstr "у записах переміщень має бути /, за яким слід вказати ="
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "встановити всі файли, навіть файли налаштувань, які у іншому разі можна було б пропустити"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"встановити всі файли, навіть файли налаштувань, які у іншому разі можна було "
+"б пропустити"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "вилучити всі пакунки, що відповідають ключу <пакунок> (зазвичай, якщо <пакунок> вказує на декілька пакунків, буде повідомлено про помилку)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"вилучити всі пакунки, що відповідають ключу <пакунок> (зазвичай, якщо "
+"<пакунок> вказує на декілька пакунків, буде повідомлено про помилку)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1891,7 +2036,9 @@ msgstr "<файл пакунка>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr "виводити символи решіток для позначення поступу встановлення (варто використовувати разом з -v)"
+msgstr ""
+"виводити символи решіток для позначення поступу встановлення (варто "
+"використовувати разом з -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -1921,7 +2068,7 @@ msgstr "оновити базу даних, але не вносити змін 
 msgid "do not verify package dependencies"
 msgstr "не перевіряти залежностей пакунків"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "не перевіряти контрольних сум файлів"
 
@@ -1999,7 +2146,9 @@ msgstr "не виконувати жодних допоміжних скрипт
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "оновити до старішої версії пакунка (--force у командах оновлення виконує таку операцію автоматично)"
+msgstr ""
+"оновити до старішої версії пакунка (--force у командах оновлення виконує "
+"таку операцію автоматично)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2041,162 +2190,182 @@ msgstr "оновити пакунки"
 msgid "reinstall package(s)"
 msgstr "перевстановити пакунки"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "опитати/перевірити всі пакунки"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "режим перевірки підписів"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "опитати/перевірити пакунки, до яких належить файл"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "опитати/перевірити пакунки з групи"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "опитати/перевірити файл пакунка"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "опитати/перевірити пакунки за ідентифікатором пакунка"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "опитати/перевірити пакунки за ідентифікатором заголовка"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "режим опитування rpm"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "опитати/перевірити екземпляр заголовка"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "опитати/перевірити пакунки з операції зі встановлення"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "опитати пакунки, які пов’язано з пакунком"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "режим перевірки rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "опитати/перевірити пакунки, які надають файли залежностей"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "не збирати аргументи разом"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "не обробляти не запаковані файли як маніфести"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "показати список всіх файлів налаштувань"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "показати список всіх файлів документації"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "показати список усіх файлів ліцензування"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "створити дамп основних даних щодо файлів"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "показати список файлів у пакунку"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "пропускати файли %%ghost"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "показати стан файлів зі списку"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "не перевіряти розмірів файлів"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "не перевіряти шляхи символічних посилань на файли"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "не перевіряти власників файлів"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "не перевіряти групу власників файлів"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "не перевіряти час зміни файлів"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "не перевіряти права доступу до файлів"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "не перевіряти можливості файлів"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "не перевіряти контексти безпеки файла"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "не перевіряти файли у пакунку"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "не перевіряти залежності пакунків"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "не виконувати скриптів перевірки"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Для %s можливості rpmlib є недостатніми:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "слід було вказати пакунок з кодами, вказано бінарний пакунок\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "у пакунку з кодами не міститься файла .spec\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "спроба розпакування архіву завершилася невдало%s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " на файлі "
 
@@ -2244,7 +2413,8 @@ msgstr "у пакунку немає списків власника/групи 
 
 #: lib/query.c:228
 msgid "package has neither file owner or id lists\n"
-msgstr "у пакунку немає ні списку власників файлів, ні списку ідентифікаторів\n"
+msgstr ""
+"у пакунку немає ні списку власників файлів, ні списку ідентифікаторів\n"
 
 #: lib/query.c:317
 #, c-format
@@ -2271,96 +2441,117 @@ msgstr "жодне з пакунків не відповідає ключу %s: 
 msgid "no package requires %s\n"
 msgstr "жоден з пакунків не потребує %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "жоден з пакунків не потребує %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "жоден з пакунків не перемикає %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "жоден з пакунків не потребує %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "жоден з пакунків не потребує %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "жоден з пакунків не надає %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "файл %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "файл %s не належить до жодного з пакунків\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "некоректний номер пакунка: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "не вдалося прочитати запис %u\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакунок %s не встановлено\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "невідомий теґ: «%s»\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: спроба імпортування ключа %d завершилася невдало.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: ключ %d не є захищеним відкритим ключем.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: помилка читання під час імпортування(%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: помилка headerRead: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr "%s: не вдалося прочитати незмінну ділянку заголовка. Пакунок пошкоджено?\n"
+msgstr ""
+"%s: не вдалося прочитати незмінну ділянку заголовка. Пакунок пошкоджено?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: помилка fread: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "ПОМИЛКА"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "Гаразд"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (НЕ ВИСТАЧАЄ КЛЮЧІВ:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (НЕНАДІЙНІ КЛЮЧІ:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: помилка відкриття: %s\n"
@@ -2385,144 +2576,201 @@ msgstr "Не вдалося змінити кореневий каталог: %m
 msgid "Unable to restore root directory: %m\n"
 msgstr "Не вдалося відновити кореневий каталог: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "НІ "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "ТАК"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides: і Obsoletes: підтримка версій залежностей."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "назви файлів збережено як кортеж (dirName,baseName,dirIndex), а не як шлях."
+msgstr ""
+"назви файлів збережено як кортеж (dirName,baseName,dirIndex), а не як шлях."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "вміст пакунка може бути стиснуто за допомогою bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "вміст пакунка може бути стиснуто за допомогою xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "вміст пакунка може бути стиснуто за допомогою lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "файли вмісту пакунка мають префікс «./»."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "назва-версія-випуск пакунка не надаються автоматично."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "теґи заголовка завжди впорядковуються після завантаження."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
-msgstr "інтерпретатор допоміжних скриптів може використовувати аргументи з заголовка."
+msgstr ""
+"інтерпретатор допоміжних скриптів може використовувати аргументи з заголовка."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "підтримується часткове встановлення набору жорстких посилань пакунка."
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "допоміжні скрипти пакунка можуть отримувати доступ до бази даних rpm під час встановлення."
+msgstr ""
+"допоміжні скрипти пакунка можуть отримувати доступ до бази даних rpm під час "
+"встановлення."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "вбудована підтримка скриптів lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
-msgstr "алгоритм обчислення контрольних сум може бути вибрано для кожного з пакунків окремо"
+msgstr ""
+"алгоритм обчислення контрольних сум може бути вибрано для кожного з пакунків "
+"окремо"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "підтримка мандатів файлів POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "допоміжні скрипти пакунка може бути розширено під час встановлення."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "порівнянням залежностей підтримується запис версій з тильдою."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "підтримка файлів, розмір яких перевищує 4 ГБ"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "не перевіряти залежностей пакунків"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Слід вказати версію"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "некоректна залежність"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "Не закрито %c: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "некоректна залежність"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "запису користувача %s не існує, — використовуємо root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "запису групи %s не існує, — використовуємо root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Помилкове значення magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Помилковий/Непридатний до читання заголовок"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Розмір заголовка занадто великий"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Файл є занадто великим для архівування"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Невідомий тип файла"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Не вистачає файлів"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Невідповідність контрольних сум"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Внутрішня помилка"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Файла архіву не вказано у заголовку"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " помилка - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (помилка 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "помилка відкриття %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: не є пакунком rpm (або маніфестом пакунка)\n"
@@ -2554,42 +2802,42 @@ msgstr "Помилкові залежності:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: не є пакунком rpm (або маніфестом пакунка): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s не можна встановити\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Отримання %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "пропускаємо %s — помилка отримання\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "пакунок %s не придатний до переміщення\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "помилка читання з файла %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "«%s» задає декілька пакунків:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "не вдалося відкрити %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Встановлення %s\n"
@@ -2615,12 +2863,12 @@ msgstr "помилка читання: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "не є пакунком rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "не вдалося створити блокування %s для %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "очікування на блокування %s на %s\n"
@@ -2692,7 +2940,8 @@ msgstr "встановлення пакунка %s потребує %<PRIu64>%c�
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr "встановлення пакунка %s потребує %<PRIu64> inod-ів у файловій системі %s"
+msgstr ""
+"встановлення пакунка %s потребує %<PRIu64> inod-ів у файловій системі %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2778,60 +3027,81 @@ msgstr "не вистачає архітектури для %s у %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "помилковий параметр «%s» у %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Не вдалося прочитати допоміжний вектор, /proc не змонтовано?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Невідома система: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Будь ласка, зв’яжіться з %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Не вдалося відкрити %s для читання: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Не вдалося відновити поточний каталог: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
-msgstr "підтримку допоміжних скриптів мовою <lua> не було передбачено під час збирання\n"
+msgstr ""
+"підтримку допоміжних скриптів мовою <lua> не було передбачено під час "
+"збирання\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Не вдалося створити тимчасовий файл для %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Не вдалося здублювати дескриптор файла: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Не вдалося прочитати піктограму %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Не вдалося відновити кореневий каталог: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: помилка Fwrite: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "помилка допоміжного скрипту %s, очікування pid (%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "помилка допоміжного скрипту %s, сигнал %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "помилка допоміжного скрипту %s, стан виходу %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Невідомий формат"
 
@@ -2843,127 +3113,146 @@ msgstr "встановити"
 msgid "erase"
 msgstr "вилучити"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "не вдалося відкрити базу даних Packages у %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "зайвий символ «(» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "не вистачає «(» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "не вистачає «)» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: спроба читання відкритого ключа завершилася невдало.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "операція"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(не є підписом OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr "розмір sigh(%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr "sigh magic: ПОМИЛКА"
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr "мітки sigh: ПОМИЛКА, кількість міток (%d) перевищує максимальну"
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr "дані sigh: ПОМИЛКА, кількість байтів (%d) перевищує максимальну"
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr "бінарний об’єкт sigh (%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "теґ sigh[%d]: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr "завантаження sigh: ПОМИЛКА"
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "pad sigh (%zd): ПОМИЛКА, прочитано %zd байтів"
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigSize sigh (%zd): ПОМИЛКА, помилка fstat(2)"
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "Сума MD5:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Не вдалося перезавантажити заголовок підпису.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Сума SHA1 заголовка:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Заголовок "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "Сума MD5:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Сума SHA1 заголовка:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Перевірка підпису: ПОМИЛКОВІ ПАРАМЕТРИ (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "пропущено"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "невдача"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr "Дублювання імені користувача або UID для користувача %s\n"
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr "Дублювання назви групи або GID для групи %s\n"
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "немає стану"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "невідомий стан"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "не вистачає   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Незадоволені залежності для %s:\n"
@@ -3037,240 +3326,245 @@ msgstr "ітератор масиву використано з двома ма�
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Створення %d пропущених покажчиків, будь ласка, зачекайте…\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "не вдалося відкрити покажчик %s за допомогою %s — %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "не було встановлено шляху dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: пропущено"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "помилка (%d) збереження запису №%d до %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: помилка regexec: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: помилка regcomp: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: пропущено"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: отримано пошкоджений заголовок №%u — пропущено.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: не вдалося прочитати заголовок за адресою 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "не було встановлено шляху dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "не вдалося створити каталог %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заголовок №%u у базі даних є помилковим — пропущено.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "не вдалося додати запис з початковим розташуванням у %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "не вдалося перебудувати базу даних: початкова база даних залишається на місці\n"
+msgstr ""
+"не вдалося перебудувати базу даних: початкова база даних залишається на "
+"місці\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "не вдалося замінити стару базу даних новою!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "замінити файли у %s файлами з %s для відновлення"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "не вдалося вилучити каталог %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s помилка (%d), повідомлено %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s помилка (%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "не вдалося отримати блокування %s на %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "спільний"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "ексклюзивний"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "некоректний тип покажчика %x у %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "помилка(%d) отримання записів «%s» з покажчика %s: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "помилка (%d) під час спроби збереження запису «%s» до %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "помилка (%d) під час спроби вилучення запису «%s» з %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "помилка (%d) під час додавання запису заголовка №%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "помилка (%d) під час вилучення запису заголовка №%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "помилка (%d) розподілу нового екземпляра пакунка\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "невідомий параметр db: «%s» проігноровано.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s має некоректне числове значення, пропущено\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s має занадто велике або занадто мале довге ціле значення, пропущено\n"
+msgstr ""
+"%s має занадто велике або занадто мале довге ціле значення, пропущено\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s має занадто велике або занадто мале ціле значення, пропущено\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "не вдалося отримати блокування %s на %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "спільний"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "ексклюзивний"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "некоректний тип покажчика %x у %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "помилка(%d) отримання записів «%s» з покажчика %s: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "помилка (%d) під час спроби збереження запису «%s» до %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "помилка (%d) під час спроби вилучення запису «%s» з %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "помилка (%d) під час додавання запису заголовка №%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "помилка (%d) під час вилучення запису заголовка №%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "помилка (%d) розподілу нового екземпляра пакунка\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(порожньо)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(порожньо)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Запис параметрів макросу %%%s не завершено\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Запис макросу %%%s не завершено\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Макрос %%%s має некоректну назву (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Тіло макросу %%%s є порожнім\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "У макросі %%%s мало бути використано пробіл перед текстом макросу\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Не вдалося розгорнути макрос %%%s\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Макрос %%%s має некоректну назву (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Макрос %%%s визначено, але не використано у області видимості\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Невідомий параметр %c у %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Забагато рівнів вкладеності у макросі. Ймовірно, це викликано рекурсивним оголошенням макросу.\n"
+msgstr ""
+"Забагато рівнів вкладеності у макросі. Ймовірно, це викликано рекурсивним "
+"оголошенням макросу.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Не закрито %c: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "За %% вказано непридатний до обробки макрос\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "не вдалося завантажити файл макросу %s"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "=================== активних %d порожніх %d\n"
@@ -3290,31 +3584,31 @@ msgstr "Файл %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Розмір файла %s є меншим за %u байтів\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "не вдалося створити каталог"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "некоректний синтаксис у допоміжному скрипті lua: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "некоректний синтаксис у скрипті lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "помилка скрипту lua: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "некоректний синтаксис у файлі lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "помилка виклику lua: %s\n"
@@ -3323,120 +3617,176 @@ msgstr "помилка виклику lua: %s\n"
 msgid "[none]"
 msgstr "[нічого]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(без помилок)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "критична помилка: "
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "помилка: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "попередження: "
 
 #: rpmio/rpmmalloc.c:25
 #, c-format
 msgid "memory alloc (%u bytes) returned NULL.\n"
-msgstr "у відповідь на спробу отримання області пам’яті (%u байтів) повернуто NULL.\n"
+msgstr ""
+"у відповідь на спробу отримання області пам’яті (%u байтів) повернуто NULL.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ід. ключа %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(нічого)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "помилка під час створення тимчасового файла %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "помилка під час створення тимчасового файла %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "помилка під час створення тимчасового файла %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "не вдалося створити каталог %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: помилка Fwrite: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: помилка Fflush: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Непідтримуваний підпис PGP\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Непідтримуваний алгоритм хешування PGP, %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Непідтримуваний алгоритм обчислення відкритого ключа PGP, %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Не вдалося створити канал для підписування: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Не вдалося виконати %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "помилка fdopen\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "Не вдалося виконати запис до каналу\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "Не вдалося виконати читання з файла %s: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "помилка виконання gpg (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg не вдалося записати підпис\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "не вдалося прочитати підпис\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: помилка rpmWriteSignature: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: помилка rpmReadSignature: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: помилка headerRead: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "помилка rpmMkTemp\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "помилка fdopen\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: помилка headerRead: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s вже містить ідентичний підпис, пропускаємо\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: помилка rpmReadSignature: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Підписування пакунків RPM версії 3 неможливе\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s вже містить ідентичний підпис, пропускаємо\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: помилка rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "помилка rpmMkTemp\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: помилка writeLead: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "спроба заміни %s зазнала невдачі: %s\n"
@@ -3449,3 +3799,28 @@ msgstr "%s: помилка читання маніфесту: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "не перевіряти підпис заголовка та вмісту"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Введіть пароль: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Пароль підтверджено.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr ""
+#~ "Не вдалося пройти перевірку паролем або строк дії ключа gpg вичерпано\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Помилкові дані щодо власника/групи: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "рядок %d: некоректний символ у: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "%s підписано непридатним до перевірки підписом"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "Помилка fread: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Не вдалося створити канал для підписування: %m"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,24 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Yuri Chornoivan <yurchor@ukr.net>, 2011-2012,2014
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 12:06+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 12:23+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
-"Language-Team: Ukrainian (http://www.transifex.com/projects/p/rpm/language/"
-"uk/)\n"
-"Language: uk\n"
+"Language-Team: Ukrainian (http://www.transifex.com/rpm-team/rpm/language/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -82,7 +80,7 @@ msgstr "Перевірити параметри (за допомогою -V аб
 msgid "Install/Upgrade/Erase options:"
 msgstr "Параметри встановлення/оновлення/вилучення:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Загальні параметри для всіх режимів та виконуваних файлів rpm:"
@@ -103,7 +101,7 @@ msgstr "неочікуваний формат запитів"
 msgid "unexpected query source"
 msgstr "неочікуване джерело запиту"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "можна визначати лише один основний режим"
 
@@ -122,14 +120,11 @@ msgstr "не можна використовувати --prefix разом з --
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"--relocate і --excludepath можна використовувати лише під час встановлення "
-"нових пакунків"
+msgstr "--relocate і --excludepath можна використовувати лише під час встановлення нових пакунків"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
-msgstr ""
-"--prefix можна використовувати, лише під час встановлення нових пакунків"
+msgstr "--prefix можна використовувати, лише під час встановлення нових пакунків"
 
 #: rpmqv.c:168
 msgid "arguments to --prefix must begin with a /"
@@ -138,13 +133,12 @@ msgstr "аргументи параметра --prefix мають починат
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr ""
-"--hash (-h) можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr "--hash (-h) можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
-msgstr ""
-"--percent можна вказувати лише під час встановлення або вилучення пакунків"
+msgid ""
+"--percent may only be specified during package installation and erasure"
+msgstr "--percent можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
@@ -160,8 +154,7 @@ msgstr "--includedocs можна вказувати лише під час вс�
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
-msgstr ""
-"можна вказувати лише один з параметрів, --excludedocs або --includedocs"
+msgstr "можна вказувати лише один з параметрів, --excludedocs або --includedocs"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
@@ -185,39 +178,31 @@ msgstr "--allfiles можна вказувати лише під час вста
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"--justdb можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr "--justdb можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"параметри вимикання скриптів можна вказувати лише під час встановлення або "
-"вилучення пакунків"
+msgstr "параметри вимикання скриптів можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"параметри вимикання перемикачів можна вказувати лише під час встановлення "
-"або вилучення пакунків"
+msgstr "параметри вимикання перемикачів можна вказувати лише під час встановлення або вилучення пакунків"
 
 #: rpmqv.c:231
 msgid ""
 "--nodeps may only be specified during package installation, erasure, and "
 "verification"
-msgstr ""
-"--nodeps можна вказувати лише під час встановлення, вилучення або перевірки "
-"пакунків"
+msgstr "--nodeps можна вказувати лише під час встановлення, вилучення або перевірки пакунків"
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"--test можна вказувати лише під час встановлення або вилучення пакунків"
+msgstr "--test можна вказувати лише під час встановлення або вилучення пакунків"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументи параметра --root (-r) мають починатися символом /"
 
@@ -237,264 +222,201 @@ msgstr "не вказано аргументів запиту"
 msgid "no arguments given for verify"
 msgstr "не вказано аргументів перевірки"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot вже вказано, ігноруємо %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"виконати команди аж до %prep (розпакувати коди і накласти латки) з <файла "
-"специфікації>"
+msgstr "виконати команди аж до %prep (розпакувати коди і накласти латки) з <файла специфікації>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<файл специфікації>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"виконати аж до команди %build (%prep, потім збирання) з <файла специфікації>"
+msgstr "виконати аж до команди %build (%prep, потім збирання) з <файла специфікації>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"виконати аж до команди %install (%prep, %build, потім встановити) з <файла "
-"специфікації>"
+msgstr "виконати аж до команди %install (%prep, %build, потім встановити) з <файла специфікації>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "перевірити розділ %files з <файла специфікації>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "зібрати пакунки з кодами та бінарними файлами за <файлом специфікації>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "зібрати за <файлом специфікації> лише пакунок з бінарними файлами"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "зібрати за <файлом специфікації> лише пакунок з кодами"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"виконати команди аж до %prep (розпакувати коди і накласти латки) з <файла "
-"специфікації>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<пакунок з кодами>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"виконати аж до команди %build (%prep, потім збирання) з <файла специфікації>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"виконати аж до команди %install (%prep, %build, потім встановити) з <пакунка "
-"з кодами>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "перевірити розділ %files з <файла специфікації>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "зібрати за <пакунком з кодами> пакунок з бінарними файлами"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "зібрати за <пакунком з кодами> пакунок з бінарними файлами"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "зібрати за <файлом специфікації> лише пакунок з кодами"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"виконати команди аж до %prep (розпакувати коди і накласти латки) з <архіву "
-"tar>"
+msgstr "виконати команди аж до %prep (розпакувати коди і накласти латки) з <архіву tar>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<архів tar>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
 msgstr "виконати аж до команди %build (%prep, потім збирання) з <архіву tar>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"виконати аж до команди %install (%prep, %build, потім встановити) з <архіву "
-"tar>"
+msgstr "виконати аж до команди %install (%prep, %build, потім встановити) з <архіву tar>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "перевірити розділ %files з <архіву tar>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "зібрати пакунки з кодами та бінарними файлами за <архівом tar>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "зібрати за <архівом tar> лише пакунок з бінарними файлами"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "зібрати за <архівом tar> лише пакунок з кодами"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "зібрати за <пакунком з кодами> пакунок з бінарними файлами"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<пакунок з кодами>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "виконати аж до команди %install (%prep, %build, потім встановити) з <пакунка з кодами>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "перевизначити кореневий каталог збирання"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Не вдалося відкрити поточний каталог: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "вилучити ієрархію каталогу збирання після завершення збирання"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "ігнорування ExcludeArch: настанови з файла специфікації"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "зневаджування кінцевого автомата файлів"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "не виконувати жодного з кроків збирання"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "не перевіряти залежності збирання"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
-msgstr ""
-"створити заголовки пакунків, сумісні з (застарілим) пакуванням версій rpm 3"
+msgstr "створити заголовки пакунків, сумісні з (застарілим) пакуванням версій rpm 3"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "не виконувати етапу %clean збирання"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "не виконувати етапу %clean збирання"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "не виконувати етапу %check збирання"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "не приймати рядки перекладів з файла специфікації"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "вилучити коди після збирання"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "вилучити файл специфікації після збирання"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "перейти одразу до вказаного кроку (лише для c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "перевизначити платформу призначення"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
-msgstr ""
-"Параметри збирання з [ <файл spec> | <архів tar> | <пакунок з кодами> ]:"
+msgstr "Параметри збирання з [ <файл spec> | <архів tar> | <пакунок з кодами> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Не вдалося зібрати залежності:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Не вдалося відкрити файл spec %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Не вдалося відкрити канал tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Декілька файлів у одному рядку: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Не вдалося прочитати файл spec з %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Не вдалося перейменувати %s на %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "не вдалося отримати дані за допомогою stat з %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Файл %s не є звичайним файлом.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Здається, файл %s не є файлом spec.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Збирання для таких платформ: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Збирання для %s\n"
@@ -505,9 +427,7 @@ msgstr "ініціалізувати базу даних"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"перебудувати зворотні списки бази даних на основі заголовків встановлених "
-"пакунків"
+msgstr "перебудувати зворотні списки бази даних на основі заголовків встановлених пакунків"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -545,7 +465,7 @@ msgstr "показати список ключів зі сховища ключ�
 msgid "Keyring options:"
 msgstr "Параметри сховища ключів:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "не вказано жодних параметрів"
 
@@ -565,10 +485,29 @@ msgstr "вилучити підписи пакунка"
 msgid "Signature options:"
 msgstr "Параметри підписування:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Не вдалося виконати %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Вам слід встановити значення \"%%_gpg_name\" у вашому файлі макросу\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Введіть пароль: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Пароль підтверджено.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Не вдалося пройти перевірку паролем або строк дії ключа gpg вичерпано\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -586,7 +525,7 @@ msgstr "обробити бінарні rpm, створені на основі 
 msgid "operate on source rpm generated by spec"
 msgstr "обробити srpm, створені на основі spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "використовувати вказаний нижче формат запиту"
 
@@ -633,71 +572,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Помилки збирання RPM:\n"
+msgstr "\n\nПомилки збирання RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "синтаксична помилка під час обробки ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "синтаксична помилка під час обробки &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "синтаксична помилка під час обробки ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "помилка обробки у виразі\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "незакрита дужка (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- лише для чисел\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! лише для чисел\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "типи мають збігатися\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / не підтримується для рядків\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- не підтримується для рядків\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& і || не підтримуються для рядків\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "синтаксична помилка у виразі\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Не вистачає «(» у %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Не вистачає «)» у %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Некоректний елемент %s: %s\n"
@@ -707,46 +643,46 @@ msgstr "Некоректний елемент %s: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Не вистачає %s у %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "За %s() вказано непробільне значення: %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Помилковий синтаксис: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Помилкові права доступу: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Помилкові права доступу до каталогу: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Незвичайна довжина locale: «%s» у %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Дублювання locale %s у %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Некоректний мандат: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Підтримку мандатів на файли не було зібрано\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Назва файла має починатися з «/»: %s\n"
@@ -754,152 +690,151 @@ msgstr "Назва файла має починатися з «/»: %s\n"
 #: build/files.c:929
 #, c-format
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
-msgstr ""
-"Невідомий алгоритм обчислення контрольної суми файла %u, буде використано "
-"MD5\n"
+msgstr "Невідомий алгоритм обчислення контрольної суми файла %u, буде використано MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Файл вказано двічі: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "під час спроби читання символічного посилання %s сталася помилка: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Символічне посилання вказує на BuildRoot: %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Шлях поза межами кореневої теки збирання: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Не знайдено каталогу: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Файл не знайдено: %s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Не є каталогом: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: не вдалося завантажити невідомий теґ (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: невдала спроба читання відкритого ключа.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: не є захищеним відкритим ключем.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: не вдалося закодувати\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Назва файла має починатися з «/»: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Не можна використовувати glob %%dev: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Каталог не знайдено glob: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "У glob файла не виявлено: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Не вдалося відкрити файл %%files %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "рядок: %s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Порожній файл %%files %s\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Помилка під час спроби читання файла %%files %s: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "некоректний формат каталогу документації %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Не можна змішувати спеціальний %s з іншими формами: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Декілька файлів у одному рядку: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Помилковий файл: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Помилкові дані щодо власника/групи: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Пошук незапакованих файлів: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Виявлено встановлені (але не запаковані) файли:\n"
-"%s"
+msgstr "Виявлено встановлені (але не запаковані) файли:\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Обробка файлів: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
-msgstr ""
-"Архітектура виконуваних файлів (%d) не збігається з архітектурою пакунка "
-"(%d).\n"
+msgstr "Архітектура виконуваних файлів (%d) не збігається з архітектурою пакунка (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Виявлено залежні від архітектури бінарні файли у пакунку noarch\n"
 
@@ -928,79 +863,79 @@ msgstr "%s: рядок: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Не вдалося привести до канонічної форми назву вузла: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Не вдалося перезавантажити заголовок підпису.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Невідомий спосіб стиснення вмісту: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Не вдалося створити незмінну область заголовка.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Не вдалося відкрити %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Не вдалося записати пакунок: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Не вдалося записати тимчасовий заголовок\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Помилкові дані CSA\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Не вдалося відкрити файл %s: %s\n"
+msgstr "Не вдалося виконати позиціювання у файлі %s: %s\n"
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "спроба створення архіву зазнала невдачі на файлі %s: %s\n"
+msgstr "Помилка fread у файлі %s: %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записано: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Виконання «%s»:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Спроба виконання «%s» зазнала невдачі.\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Спроба перевірки пакунка «%s» зазнала невдачі.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Не вдалося створити назву файла виведених даних для пакунка %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "не вдалося створити %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "рядок %d: друге %s\n"
@@ -1051,19 +986,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "рядок %d: помилка під час обробки %%description: %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "рядок %d: помилковий параметр %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "рядок %d: забагато назв: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "рядок %d: пакунка не існує: %s\n"
@@ -1169,96 +1104,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "рядок %d: у тезі має бути лише один елемент: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "рядок %d: некоректний символ «%c» у: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "рядок %d: некоректна послідовність «..» у: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "рядок %d: некоректний символ у: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "рядок %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "рядок %d: некоректна послідовність «..» у: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: рядок: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "рядок %d: помилковий теґ: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "рядок %d: порожній теґ: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "рядок %d: префікси не повинні завершуватися на «/»: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "рядок %d: запис Docdir має починатися з «/»: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "рядок %d: у полі Epoch має бути вказано ціле невід’ємне число: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "рядок %d: помилкове значення %s: специфікатори: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "рядок %d: помилковий формат BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "рядок %d: передбачено підтримку лише підпакунків типу noarch: %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Внутрішня помилка: зайвий теґ %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "рядок %d: %s вважається застарілим: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Помилкова специфікація пакунка: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Пакунок вже існує: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "рядок %d: невідомий теґ: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не може бути порожнім\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не може приймати значення «/»\n"
@@ -1268,198 +1198,161 @@ msgstr "%%{buildroot} не може приймати значення «/»\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Помилкове джерело: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Латки з номером %u не існує\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch без відповідного теґу \"Patch:\"\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Джерела з номером %u не існує\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "У файлі spec немає теґу \"Source:\"\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Помилка під час обробки %%setup: %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "рядок %d: помилковий аргумент %%setup: %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "рядок %d: помилковий параметр %%setup %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Некоректний номер латки %s: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "рядок %d: друге %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr "записи залежностей мають починатися з букви, числа, «_» або «/»"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "не можна використовувати версії у назвах файлів"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "некоректна залежність"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Слід вказати версію"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "некоректна залежність"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "рядок %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "рядок %d: у записах перемикачів має бути --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "рядок %d: помилка під час обробки %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
-msgstr ""
-"рядок %d: запис вбудованого скрипту має завершуватися символом «>»: %s\n"
+msgstr "рядок %d: запис вбудованого скрипту має завершуватися символом «>»: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "рядок %d: програма скрипту має починатися з  символу «/»: %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-"рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: "
-"%s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "рядок %d: друге %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "рядок %d: непідтримуваний вбудований скрипт: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
-msgstr ""
-"рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: "
-"%s\n"
+msgstr "рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "рядок %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Не вдалося відкрити %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: мало бути вказано аргумент для %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "рядок %d: незавершена команда %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "рядок %d: незавершений макрос або помилкове продовження рядка\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: помилкова умова %%if\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: вказано %%else без %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: вказано %%endif без %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: помилкове форматування інструкції %%include\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Не знайдено сумісних архітектур для збирання\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "У пакунка немає поля %%description: %s\n"
@@ -1503,9 +1396,7 @@ msgstr "Не вдалося визначити назву правил: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"Тип «%s» вказано з іншими типами у %%semodule %s. Стискання запису типів до "
-"«%s».\n"
+msgstr "Тип «%s» вказано з іншими типами у %%semodule %s. Стискання запису типів до «%s».\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1532,287 +1423,291 @@ msgstr "Забагато аргументів у рядку: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Обробка правил: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ігноруємо некоректний формальний вираз %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Не вдалося створити канал для %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Не вдалося виконати %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Не вдалося розгалуження %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "Помилка %s: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "Не вдалося записати всі дані до %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr "помилковий оператор"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr "помилковий формат"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "некоректна залежність (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Невдала спроба перетворення %s у формат long integer.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Порожній класифікатор файла\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Не вказано атрибутів файла\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "помилка magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "помилка magic_load: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Спроба розпізнавання файла «%s» зазнала невдачі: режим %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Пошук %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Не вдалося знайти %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
-msgstr ""
-"спроба опитування файла специфікації %s зазнала невдачі, не вдалося "
-"обробити\n"
+msgstr "спроба опитування файла специфікації %s зазнала невдачі, не вдалося обробити\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
-msgstr ""
-"%s належить до типу Delta RPM, його не можна встановлювати безпосередньо\n"
+msgstr "%s належить до типу Delta RPM, його не можна встановлювати безпосередньо\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Непідтримуваний вміст (%s) у пакунку %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакунок %s вже було додано, пропускаємо %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакунок %s вже було додано, замінюємо на %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(не є числом)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(не є base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(некоректний тип)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(не є бінарним об’єктом)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(некоректний тип xml)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(не є підписом OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Некоректна дата %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "звичайний"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "замінено"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "не встановлено"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "мережевий"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "помилковий колір"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "немає"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(невідомо)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(не є рядком)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s збережено як %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s створено як %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: спроба вилучення зазнала невдачі: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "каталог"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "файл"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "%s підписано непридатним до перевірки підписом"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "теґ[%d]: ПОМИЛКА, теґ %d тип %d зміщення %d лічильник %d"
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr "SHA1 заголовка: ПОМИЛКА, не є шістнадцятковою"
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr "RSA заголовка: ПОМИЛКА, не є двійковою"
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr "DSA заголовка: ПОМИЛКА, не є двійковою"
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "мітка області: BAD, мітка %d тип %d відступ %d кількість %d"
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "зміщення ділянки: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "залишок ділянки: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr "розмір ділянки: ПОМИЛКА, ril(%d) > il(%d)"
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "розмір бінарного об’єкта (%d): ПОМИЛКА, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "розмір заголовка(%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr "magic заголовка: ПОМИЛКА"
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "теґи заголовка: ПОМИЛКА, кількість теґів(%d) перевищує максимальну"
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "дані заголовка: ПОМИЛКА, кількість байтів(%d) перевищує максимальну"
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "бінарний елемент заголовка(%zd): ПОМИЛКА, read повернуто %d"
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
 msgstr "завантаження заголовка: ПОМИЛКА"
 
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "Помилка fread: %s"
+
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr ""
-"%s: помилка: вказано декілька параметрів --pipe (несумісні альтернативні "
-"назви popt?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr "%s: помилка: вказано декілька параметрів --pipe (несумісні альтернативні назви popt?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1852,7 +1747,7 @@ msgstr "<ФАЙЛ:...>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "не вмикати жодних додатків"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
@@ -1940,18 +1835,15 @@ msgid "relocations must have a / following the ="
 msgstr "у записах переміщень має бути /, за яким слід вказати ="
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"встановити всі файли, навіть файли налаштувань, які у іншому разі можна було "
-"б пропустити"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "встановити всі файли, навіть файли налаштувань, які у іншому разі можна було б пропустити"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"вилучити всі пакунки, що відповідають ключу <пакунок> (зазвичай, якщо "
-"<пакунок> вказує на декілька пакунків, буде повідомлено про помилку)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "вилучити всі пакунки, що відповідають ключу <пакунок> (зазвичай, якщо <пакунок> вказує на декілька пакунків, буде повідомлено про помилку)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1999,9 +1891,7 @@ msgstr "<файл пакунка>+"
 
 #: lib/poptI.c:150
 msgid "print hash marks as package installs (good with -v)"
-msgstr ""
-"виводити символи решіток для позначення поступу встановлення (варто "
-"використовувати разом з -v)"
+msgstr "виводити символи решіток для позначення поступу встановлення (варто використовувати разом з -v)"
 
 #: lib/poptI.c:153
 msgid "don't verify package architecture"
@@ -2031,7 +1921,7 @@ msgstr "оновити базу даних, але не вносити змін 
 msgid "do not verify package dependencies"
 msgstr "не перевіряти залежностей пакунків"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "не перевіряти контрольних сум файлів"
 
@@ -2109,9 +1999,7 @@ msgstr "не виконувати жодних допоміжних скрипт
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"оновити до старішої версії пакунка (--force у командах оновлення виконує "
-"таку операцію автоматично)"
+msgstr "оновити до старішої версії пакунка (--force у командах оновлення виконує таку операцію автоматично)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2153,182 +2041,162 @@ msgstr "оновити пакунки"
 msgid "reinstall package(s)"
 msgstr "перевстановити пакунки"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "опитати/перевірити всі пакунки"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "режим перевірки підписів"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "опитати/перевірити пакунки, до яких належить файл"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "опитати/перевірити пакунки з групи"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "опитати/перевірити файл пакунка"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "опитати/перевірити пакунки за ідентифікатором пакунка"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "опитати/перевірити пакунки за ідентифікатором заголовка"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "режим опитування rpm"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "опитати/перевірити екземпляр заголовка"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "опитати/перевірити пакунки з операції зі встановлення"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "опитати пакунки, які пов’язано з пакунком"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "режим перевірки rpm"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "опитати/перевірити пакунки, які надають файли залежностей"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "опитати/перевірити пакунки, яким потрібні залежні пакунки"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "не збирати аргументи разом"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "не обробляти не запаковані файли як маніфести"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "показати список всіх файлів налаштувань"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "показати список всіх файлів документації"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr "показати список усіх файлів ліцензування"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "створити дамп основних даних щодо файлів"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "показати список файлів у пакунку"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "пропускати файли %%ghost"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "показати стан файлів зі списку"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "не перевіряти розмірів файлів"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "не перевіряти шляхи символічних посилань на файли"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "не перевіряти власників файлів"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "не перевіряти групу власників файлів"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "не перевіряти час зміни файлів"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "не перевіряти права доступу до файлів"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "не перевіряти можливості файлів"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "не перевіряти контексти безпеки файла"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "не перевіряти файли у пакунку"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "не перевіряти залежності пакунків"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "не виконувати скриптів перевірки"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Для %s можливості rpmlib є недостатніми:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "слід було вказати пакунок з кодами, вказано бінарний пакунок\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "у пакунку з кодами не міститься файла .spec\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "спроба розпакування архіву завершилася невдало%s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " на файлі "
 
@@ -2376,8 +2244,7 @@ msgstr "у пакунку немає списків власника/групи 
 
 #: lib/query.c:228
 msgid "package has neither file owner or id lists\n"
-msgstr ""
-"у пакунку немає ні списку власників файлів, ні списку ідентифікаторів\n"
+msgstr "у пакунку немає ні списку власників файлів, ні списку ідентифікаторів\n"
 
 #: lib/query.c:317
 #, c-format
@@ -2404,117 +2271,96 @@ msgstr "жодне з пакунків не відповідає ключу %s: 
 msgid "no package requires %s\n"
 msgstr "жоден з пакунків не потребує %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "жоден з пакунків не потребує %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "жоден з пакунків не перемикає %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "жоден з пакунків не потребує %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "жоден з пакунків не потребує %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "жоден з пакунків не надає %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "файл %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "файл %s не належить до жодного з пакунків\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "некоректний номер пакунка: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "не вдалося прочитати запис %u\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакунок %s не встановлено\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "невідомий теґ: «%s»\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: спроба імпортування ключа %d завершилася невдало.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: ключ %d не є захищеним відкритим ключем.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: помилка читання під час імпортування(%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: помилка headerRead: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
-msgstr ""
-"%s: не вдалося прочитати незмінну ділянку заголовка. Пакунок пошкоджено?\n"
+msgstr "%s: не вдалося прочитати незмінну ділянку заголовка. Пакунок пошкоджено?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: помилка fread: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "ПОМИЛКА"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "Гаразд"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (НЕ ВИСТАЧАЄ КЛЮЧІВ:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (НЕНАДІЙНІ КЛЮЧІ:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: помилка відкриття: %s\n"
@@ -2539,201 +2385,144 @@ msgstr "Не вдалося змінити кореневий каталог: %m
 msgid "Unable to restore root directory: %m\n"
 msgstr "Не вдалося відновити кореневий каталог: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "НІ "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "ТАК"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:, Provides: і Obsoletes: підтримка версій залежностей."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"назви файлів збережено як кортеж (dirName,baseName,dirIndex), а не як шлях."
+msgstr "назви файлів збережено як кортеж (dirName,baseName,dirIndex), а не як шлях."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "вміст пакунка може бути стиснуто за допомогою bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "вміст пакунка може бути стиснуто за допомогою xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "вміст пакунка може бути стиснуто за допомогою lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "файли вмісту пакунка мають префікс «./»."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "назва-версія-випуск пакунка не надаються автоматично."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "теґи заголовка завжди впорядковуються після завантаження."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
-msgstr ""
-"інтерпретатор допоміжних скриптів може використовувати аргументи з заголовка."
+msgstr "інтерпретатор допоміжних скриптів може використовувати аргументи з заголовка."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "підтримується часткове встановлення набору жорстких посилань пакунка."
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"допоміжні скрипти пакунка можуть отримувати доступ до бази даних rpm під час "
-"встановлення."
+msgstr "допоміжні скрипти пакунка можуть отримувати доступ до бази даних rpm під час встановлення."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "вбудована підтримка скриптів lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
-msgstr ""
-"алгоритм обчислення контрольних сум може бути вибрано для кожного з пакунків "
-"окремо"
+msgstr "алгоритм обчислення контрольних сум може бути вибрано для кожного з пакунків окремо"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "підтримка мандатів файлів POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "допоміжні скрипти пакунка може бути розширено під час встановлення."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "порівнянням залежностей підтримується запис версій з тильдою."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr "підтримка файлів, розмір яких перевищує 4 ГБ"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "не перевіряти залежностей пакунків"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Слід вказати версію"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "некоректна залежність"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "Не закрито %c: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "некоректна залежність"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "запису користувача %s не існує, — використовуємо root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "запису групи %s не існує, — використовуємо root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Помилкове значення magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Помилковий/Непридатний до читання заголовок"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Розмір заголовка занадто великий"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Файл є занадто великим для архівування"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Невідомий тип файла"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr "Не вистачає файлів"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Невідповідність контрольних сум"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Внутрішня помилка"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Файла архіву не вказано у заголовку"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " помилка - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (помилка 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "помилка відкриття %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: не є пакунком rpm (або маніфестом пакунка)\n"
@@ -2765,42 +2554,42 @@ msgstr "Помилкові залежності:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: не є пакунком rpm (або маніфестом пакунка): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s не можна встановити\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Отримання %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "пропускаємо %s — помилка отримання\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "пакунок %s не придатний до переміщення\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "помилка читання з файла %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "«%s» задає декілька пакунків:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "не вдалося відкрити %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Встановлення %s\n"
@@ -2826,12 +2615,12 @@ msgstr "помилка читання: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "не є пакунком rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "не вдалося створити блокування %s для %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "очікування на блокування %s на %s\n"
@@ -2847,9 +2636,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Спроба визначення символу %s завершилася невдало: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Модуль %s не завантажено\n"
+msgstr "Додаток %%__%s_%s не налаштовано\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2903,8 +2692,7 @@ msgstr "встановлення пакунка %s потребує %<PRIu64>%c�
 #: lib/rpmprob.c:155
 #, c-format
 msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
-msgstr ""
-"встановлення пакунка %s потребує %<PRIu64> inod-ів у файловій системі %s"
+msgstr "встановлення пакунка %s потребує %<PRIu64> inod-ів у файловій системі %s"
 
 #: lib/rpmprob.c:159
 #, c-format
@@ -2994,77 +2782,56 @@ msgstr "помилковий параметр «%s» у %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Не вдалося прочитати допоміжний вектор, /proc не змонтовано?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Невідома система: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Будь ласка, зв’яжіться з %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Не вдалося відкрити %s для читання: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Не вдалося відновити поточний каталог: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
-msgstr ""
-"підтримку допоміжних скриптів мовою <lua> не було передбачено під час "
-"збирання\n"
+msgstr "підтримку допоміжних скриптів мовою <lua> не було передбачено під час збирання\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Не вдалося створити тимчасовий файл для %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Не вдалося здублювати дескриптор файла: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Не вдалося прочитати піктограму %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Не вдалося відновити кореневий каталог: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: помилка Fwrite: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "помилка допоміжного скрипту %s, очікування pid (%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "помилка допоміжного скрипту %s, сигнал %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "помилка допоміжного скрипту %s, стан виходу %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Невідомий формат"
 
@@ -3076,142 +2843,127 @@ msgstr "встановити"
 msgid "erase"
 msgstr "вилучити"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "не вдалося відкрити базу даних Packages у %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "зайвий символ «(» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "не вистачає «(» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "не вистачає «)» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: спроба читання відкритого ключа завершилася невдало.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "операція"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(не є підписом OpenPGP)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr "розмір sigh(%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr "sigh magic: ПОМИЛКА"
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr "мітки sigh: ПОМИЛКА, кількість міток (%d) перевищує максимальну"
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr "дані sigh: ПОМИЛКА, кількість байтів (%d) перевищує максимальну"
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr "бінарний об’єкт sigh (%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "теґ sigh[%d]: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr "завантаження sigh: ПОМИЛКА"
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "pad sigh (%zd): ПОМИЛКА, прочитано %zd байтів"
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigSize sigh (%zd): ПОМИЛКА, помилка fstat(2)"
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Заголовок "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "Сума MD5:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Сума SHA1 заголовка:"
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Заголовок "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Перевірка підпису: ПОМИЛКОВІ ПАРАМЕТРИ (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "пропущено"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "невдача"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
-msgstr ""
+msgstr "Дублювання імені користувача або UID для користувача %s\n"
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
-msgstr ""
+msgstr "Дублювання назви групи або GID для групи %s\n"
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr "немає стану"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr "невідомий стан"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "не вистачає   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Незадоволені залежності для %s:\n"
@@ -3285,245 +3037,240 @@ msgstr "ітератор масиву використано з двома ма�
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Створення %d пропущених покажчиків, будь ласка, зачекайте…\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "не вдалося відкрити покажчик %s за допомогою %s — %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "не було встановлено шляху dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: пропущено"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "помилка (%d) збереження запису №%d до %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: помилка regexec: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: помилка regcomp: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: пропущено"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: отримано пошкоджений заголовок №%u — пропущено.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: не вдалося прочитати заголовок за адресою 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "не було встановлено шляху dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "не вдалося створити каталог %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заголовок №%u у базі даних є помилковим — пропущено.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "не вдалося додати запис з початковим розташуванням у %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"не вдалося перебудувати базу даних: початкова база даних залишається на "
-"місці\n"
+msgstr "не вдалося перебудувати базу даних: початкова база даних залишається на місці\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "не вдалося замінити стару базу даних новою!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "замінити файли у %s файлами з %s для відновлення"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "не вдалося вилучити каталог %s: %s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s помилка (%d), повідомлено %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s помилка (%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "невідомий параметр db: «%s» проігноровано.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s має некоректне числове значення, пропущено\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr ""
-"%s має занадто велике або занадто мале довге ціле значення, пропущено\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s має занадто велике або занадто мале ціле значення, пропущено\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "не вдалося отримати блокування %s на %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "спільний"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "ексклюзивний"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "некоректний тип покажчика %x у %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "помилка(%d) отримання записів «%s» з покажчика %s: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "помилка (%d) під час спроби збереження запису «%s» до %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "помилка (%d) під час спроби вилучення запису «%s» з %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "помилка (%d) під час додавання запису заголовка №%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "помилка (%d) під час вилучення запису заголовка №%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "помилка (%d) розподілу нового екземпляра пакунка\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "невідомий параметр db: «%s» проігноровано.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s має некоректне числове значення, пропущено\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s має занадто велике або занадто мале довге ціле значення, пропущено\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s має занадто велике або занадто мале ціле значення, пропущено\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(порожньо)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(порожньо)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Запис параметрів макросу %%%s не завершено\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Запис макросу %%%s не завершено\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Макрос %%%s має некоректну назву (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Тіло макросу %%%s є порожнім\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "У макросі %%%s мало бути використано пробіл перед текстом макросу\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Не вдалося розгорнути макрос %%%s\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Макрос %%%s має некоректну назву (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Макрос %%%s визначено, але не використано у області видимості\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Невідомий параметр %c у %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Забагато рівнів вкладеності у макросі. Ймовірно, це викликано рекурсивним "
-"оголошенням макросу.\n"
+msgstr "Забагато рівнів вкладеності у макросі. Ймовірно, це викликано рекурсивним оголошенням макросу.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Не закрито %c: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "За %% вказано непридатний до обробки макрос\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "не вдалося завантажити файл макросу %s"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "=================== активних %d порожніх %d\n"
@@ -3543,31 +3290,31 @@ msgstr "Файл %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Розмір файла %s є меншим за %u байтів\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "не вдалося створити каталог"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "некоректний синтаксис у допоміжному скрипті lua: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "некоректний синтаксис у скрипті lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "помилка скрипту lua: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "некоректний синтаксис у файлі lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "помилка виклику lua: %s\n"
@@ -3576,143 +3323,120 @@ msgstr "помилка виклику lua: %s\n"
 msgid "[none]"
 msgstr "[нічого]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(без помилок)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "критична помилка: "
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "помилка: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "попередження: "
 
 #: rpmio/rpmmalloc.c:25
 #, c-format
 msgid "memory alloc (%u bytes) returned NULL.\n"
-msgstr ""
-"у відповідь на спробу отримання області пам’яті (%u байтів) повернуто NULL.\n"
+msgstr "у відповідь на спробу отримання області пам’яті (%u байтів) повернуто NULL.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ід. ключа %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(нічого)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "помилка під час створення тимчасового файла %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "помилка під час створення тимчасового файла %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "помилка під час створення тимчасового файла %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "не вдалося створити каталог %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: помилка Fwrite: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: помилка Fflush: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Непідтримуваний підпис PGP\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Непідтримуваний алгоритм хешування PGP, %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Непідтримуваний алгоритм обчислення відкритого ключа PGP, %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Не вдалося виконати %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Не вдалося створити канал для підписування: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: помилка відкриття: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "помилка fdopen\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Не вдалося відкрити файл %s: %s\n"
+msgstr "Не вдалося виконати запис до каналу\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Не вдалося відкрити файл %%files %s: %m\n"
+msgstr "Не вдалося виконати читання з файла %s: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "помилка виконання gpg (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg не вдалося записати підпис\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "не вдалося прочитати підпис\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: помилка rpmReadSignature: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Підписування пакунків RPM версії 3 неможливе\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s вже містить ідентичний підпис, пропускаємо\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: помилка rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "помилка rpmMkTemp\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: помилка writeLead: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "спроба заміни %s зазнала невдачі: %s\n"
@@ -3725,114 +3449,3 @@ msgstr "%s: помилка читання маніфесту: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "не перевіряти підпис заголовка та вмісту"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Введіть пароль: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Пароль підтверджено.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr ""
-#~ "Не вдалося пройти перевірку паролем або строк дії ключа gpg вичерпано\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Помилкові дані щодо власника/групи: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "рядок %d: некоректний символ у: %s\n"
-
-#~ msgid "%s has unverifiable signature"
-#~ msgstr "%s підписано непридатним до перевірки підписом"
-
-#~ msgid "Fread failed: %s"
-#~ msgstr "Помилка fread: %s"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Не вдалося створити канал для підписування: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Не вдалося записати вміст до %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Не вдалося прочитати вміст з %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Не вдалося відкрити файл тимчасових даних.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Не вдалося відкрити ціль підписування %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Не вдалося прочитати заголовок з %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Не вдалося записати заголовок до %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "не виконувати жодних дій зі збірками"
-
-#~ msgid "Failed to expand %%__%s_%s macro\n"
-#~ msgstr "Не вдалося розгорнути макрос %%__%s_%s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr ""
-#~ "Не вдалося прочитати незмінну ділянку заголовка. Пакунок пошкоджено?\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Не вдалося розкодувати правила для %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Не вдалося створити тимчасовий файл для %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Не вдалося виконати запису правил %s до файла %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Не вдалося створити обробник semanage\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Не вдалося встановити зв’язок з обробником правил\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Не вдалося розпочати дію над правилами: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Не вдалося вилучити тимчасовий файл правил %s: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Не вдалося встановити модуль правил: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Не вдалося вилучити модуль правил: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Не вдалося створити відгалуження процесу: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Не вдалося виконати %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "Аварійне завершення %s\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "Помилка %s з кодом завершення %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Не вдалося внести зміни до правил\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Не вдалося розгорнути шлях макрос restorecon"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Не вдалося змінити мітки у файловій системі. Файли може бути позначено "
-#~ "помилковими мітками.\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Не вдалося перезавантажити контексти файлів. Файли може бути позначено "
-#~ "помилковими мітками.\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Не вдалося видобути правила з %s\n"

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,21 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Trần Ngọc Quân <vnwildman@gmail.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-21 08:30+0000\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
-"Language-Team: Vietnamese (http://www.transifex.com/rpm-team/rpm/language/vi/)\n"
+"Language-Team: Vietnamese (http://www.transifex.com/rpm-team/rpm/language/"
+"vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -37,7 +38,9 @@ msgstr "Bản quyền (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr "Phần mềm này được phân phối lại một cách tự do như theo các điều khoản của giấy phép Công GNU\n"
+msgstr ""
+"Phần mềm này được phân phối lại một cách tự do như theo các điều khoản của "
+"giấy phép Công GNU\n"
 
 #: cliutils.c:53
 #, c-format
@@ -80,7 +83,7 @@ msgstr "Tùy chọn kiểm tra (với -V hoặc --verify):"
 msgid "Install/Upgrade/Erase options:"
 msgstr "Tùy chọn cho Cài-đặt/Nâng-cấp/Xóa:"
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Các tùy chọn chung với mọi chế độ và tập tin thực hiện được kiểu rpm:"
@@ -101,7 +104,7 @@ msgstr "gặp định dạng truy vấn bất thường"
 msgid "unexpected query source"
 msgstr "gặp nguồn truy vấn bất thường"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "chỉ có thể đưa ra một chế độ chính"
 
@@ -115,12 +118,16 @@ msgstr "chỉ có thể tái định vị tập tin trong khi cài đặt gói"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
-msgstr "không cho phép dùng tùy chọn “--prefix” (tiền tố) cùng với “--relocate” (tái định vị) hoặc “--excludepath” (loại trừ đường dẫn)"
+msgstr ""
+"không cho phép dùng tùy chọn “--prefix” (tiền tố) cùng với “--relocate” (tái "
+"định vị) hoặc “--excludepath” (loại trừ đường dẫn)"
 
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr "tùy chọn “--relocate” (tái định vị) và --excludepath (loại trừ đường dẫn) chỉ có thể được dùng khi cài đặt gói mới"
+msgstr ""
+"tùy chọn “--relocate” (tái định vị) và --excludepath (loại trừ đường dẫn) "
+"chỉ có thể được dùng khi cài đặt gói mới"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -133,36 +140,50 @@ msgstr "đối số cho “--prefix” (tiền tố) phải bắt đầu với d
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr "tùy chọn --hash (-h) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
+msgstr ""
+"tùy chọn --hash (-h) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
-msgstr "tùy chọn “--percent” (phần trăm) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
+msgid "--percent may only be specified during package installation and erasure"
+msgstr ""
+"tùy chọn “--percent” (phần trăm) chỉ có thể được chỉ ra trong khi cài đặt và "
+"xóa gói"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr "tùy chọn “--replacepkgs” (thay thế các gói) chỉ có thể được chỉ ra trong khi cài đặt gói"
+msgstr ""
+"tùy chọn “--replacepkgs” (thay thế các gói) chỉ có thể được chỉ ra trong khi "
+"cài đặt gói"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr "tùy chọn “--excludedocs” (loại bỏ các tài liệu) chỉ có thể được chỉ ra trong khi cài đặt gói"
+msgstr ""
+"tùy chọn “--excludedocs” (loại bỏ các tài liệu) chỉ có thể được chỉ ra trong "
+"khi cài đặt gói"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr "tùy chọn “--includedocs” (bao gồm các tài liệu) chỉ có thể được chỉ ra trong khi cài đặt gói"
+msgstr ""
+"tùy chọn “--includedocs” (bao gồm các tài liệu) chỉ có thể được chỉ ra trong "
+"khi cài đặt gói"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
-msgstr "có thể chỉ ra chỉ một trong hai tùy chọn “-excludedocs” (loại bỏ các tài liệu)  và “-includedocs” (bao gồm các tài liệu)"
+msgstr ""
+"có thể chỉ ra chỉ một trong hai tùy chọn “-excludedocs” (loại bỏ các tài "
+"liệu)  và “-includedocs” (bao gồm các tài liệu)"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr "tùy chọn “--ignorearch” (bỏ qua kiến trúc) chỉ có thể được chỉ ra trong khi cài đặt gói"
+msgstr ""
+"tùy chọn “--ignorearch” (bỏ qua kiến trúc) chỉ có thể được chỉ ra trong khi "
+"cài đặt gói"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr "tùy chọn “--ignoreos” (bỏ qua hệ điều hành) chỉ có thể được chỉ ra trong khi cài đặt gói"
+msgstr ""
+"tùy chọn “--ignoreos” (bỏ qua hệ điều hành) chỉ có thể được chỉ ra trong khi "
+"cài đặt gói"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
@@ -170,27 +191,37 @@ msgstr "--ignoresize chỉ được chỉ ra trong quá trình cài đặt"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr "tùy chọn “--allmatches” (mọi sự tương ứng) chỉ có thể được chỉ ra trong khi xóa gói"
+msgstr ""
+"tùy chọn “--allmatches” (mọi sự tương ứng) chỉ có thể được chỉ ra trong khi "
+"xóa gói"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr "tùy chọn “--allfiles” (mọi tập tin) chỉ có thể được chỉ ra trong khi cài đặt gói"
+msgstr ""
+"tùy chọn “--allfiles” (mọi tập tin) chỉ có thể được chỉ ra trong khi cài đặt "
+"gói"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr "tùy chọn “--justdb” (chỉ cơ sở dữ liệu) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
+msgstr ""
+"tùy chọn “--justdb” (chỉ cơ sở dữ liệu) chỉ có thể được chỉ ra trong khi cài "
+"đặt và xóa gói"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr "các tùy chọn vô hiệu hóa văn lệnh chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
+msgstr ""
+"các tùy chọn vô hiệu hóa văn lệnh chỉ có thể được chỉ ra trong khi cài đặt "
+"và xóa gói"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr "các tùy chọn vô hiệu hóa bộ gây nên chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
+msgstr ""
+"các tùy chọn vô hiệu hóa bộ gây nên chỉ có thể được chỉ ra trong khi cài đặt "
+"và xóa gói"
 
 #: rpmqv.c:231
 msgid ""
@@ -200,9 +231,11 @@ msgstr "--nodeps chỉ được chỉ ra trong quá trình cài đặt, tẩy ha
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr "tùy chọn “--test” (kiểm tra) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
+msgstr ""
+"tùy chọn “--test” (kiểm tra) chỉ có thể được chỉ ra trong khi cài đặt và xóa "
+"gói"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "đối số của “--root” (-r) phải bắt đầu với dấu sổ chéo “/”"
 
@@ -222,201 +255,266 @@ msgstr "chưa đưa ra đối số để truy vấn"
 msgid "no arguments given for verify"
 msgstr "chưa đưa ra đối số để xác nhận"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "gốc-biên-dịch đã được chỉ ra rồi, bỏ qua %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr "xây dựng qua %prep (chuẩn bị: mở gói nguồn và áp dụng những miếng vá) từ <tập_tin_đặc_tả>"
+msgstr ""
+"xây dựng qua %prep (chuẩn bị: mở gói nguồn và áp dụng những miếng vá) từ "
+"<tập_tin_đặc_tả>"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<tập_tin_đặc_tả>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr "xây dựng qua %build (xây dựng: %prep [chuẳn bị], sau đó biên dịch) từ <tập_tin_đặc_tả>"
+msgstr ""
+"xây dựng qua %build (xây dựng: %prep [chuẳn bị], sau đó biên dịch) từ "
+"<tập_tin_đặc_tả>"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr "xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó cài đặt) từ <tập_tin_đặc_tả>"
+msgstr ""
+"xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó "
+"cài đặt) từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "thẩm tra phần tập tin (%files) từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "xây dựng các gói kiểu nguồn và nhị phân từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "xây dựng gói chỉ gói nhị phân từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "xây dựng chỉ gói nguồn từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:142
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr ""
+"xây dựng qua %prep (chuẩn bị: mở gói nguồn và áp dụng những miếng vá) từ "
+"<tập_tin_đặc_tả>"
+
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+msgid "<source package>"
+msgstr "<gói nguồn>"
+
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr ""
+"xây dựng qua %build (xây dựng: %prep [chuẳn bị], sau đó biên dịch) từ "
+"<tập_tin_đặc_tả>"
+
+#: rpmbuild.c:168 rpmbuild.c:209
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr ""
+"xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó "
+"cài đặt) từ <gói nguồn>"
+
+#: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "thẩm tra phần tập tin (%files) từ <tập_tin_đặc_tả>"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "xây dựng gói nhị phân từ <gói nguồn>"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "xây dựng gói nhị phân từ <gói nguồn>"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "xây dựng chỉ gói nguồn từ <tập_tin_đặc_tả>"
+
+#: rpmbuild.c:184
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "xây dựng qua %prep (chuẩn bị: giải nén các nguồn và áp dụng các đắp vá) từ <kho_tar>"
+msgstr ""
+"xây dựng qua %prep (chuẩn bị: giải nén các nguồn và áp dụng các đắp vá) từ "
+"<kho_tar>"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
 msgid "<tarball>"
 msgstr "<kho_tar>"
 
-#: rpmbuild.c:145
+#: rpmbuild.c:187
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "xây dựng qua %build (xây dựng: %prep [chuẩn bị], sau đó biên dịch) từ <kho_tar>"
+msgstr ""
+"xây dựng qua %build (xây dựng: %prep [chuẩn bị], sau đó biên dịch) từ "
+"<kho_tar>"
 
-#: rpmbuild.c:148
+#: rpmbuild.c:190
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó cài đặt) từ <kho_tar>"
+msgstr ""
+"xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó "
+"cài đặt) từ <kho_tar>"
 
-#: rpmbuild.c:151
+#: rpmbuild.c:193
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "xác nhận phần tập tin (%files) từ <kho_tar>"
 
-#: rpmbuild.c:154
+#: rpmbuild.c:196
 msgid "build source and binary packages from <tarball>"
 msgstr "xây dựng các gói kiểu nguồn và nhị phân từ <kho_tar>"
 
-#: rpmbuild.c:157
+#: rpmbuild.c:199
 msgid "build binary package only from <tarball>"
 msgstr "xây dựng chỉ gói nhị phân từ <kho_tar>"
 
-#: rpmbuild.c:160
+#: rpmbuild.c:202
 msgid "build source package only from <tarball>"
 msgstr "xây dựng chỉ gói nguồn từ <kho_tar>"
 
-#: rpmbuild.c:164
+#: rpmbuild.c:206
 msgid "build binary package from <source package>"
 msgstr "xây dựng gói nhị phân từ <gói nguồn>"
 
-#: rpmbuild.c:165 rpmbuild.c:168
-msgid "<source package>"
-msgstr "<gói nguồn>"
-
-#: rpmbuild.c:167
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr "xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó cài đặt) từ <gói nguồn>"
-
-#: rpmbuild.c:171
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "đè lên gốc biên dịch"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "Không thể mở thư mục làm việc hiện thời: %m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "làm xong thì gỡ bỏ cây xây dựng"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "bỏ qua ExcludeArch: các chỉ thị từ tập tin spec"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "gõ lỗi tập tin máy trạng thái"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "không thực thi bất kỳ giai đoạn nào của việc xây dựng"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "không xác nhận quan hệ phụ thuộc khi xây dựng"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "tạo phần đầu gói tương thích với gói rmp phiên bản 3 kiểu cũ"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "không thể thực thi bước %clean để biên dịch"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "không thể thực thi bước %clean để biên dịch"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "không thể thực thi bước %check để biên dịch"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "không chấp nhận chuỗi đã dịch i18n từ tập tin đặc tả"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "làm xong thì cũng gỡ bỏ các nguồn"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "làm xong thì cũng gỡ bỏ tập tin đặc tả"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "bỏ qua thẳng tới giai đoạn định rõ (chỉ cho c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "có quyền cao hơn nền tảng đích"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Tùy chọn xây dựng với [ <tập_tin_đặc_tả> | <kho_tar> | <gói nguồn> ]:"
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "Gặp lỗi khi xây dựng các thành phần phụ thuộc:\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Không thể mở tập tin đặc tả %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Gặp lỗi khi mở đường ống tar: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "Nhiều hơn một tập tin mỗi dòng: %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Lỗi đọc tập tin đặc tả từ %s\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Lỗi thay đổi tên %s thành %s: %m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "lỗi lấy trạng thái về %s: %m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Tập tin %s không phải là một tập tin thường.\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "Tập tin %s hình như không phải là tập tin đặc tả.\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Đang xây dựng các nền tảng đích: %s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Đang xây dựng cho nền tảng đích %s\n"
@@ -427,7 +525,9 @@ msgstr "khởi tạo cơ sở dữ liệu"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr "xây dựng lại các danh sách nghịch chuyển cơ sở dữ liệu từ các phần đầu gói được cài đặt"
+msgstr ""
+"xây dựng lại các danh sách nghịch chuyển cơ sở dữ liệu từ các phần đầu gói "
+"được cài đặt"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -465,49 +565,66 @@ msgstr "liệt kê các khóa từ chùm chìa khóa RPM"
 msgid "Keyring options:"
 msgstr "Tùy chọn chùm chìa khóa:"
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "chưa đưa ra đối số"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "ký (các) gói"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "ký tên gói (đồng nhất tới --addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "xóa chữ ký của gói"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "ký (các) gói"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "Tùy chọn chữ ký:"
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Không thể thực hiện %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Bạn phải đặt \"%%_gpg_name\" trong tập tin vĩ lệnh\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "Gõ cụm từ mật khẩu: "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "Cụm từ mật khẩu đúng.\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "Gặp lỗi khi phân tích cú pháp hay khóa gpg đã hết hạn\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "tùy chọn “--prefix” (tiền tố) chỉ có thể được dùng khi cài đặt gói mới"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr ""
+"tùy chọn “--allmatches” (mọi sự tương ứng) chỉ có thể được chỉ ra trong khi "
+"xóa gói"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -525,7 +642,7 @@ msgstr "thao tác trên gói nhị phân rpm được tạo bởi spec (mặc đ
 msgid "operate on source rpm generated by spec"
 msgstr "thao tác trên gói nguồn rpm được tạo bởi spec"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "dùng định dạng truy vấn theo đây"
 
@@ -572,68 +689,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nLỗi xây dựng RPM:\n"
+msgstr ""
+"\n"
+"\n"
+"Lỗi xây dựng RPM:\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "gặp lỗi cú pháp khi phân tích ==\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "gặp lỗi cú pháp khi phân tích &&\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "gặp lỗi cú pháp khi phân tích ||\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "gặp lỗi phân tích trong biểu thức\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "có dấu ngoặc mở “(” lẻ đôi\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- chỉ với con số\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! chỉ với con số\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "các kiểu phải tương ứng\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / không được hỗ trợ cho chuỗi\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- không được hỗ trợ cho chuỗi\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& và || không được hỗ trợ cho chuỗi\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "gặp lỗi cú pháp trong biểu thức\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Thiếu dấu ngoặc mở “(” trong %s %s\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Thiếu dấu ngoặc đóng “)” trong %s(%s\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Hiệu bài %s không hợp lệ: %s\n"
@@ -643,46 +763,46 @@ msgstr "Hiệu bài %s không hợp lệ: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Thiếu %s trong %s %s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Không có khoảng trắng theo sau %s(): %s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Cú pháp sai: %s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Đặc tả chế độ sai: %s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Đặc tả dirmode (chế độ thư mục) sai: %s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Chiều dài miền địa phương không bình thường “%s” trong %%lang(%s)\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Miền địa phương trùng %s trong %%lang(%s)\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Dung lượng không hợp lệ: %s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "Hỗ trợ dung lượng tập tin không được biên dịch sẵn\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Tập tin phải bắt đầu bằng dấu sổ chéo “/”: %s\n"
@@ -692,149 +812,151 @@ msgstr "Tập tin phải bắt đầu bằng dấu sổ chéo “/”: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Không hiểu thuật toán băm tập tin %u, quay lại dùng MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Tập tin được liệt kê hai lần: %s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "gặp lỗi khi đọc liên kết mềm “%s”: %s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Liên kết mềm chỉ tới BuildRoot (gốc xây dựng): %s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Đường dẫn nằm ngoài buildroot (gốc xây dựng): %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Không tìm thấy thư mục: %s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Không tìm thấy tập tin: %s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Không phải là một thư mục: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: không thể nạp thẻ bất thường (%d).\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: gặp lỗi khi đọc khóa công.\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: không phải là khóa công dạng văn bản.\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: gặp lỗi khi giải mã\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Tập tin cần có dấu sổ chéo “/” đi trước: %s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "không cho phép %%dev glob: %s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "Glob (chức năng mở rộng mẫu khi tìm kiếm) không tìm thấy thư mục: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Glob (chức năng mở rộng mẫu khi tìm kiếm) không tìm thấy tập tin: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Không thể mở tập tin %%files %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "dòng: %s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "Tập tin %%files trống rỗng %s\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Gặp lỗi khi đang đọc tập tin %%files %s: %m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "_docdir_fmt không hợp lệ %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "Glob (chức năng mở rộng mẫu khi tìm kiếm) không tìm thấy tập tin: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Không thể trộn lẫn %s đặc biệt với dạng khác: %s\n"
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Nhiều hơn một tập tin mỗi dòng: %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Tập tin sai: %s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "Chủ/nhóm sai: %s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Đang kiểm tra có tập tin chưa đóng gói: %s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "Tìm thấy tập tin đã cài đặt (nhưng chưa đóng gói):\n%s"
+msgstr ""
+"Tìm thấy tập tin đã cài đặt (nhưng chưa đóng gói):\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Đang xử lý tập tin: %s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "Kiến trúc nhị phân (%d) không khớp với kiến trúc gói (%d).\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Nhị phân phụ thuộc kiến trúc trong gói không phụ thuộc kiến trúc\n"
 
@@ -863,79 +985,76 @@ msgstr "%s: dòng: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Không thể làm hợp quy tắc tên máy: %s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "Không thể nạp lại phần đầu chữ ký.\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Không thể nén phần trọng tải: %s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "Không thể tạo vùng đầu không thể thay đổi được.\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Không thể mở %s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Không thể ghi gói: %s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "Không thể ghi phần đầu tạm\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "Dữ liệu CSA sai\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Không thể di chuyển vị trí đọc trong tập tin %s: %s\n"
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr "gặp lỗi khi fread ở tập tin %s: %s\n"
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Đã ghi: %s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Thực hiện %s:\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Việc thực hiện %s bị lỗi\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Gặp lỗi khi kiểm tra “%s”.\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Không thể tạo tên tập tin kết xuất cho gói %s: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "không thể tạo %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "dòng %d: %s thứ hai\n"
@@ -986,19 +1105,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "dòng %d: Gặp lỗi khi phân tích mô tả (%%description): %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "dòng %d: Tùy chọn sai %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "dòng %d: Quá nhiều tên: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "dòng %d: Gói không tồn tại: %s\n"
@@ -1104,91 +1223,97 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "dòng %d: Thẻ chấp nhận chỉ một hiệu bài: %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "dòng %d: Ký tự không hợp lệ “%c” trong: %s\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "dòng %d: Ký tự không hợp lệ trong: %s\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "dòng %d: Chuỗi ký tự không hợp lệ \"..\" trong: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "dòng %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: dòng: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "dòng %d: Thẻ dạng sai: %s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "dòng %d: Thẻ rỗng: %s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "dòng %d: Tiền tố không nên kết thúc với dấu sổ chéo “/”: %s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
-msgstr "dòng %d: Docdir (thư mục tài liệu) phải bắt đầu với dấu sổ chéo “/”: %s\n"
+msgstr ""
+"dòng %d: Docdir (thư mục tài liệu) phải bắt đầu với dấu sổ chéo “/”: %s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "dòng %d: trường Epoch (Kỷ nguyên) phải là con số không dấu: %s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "dòng %d: %s sai: điều kiện: %s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "dòng %d: định dạng BuildArchitecture (kiến trúc xây dựng) sai: %s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "dòng %d: Chỉ hỗ trợ gói phụ kiểu “noarch” (không có kiến trúc): %s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Lỗi nội bộ: Thẻ giả %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "dòng %d: không tán thành %s: %s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Đặc tả gói sai: %s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Gói đã sẵn có: %s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "dòng %d: Không rõ thẻ: %s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} không thể là rỗng\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} không thể là \"/\"\n"
@@ -1198,161 +1323,196 @@ msgstr "%%{buildroot} không thể là \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Nguồn sai: %s: %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Không có miếng và số %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch mà không có thẻ \"Patch:\" tương ứng\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "Không có số nguồn %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Không có thẻ \"Source:\" trong tập tin đặc tả\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Lỗi phân tích thiết lập (%%setup): %s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "dòng %d: Đối số sai tới thiết lập (%%setup): %s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "dòng %d: Tùy chọn thiết lập (%%setup) sai %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Miếng và sô %s không hợp lệ: %s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "dòng %d: chuẩn bị (%%prep) thứ hai\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr "Các thẻ bài về quan hệ phụ thuộc phải bắt đầu với chữ cái, chữ số, dấu gạch dưới “_” hoặc dấu sổ chéo “/”"
+msgstr ""
+"Các thẻ bài về quan hệ phụ thuộc phải bắt đầu với chữ cái, chữ số, dấu gạch "
+"dưới “_” hoặc dấu sổ chéo “/”"
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "Không cho phép tên tập tin đặt phiên bản"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "Yêu cầu phiên bản"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "phần phụ thuộc không hợp lệ"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "Yêu cầu phiên bản"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "dòng %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "dòng %d: các bẫy phải có --: %s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "dòng %d: Lỗi phân tích %s: %s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "dòng %d: văn lệnh nội tại phải kết thúc bằng “>”: %s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
-msgstr "dòng %d: Chương trình đặt văn lệnh phải bắt đầu với dấu sổ chéo “/”: %s\n"
+msgstr ""
+"dòng %d: Chương trình đặt văn lệnh phải bắt đầu với dấu sổ chéo “/”: %s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, fuzzy, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr "dòng %d: phiên dịch tham số không được phép trong bẫy: %s\n"
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "dòng %d: %s thứ hai\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "dòng %d: văn lệnh nội bộ không được hỗ trợ: %s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "dòng %d: phiên dịch tham số không được phép trong bẫy: %s\n"
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "dòng %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Không thể mở %s: %s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Cần đối số cho %s\n"
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "dòng %d: Chưa đóng %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "dòng %d: chưa đóng vĩ lệnh hoặc dòng kéo dài sai\n"
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: điều kiện %%if sai\n"
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Có một toán tử %%else (nếu không) mà không có %%if (nếu)\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Có một toán tử %%endif (kết thúc nếu) mà không có %%if (nếu)\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: câu lệnh bao gồm (%%include) sai dạng\n"
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "Không tìm thấy kiến trúc tương thích để xây dựng\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Gói không có mô tả (%%description): %s\n"
@@ -1396,7 +1556,9 @@ msgstr "Gặp lỗi khi dò tìm tên chính sách: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr "kiểu “%s” đưa ra với kiểu khác trong %%semodule %s. Tóm lược các kiểu thành “%s”.\n"
+msgstr ""
+"kiểu “%s” đưa ra với kiểu khác trong %%semodule %s. Tóm lược các kiểu thành "
+"“%s”.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1423,291 +1585,283 @@ msgstr "Quá nhiều đối số trong dòng: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Thực hiện các chính sách: %s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Bỏ qua biểu thức chính quy không hợp lệ %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Không thể tạo ống dẫn cho %s: %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Không thể thực hiện %s: %s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Không thể tạo tiến trình con %s: %s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s bị lỗi: %x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "gặp lỗi khi toàn bộ dữ liệu vào %s: %s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "thao tác sai"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "định dạng sai"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr "phần phụ thuộc không hợp lệ (%s): %s\n"
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Việc chuyển đổi %s sang số nguyên dài gặp lỗi.\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "Phân loại tập tin trống rỗng\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "Chưa có các thuộc tính tập tin được cấu hình\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) bị lỗi: %s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load gặp lỗi: %s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Gặp lỗi khi chấp nhận tập tin \"%s\": chế độ %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Đang tìm  %s: %s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Gặp lỗi khi tìm %s:\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "lỗi truy vấn tập tin đặc tả %s nên không phân tích được\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s là một Delta RPM và không thể được cài đặt trực tiếp\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Không hỗ trợ phần tải (%s) trong gói %s\n"
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "gói %s đã được thêm vào nên bỏ qua %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "gói %s đã được thêm vào nên thay thế bằng %s\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(không phải con số)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(không phải base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(kiểu không hợp lệ)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(không phải blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(kiểu XML không hợp lệ)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(không phải chữ ký OpenPGP)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ngày không hợp lệ %u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "thông thường"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "đã thay thế"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "chưa cài đặt"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "chia sẻ qua mạng"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "màu sai"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "thiếu"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(không hiểu)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(không phải chuỗi)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s được lưu dạng %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s được tạo dạng %s\n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: gặp lỗi khi gỡ bỏ: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "thư mục"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "tập tin"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr "%s có chữ ký không thể xác minh tra được"
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "thẻ [%d]: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr "hdr SHA1: SAI, không phải thập lục"
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr "hdr RSA: SAI, không phải nhị phân"
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr "hdr DSA: SAI, không phải nhị phân"
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "thẻ vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "bù vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "vùng theo đuôi: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr "kích cỡ vùng: SAI, ril(%d) > il(%d)"
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "kích cỡ blob (%d): SAI, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "kích cỡ hdr (%d): SAI, hàm đọc đã trả về %d"
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr "ma thuật hdr: SAI"
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "thẻ hdr: SAI, tổng số thẻ (%d) ở ngoài phạm vi"
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "dữ liệu hdr: SAI, tổng số byte (%d) ở ngoài phạm vi"
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "hdr blob(%zd): SAI, việc đọc trả về %d"
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr "tải hdr: SAI"
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "Fread bị lỗi: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr "%s: lỗi: đã cho nhiều hơn một --pipe (bí danh popt không tương thích?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr ""
+"%s: lỗi: đã cho nhiều hơn một --pipe (bí danh popt không tương thích?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1835,15 +1989,18 @@ msgid "relocations must have a / following the ="
 msgstr "sự tái định vị phải có một dấu sổ chéo “/” theo sau dấu bằng “=”"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
-msgstr "cài đặt tất cả các tập tin, ngay cả cấu hình mà có thể bị bỏ qua bằng cách khác"
+msgid "install all files, even configurations which might otherwise be skipped"
+msgstr ""
+"cài đặt tất cả các tập tin, ngay cả cấu hình mà có thể bị bỏ qua bằng cách "
+"khác"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "gỡ bỏ tất cả các gói tương ứng với <gói> (thường thì một lỗi phát sinh nếu <gói> định rõ nhiều gói)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"gỡ bỏ tất cả các gói tương ứng với <gói> (thường thì một lỗi phát sinh nếu "
+"<gói> định rõ nhiều gói)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1921,7 +2078,7 @@ msgstr "cập nhật cơ sở dữ liệu, mà không sửa đổi hệ thống 
 msgid "do not verify package dependencies"
 msgstr "không thẩm tra quan hệ phụ thuộc giữa các gói"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "không thẩm tra mã băm của tập tin"
 
@@ -1978,7 +2135,8 @@ msgstr "không chạy bất kỳ văn lệnh nhỏ nào được gói này kích
 #: lib/poptI.c:216
 #, c-format
 msgid "do not execute any %%triggerprein scriptlet(s)"
-msgstr "không chạy bất kỳ văn lệnh nhỏ cài đặt sẵn đã kích hoạt (%%triggerprein)"
+msgstr ""
+"không chạy bất kỳ văn lệnh nhỏ cài đặt sẵn đã kích hoạt (%%triggerprein)"
 
 #: lib/poptI.c:219
 #, c-format
@@ -1999,7 +2157,9 @@ msgstr "không chạy bất kỳ vi văn lệnh xóa cuối đã kích hoạt (%
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr "hạ cấp xuống một phiên bản cũ của gói (tùy chọn “--force” khi nâng cấp thì tự động làm)"
+msgstr ""
+"hạ cấp xuống một phiên bản cũ của gói (tùy chọn “--force” khi nâng cấp thì "
+"tự động làm)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2041,162 +2201,182 @@ msgstr "nâng cấp gói"
 msgid "reinstall package(s)"
 msgstr "cài đặt lại (các) gói"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "truy vấn/thẩm tra mọi gói"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "chế độ kiểm tra chữ ký RPM"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "truy vấn/thẩm tra (những) gói nào sở hữu tập tin"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "truy vấn/thẩm tra (các) gói trong nhóm"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "truy vấn/thẩm tra một tập tin gói"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "truy vấn/thẩm tra (các) gói với định danh gói"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "truy vấn/thẩm tra (các) gói với định danh phần đầu"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "chế độ truy vấn RPM"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "truy vấn/thẩm tra một phần đầu cụ thể"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "truy vấn/thẩm tra (các) gói từ giao dịch cài đặt"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "truy vấn (các) gói được gói kích hoạt"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "chế độ thẩm tra RPM"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "truy vấn/thẩm tra (các) gói mà thỏa một quan hệ phụ thuộc"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "không glob đối số"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "không xử lý dạng bản kê tập tin không phải gói "
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "liệt kê mọi tập tin cấu hình"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "liệt kê mọi tập tin tài liệu hướng dẫn"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "liệt kê mọi tập tin giấy phép"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "đổ thông tin tập tin cơ bản"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "liệt kê các tập tin trong gói"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "bỏ qua các tập tin ma (%%ghost)"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "hiển thị các tình trạng của những tập tin đã liệt kê"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "không thẩm tra kích cỡ của tập tin"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "không thẩm tra đường dẫn liên kết mềm của tập tin"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "không thẩm tra người sở hữu tập tin"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "không thẩm tra nhóm của tập tin"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "không thẩm tra thời gian sửa đổi của tập tin"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "không thẩm tra chế độ của tập tin"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "không thể thẩm tra kích cỡ của các tập tin"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "không thẩm tra ngữ cảnh bảo mật của tập tin"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "không thẩm tra các tập tin trong gói"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "không thẩm tra các quan hệ phụ thuộc của gói"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "không chạy văn lệnh thẩm tra"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Thiếu tính năng rpmlib cho %s:\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "cần gói nguồn còn tìm thấy gói nhị phân\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "gói nguồn không chứa tập tin đặc tả\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "lỗi giải nén kho %s%s: %s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr " ở tập tin"
 
@@ -2271,96 +2451,116 @@ msgstr "không có gói tương ứng với %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "không có gói cần thiết %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "không có gói cần thiết %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "không có bộ gây nên gói %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "không có gói cần thiết %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "không có gói cần thiết %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "không có gói cung cấp %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "tập tin %s: %s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "tập tin %s không được bất kỳ gói sở hưu\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "số thứ tự gói không hợp lệ: %s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "không thể đọc mục ghi %u\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "chưa cài đặt gói %s\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "không hiểu thẻ: “%s”\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: gặp lỗi khi nhập khóa %d.\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: khóa %d không phải là khóa công dạng văn bản.\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: lỗi đọc khi nhập (%d).\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: gặp lỗi khi headerRead: %s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Vùng phần đầu không thay đổi không thể đọc được. Gói đã hỏng?\n"
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread bị lỗi: %s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "KHÔNG_ĐƯỢC"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (KHÓA BỊ THIẾU:"
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (KHÓA KHÔNG TIN CẬY:"
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: gặp lỗi khi mở: %s\n"
@@ -2385,144 +2585,201 @@ msgstr "Không thể chuyển đổi thư mục gốc: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Không thể phục hồi thư mục gốc: %m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "KHÔNG "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "CÓ"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr "Cả kiểu quan hệ phụ thuộc PreReq: (điều kiện tiên quyết), Provides: (cung cấp) và Obsoletes: (làm cũ) đều hỗ trợ phiên bản."
+msgstr ""
+"Cả kiểu quan hệ phụ thuộc PreReq: (điều kiện tiên quyết), Provides: (cung "
+"cấp) và Obsoletes: (làm cũ) đều hỗ trợ phiên bản."
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr "tên tập tin được cất giữ dạng một đối tượng dữ liệu đa thành phần (dirName,baseName,dirIndex), không phải dạng đường dẫn."
+msgstr ""
+"tên tập tin được cất giữ dạng một đối tượng dữ liệu đa thành phần (dirName,"
+"baseName,dirIndex), không phải dạng đường dẫn."
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "trọng tải của gói có thể được nén bằng bzip2."
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "trọng tải gói cũng có thể được nén bằng xz."
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "trọng tải gói cũng có thể được nén bằng lzma."
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "tập tin trọng tải gói có tiền tố “./”."
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "không cung cấp dứt khoát tên-phiên_bản-bản_phát_hành của gói."
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "các thẻ của phần đầu luôn được sắp xếp sau khi được nạp."
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "bộ phiên dịch vi văn lệnh có thể sử dụng các đối số từ phần đầu."
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
-msgstr "một bộ tập tin đường liên kết cứng chưa hoàn toàn cũng có thể được cài đặt"
+msgstr ""
+"một bộ tập tin đường liên kết cứng chưa hoàn toàn cũng có thể được cài đặt"
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
-msgstr "vi văn lệnh của gói cũng có thể truy cập cơ sở dữ liệu RPM trong khi cài đặt."
+msgstr ""
+"vi văn lệnh của gói cũng có thể truy cập cơ sở dữ liệu RPM trong khi cài đặt."
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "bản thân có hỗ trợ văn lệnh lua."
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr "thuật toán băm tập tin là có phụ thuộc vào cấu hình từng gói"
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr "hỗ trợ cho dung lượng tập tin POSIX.1e"
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr "scriptlets gói có thể được khai triển lúc cài đặt."
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr "hỗ trợ so sánh phiên bản phụ thuộc với dấu sóng ~."
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "Hỗ trợ các tập tin lớn hơn 4GB"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "không thẩm tra quan hệ phụ thuộc giữa các gói"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "Yêu cầu phiên bản"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "phần phụ thuộc không hợp lệ"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "%c chưa chấm dứt: %s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "phần phụ thuộc không hợp lệ"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "người dùng %s không tồn tại nên dùng người chủ (root)\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "nhóm %s không tồn tại nên dùng người chủ (root)\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Ma thuật sai"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "Phần đầu sai hoặc không đọc được"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "Kích cỡ phần đầu quá lớn "
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "Tập tin quá lớn để nén"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "Không rõ kiểu tập tin"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "Thiếu các tập tin"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "Mã băm tập tin không khớp"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "Lỗi nội bộ"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "Tập tin kho lưu không phải trong phần đầu"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " bị lỗi — "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (lỗi 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "lỗi mở %s: %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: không phải là gói rpm (hoặc manifest gói)\n"
@@ -2554,42 +2811,42 @@ msgstr "Quan hệ phụ thuộc bị lỗi:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: không phải là gói rpm (hoặc manifest gói): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s không thể được cài đặt\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Đang lấy %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "bỏ qua %s - bộ truyền gặp lỗi\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "không thể tái định vị gói %s\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "gặp lỗi khi đọc từ tập tin %s\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "“%s” chỉ định nhiều gói:\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "không thể mở %s: %s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "Đang cài đặt %s\n"
@@ -2615,12 +2872,12 @@ msgstr "gặp lỗi khi đọc: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "không phải là gói rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr "không thể tạo khóa %s trên %s (%s)\n"
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "đang đợi %s khóa %s\n"
@@ -2778,60 +3035,79 @@ msgstr "thiếu kiến trúc cho %s tại %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "tùy chọn sai “%s” tại %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Gặp lỗi khi đọc véc tơ bổ trợ, /proc đã gắn chưa?\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Không hiểu hệ thống: %s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Hãy liên lạc %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Không thể mở %s để đọc: %m.\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Không thể phục hồi thư mục hiện tại: %m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "chưa hỗ trợ <lua> scriptlet dựng sẵn\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Không thể tạo tập tin tạm cho %s: %s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Không thể nhân bản bộ mô tả tập tin: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "Không thể đọc biểu tượng %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "Không thể phục hồi thư mục gốc: %m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite bị lỗi: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s scriptlet gặp lỗi, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s scriptlet gặp lỗi, tín hiệu %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s scriptlet gặp lỗi, trạng thái thoát %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "Không hiểu định dạng"
 
@@ -2843,127 +3119,146 @@ msgstr "cài đặt"
 msgid "erase"
 msgstr "tẩy"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "không thể mở cơ sở dữ liệu Gói trong %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "thừa “(” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "thiếu “(” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "thiếu “)” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: gặp lỗi khi đọc khóa công khai.\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "giao dịch"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(không phải chữ ký OpenPGP)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr "kích cỡ sigh (%d): SAI, hàm đọc đã trả về %d"
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr "ma thuật sigh: SAI"
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr "thẻ sigh: SAI, tổng số thẻ (%d) ở ngoài phạm vi"
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr "dữ liệu sigh: SAI, tổng số byte (%d) ở ngoài phạm vi"
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr "sigh blob(%d): SAI, hàm đọc đã trả về %d"
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr "thẻ sigh [%d]: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr "phần tải sigh: SAI"
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "đệm sigh(%zd): SAI, đọc %zd byte"
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigh sigSize(%zd): SAI, hàm fstat(2) gặp lỗi"
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "Mã băm MD5:"
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "Không thể nạp lại phần đầu chữ ký.\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "Mã băm SHA1 phần đầu:"
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "Phần đầu"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "Mã băm MD5:"
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "Mã băm SHA1 phần đầu:"
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "Xác minh chữ ký: CÁC ĐỐI SỐ SAI (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "bị bỏ qua"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "gặp lỗi"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr "Trùng tài khoản hoặc mã số người dùng cho tài khoản %s\n"
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr "Trùng tên nhóm hoặc mã số nhóm cho nhóm %s\n"
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "không có tình trạng"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "trạng thái không rõ"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "thiếu   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Quan hệ phụ thuộc chưa thỏa đối với %s:\n"
@@ -3037,240 +3332,245 @@ msgstr "đồ lặp lại mảng được sử dụng với các mảng có kíc
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Đang tạo %d thiếu mục lục, vui lòng chờ…\n"
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "không thể mở bảng mục lục %s dùng %s - %s (%d)\n"
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "chưa đặt đường dẫn cơ sở dữ liệu (dbpath)\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: bỏ qua"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "gặp lỗi (%d) khi lưu bản ghi #%d vào %s\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec (thực hiện biểu thức chính quy) bị lỗi: %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp bị lỗi: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: bỏ qua"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: nhận được phần đầu bị hỏng #%u -- bỏ qua.\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: không thể đọc phần đầu ở 0x%x\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "chưa đặt đường dẫn cơ sở dữ liệu (dbpath)"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "gặp lỗi khi tạo thư mục %s: %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "phần đầu #%u trong cơ sở dữ liệu là sai -- bỏ qua.\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "không thể thêm bản ghi nguyên gốc tại %u\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr "gặp lỗi khi xây dựng lại cơ sở dữ liệu: cơ sỏ dữ liệu nguyên gốc được giữ lại để thay thế\n"
+msgstr ""
+"gặp lỗi khi xây dựng lại cơ sở dữ liệu: cơ sỏ dữ liệu nguyên gốc được giữ "
+"lại để thay thế\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "gặp lỗi khi thay thế cơ sở dữ liệu cũ bằng cái mới!\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "thay thế các tập tin trong %s bằng các tập tin từ %s để phục hồi"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "gặp lỗi khi xóa thư mục %s: %s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s lỗi(%d) từ %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s lỗi(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "không thể lấy khóa %s ở %s/%s\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "chung"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "độc quyền"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "kiểu bảng mục mục không hợp lệ %x trên %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr "gặp lỗi (%d) khi lấy bản ghi \"%s\" từ chỉ mục %s: %s\n"
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "gặp lỗi (%d) khi ghi bản ghi %s vào %s\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "Gặp lỗi (%d) khi gỡ bỏ bản ghi “%s” ra khỏi %s\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "lỗi (%d) khi thêm bản ghi phần đầu #%d\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "lỗi (%d) khi gỡ bỏ bản ghi phần đầu #%d\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "lỗi (%d) phân bỏ minh dụ gói mới\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "không nhận ra tùy chọn cơ sở dữ liệu “%s” nên bỏ qua.\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s có giá trị thuộc số không hợp lệ nên bỏ qua\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s có giá trị dài quá lớn hoặc quá nhỏ nên bỏ qua\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s có giá trị nguyên quá lớn hoặc quá nhỏ nên bỏ qua\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "không thể lấy khóa %s ở %s/%s\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "chung"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "độc quyền"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "kiểu bảng mục mục không hợp lệ %x trên %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr "gặp lỗi (%d) khi lấy bản ghi \"%s\" từ chỉ mục %s: %s\n"
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "gặp lỗi (%d) khi ghi bản ghi %s vào %s\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "Gặp lỗi (%d) khi gỡ bỏ bản ghi “%s” ra khỏi %s\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr "lỗi (%d) khi thêm bản ghi phần đầu #%d\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "lỗi (%d) khi gỡ bỏ bản ghi phần đầu #%d\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "lỗi (%d) phân bỏ minh dụ gói mới\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s (trống)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s (trống)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Vĩ lệnh %%%s có tùy chọn chưa chấm dứt\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Vĩ lệnh %%%s có thân chưa chấm dứt\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Vĩ lệnh %%%s có tên không hợp lệ (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Vĩ lệnh %%%s có thân rỗng\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Vĩ lệnh %%%s cần có dấu cách trước phần thân\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Vĩ lệnh %%%s không mở rộng được\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Vĩ lệnh %%%s có tên không hợp lệ (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
-msgstr "Vĩ lệnh %%%s được định nghĩa nhưng lại không được dùng trong phạm vi của nó\n"
+msgstr ""
+"Vĩ lệnh %%%s được định nghĩa nhưng lại không được dùng trong phạm vi của nó\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Không hiểu tùy chọn %c trong %s(%s)\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr "Quá nhiều mức đệ quy trong khai triển vĩ lệnh. Nó giống như là có nguyên nhân bởi khai báo vĩ lệnh đệ quy.\n"
+msgstr ""
+"Quá nhiều mức đệ quy trong khai triển vĩ lệnh. Nó giống như là có nguyên "
+"nhân bởi khai báo vĩ lệnh đệ quy.\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c chưa chấm dứt: %s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Một dấu %% đi trước một vĩ lệnh không thể phân tích được\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "gặp lỗi khi tải tập tin vĩ lệnh %s"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== hoạt động %d trống %d\n"
@@ -3290,31 +3590,31 @@ msgstr "Tập tin %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Tập tin %s nhỏ hơn %u byte\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "gặp lỗi khi tạo thư mục"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "có lỗi cú pháp trong lua scriptlet: %s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "cú pháp không hợp lệ trong văn lệnh lua: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "gặp lỗi khi thực thi văn lệnh lua: %s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "cú pháp không hợp lệ trong tập tin Lua: %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Lỗi kích hoạt khả năng Lua: %s\n"
@@ -3323,19 +3623,19 @@ msgstr "Lỗi kích hoạt khả năng Lua: %s\n"
 msgid "[none]"
 msgstr "[không có]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(không có lỗi)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "lỗi nghiêm trọng:"
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "lỗi: "
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "cảnh báo: "
 
@@ -3344,99 +3644,154 @@ msgstr "cảnh báo: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "cấp phát bộ nhớ (%u byte) trở về VÔ GIÁ TRỊ.\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, Mã số khóa %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(không có)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "gặp lỗi khi đang tạo tập tin tạm thời %s: %m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "gặp lỗi khi đang tạo tập tin tạm thời %s: %m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "gặp lỗi khi đang tạo tập tin tạm thời %s: %m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "gặp lỗi khi tạo thư mục %s: %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite bị lỗi: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush bị lỗi: %s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "Không hỗ trợ ký bằng GPG\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Không hỗ trợ thuật toán băm PGP %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Không hỗ trợ thuật toán khóa công PGP %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "Không thể tạo ống dẫn để ký: %m"
+msgid "Could not exec %s: %s\n"
+msgstr "Không thể thực hiện %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "fdopen bị lỗi\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "Không thể ghi ra đường ống\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "Không thể đọc từ tập tin %s: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "lỗi thực hiện gpg (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "gpg không ghi được chữ ký\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "không thể đọc chữ ký\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s: gặp lỗi khi rpmWriteSignature: %s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s: rpmReadSignature gặp lỗi: %s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s: gặp lỗi khi headerRead: %s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "gặp lỗi khi rpmMkTemp\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "fdopen bị lỗi\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s: gặp lỗi khi headerRead: %s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s đã sẵn chứa chữ ký định danh nên bỏ qua\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature gặp lỗi: %s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Không thể ký gói RPM v3\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s đã sẵn chứa chữ ký định danh nên bỏ qua\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: gặp lỗi khi rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "gặp lỗi khi rpmMkTemp\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: Gặp lỗi khi writeLead: %s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "gặp lỗi khi thay thế %s: %s\n"
@@ -3449,3 +3804,27 @@ msgstr "%s: gặp lỗi khi đọc manifest: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "không nên thẩm tra chữ ký phần_đầu+trọng_tải"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "Gõ cụm từ mật khẩu: "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "Cụm từ mật khẩu đúng.\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "Gặp lỗi khi phân tích cú pháp hay khóa gpg đã hết hạn\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "Chủ/nhóm sai: %s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "dòng %d: Ký tự không hợp lệ trong: %s\n"
+
+#~ msgid "%s has unverifiable signature"
+#~ msgstr "%s có chữ ký không thể xác minh tra được"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "Fread bị lỗi: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "Không thể tạo ống dẫn để ký: %m"

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,26 +1,22 @@
-# Vietnamese translations for rmp package
-# Bản dịch tiếng Việt cho gói rmp phiên bản 4.
-# This file is distributed under the same license as the rmp package.
-# Trần Ngọc Quân <vnwildman@gmail.com>, 2013-2014.
-#
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# 
+# Translators:
+# Trần Ngọc Quân <vnwildman@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: rpm-4\n"
+"Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-05-15 07:49+0700\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-21 08:30+0000\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
-"Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
-"Language: vi\n"
+"Language-Team: Vietnamese (http://www.transifex.com/rpm-team/rpm/language/vi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 1.5.5\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Poedit-Language: Vietnamese\n"
-"X-Poedit-Country: VIET NAM\n"
-"X-Poedit-SourceCharset: utf-8\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format
@@ -41,9 +37,7 @@ msgstr "Bản quyền (C) 1998-2002 - Red Hat, Inc.\n"
 #, c-format
 msgid ""
 "This program may be freely redistributed under the terms of the GNU GPL\n"
-msgstr ""
-"Phần mềm này được phân phối lại một cách tự do như theo các điều khoản của "
-"giấy phép Công GNU\n"
+msgstr "Phần mềm này được phân phối lại một cách tự do như theo các điều khoản của giấy phép Công GNU\n"
 
 #: cliutils.c:53
 #, c-format
@@ -68,7 +62,7 @@ msgstr "gặp lỗi khi đọc phần đầu từ gói\n"
 #: rpm2archive.c:111 rpm2cpio.c:83
 #, c-format
 msgid "cannot re-open payload: %s\n"
-msgstr "không thể mở lại trọng tải: %s\n"
+msgstr "không thể mở lại phần trọng tải: %s\n"
 
 #: rpmqv.c:41
 msgid "Query/Verify package selection options:"
@@ -84,9 +78,9 @@ msgstr "Tùy chọn kiểm tra (với -V hoặc --verify):"
 
 #: rpmqv.c:57
 msgid "Install/Upgrade/Erase options:"
-msgstr "Tùy chọn cho Cài-đặt/Nâng-cấp/Xoá:"
+msgstr "Tùy chọn cho Cài-đặt/Nâng-cấp/Xóa:"
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "Các tùy chọn chung với mọi chế độ và tập tin thực hiện được kiểu rpm:"
@@ -107,7 +101,7 @@ msgstr "gặp định dạng truy vấn bất thường"
 msgid "unexpected query source"
 msgstr "gặp nguồn truy vấn bất thường"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "chỉ có thể đưa ra một chế độ chính"
 
@@ -117,20 +111,16 @@ msgstr "chỉ có cài đặt và nâng cấp là có thể ép buộc"
 
 #: rpmqv.c:156
 msgid "files may only be relocated during package installation"
-msgstr "chỉ có thể định vị lại tập tin trong khi cài đặt gói"
+msgstr "chỉ có thể tái định vị tập tin trong khi cài đặt gói"
 
 #: rpmqv.c:159
 msgid "cannot use --prefix with --relocate or --excludepath"
-msgstr ""
-"không cho phép dùng tùy chọn “--prefix” (tiền tố) với “--relocate” (định vị "
-"lại) hoặc “--excludepath” (loại trừ đường dẫn)"
+msgstr "không cho phép dùng tùy chọn “--prefix” (tiền tố) cùng với “--relocate” (tái định vị) hoặc “--excludepath” (loại trừ đường dẫn)"
 
 #: rpmqv.c:162
 msgid ""
 "--relocate and --excludepath may only be used when installing new packages"
-msgstr ""
-"tùy chọn “--relocate” (định vị lại) và --excludepath (loại trừ đường dẫn) "
-"chỉ có thể được dùng khi cài đặt gói mới"
+msgstr "tùy chọn “--relocate” (tái định vị) và --excludepath (loại trừ đường dẫn) chỉ có thể được dùng khi cài đặt gói mới"
 
 #: rpmqv.c:165
 msgid "--prefix may only be used when installing new packages"
@@ -143,50 +133,36 @@ msgstr "đối số cho “--prefix” (tiền tố) phải bắt đầu với d
 #: rpmqv.c:171
 msgid ""
 "--hash (-h) may only be specified during package installation and erasure"
-msgstr ""
-"tùy chọn --hash (-h) chỉ có thể được chỉ ra trong khi cài đặt và xoá gói"
+msgstr "tùy chọn --hash (-h) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
-msgstr ""
-"tùy chọn “--percent” (phần trăm) chỉ có thể được chỉ ra trong khi cài đặt và "
-"xoá gói"
+msgid ""
+"--percent may only be specified during package installation and erasure"
+msgstr "tùy chọn “--percent” (phần trăm) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
 #: rpmqv.c:179
 msgid "--replacepkgs may only be specified during package installation"
-msgstr ""
-"tùy chọn “--replacepkgs” (thay thế các gói) chỉ có thể được chỉ ra trong khi "
-"cài đặt gói"
+msgstr "tùy chọn “--replacepkgs” (thay thế các gói) chỉ có thể được chỉ ra trong khi cài đặt gói"
 
 #: rpmqv.c:183
 msgid "--excludedocs may only be specified during package installation"
-msgstr ""
-"tùy chọn “--excludedocs” (loại trừ các tài liệu) chỉ có thể được chỉ ra "
-"trong khi cài đặt gói"
+msgstr "tùy chọn “--excludedocs” (loại bỏ các tài liệu) chỉ có thể được chỉ ra trong khi cài đặt gói"
 
 #: rpmqv.c:187
 msgid "--includedocs may only be specified during package installation"
-msgstr ""
-"tùy chọn “--includedocs” (bao gồm các tài liệu) chỉ có thể được chỉ ra trong "
-"khi cài đặt gói"
+msgstr "tùy chọn “--includedocs” (bao gồm các tài liệu) chỉ có thể được chỉ ra trong khi cài đặt gói"
 
 #: rpmqv.c:191
 msgid "only one of --excludedocs and --includedocs may be specified"
-msgstr ""
-"có thể chỉ ra chỉ một trong hai tùy chọn “-excludedocs” (loại trừ các tài "
-"liệu)  và “-includedocs” (bao gồm các tài liệu)"
+msgstr "có thể chỉ ra chỉ một trong hai tùy chọn “-excludedocs” (loại bỏ các tài liệu)  và “-includedocs” (bao gồm các tài liệu)"
 
 #: rpmqv.c:195
 msgid "--ignorearch may only be specified during package installation"
-msgstr ""
-"tùy chọn “--ignorearch” (bỏ qua kiến trúc) chỉ có thể được chỉ ra trong khi "
-"cài đặt gói"
+msgstr "tùy chọn “--ignorearch” (bỏ qua kiến trúc) chỉ có thể được chỉ ra trong khi cài đặt gói"
 
 #: rpmqv.c:199
 msgid "--ignoreos may only be specified during package installation"
-msgstr ""
-"tùy chọn “--ignoreos” (bỏ qua hệ điều hành) chỉ có thể được chỉ ra trong khi "
-"cài đặt gói"
+msgstr "tùy chọn “--ignoreos” (bỏ qua hệ điều hành) chỉ có thể được chỉ ra trong khi cài đặt gói"
 
 #: rpmqv.c:204
 msgid "--ignoresize may only be specified during package installation"
@@ -194,37 +170,27 @@ msgstr "--ignoresize chỉ được chỉ ra trong quá trình cài đặt"
 
 #: rpmqv.c:208
 msgid "--allmatches may only be specified during package erasure"
-msgstr ""
-"tùy chọn “--allmatches” (mọi sự tương ứng) chỉ có thể được chỉ ra trong khi "
-"xoá gói"
+msgstr "tùy chọn “--allmatches” (mọi sự tương ứng) chỉ có thể được chỉ ra trong khi xóa gói"
 
 #: rpmqv.c:212
 msgid "--allfiles may only be specified during package installation"
-msgstr ""
-"tùy chọn “--allfiles” (mọi tập tin) chỉ có thể được chỉ ra trong khi cài đặt "
-"gói"
+msgstr "tùy chọn “--allfiles” (mọi tập tin) chỉ có thể được chỉ ra trong khi cài đặt gói"
 
 #: rpmqv.c:217
 msgid "--justdb may only be specified during package installation and erasure"
-msgstr ""
-"tùy chọn “--justdb” (chỉ cơ sở dữ liệu) chỉ có thể được chỉ ra trong khi cài "
-"đặt và xoá gói"
+msgstr "tùy chọn “--justdb” (chỉ cơ sở dữ liệu) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
 #: rpmqv.c:222
 msgid ""
 "script disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"các tùy chọn vô hiệu hoá văn lệnh chỉ có thể được chỉ ra trong khi cài đặt "
-"và xoá gói"
+msgstr "các tùy chọn vô hiệu hóa văn lệnh chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
 #: rpmqv.c:227
 msgid ""
 "trigger disabling options may only be specified during package installation "
 "and erasure"
-msgstr ""
-"các tùy chọn vô hiệu hoá bộ gây nên chỉ có thể được chỉ ra trong khi cài đặt "
-"và xoá gói"
+msgstr "các tùy chọn vô hiệu hóa bộ gây nên chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
 #: rpmqv.c:231
 msgid ""
@@ -234,17 +200,15 @@ msgstr "--nodeps chỉ được chỉ ra trong quá trình cài đặt, tẩy ha
 
 #: rpmqv.c:235
 msgid "--test may only be specified during package installation and erasure"
-msgstr ""
-"tùy chọn “--test” (kiểm tra) chỉ có thể được chỉ ra trong khi cài đặt và xoá "
-"gói"
+msgstr "tùy chọn “--test” (kiểm tra) chỉ có thể được chỉ ra trong khi cài đặt và xóa gói"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "đối số của “--root” (-r) phải bắt đầu với dấu sổ chéo “/”"
 
 #: rpmqv.c:257
 msgid "no packages given for erase"
-msgstr "chưa đưa ra gói cần xoá"
+msgstr "chưa đưa ra gói cần xóa"
 
 #: rpmqv.c:291
 msgid "no packages given for install"
@@ -258,266 +222,201 @@ msgstr "chưa đưa ra đối số để truy vấn"
 msgid "no arguments given for verify"
 msgstr "chưa đưa ra đối số để xác nhận"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "gốc-biên-dịch đã được chỉ ra rồi, bỏ qua %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
-msgstr ""
-"xây dựng qua %prep (chuẩn bị: mở gói nguồn và áp dụng những miếng vá) từ "
-"<tập_tin_đặc_tả>"
+msgstr "xây dựng qua %prep (chuẩn bị: mở gói nguồn và áp dụng những miếng vá) từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<tập_tin_đặc_tả>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
-msgstr ""
-"xây dựng qua %build (xây dựng: %prep [chuẳn bị], sau đó biên dịch) từ "
-"<tập_tin_đặc_tả>"
+msgstr "xây dựng qua %build (xây dựng: %prep [chuẳn bị], sau đó biên dịch) từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
-msgstr ""
-"xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó "
-"cài đặt) từ <tập_tin_đặc_tả>"
+msgstr "xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó cài đặt) từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "thẩm tra phần tập tin (%files) từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "xây dựng các gói kiểu nguồn và nhị phân từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "xây dựng gói chỉ gói nhị phân từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "xây dựng chỉ gói nguồn từ <tập_tin_đặc_tả>"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr ""
-"xây dựng qua %prep (chuẩn bị: mở gói nguồn và áp dụng những miếng vá) từ "
-"<tập_tin_đặc_tả>"
-
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
-msgid "<source package>"
-msgstr "<gói nguồn>"
-
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr ""
-"xây dựng qua %build (xây dựng: %prep [chuẳn bị], sau đó biên dịch) từ "
-"<tập_tin_đặc_tả>"
-
-#: rpmbuild.c:168 rpmbuild.c:209
-msgid ""
-"build through %install (%prep, %build, then install) from <source package>"
-msgstr ""
-"xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó "
-"cài đặt) từ <gói nguồn>"
-
-#: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "thẩm tra phần tập tin (%files) từ <tập_tin_đặc_tả>"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "xây dựng gói nhị phân từ <gói nguồn>"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "xây dựng gói nhị phân từ <gói nguồn>"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "xây dựng chỉ gói nguồn từ <tập_tin_đặc_tả>"
-
-#: rpmbuild.c:184
+#: rpmbuild.c:142
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr ""
-"xây dựng qua %prep (chuẩn bị: giải nén các nguồn và áp dụng các đắp vá) từ "
-"<kho_tar>"
+msgstr "xây dựng qua %prep (chuẩn bị: giải nén các nguồn và áp dụng các đắp vá) từ <kho_tar>"
 
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
 msgid "<tarball>"
 msgstr "<kho_tar>"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:145
 msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr ""
-"xây dựng qua %build (xây dựng: %prep [chuẩn bị], sau đó biên dịch) từ "
-"<kho_tar>"
+msgstr "xây dựng qua %build (xây dựng: %prep [chuẩn bị], sau đó biên dịch) từ <kho_tar>"
 
-#: rpmbuild.c:190
+#: rpmbuild.c:148
 msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr ""
-"xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó "
-"cài đặt) từ <kho_tar>"
+msgstr "xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó cài đặt) từ <kho_tar>"
 
-#: rpmbuild.c:193
+#: rpmbuild.c:151
 #, c-format
 msgid "verify %files section from <tarball>"
 msgstr "xác nhận phần tập tin (%files) từ <kho_tar>"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:154
 msgid "build source and binary packages from <tarball>"
 msgstr "xây dựng các gói kiểu nguồn và nhị phân từ <kho_tar>"
 
-#: rpmbuild.c:199
+#: rpmbuild.c:157
 msgid "build binary package only from <tarball>"
 msgstr "xây dựng chỉ gói nhị phân từ <kho_tar>"
 
-#: rpmbuild.c:202
+#: rpmbuild.c:160
 msgid "build source package only from <tarball>"
 msgstr "xây dựng chỉ gói nguồn từ <kho_tar>"
 
-#: rpmbuild.c:206
+#: rpmbuild.c:164
 msgid "build binary package from <source package>"
 msgstr "xây dựng gói nhị phân từ <gói nguồn>"
 
-#: rpmbuild.c:213
+#: rpmbuild.c:165 rpmbuild.c:168
+msgid "<source package>"
+msgstr "<gói nguồn>"
+
+#: rpmbuild.c:167
+msgid ""
+"build through %install (%prep, %build, then install) from <source package>"
+msgstr "xây dựng qua %install (cài đặt: %prep [chuẩn bị], %build [xây dựng], sau đó cài đặt) từ <gói nguồn>"
+
+#: rpmbuild.c:171
 msgid "override build root"
 msgstr "đè lên gốc biên dịch"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "Không thể mở thư mục làm việc hiện thời: %m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "làm xong thì gỡ bỏ cây xây dựng"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "bỏ qua ExcludeArch: các chỉ thị từ tập tin spec"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "gõ lỗi tập tin máy trạng thái"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "không thực thi bất kỳ giai đoạn nào của việc xây dựng"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "không xác nhận quan hệ phụ thuộc khi xây dựng"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "tạo phần đầu gói tương thích với gói rmp phiên bản 3 kiểu cũ"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "không thể thực thi bước %clean để biên dịch"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "không thể thực thi bước %clean để biên dịch"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "không thể thực thi bước %check để biên dịch"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "không chấp nhận chuỗi đã dịch i18n từ tập tin đặc tả"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "làm xong thì cũng gỡ bỏ các nguồn"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "làm xong thì cũng gỡ bỏ tập tin đặc tả"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "bỏ qua thẳng tới giai đoạn định rõ (chỉ cho c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "có quyền cao hơn nền tảng đích"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Tùy chọn xây dựng với [ <tập_tin_đặc_tả> | <kho_tar> | <gói nguồn> ]:"
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "Gặp lỗi khi xây dựng các thành phần phụ thuộc:\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "Không thể mở tập tin đặc tả %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "Gặp lỗi khi mở đường ống tar: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "Nhiều hơn một tập tin mỗi dòng: %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "Lỗi đọc tập tin đặc tả từ %s\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "Lỗi thay đổi tên %s thành %s: %m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "lỗi lấy trạng thái về %s: %m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "Tập tin %s không phải là một tập tin thường.\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
-msgstr "Tập tin %s không hình như tập tin đặc tả.\n"
+msgstr "Tập tin %s hình như không phải là tập tin đặc tả.\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "Đang xây dựng các nền tảng đích: %s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "Đang xây dựng cho nền tảng đích %s\n"
@@ -528,9 +427,7 @@ msgstr "khởi tạo cơ sở dữ liệu"
 
 #: rpmdb.c:27
 msgid "rebuild database inverted lists from installed package headers"
-msgstr ""
-"xây dựng lại các danh sách nghịch chuyển cơ sở dữ liệu từ các phần đầu gói "
-"được cài đặt"
+msgstr "xây dựng lại các danh sách nghịch chuyển cơ sở dữ liệu từ các phần đầu gói được cài đặt"
 
 #: rpmdb.c:30
 msgid "verify database files"
@@ -538,11 +435,11 @@ msgstr "thẩm tra các tập tin cơ sở dữ liệu"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr ""
+msgstr "xuất cơ sở dữ liệu ra danh sách phần đầu đầu ra tiêu chuẩn"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr ""
+msgstr "nhập cơ sở dữ liệu từ danh sách phần đầu đầu vào tiêu chuẩn"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -554,7 +451,7 @@ msgstr "thẩm tra (các) chữ ký của gói"
 
 #: rpmkeys.c:26
 msgid "import an armored public key"
-msgstr "nhập một khoá công bọc sắt"
+msgstr "nhập một khóa công dạng văn bản"
 
 #: rpmkeys.c:28
 msgid "don't import, but tell if it would work or not"
@@ -568,7 +465,7 @@ msgstr "liệt kê các khóa từ chùm chìa khóa RPM"
 msgid "Keyring options:"
 msgstr "Tùy chọn chùm chìa khóa:"
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "chưa đưa ra đối số"
 
@@ -582,16 +479,35 @@ msgstr "ký tên gói (đồng nhất tới --addsign)"
 
 #: rpmsign.c:29
 msgid "delete package signatures"
-msgstr "xoá chữ ký của gói"
+msgstr "xóa chữ ký của gói"
 
 #: rpmsign.c:35
 msgid "Signature options:"
 msgstr "Tùy chọn chữ ký:"
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "Không thể thực hiện %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Bạn phải đặt \"%%_gpg_name\" trong tập tin vĩ lệnh\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "Gõ cụm từ mật khẩu: "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "Cụm từ mật khẩu đúng.\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "Gặp lỗi khi phân tích cú pháp hay khóa gpg đã hết hạn\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -609,7 +525,7 @@ msgstr "thao tác trên gói nhị phân rpm được tạo bởi spec (mặc đ
 msgid "operate on source rpm generated by spec"
 msgstr "thao tác trên gói nguồn rpm được tạo bởi spec"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "dùng định dạng truy vấn theo đây"
 
@@ -656,71 +572,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"Lỗi xây dựng RPM:\n"
+msgstr "\n\nLỗi xây dựng RPM:\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "gặp lỗi cú pháp khi phân tích ==\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "gặp lỗi cú pháp khi phân tích &&\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "gặp lỗi cú pháp khi phân tích ||\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "gặp lỗi phân tích trong biểu thức\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "có dấu ngoặc mở “(” lẻ đôi\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- chỉ với con số\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! chỉ với con số\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "các kiểu phải tương ứng\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / không được hỗ trợ cho chuỗi\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- không được hỗ trợ cho chuỗi\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& và || không được hỗ trợ cho chuỗi\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "gặp lỗi cú pháp trong biểu thức\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "Thiếu dấu ngoặc mở “(” trong %s %s\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "Thiếu dấu ngoặc đóng “)” trong %s(%s\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "Hiệu bài %s không hợp lệ: %s\n"
@@ -730,46 +643,46 @@ msgstr "Hiệu bài %s không hợp lệ: %s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "Thiếu %s trong %s %s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "Không có khoảng trắng theo sau %s(): %s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "Cú pháp sai: %s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "Đặc tả chế độ sai: %s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "Đặc tả dirmode (chế độ thư mục) sai: %s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "Chiều dài miền địa phương không bình thường “%s” trong %%lang(%s)\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "Miền địa phương trùng %s trong %%lang(%s)\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "Dung lượng không hợp lệ: %s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "Hỗ trợ dung lượng tập tin không được biên dịch sẵn\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "Tập tin phải bắt đầu bằng dấu sổ chéo “/”: %s\n"
@@ -779,146 +692,149 @@ msgstr "Tập tin phải bắt đầu bằng dấu sổ chéo “/”: %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "Không hiểu thuật toán băm tập tin %u, quay lại dùng MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "Tập tin được liệt kê hai lần: %s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "gặp lỗi khi đọc liên kết mềm “%s”: %s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
-msgstr "Liên kết tượng trưng chỉ tới BuildRoot (gốc xây dựng): %s -> %s\n"
+msgstr "Liên kết mềm chỉ tới BuildRoot (gốc xây dựng): %s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
-msgstr ""
+msgstr "Đường dẫn nằm ngoài buildroot (gốc xây dựng): %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Không tìm thấy thư mục: %s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Không tìm thấy tập tin: %s\n"
 
-#: build/files.c:1297
-#, fuzzy, c-format
+#: build/files.c:1273
+#, c-format
 msgid "Not a directory: %s\n"
-msgstr "gặp lỗi khi tạo thư mục %s: %s\n"
+msgstr "Không phải là một thư mục: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: không thể nạp thẻ bất thường (%d).\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
-msgstr "%s: lỗi đọc khoá công.\n"
+msgstr "%s: gặp lỗi khi đọc khóa công.\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
-msgstr "%s: không phải là khoá công bọc sắt.\n"
+msgstr "%s: không phải là khóa công dạng văn bản.\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: gặp lỗi khi giải mã\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Tập tin cần có dấu sổ chéo “/” đi trước: %s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "không cho phép %%dev glob: %s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "Glob (chức năng mở rộng mẫu khi tìm kiếm) không tìm thấy thư mục: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Glob (chức năng mở rộng mẫu khi tìm kiếm) không tìm thấy tập tin: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "Không thể mở tập tin %%files %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "dòng: %s\n"
 
-#: build/files.c:1649
-#, fuzzy, c-format
+#: build/files.c:1619
+#, c-format
 msgid "Empty %%files file %s\n"
-msgstr "Phân loại tập tin trống rỗng\n"
+msgstr "Tập tin %%files trống rỗng %s\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "Gặp lỗi khi đang đọc tập tin %%files %s: %m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "_docdir_fmt không hợp lệ %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Không thể trộn lẫn %s đặc biệt với dạng khác: %s\n"
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Nhiều hơn một tập tin mỗi dòng: %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Tập tin sai: %s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "Chủ/nhóm sai: %s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Đang kiểm tra có tập tin chưa đóng gói: %s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"Tìm thấy tập tin đã cài đặt (nhưng chưa đóng gói):\n"
-"%s"
+msgstr "Tìm thấy tập tin đã cài đặt (nhưng chưa đóng gói):\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Đang xử lý tập tin: %s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "Kiến trúc nhị phân (%d) không khớp với kiến trúc gói (%d).\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Nhị phân phụ thuộc kiến trúc trong gói không phụ thuộc kiến trúc\n"
 
@@ -947,79 +863,79 @@ msgstr "%s: dòng: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "Không thể làm hợp quy tắc tên máy: %s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "Không thể nạp lại phần đầu chữ ký.\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Không thể nén phần trọng tải: %s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "Không thể tạo vùng đầu không thể thay đổi được.\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Không thể mở %s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Không thể ghi gói: %s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "Không thể ghi phần đầu tạm\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "Dữ liệu CSA sai\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "Không thể mở tập tin %s: %s\n"
+msgstr "Không thể di chuyển vị trí đọc trong tập tin %s: %s\n"
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s bị lỗi ở tập tin %s: %s\n"
+msgstr "gặp lỗi khi fread ở tập tin %s: %s\n"
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Đã ghi: %s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Thực hiện %s:\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Việc thực hiện %s bị lỗi\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Gặp lỗi khi kiểm tra “%s”.\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Không thể tạo tên tập tin kết xuất cho gói %s: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "không thể tạo %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "dòng %d: %s thứ hai\n"
@@ -1060,9 +976,9 @@ msgid "no description in %%changelog\n"
 msgstr "không có mô tả trong bản ghi thay đổi (%%changelog)\n"
 
 #: build/parseChangelog.c:237
-#, fuzzy, c-format
+#, c-format
 msgid "line %d: second %%changelog\n"
-msgstr "dòng %d: chuẩn bị (%%prep) thứ hai\n"
+msgstr "dòng %d: %%changelog thứ hai\n"
 
 #: build/parseDescription.c:32
 #, c-format
@@ -1070,19 +986,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "dòng %d: Gặp lỗi khi phân tích mô tả (%%description): %s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "dòng %d: Tùy chọn sai %s: %s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "dòng %d: Quá nhiều tên: %s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "dòng %d: Gói không tồn tại: %s\n"
@@ -1093,9 +1009,9 @@ msgid "line %d: Error parsing %%files: %s\n"
 msgstr "dòng %d: Gặp lỗi khi phân tích tập tin (%%files): %s\n"
 
 #: build/parseFiles.c:76
-#, fuzzy, c-format
+#, c-format
 msgid "line %d: second %%files\n"
-msgstr "dòng %d: %s thứ hai\n"
+msgstr "dòng %d: %%files thứ hai\n"
 
 #: build/parsePolicies.c:32
 #, c-format
@@ -1188,97 +1104,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "dòng %d: Thẻ chấp nhận chỉ một hiệu bài: %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "dòng %d: Ký tự không hợp lệ “%c” trong: %s\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "dòng %d: Chuỗi ký tự không hợp lệ \"..\" trong: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "dòng %d: Ký tự không hợp lệ trong: %s\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "dòng %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "dòng %d: Chuỗi ký tự không hợp lệ \"..\" trong: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: dòng: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "dòng %d: Thẻ dạng sai: %s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "dòng %d: Thẻ rỗng: %s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "dòng %d: Tiền tố không nên kết thúc với dấu sổ chéo “/”: %s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
-msgstr ""
-"dòng %d: Docdir (thư mục tài liệu) phải bắt đầu với dấu sổ chéo “/”: %s\n"
+msgstr "dòng %d: Docdir (thư mục tài liệu) phải bắt đầu với dấu sổ chéo “/”: %s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "dòng %d: trường Epoch (Kỷ nguyên) phải là con số không dấu: %s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "dòng %d: %s sai: điều kiện: %s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "dòng %d: định dạng BuildArchitecture (kiến trúc xây dựng) sai: %s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "dòng %d: Chỉ hỗ trợ gói phụ kiểu “noarch” (không có kiến trúc): %s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Lỗi nội bộ: Thẻ giả %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "dòng %d: không tán thành %s: %s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Đặc tả gói sai: %s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "Gói đã sẵn có: %s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "dòng %d: Không rõ thẻ: %s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} không thể là rỗng\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} không thể là \"/\"\n"
@@ -1288,196 +1198,161 @@ msgstr "%%{buildroot} không thể là \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Nguồn sai: %s: %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Không có miếng và số %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%patch mà không có thẻ \"Patch:\" tương ứng\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "Không có số nguồn %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "Không có thẻ \"Source:\" trong tập tin đặc tả\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "Lỗi phân tích thiết lập (%%setup): %s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "dòng %d: Đối số sai tới thiết lập (%%setup): %s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "dòng %d: Tùy chọn thiết lập (%%setup) sai %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Miếng và sô %s không hợp lệ: %s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "dòng %d: chuẩn bị (%%prep) thứ hai\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
-msgstr ""
-"Các thẻ bài về quan hệ phụ thuộc phải bắt đầu với chữ cái, chữ số, dấu gạch "
-"dưới “_” hoặc dấu sổ chéo “/”"
+msgstr "Các thẻ bài về quan hệ phụ thuộc phải bắt đầu với chữ cái, chữ số, dấu gạch dưới “_” hoặc dấu sổ chéo “/”"
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "Không cho phép tên tập tin đặt phiên bản"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "phần phụ thuộc không hợp lệ"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "Yêu cầu phiên bản"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "phần phụ thuộc không hợp lệ"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "dòng %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "dòng %d: các bẫy phải có --: %s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "dòng %d: Lỗi phân tích %s: %s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "dòng %d: văn lệnh nội tại phải kết thúc bằng “>”: %s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
-msgstr ""
-"dòng %d: Chương trình đặt văn lệnh phải bắt đầu với dấu sổ chéo “/”: %s\n"
+msgstr "dòng %d: Chương trình đặt văn lệnh phải bắt đầu với dấu sổ chéo “/”: %s\n"
 
-#: build/parseScript.c:298
-#, fuzzy, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr "dòng %d: phiên dịch tham số không được phép trong bẫy: %s\n"
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "dòng %d: %s thứ hai\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "dòng %d: văn lệnh nội bộ không được hỗ trợ: %s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "dòng %d: phiên dịch tham số không được phép trong bẫy: %s\n"
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "dòng %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Không thể mở %s: %s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Cần đối số cho %s\n"
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "dòng %d: Chưa đóng %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "dòng %d: chưa đóng vĩ lệnh hoặc dòng kéo dài sai\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr "%s:%d: điều kiện %%if sai\n"
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d: Có một toán tử %%else (nếu không) mà không có %%if (nếu)\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d: Có một toán tử %%endif (kết thúc nếu) mà không có %%if (nếu)\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: câu lệnh bao gồm (%%include) sai dạng\n"
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "Không tìm thấy kiến trúc tương thích để xây dựng\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Gói không có mô tả (%%description): %s\n"
@@ -1521,9 +1396,7 @@ msgstr "Gặp lỗi khi dò tìm tên chính sách: %s\n"
 msgid ""
 "'%s' type given with other types in %%semodule %s. Compacting types to "
 "'%s'.\n"
-msgstr ""
-"kiểu “%s” đưa ra với kiểu khác trong %%semodule %s. Tóm lược các kiểu thành "
-"“%s”.\n"
+msgstr "kiểu “%s” đưa ra với kiểu khác trong %%semodule %s. Tóm lược các kiểu thành “%s”.\n"
 
 #: build/policies.c:246
 #, c-format
@@ -1550,288 +1423,291 @@ msgstr "Quá nhiều đối số trong dòng: %s\n"
 msgid "Processing policies: %s\n"
 msgstr "Thực hiện các chính sách: %s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Bỏ qua biểu thức chính quy không hợp lệ %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Không thể tạo ống dẫn cho %s: %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "Không thể thực hiện %s: %s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Không thể tạo tiến trình con %s: %s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s bị lỗi: %x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "gặp lỗi khi toàn bộ dữ liệu vào %s: %s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
-msgstr ""
+msgstr "thao tác sai"
 
-#: build/rpmfc.c:472
-#, fuzzy
+#: build/rpmfc.c:474
 msgid "bad format"
-msgstr "định dạng thẻ trống"
+msgstr "định dạng sai"
 
-#: build/rpmfc.c:539
-#, fuzzy, c-format
+#: build/rpmfc.c:540
+#, c-format
 msgid "invalid dependency (%s): %s\n"
-msgstr "phần phụ thuộc không hợp lệ"
+msgstr "phần phụ thuộc không hợp lệ (%s): %s\n"
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "Việc chuyển đổi %s sang số nguyên dài gặp lỗi.\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "Phân loại tập tin trống rỗng\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "Chưa có các thuộc tính tập tin được cấu hình\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) bị lỗi: %s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load gặp lỗi: %s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Gặp lỗi khi chấp nhận tập tin \"%s\": chế độ %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Đang tìm  %s: %s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Gặp lỗi khi tìm %s:\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "lỗi truy vấn tập tin đặc tả %s nên không phân tích được\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s là một Delta RPM và không thể được cài đặt trực tiếp\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Không hỗ trợ phần tải (%s) trong gói %s\n"
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "gói %s đã được thêm vào nên bỏ qua %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "gói %s đã được thêm vào nên thay thế bằng %s\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(không phải con số)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(không phải base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(kiểu không hợp lệ)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(không phải blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(kiểu XML không hợp lệ)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(không phải chữ ký OpenPGP)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ngày không hợp lệ %u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "thông thường"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "đã thay thế"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "chưa cài đặt"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "chia sẻ qua mạng"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "màu sai"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "thiếu"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(không hiểu)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(không phải chuỗi)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s được lưu dạng %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s được tạo dạng %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: gặp lỗi khi gỡ bỏ: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "thư mục"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "tập tin"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
-#, fuzzy, c-format
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr "%s có chữ ký không thể xác minh tra được"
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
-msgstr "thẻ [%d]: SAI, thẻ %d kiểu %d bù %d số lượng %d\n"
+msgstr "thẻ [%d]: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:192
-#, fuzzy
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
-msgstr "hdr SHA1: SAI, không phải thập lục\n"
-
-#: lib/package.c:204
-#, fuzzy
-msgid "hdr RSA: BAD, not binary"
-msgstr "hdr RSA: SAI, không phải nhị phân\n"
+msgstr "hdr SHA1: SAI, không phải thập lục"
 
 #: lib/package.c:214
-#, fuzzy
+msgid "hdr RSA: BAD, not binary"
+msgstr "hdr RSA: SAI, không phải nhị phân"
+
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
-msgstr "hdr DSA: SAI, không phải nhị phân\n"
+msgstr "hdr DSA: SAI, không phải nhị phân"
 
-#: lib/package.c:292
-#, fuzzy, c-format
+#: lib/package.c:313
+#, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
-msgstr "thẻ vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d\n"
+msgstr "thẻ vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:301
-#, fuzzy, c-format
+#: lib/package.c:322
+#, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
-msgstr "bù vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d\n"
+msgstr "bù vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:320
-#, fuzzy, c-format
+#: lib/package.c:341
+#, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
-msgstr "vùng theo đuôi: SAI, thẻ %d kiểu %d bù %d số lượng %d\n"
+msgstr "vùng theo đuôi: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/package.c:329
-#, fuzzy, c-format
+#: lib/package.c:350
+#, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
-msgstr "kích cỡ vùng: SAI, ril(%d) > il(%d)\n"
+msgstr "kích cỡ vùng: SAI, ril(%d) > il(%d)"
 
-#: lib/package.c:360
-#, fuzzy, c-format
+#: lib/package.c:381
+#, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
-msgstr "kích cỡ blob (%d): SAI, 8 + 16 * il(%d) + dl(%d)\n"
+msgstr "kích cỡ blob (%d): SAI, 8 + 16 * il(%d) + dl(%d)"
 
-#: lib/package.c:437
-#, fuzzy, c-format
+#: lib/package.c:458
+#, c-format
 msgid "hdr size(%d): BAD, read returned %d"
-msgstr "kích cỡ hdr (%d): SAI, hàm đọc đã trả về %d\n"
-
-#: lib/package.c:441
-#, fuzzy
-msgid "hdr magic: BAD"
-msgstr "ma thuật hdr: SAI\n"
-
-#: lib/package.c:446
-#, fuzzy, c-format
-msgid "hdr tags: BAD, no. of tags(%d) out of range"
-msgstr "thẻ hdr: SAI, tổng số thẻ (%d) ở ngoài phạm vi\n"
-
-#: lib/package.c:452
-#, fuzzy, c-format
-msgid "hdr data: BAD, no. of bytes(%d) out of range"
-msgstr "dữ liệu hdr: SAI, tổng số byte (%d) ở ngoài phạm vi\n"
+msgstr "kích cỡ hdr (%d): SAI, hàm đọc đã trả về %d"
 
 #: lib/package.c:462
-#, fuzzy, c-format
-msgid "hdr blob(%zd): BAD, read returned %d"
-msgstr "hdr blob(%zd): SAI, việc đọc trả về %d\n"
+msgid "hdr magic: BAD"
+msgstr "ma thuật hdr: SAI"
 
-#: lib/package.c:475
-#, fuzzy
+#: lib/package.c:467
+#, c-format
+msgid "hdr tags: BAD, no. of tags(%d) out of range"
+msgstr "thẻ hdr: SAI, tổng số thẻ (%d) ở ngoài phạm vi"
+
+#: lib/package.c:473
+#, c-format
+msgid "hdr data: BAD, no. of bytes(%d) out of range"
+msgstr "dữ liệu hdr: SAI, tổng số byte (%d) ở ngoài phạm vi"
+
+#: lib/package.c:483
+#, c-format
+msgid "hdr blob(%zd): BAD, read returned %d"
+msgstr "hdr blob(%zd): SAI, việc đọc trả về %d"
+
+#: lib/package.c:496
 msgid "hdr load: BAD"
-msgstr "nạp hdr: SAI\n"
+msgstr "tải hdr: SAI"
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "Fread bị lỗi: %s"
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
-msgstr ""
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgstr "%s: lỗi: đã cho nhiều hơn một --pipe (bí danh popt không tương thích?)\n"
 
 #: lib/poptALL.c:175
 msgid "predefine MACRO with value EXPR"
@@ -1863,15 +1739,15 @@ msgstr "“B_THỨC”"
 
 #: lib/poptALL.c:187 lib/poptALL.c:206
 msgid "read <FILE:...> instead of default file(s)"
-msgstr "đọc <TẬP TIN:...> thay cho (những) tập tin mặc định"
+msgstr "đọc <TẬP TIN:…> thay cho (những) tập tin mặc định"
 
 #: lib/poptALL.c:188 lib/poptALL.c:207
 msgid "<FILE:...>"
-msgstr "<TẬP-TIN:...>"
+msgstr "<TẬP-TIN:…>"
 
 #: lib/poptALL.c:193
 msgid "don't enable any plugins"
-msgstr ""
+msgstr "không thể bật bất kỳ phần bổ xung nào"
 
 #: lib/poptALL.c:196
 msgid "don't verify package digest(s)"
@@ -1883,7 +1759,7 @@ msgstr "không thẩm tra phần đầu cơ sở dữ liệu khi tìm được"
 
 #: lib/poptALL.c:200
 msgid "don't verify package signature(s)"
-msgstr "không thẩm tra chữ ký gói"
+msgstr "không xác minh chữ ký gói"
 
 #: lib/poptALL.c:203
 msgid "send stdout to CMD"
@@ -1895,7 +1771,7 @@ msgstr "LỆNH"
 
 #: lib/poptALL.c:209
 msgid "use ROOT as top level directory"
-msgstr "dùng GỐC là thư mục cấp đầu"
+msgstr "dùng GỐC là thư mục cấp cao nhất"
 
 #: lib/poptALL.c:210
 msgid "ROOT"
@@ -1948,33 +1824,30 @@ msgstr "đường dẫn loại trừ phải bắt đầu với dấu sổ chéo 
 
 #: lib/poptI.c:64
 msgid "relocations must begin with a /"
-msgstr "sự định vị lại phải bắt đầu với dấu sổ chéo “/”"
+msgstr "sự tái định vị phải bắt đầu với dấu sổ chéo “/”"
 
 #: lib/poptI.c:67
 msgid "relocations must contain a ="
-msgstr "sự định vị lại phải chứa một dấu bằng “=”"
+msgstr "sự tái định vị phải chứa một dấu bằng “=”"
 
 #: lib/poptI.c:70
 msgid "relocations must have a / following the ="
-msgstr "sự định vị lại phải có một dấu sổ chéo “/” theo sau dấu bằng “=”"
+msgstr "sự tái định vị phải có một dấu sổ chéo “/” theo sau dấu bằng “=”"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
-msgstr ""
-"cài đặt tất cả các tập tin, ngay cả cấu hình mà có thể bị bỏ qua bằng cách "
-"khác"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
+msgstr "cài đặt tất cả các tập tin, ngay cả cấu hình mà có thể bị bỏ qua bằng cách khác"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"gỡ bỏ tất cả các gói tương ứng với <gói> (thường thì một lỗi phát sinh nếu "
-"<gói> định rõ nhiều gói)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "gỡ bỏ tất cả các gói tương ứng với <gói> (thường thì một lỗi phát sinh nếu <gói> định rõ nhiều gói)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
-msgstr "định vị lại các tập tin trong gói không thể định vị lại"
+msgstr "tái định vị các tập tin trong gói không thể tái định vị"
 
 #: lib/poptI.c:127
 msgid "print dependency loops as warning"
@@ -1982,7 +1855,7 @@ msgstr "in dạng cảnh báo các vòng lặp của quan hệ phụ thuộc"
 
 #: lib/poptI.c:131
 msgid "erase (uninstall) package"
-msgstr "xoá (gỡ bỏ) gói"
+msgstr "xóa (gỡ bỏ) gói"
 
 #: lib/poptI.c:131
 msgid "<package>+"
@@ -1998,11 +1871,11 @@ msgstr "không cài đặt tài liệu hướng dẫn"
 
 #: lib/poptI.c:139
 msgid "skip files with leading component <path> "
-msgstr "bỏ qua các tập tin với bộ phận hướng dẫn <đường dẫn>"
+msgstr "bỏ qua các tập tin với bộ phận hướng dẫn <đường_dẫn>"
 
 #: lib/poptI.c:140
 msgid "<path>"
-msgstr "<đường dẫn>"
+msgstr "<đường_dẫn>"
 
 #: lib/poptI.c:143
 msgid "short hand for --replacepkgs --replacefiles"
@@ -2048,7 +1921,7 @@ msgstr "cập nhật cơ sở dữ liệu, mà không sửa đổi hệ thống 
 msgid "do not verify package dependencies"
 msgstr "không thẩm tra quan hệ phụ thuộc giữa các gói"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "không thẩm tra mã băm của tập tin"
 
@@ -2089,14 +1962,14 @@ msgid "do not execute %%postun scriptlet (if any)"
 msgstr "không thực hiện văn lệnh nhỏ %%postun (nếu có)"
 
 #: lib/poptI.c:207
-#, fuzzy, c-format
+#, c-format
 msgid "do not execute %%pretrans scriptlet (if any)"
-msgstr "không thực hiện văn lệnh nhỏ %%preun (nếu có)"
+msgstr "không thực hiện văn lệnh nhỏ %%pretrans (nếu có)"
 
 #: lib/poptI.c:210
-#, fuzzy, c-format
+#, c-format
 msgid "do not execute %%posttrans scriptlet (if any)"
-msgstr "không thực hiện văn lệnh nhỏ %%postun (nếu có)"
+msgstr "không thực hiện văn lệnh nhỏ %%postrans (nếu có)"
 
 #: lib/poptI.c:213
 msgid "do not execute any scriptlet(s) triggered by this package"
@@ -2105,8 +1978,7 @@ msgstr "không chạy bất kỳ văn lệnh nhỏ nào được gói này kích
 #: lib/poptI.c:216
 #, c-format
 msgid "do not execute any %%triggerprein scriptlet(s)"
-msgstr ""
-"không chạy bất kỳ văn lệnh nhỏ cài đặt sẵn đã kích hoạt (%%triggerprein)"
+msgstr "không chạy bất kỳ văn lệnh nhỏ cài đặt sẵn đã kích hoạt (%%triggerprein)"
 
 #: lib/poptI.c:219
 #, c-format
@@ -2116,20 +1988,18 @@ msgstr "không chạy bất kỳ văn lệnh nhỏ cài đặt đã kích hoạt
 #: lib/poptI.c:222
 #, c-format
 msgid "do not execute any %%triggerun scriptlet(s)"
-msgstr "không chạy bất kỳ văn lệnh nhỏ xoá đã kích hoạt (%%triggerun)"
+msgstr "không chạy bất kỳ văn lệnh nhỏ xóa đã kích hoạt (%%triggerun)"
 
 #: lib/poptI.c:225
 #, c-format
 msgid "do not execute any %%triggerpostun scriptlet(s)"
-msgstr "không chạy bất kỳ vi văn lệnh xoá cuối đã kích hoạt (%%triggerpostun)"
+msgstr "không chạy bất kỳ vi văn lệnh xóa cuối đã kích hoạt (%%triggerpostun)"
 
 #: lib/poptI.c:229
 msgid ""
 "upgrade to an old version of the package (--force on upgrades does this "
 "automatically)"
-msgstr ""
-"hạ cấp xuống một phiên bản cũ của gói (tùy chọn “--force” khi nâng cấp thì "
-"tự động làm)"
+msgstr "hạ cấp xuống một phiên bản cũ của gói (tùy chọn “--force” khi nâng cấp thì tự động làm)"
 
 #: lib/poptI.c:233
 msgid "print percentages as package installs"
@@ -2137,7 +2007,7 @@ msgstr "in ra phần trăm trong khi cài đặt gói"
 
 #: lib/poptI.c:235
 msgid "relocate the package to <dir>, if relocatable"
-msgstr "có thể định vị lại thì chuyển gói vào <thư_mục>"
+msgstr "có thể tái định vị thì chuyển gói vào <thư_mục>"
 
 #: lib/poptI.c:236
 msgid "<dir>"
@@ -2145,7 +2015,7 @@ msgstr "<th.mục>"
 
 #: lib/poptI.c:238
 msgid "relocate files from path <old> to <new>"
-msgstr "định vị lại các tập tin từ đường dẫn <cũ> tới <mới>"
+msgstr "tái định vị các tập tin từ đường dẫn <cũ> tới <mới>"
 
 #: lib/poptI.c:239
 msgid "<old>=<new>"
@@ -2168,186 +2038,165 @@ msgid "upgrade package(s)"
 msgstr "nâng cấp gói"
 
 #: lib/poptI.c:254
-#, fuzzy
 msgid "reinstall package(s)"
-msgstr "cài đặt gói"
+msgstr "cài đặt lại (các) gói"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "truy vấn/thẩm tra mọi gói"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "chế độ kiểm tra chữ ký RPM"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "truy vấn/thẩm tra (những) gói nào sở hữu tập tin"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "truy vấn/thẩm tra (các) gói trong nhóm"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "truy vấn/thẩm tra một tập tin gói"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
-msgstr "truy vấn/thẩm tra (các) gói với đồ nhận diện gói"
+msgstr "truy vấn/thẩm tra (các) gói với định danh gói"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
-msgstr "truy vấn/thẩm tra (các) gói với đồ nhận diện phần đầu"
+msgstr "truy vấn/thẩm tra (các) gói với định danh phần đầu"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "chế độ truy vấn RPM"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "truy vấn/thẩm tra một phần đầu cụ thể"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "truy vấn/thẩm tra (các) gói từ giao dịch cài đặt"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "truy vấn (các) gói được gói kích hoạt"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "chế độ thẩm tra RPM"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "truy vấn/thẩm tra (các) gói mà thỏa một quan hệ phụ thuộc"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "truy vấn/thẩm tra (các) gói mà cần thiết quan hệ phụ thuộc"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "không glob đối số"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "không xử lý dạng bản kê tập tin không phải gói "
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "liệt kê mọi tập tin cấu hình"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "liệt kê mọi tập tin tài liệu hướng dẫn"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr "liệt kê mọi tập tin giấy phép"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "đổ thông tin tập tin cơ bản"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "liệt kê các tập tin trong gói"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "bỏ qua các tập tin ma (%%ghost)"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "hiển thị các tình trạng của những tập tin đã liệt kê"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "không thẩm tra kích cỡ của tập tin"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
-msgstr "không thẩm tra đường dẫn liên kết tượng trưng của tập tin"
+msgstr "không thẩm tra đường dẫn liên kết mềm của tập tin"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "không thẩm tra người sở hữu tập tin"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "không thẩm tra nhóm của tập tin"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "không thẩm tra thời gian sửa đổi của tập tin"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "không thẩm tra chế độ của tập tin"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "không thể thẩm tra kích cỡ của các tập tin"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "không thẩm tra ngữ cảnh bảo mật của tập tin"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "không thẩm tra các tập tin trong gói"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "không thẩm tra các quan hệ phụ thuộc của gói"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "không chạy văn lệnh thẩm tra"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Thiếu tính năng rpmlib cho %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "cần gói nguồn còn tìm thấy gói nhị phân\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "gói nguồn không chứa tập tin đặc tả\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "lỗi giải nén kho %s%s: %s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr " ở tập tin"
 
@@ -2422,119 +2271,99 @@ msgstr "không có gói tương ứng với %s: %s\n"
 msgid "no package requires %s\n"
 msgstr "không có gói cần thiết %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "không có gói cần thiết %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "không có bộ gây nên gói %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "không có gói cần thiết %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "không có gói cần thiết %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "không có gói cung cấp %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "tập tin %s: %s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "tập tin %s không được bất kỳ gói sở hưu\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "số thứ tự gói không hợp lệ: %s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "không thể đọc mục ghi %u\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "chưa cài đặt gói %s\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "không hiểu thẻ: “%s”\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: gặp lỗi khi nhập khóa %d.\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
-msgstr "%s: khóa %d không phải là khoá công dạng văn bản.\n"
+msgstr "%s: khóa %d không phải là khóa công dạng văn bản.\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: lỗi đọc khi nhập (%d).\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: gặp lỗi khi headerRead: %s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr "%s: Vùng phần đầu không thay đổi không thể đọc được. Gói đã hỏng?\n"
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s: Fread bị lỗi: %s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "KHÔNG_ĐƯỢC"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "OK"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
-msgstr " (KHOÁ BỊ THIẾU:"
+msgstr " (KHÓA BỊ THIẾU:"
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
-msgstr " (KHOÁ KHÔNG TIN CẬY:"
+msgstr " (KHÓA KHÔNG TIN CẬY:"
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
-msgstr "%s: lỗi mở: %s\n"
+msgstr "%s: gặp lỗi khi mở: %s\n"
 
 #: lib/rpmchroot.c:43
 #, c-format
@@ -2556,202 +2385,144 @@ msgstr "Không thể chuyển đổi thư mục gốc: %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "Không thể phục hồi thư mục gốc: %m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "KHÔNG "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "CÓ"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
-msgstr ""
-"Cả kiểu quan hệ phụ thuộc PreReq: (điều kiện tiên quyết), Provides: (cung "
-"cấp) và Obsoletes: (làm cũ) đều hỗ trợ phiên bản."
+msgstr "Cả kiểu quan hệ phụ thuộc PreReq: (điều kiện tiên quyết), Provides: (cung cấp) và Obsoletes: (làm cũ) đều hỗ trợ phiên bản."
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
-msgstr ""
-"tên tập tin được cất giữ dạng một đối tượng dữ liệu đa thành phần (dirName,"
-"baseName,dirIndex), không phải dạng đường dẫn."
+msgstr "tên tập tin được cất giữ dạng một đối tượng dữ liệu đa thành phần (dirName,baseName,dirIndex), không phải dạng đường dẫn."
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "trọng tải của gói có thể được nén bằng bzip2."
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "trọng tải gói cũng có thể được nén bằng xz."
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "trọng tải gói cũng có thể được nén bằng lzma."
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "tập tin trọng tải gói có tiền tố “./”."
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "không cung cấp dứt khoát tên-phiên_bản-bản_phát_hành của gói."
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "các thẻ của phần đầu luôn được sắp xếp sau khi được nạp."
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "bộ phiên dịch vi văn lệnh có thể sử dụng các đối số từ phần đầu."
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
-msgstr ""
-"một bộ tập tin đường liên kết cứng chưa hoàn toàn cũng có thể được cài đặt"
+msgstr "một bộ tập tin đường liên kết cứng chưa hoàn toàn cũng có thể được cài đặt"
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
-msgstr ""
-"vi văn lệnh của gói cũng có thể truy cập cơ sở dữ liệu RPM trong khi cài đặt."
+msgstr "vi văn lệnh của gói cũng có thể truy cập cơ sở dữ liệu RPM trong khi cài đặt."
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "bản thân có hỗ trợ văn lệnh lua."
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr "thuật toán băm tập tin là có phụ thuộc vào cấu hình từng gói"
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr "hỗ trợ cho dung lượng tập tin POSIX.1e"
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr "scriptlets gói có thể được khai triển lúc cài đặt."
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr "hỗ trợ so sánh phiên bản phụ thuộc với dấu sóng ~."
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
-msgstr ""
+msgstr "Hỗ trợ các tập tin lớn hơn 4GB"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "không thẩm tra quan hệ phụ thuộc giữa các gói"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "Yêu cầu phiên bản"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "phần phụ thuộc không hợp lệ"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "%c chưa chấm dứt: %s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "phần phụ thuộc không hợp lệ"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "người dùng %s không tồn tại nên dùng người chủ (root)\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "nhóm %s không tồn tại nên dùng người chủ (root)\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Ma thuật sai"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "Phần đầu sai hoặc không đọc được"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "Kích cỡ phần đầu quá lớn "
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "Tập tin quá lớn để nén"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "Không rõ kiểu tập tin"
 
-#: lib/rpmfi.c:2221
-#, fuzzy
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
-msgstr "Thiếu liên kết cứng"
+msgstr "Thiếu các tập tin"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "Mã băm tập tin không khớp"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "Lỗi nội bộ"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "Tập tin kho lưu không phải trong phần đầu"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " bị lỗi — "
 
-#: lib/rpmfi.c:2235
-#, fuzzy, c-format
+#: lib/rpmfi.c:2152
+#, c-format
 msgid "%s: (error 0x%x)"
-msgstr "(lỗi 0x%x)"
+msgstr "%s: (lỗi 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "lỗi mở %s: %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: không phải là gói rpm (hoặc manifest gói)\n"
@@ -2759,20 +2530,20 @@ msgstr "%s: không phải là gói rpm (hoặc manifest gói)\n"
 #: lib/rpminstall.c:141
 #, c-format
 msgid "Updating / installing...\n"
-msgstr "Đang cài đặt hay nâng cấp...\n"
+msgstr "Đang cài đặt hay nâng cấp…\n"
 
 #: lib/rpminstall.c:143
 #, c-format
 msgid "Cleaning up / removing...\n"
-msgstr "Đang xóa bỏ hay tẩy các đặc quyền...\n"
+msgstr "Đang dọn dẹp hoặc gỡ bỏ…\n"
 
 #: lib/rpminstall.c:192
 msgid "Preparing..."
-msgstr "Đang chuẩn bị..."
+msgstr "Đang chuẩn bị…"
 
 #: lib/rpminstall.c:194
 msgid "Preparing packages..."
-msgstr "Đang chuẩn bị các gói..."
+msgstr "Đang chuẩn bị các gói…"
 
 #: lib/rpminstall.c:270 tools/rpmgraph.c:168
 msgid "Failed dependencies:\n"
@@ -2783,42 +2554,42 @@ msgstr "Quan hệ phụ thuộc bị lỗi:\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: không phải là gói rpm (hoặc manifest gói): %s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s không thể được cài đặt\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "Đang lấy %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "bỏ qua %s - bộ truyền gặp lỗi\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
-msgstr "không thể định vị lại gói %s\n"
+msgstr "không thể tái định vị gói %s\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "gặp lỗi khi đọc từ tập tin %s\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "“%s” chỉ định nhiều gói:\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "không thể mở %s: %s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "Đang cài đặt %s\n"
@@ -2844,15 +2615,15 @@ msgstr "gặp lỗi khi đọc: %s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "không phải là gói rpm\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
-msgstr "không thể tạo khoá %s trên %s (%s)\n"
+msgstr "không thể tạo khóa %s trên %s (%s)\n"
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
-msgstr "đang đợi %s khoá %s\n"
+msgstr "đang đợi %s khóa %s\n"
 
 #: lib/rpmplugins.c:65
 #, c-format
@@ -2865,9 +2636,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Gặp lỗi khi phân giải ký hiệu %s: %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "Phần bổ xung %s chưa được tải\n"
+msgstr "Chưa cấu hình phần bổ xung %%__%s_%s\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2896,7 +2667,7 @@ msgstr "gói %s đã được cài đặt"
 #: lib/rpmprob.c:125
 #, c-format
 msgid "path %s in package %s is not relocatable"
-msgstr "không thể định vị lại đường dẫn %s trong gói %s"
+msgstr "không thể tái định vị đường dẫn %s trong gói %s"
 
 #: lib/rpmprob.c:130
 #, c-format
@@ -3011,75 +2782,56 @@ msgstr "tùy chọn sai “%s” tại %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "Gặp lỗi khi đọc véc tơ bổ trợ, /proc đã gắn chưa?\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "Không hiểu hệ thống: %s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "Hãy liên lạc %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "Không thể mở %s để đọc: %m.\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Không thể phục hồi thư mục hiện tại: %m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "chưa hỗ trợ <lua> scriptlet dựng sẵn\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "Không thể tạo tập tin tạm cho %s: %s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "Không thể nhân bản bộ mô tả tập tin: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "Không thể đọc biểu tượng %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "Không thể phục hồi thư mục gốc: %m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite bị lỗi: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s scriptlet gặp lỗi, waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s scriptlet gặp lỗi, tín hiệu %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s scriptlet gặp lỗi, trạng thái thoát %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "Không hiểu định dạng"
 
@@ -3091,146 +2843,127 @@ msgstr "cài đặt"
 msgid "erase"
 msgstr "tẩy"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "không thể mở cơ sở dữ liệu Gói trong %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "thừa “(” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "thiếu “(” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "thiếu “)” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
-msgstr "%s: gặp lỗi khi đọc khoá công khai.\n"
+msgstr "%s: gặp lỗi khi đọc khóa công khai.\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "giao dịch"
 
-#: lib/signature.c:77
+#: lib/signature.c:74
 #, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(không phải chữ ký OpenPGP)"
-
-#: lib/signature.c:159
-#, fuzzy, c-format
 msgid "sigh size(%d): BAD, read returned %d"
-msgstr "kích cỡ sigh (%d): SAI, hàm đọc đã trả về %d\n"
+msgstr "kích cỡ sigh (%d): SAI, hàm đọc đã trả về %d"
 
-#: lib/signature.c:164
-#, fuzzy
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
-msgstr "ma thuật sigh: SAI\n"
+msgstr "ma thuật sigh: SAI"
 
-#: lib/signature.c:170
-#, fuzzy, c-format
+#: lib/signature.c:85
+#, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
-msgstr "thẻ sigh: SAI, tổng số thẻ (%d) ở ngoài phạm vi\n"
+msgstr "thẻ sigh: SAI, tổng số thẻ (%d) ở ngoài phạm vi"
 
-#: lib/signature.c:176
-#, fuzzy, c-format
+#: lib/signature.c:91
+#, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
-msgstr "dữ liệu sigh: SAI, tổng số byte (%d) ở ngoài phạm vi\n"
+msgstr "dữ liệu sigh: SAI, tổng số byte (%d) ở ngoài phạm vi"
 
-#: lib/signature.c:191
-#, fuzzy, c-format
+#: lib/signature.c:106
+#, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
-msgstr "sigh blob(%d): SAI, hàm đọc đã trả về %d\n"
+msgstr "sigh blob(%d): SAI, hàm đọc đã trả về %d"
 
-#: lib/signature.c:208
-#, fuzzy, c-format
+#: lib/signature.c:123
+#, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
-msgstr "thẻ sigh [%d]: SAI, thẻ %d kiểu %d bù %d số lượng %d\n"
+msgstr "thẻ sigh [%d]: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/signature.c:218
-#, fuzzy
+#: lib/signature.c:133
 msgid "sigh load: BAD"
-msgstr "phần tải sigh: SAI\n"
+msgstr "phần tải sigh: SAI"
 
-#: lib/signature.c:232
-#, fuzzy, c-format
+#: lib/signature.c:146
+#, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
-msgstr "đệm sigh(%zd): SAI, đọc %zd byte\n"
+msgstr "đệm sigh(%zd): SAI, đọc %zd byte"
 
-#: lib/signature.c:248
-#, fuzzy, c-format
+#: lib/signature.c:162
+#, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
-msgstr "sigh sigSize(%zd): SAI, hàm fstat(2) gặp lỗi\n"
+msgstr "sigh sigSize(%zd): SAI, hàm fstat(2) gặp lỗi"
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "Phần đầu"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "Mã băm MD5:"
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "Mã băm SHA1 phần đầu:"
 
-#: lib/signature.c:399
-#, fuzzy, c-format
-msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
-msgstr "Xác minh chữ ký: CÁC ĐỐI SỐ SAI (%d %p %d %p %p)\n"
+#: lib/signature.c:316
+msgid "Header "
+msgstr "Phần đầu"
 
-#: lib/transaction.c:1360
+#: lib/signature.c:357
+#, c-format
+msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
+msgstr "Xác minh chữ ký: CÁC ĐỐI SỐ SAI (%d %p %d %p %p)"
+
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "bị bỏ qua"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "gặp lỗi"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
-msgstr ""
+msgstr "Trùng tài khoản hoặc mã số người dùng cho tài khoản %s\n"
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
-msgstr ""
+msgstr "Trùng tên nhóm hoặc mã số nhóm cho nhóm %s\n"
 
-#: lib/verify.c:377
-#, fuzzy
+#: lib/verify.c:371
 msgid "no state"
-msgstr "(không có tình trạng)"
+msgstr "không có tình trạng"
 
-#: lib/verify.c:379
-#, fuzzy
+#: lib/verify.c:373
 msgid "unknown state"
-msgstr "thẻ không rõ"
+msgstr "trạng thái không rõ"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "thiếu   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "Quan hệ phụ thuộc chưa thỏa đối với %s:\n"
@@ -3302,246 +3035,242 @@ msgstr "đồ lặp lại mảng được sử dụng với các mảng có kíc
 #: lib/rpmdb.c:71
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
-msgstr "Đang tạo %d thiếu mục lục, vui lòng chờ...\n"
+msgstr "Đang tạo %d thiếu mục lục, vui lòng chờ…\n"
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
-#, fuzzy, c-format
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
-msgstr "không thể mở bảng mục lục %s dùng db%d - %s (%d)\n"
+msgstr "không thể mở bảng mục lục %s dùng %s - %s (%d)\n"
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "chưa đặt đường dẫn cơ sở dữ liệu (dbpath)\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: bỏ qua"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "gặp lỗi (%d) khi lưu bản ghi #%d vào %s\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec (thực hiện biểu thức chính quy) bị lỗi: %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp bị lỗi: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: bỏ qua"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: nhận được phần đầu bị hỏng #%u -- bỏ qua.\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: không thể đọc phần đầu ở 0x%x\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "chưa đặt đường dẫn cơ sở dữ liệu (dbpath)"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "gặp lỗi khi tạo thư mục %s: %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "phần đầu #%u trong cơ sở dữ liệu là sai -- bỏ qua.\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "không thể thêm bản ghi nguyên gốc tại %u\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
-msgstr ""
-"gặp lỗi khi xây dựng lại cơ sở dữ liệu: cơ sỏ dữ liệu nguyên gốc được giữ "
-"lại để thay thế\n"
+msgstr "gặp lỗi khi xây dựng lại cơ sở dữ liệu: cơ sỏ dữ liệu nguyên gốc được giữ lại để thay thế\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "gặp lỗi khi thay thế cơ sở dữ liệu cũ bằng cái mới!\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "thay thế các tập tin trong %s bằng các tập tin từ %s để phục hồi"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "gặp lỗi khi xóa thư mục %s: %s\n"
 
-#: lib/backend/db3.c:96
-#, fuzzy, c-format
+#: lib/backend/db3.c:36
+#, c-format
 msgid "%s error(%d) from %s: %s\n"
-msgstr "db%d lỗi(%d) từ %s: %s\n"
+msgstr "%s lỗi(%d) từ %s: %s\n"
 
-#: lib/backend/db3.c:99
-#, fuzzy, c-format
+#: lib/backend/db3.c:39
+#, c-format
 msgid "%s error(%d): %s\n"
-msgstr "db%d lỗi(%d): %s\n"
+msgstr "%s lỗi(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "không nhận ra tùy chọn cơ sở dữ liệu “%s” nên bỏ qua.\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s có giá trị thuộc số không hợp lệ nên bỏ qua\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s có giá trị dài quá lớn hoặc quá nhỏ nên bỏ qua\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s có giá trị nguyên quá lớn hoặc quá nhỏ nên bỏ qua\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
-msgstr "không thể lấy khoá %s ở %s/%s\n"
+msgstr "không thể lấy khóa %s ở %s/%s\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "chung"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "độc quyền"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "kiểu bảng mục mục không hợp lệ %x trên %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "gặp lỗi (%d) khi lấy bản ghi \"%s\" từ chỉ mục %s: %s\n"
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "gặp lỗi (%d) khi ghi bản ghi %s vào %s\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "Gặp lỗi (%d) khi gỡ bỏ bản ghi “%s” ra khỏi %s\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "lỗi (%d) khi thêm bản ghi phần đầu #%d\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "lỗi (%d) khi gỡ bỏ bản ghi phần đầu #%d\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "lỗi (%d) phân bỏ minh dụ gói mới\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "không nhận ra tùy chọn cơ sở dữ liệu “%s” nên bỏ qua.\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s có giá trị thuộc số không hợp lệ nên bỏ qua\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s có giá trị dài quá lớn hoặc quá nhỏ nên bỏ qua\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s có giá trị nguyên quá lớn hoặc quá nhỏ nên bỏ qua\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s (trống)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s (trống)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Vĩ lệnh %%%s có tùy chọn chưa chấm dứt\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Vĩ lệnh %%%s có thân chưa chấm dứt\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "Vĩ lệnh %%%s có tên không hợp lệ (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Vĩ lệnh %%%s có thân rỗng\n"
 
-#: rpmio/macro.c:574
-#, fuzzy, c-format
+#: rpmio/macro.c:573
+#, c-format
 msgid "Macro %%%s needs whitespace before body\n"
-msgstr "Vĩ lệnh %%%s có thân rỗng\n"
+msgstr "Vĩ lệnh %%%s cần có dấu cách trước phần thân\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Vĩ lệnh %%%s không mở rộng được\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "Vĩ lệnh %%%s có tên không hợp lệ (%%undefine)\n"
 
-#: rpmio/macro.c:647
-#, fuzzy, c-format
+#: rpmio/macro.c:645
+#, c-format
 msgid "Macro %%%s defined but not used within scope\n"
-msgstr "Vĩ lệnh %%%s không mở rộng được\n"
+msgstr "Vĩ lệnh %%%s được định nghĩa nhưng lại không được dùng trong phạm vi của nó\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Không hiểu tùy chọn %c trong %s(%s)\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
-msgstr ""
-"Quá nhiều mức đệ quy trong khai triển vĩ lệnh. Nó giống như là có nguyên "
-"nhân bởi khai báo vĩ lệnh đệ quy.\n"
+msgstr "Quá nhiều mức đệ quy trong khai triển vĩ lệnh. Nó giống như là có nguyên nhân bởi khai báo vĩ lệnh đệ quy.\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c chưa chấm dứt: %s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Một dấu %% đi trước một vĩ lệnh không thể phân tích được\n"
 
-#: rpmio/macro.c:1106
-#, fuzzy, c-format
+#: rpmio/macro.c:1103
+#, c-format
 msgid "failed to load macro file %s"
-msgstr "Gặp lỗi khi đọc tập tin chính sách: %s\n"
+msgstr "gặp lỗi khi tải tập tin vĩ lệnh %s"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== hoạt động %d trống %d\n"
@@ -3561,31 +3290,31 @@ msgstr "Tập tin %s: %s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "Tập tin %s nhỏ hơn %u byte\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "gặp lỗi khi tạo thư mục"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "có lỗi cú pháp trong lua scriptlet: %s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "cú pháp không hợp lệ trong văn lệnh lua: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "gặp lỗi khi thực thi văn lệnh lua: %s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "cú pháp không hợp lệ trong tập tin Lua: %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Lỗi kích hoạt khả năng Lua: %s\n"
@@ -3594,19 +3323,19 @@ msgstr "Lỗi kích hoạt khả năng Lua: %s\n"
 msgid "[none]"
 msgstr "[không có]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(không có lỗi)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "lỗi nghiêm trọng:"
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "lỗi: "
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "cảnh báo: "
 
@@ -3615,121 +3344,99 @@ msgstr "cảnh báo: "
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "cấp phát bộ nhớ (%u byte) trở về VÔ GIÁ TRỊ.\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, Mã số khóa %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(không có)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "gặp lỗi khi đang tạo tập tin tạm thời %s: %m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "gặp lỗi khi đang tạo tập tin tạm thời %s: %m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "gặp lỗi khi đang tạo tập tin tạm thời %s: %m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "gặp lỗi khi tạo thư mục %s: %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite bị lỗi: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush bị lỗi: %s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "Không hỗ trợ ký bằng GPG\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "Không hỗ trợ thuật toán băm PGP %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "Không hỗ trợ thuật toán khóa công PGP %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "Không thể thực hiện %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "Không thể tạo ống dẫn để ký: %m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: lỗi mở: %s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "fdopen bị lỗi\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "Không thể mở tập tin %s: %s\n"
+msgstr "Không thể ghi ra đường ống\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "Không thể mở tập tin %%files %s: %m\n"
+msgstr "Không thể đọc từ tập tin %s: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "lỗi thực hiện gpg (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "gpg không ghi được chữ ký\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "không thể đọc chữ ký\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature gặp lỗi: %s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Không thể ký gói RPM v3\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s đã sẵn chứa chữ ký định danh nên bỏ qua\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: gặp lỗi khi rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "gặp lỗi khi rpmMkTemp\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: Gặp lỗi khi writeLead: %s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "gặp lỗi khi thay thế %s: %s\n"
@@ -3742,144 +3449,3 @@ msgstr "%s: gặp lỗi khi đọc manifest: %s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "không nên thẩm tra chữ ký phần_đầu+trọng_tải"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "Gõ cụm từ mật khẩu: "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "Cụm từ mật khẩu đúng.\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "Gặp lỗi khi phân tích cú pháp hay khóa gpg đã hết hạn\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "Chủ/nhóm sai: %s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "dòng %d: Ký tự không hợp lệ trong: %s\n"
-
-#, fuzzy
-#~ msgid "%s has unverifiable signature"
-#~ msgstr "đang bỏ qua %s với chữ ký không thể thầm tra được\n"
-
-#, fuzzy
-#~ msgid "Fread failed: %s"
-#~ msgstr "%s: Fread bị lỗi: %s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "Không thể tạo ống dẫn để ký: %m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "Không thể ghi trọng tải vào %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "Không thể đọc trọng tải từ %s: %s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "Không thể mở tập tin tạm thời.\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "Không thể mở sigtarget (đích chữ ký) %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "Không thể đọc được phần đầu từ %s: %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "Không thể ghi phần đầu thành %s: %s\n"
-
-#~ msgid "line %d: Second description\n"
-#~ msgstr "dòng %d: Phần mô tả thứ hai\n"
-
-#~ msgid "skipping %s %s with unverifiable signature\n"
-#~ msgstr "đang bỏ qua %s %s với chữ ký không thể thầm tra được\n"
-
-#~ msgid "%s: No signature available\n"
-#~ msgstr "%s: Không có sẵn chữ ký\n"
-
-#~ msgid "%s: headerRead failed: %s"
-#~ msgstr "%s: headerRead gặp lỗi: %s"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "không thực hiện bất kỳ hành động thu thập nào"
-
-#~ msgid "%s failed: %s\n"
-#~ msgstr "%s bị lỗi: %s\n"
-
-#~ msgid "Failed to expand %%__%s_%s macro\n"
-#~ msgstr "Gặp lỗi khi mở rộng vĩ lệnh %%__%s_%s\n"
-
-#~ msgid "Failed to resolve %s plugin symbol %s: %s\n"
-#~ msgstr "Gặp lỗi khi phân giải phần bổ xung %s ký hiệu %s: %s\n"
-
-#~ msgid "Immutable header region could not be read. Corrupted package?\n"
-#~ msgstr "Không thể đọc được vùng phần đầu không thay đổi. Gói hỏng?\n"
-
-#~ msgid "error(%d:%s) getting next key from %s index\n"
-#~ msgstr "lỗi(%d:%s) đang lấy khóa kế từ mục lục %s\n"
-
-#~ msgid "error(%d) setting \"%s\" records from %s index\n"
-#~ msgstr "gặp lỗi (%d) khi đặt bản ghi \"%s\" từ chỉ mục %s\n"
-
-#~ msgid "error(%d) getting \"%s\" records from %s index\n"
-#~ msgstr "gặp lỗi (%d) khi lấy bản ghi “%s” từ bảng mục lục %s\n"
-
-#~ msgid "error(%d) storing record %s into %s\n"
-#~ msgstr "gặp lỗi (%d) khi lưu bản ghi %s vào %s\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "Gặp lỗi khi giải mã chính sách cho %s\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "Gặp lỗi khi tạo tạo tập tin tạm cho %s: %s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "Gặp lỗi khi ghi chính sách %s vào tập tin %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "Gặp lỗi khi tạo bộ tiếp hợp xử lý semanage\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "Gặp lỗi khi kết nối đến bộ tiếp hợp xử lý chính sách\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "Gặp lỗi khi bắt đầu giao dịch chính sách: %s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "Gặp lỗi khi gỡ bỏ tập tin chính sách tạm thời %s: %s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "Gặp lỗi khi cài đặt mô-đun chính sách: %s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "Gặp lỗi khi gỡ bỏ mô-đun chính sách: %s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "Gặp lỗi khi rẽ nhánh tiến trình: %s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "Gặp lỗi khi thực thi %s: %s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s đã chấm dứt bất thường\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s gặp lỗi với mã thoát là %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "Gặp lỗi khi chuyển giao các thay đổi chính sách\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "Gặp lỗi khi khai triển đường dẫn “restorecon”"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr ""
-#~ "Gặp lỗi đánh nhãn lại hệ thống tập tin. Tập tin có lẽ đã thiếu nhãn\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr "Gặp lỗi khi tải lại nội dung tập tin. Tập tin có lẽ đã thiếu nhãn\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "Gặp lỗi khi rút trích chính sách từ %s\n"
-
-#~ msgid "Macro %%%s (%s) was not used below level %d\n"
-#~ msgstr "Vĩ lệnh %%%s (%s) không sử dụng được dưới mức %d\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,28 +1,32 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Christopher Meng <cickumqt@gmail.com>, 2012-2013
+# dongfengweixia88616b04c28344fa <dongfengweixiao@gmail.com>, 2012
 # dongfengweixiao <dongfengweixiao@gmail.com>, 2013-2014
 # dongfengweixiao <dongfengweixiao@gmail.com>, 2012
 # Tommy He <lovenemesis@gmail.com>, 2012
 # Mike Manilone <zhtx10@gmail.com>, 2011
+# Ma Kai <crtmike@gmail.com>, 2011
+# qingxianhao <qinghao1@foxmail.com>, 2012
 # qingxianhao <qinghao1@foxmail.com>, 2012
 # Tiansworld <tiansworld@fedoraproject.org>, 2013
+# Tommy He <lovenemesis@gmail.com>, 2012
+# 白铭骢 <jeffbaichina@members.fsf.org>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-10 01:15+0000\n"
-"Last-Translator: dongfengweixiao <dongfengweixiao@gmail.com>\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/projects/p/rpm/"
-"language/zh_CN/)\n"
-"Language: zh_CN\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2015-08-23 16:38+0000\n"
+"Last-Translator: 白铭骢 <jeffbaichina@members.fsf.org>\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/rpm-team/rpm/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -87,7 +91,7 @@ msgstr "验证选项（用 -V 或 --verify）："
 msgid "Install/Upgrade/Erase options:"
 msgstr "安装/升级/擦除选项："
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "所有 rpm 模式和可执行文件的通用选项："
@@ -108,7 +112,7 @@ msgstr "意外的查询格式"
 msgid "unexpected query source"
 msgstr "意外的查询源"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "仅能指定一个主模式"
 
@@ -143,7 +147,8 @@ msgid ""
 msgstr "--hash (-h) 选项只能在软件包安装和擦除时指定"
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr "--percent 选项只能在软件包安装和擦除时指定"
 
 #: rpmqv.c:179
@@ -208,7 +213,7 @@ msgstr "--nodeps 只能在软件包安装、擦除和检验时指定"
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test 只能在软件包安装和擦除时指定"
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的参数必须以 / 开头"
 
@@ -228,248 +233,201 @@ msgstr "未给出要查询的参数"
 msgid "no arguments given for verify"
 msgstr "未给出要检验的参数"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot 已经指定，忽略 %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "依据 <specfile> 从 %prep (解压缩源代码并应用补丁) 开始构建"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "依据 <specfile> 从 %build (%prep 之后编译) 开始构建"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "依据 <specfile> 从 %install (%prep、%build 后安装) 开始构建"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "依据 <specfile> 检验 %files 区域"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "依据 <specfile> 构建源代码和二进制软件包"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "依据 <specfile> 构建二进制软件包"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "依据 <specfile> 构建源代码软件包"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "依据 <specfile> 从 %prep (解压缩源代码并应用补丁) 开始构建"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "依据 <tarball> 从 %prep (解压源代码并应用补丁)开始构建"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "依据 <tarball> 从 %build (%prep，之后编译)开始构建"
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "依据 <tarball> 从 %install (%prep、%build 然后安装)开始构建"
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "依据 <tarball> 检验 %files 区域"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "依据 <tarball> 构建源代码和二进制软件包"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr "依据 <tarball> 构建二进制软件包"
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr "依据 <tarball> 构建源代码软件包"
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "依据 <source package> 构建二进制软件包"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "依据 <specfile> 从 %build (%prep 之后编译) 开始构建"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "依据 <source package> 从 %install (%prep、%build 然后安装)开始构建"
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "依据 <specfile> 检验 %files 区域"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "依据 <source package> 构建二进制软件包"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "依据 <source package> 构建二进制软件包"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "依据 <specfile> 构建源代码软件包"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "依据 <tarball> 从 %prep (解压源代码并应用补丁)开始构建"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "依据 <tarball> 从 %build (%prep，之后编译)开始构建"
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "依据 <tarball> 从 %install (%prep、%build 然后安装)开始构建"
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "依据 <tarball> 检验 %files 区域"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "依据 <tarball> 构建源代码和二进制软件包"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr "依据 <tarball> 构建二进制软件包"
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr "依据 <tarball> 构建源代码软件包"
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "依据 <source package> 构建二进制软件包"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "重载构建根路径"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "无法打开当前目录：%m\n"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "完成后移除构建树"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "忽略 spec 文件中的 ExcludeArch 规则"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "除错文件状态机"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "不执行任何构建步骤 "
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "不检验构建依赖"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "生成和 rpm v3 包管理(旧版本)兼容的软件包头"
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "构建过程中不执行 %clean 步骤"
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "构建过程中不执行 %clean 步骤"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "构建过程中不执行 %check 步骤"
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "不接受来自 specfile 的 i18N 字符串信息"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "完成时移除源代码"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "完成时移除 specfile"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "直接跳转到指定步骤 (仅限 c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "重载目标平台"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "适用于 [ <specfile> | <tarball> | <source package> ] 的构建选项："
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "构建依赖失败：\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "无法打开 spec 文件 %s: %s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "打开 tar 管道失败: %m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "一行中有多个文件： %s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "从 %s 读取 spec 文件失败\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "重命名 %s 为 %s 时失败：%m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat %s 失败：%m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "文件 %s 不是常规文件。\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "文件 %s 不像是 spec 文件。\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "构建目标平台：%s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "为目标%s构建\n"
@@ -488,11 +446,11 @@ msgstr "校验数据库文件"
 
 #: rpmdb.c:32
 msgid "export database to stdout header list"
-msgstr ""
+msgstr "将数据库导出到标准输出头列表"
 
 #: rpmdb.c:35
 msgid "import database from stdin header list"
-msgstr ""
+msgstr "从标准输入头列表导入数据库"
 
 #: rpmdb.c:42
 msgid "Database options:"
@@ -518,7 +476,7 @@ msgstr "列出RPM密钥环中的密钥"
 msgid "Keyring options:"
 msgstr "密钥环选项："
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "没有指定参数"
 
@@ -538,10 +496,29 @@ msgstr "删除软件包签名"
 msgid "Signature options:"
 msgstr "签名选项："
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "无法exec %s: %s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "你必须在你的宏文件中设置 \"%%_gpg_name\" \n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "输入密码："
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "密码正确。\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr "密码检查失败或者 gpg 密钥过期\n"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -559,7 +536,7 @@ msgstr "操纵 spec 生成的二进制 rpm 包(缺省值)"
 msgid "operate on source rpm generated by spec"
 msgstr "操纵 spec 生成的源 rpm 包"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "使用这种格式打印信息"
 
@@ -606,71 +583,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM 构建错误：\n"
+msgstr "\n\nRPM 构建错误：\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "== 语法解析错误\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "&& 语法解析错误\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "解析 || 时有语法错误\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "表达式解析错误\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "不匹配的 (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- 只用于数字\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! 只用于数字\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "类型必须匹配\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "* / 不支持字符串\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "- 不支持字符串\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "&& 和 || 不支持字符串\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "表达式语法错误\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s %s 中丢失 '(' \n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s(%s 中丢失 ')'\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "无效的 %s 令牌：%s\n"
@@ -680,46 +654,46 @@ msgstr "无效的 %s 令牌：%s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%2$s %3$s 中丢失 %1$s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 后有非空白字符：%s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "语法错误：%s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "spec 文件权限不好：%s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "spec 目录权限不好：%s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "异常的 locale 长度：\"%s\" 在%%lang(%s) 中\n"
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "重复的 locale %s 在%%lang(%s) 中\n"
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "无效的 capability：%s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "无内建文件capability 支持\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "文件必须以 \"/\" 开头： %s\n"
@@ -729,146 +703,149 @@ msgstr "文件必须以 \"/\" 开头： %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "未知的文件摘要算法 %u, 回退到MD5\n"
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "被列出两次的文件：%s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "读取符号连接 %s 失败：%s\n"
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "符号链接指向了 BuildRoot：%s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
-msgstr ""
+msgstr "路径在 buildroot 之外: %s\n"
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "没有找到目录：%s\n"
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "没有找到文件：%s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
-msgstr ""
+msgstr "此路径不是一个目录: %s\n"
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: 无法加载未知标签(%d)。\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: 公钥读取失败。\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: 不是带装甲的(armored)公钥。\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：编码失败\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "文件需要 \"/\" 开头：%s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob 不被允许：%s\n"
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr "目录未找到，所用 glob: %s\n"
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "文件未找到，所用 glob: %s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "无法打开 %%files 文件 %s: %m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "行：%s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
-msgstr ""
+msgstr "空 %%file 文件 %s\n"
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "读取 %%files 文件 %s 失败：%m\n"
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一行中有多个文件： %s\n"
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "坏文件：%s: %s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "坏的属主/群组：%s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "检查未打包文件：%s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"发现已安装(但未打包的)文件：\n"
-"%s"
+msgstr "发现已安装(但未打包的)文件：\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "处理文件：%s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二进制架构 (%d) 和软件包构架 (%d)不匹配。\n"
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 软件包中有架构相关的二进制文件\n"
 
@@ -897,79 +874,79 @@ msgstr "%s: 行: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "无法正规化主机名：%s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "无法重载签名头。\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "未知的净负荷压缩：%s\n"
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "无法创建不可改变的头区。\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "无法打开%s: %s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "无法写入软件包：%s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "无法写入临时头\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "不合法的CSA数据\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "不能打开文件 %s：%s\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "对此文件创建归档失败 %s：%s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已写至：%s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在执行 \"%s\"：\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr " \"%s\" 执行失败。\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "软件包检查 \"%s\" 失败。\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "无法为软件包 %s 生成输出文件名: %s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "无法创建 %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "行 %d：第二个 %s\n"
@@ -1012,7 +989,7 @@ msgstr "%%changelog 中没有描述\n"
 #: build/parseChangelog.c:237
 #, c-format
 msgid "line %d: second %%changelog\n"
-msgstr ""
+msgstr "行 %d: 第二个 %%changelog\n"
 
 #: build/parseDescription.c:32
 #, c-format
@@ -1020,19 +997,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "行 %d：解析 %%description 时发生错误：%s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "行 %d：错误的选项 %s：%s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "列 %d：过多的名称：%s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "行 %d：套件不存在：%s\n"
@@ -1045,7 +1022,7 @@ msgstr "行 %d：解析 %%files 时发生错误：%s\n"
 #: build/parseFiles.c:76
 #, c-format
 msgid "line %d: second %%files\n"
-msgstr ""
+msgstr "行 %d: 第二个 %%files\n"
 
 #: build/parsePolicies.c:32
 #, c-format
@@ -1138,96 +1115,91 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "行 %d：标签只需要一个令牌： %s\n"
 
 #: build/parsePreamble.c:616
-#, fuzzy, c-format
-msgid "Illegal char '%c' (0x%x)"
+#, c-format
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr "行 %d：非法的字符 '%c' 在: %s 中\n"
 
-#: build/parsePreamble.c:620
-#, fuzzy
-msgid "Illegal sequence \"..\""
-msgstr "行 %d：非法序列 \"..\" in: %s\n"
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
+msgstr "行 %d：非法的字符在: %s 中\n"
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "行 %d: %s: %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr "行 %d：非法序列 \"..\" in: %s\n"
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: 行: %s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "行 %d：有缺陷的标签：%s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "行 %d：空的标签：%s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "行 %d：前缀不能以 “/” 结尾：%s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "行 %d：Docdir 必须以 “/\" 開頭：%s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "行 %d:：Epoch field 必须是无符号数：%s\n"
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "行 %d：错误的 %s：限定符：%s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "行 %d：错误的 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "行 %d：只能支持noarch的子包：%s\n"
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "内部错误：虚假标签 %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "行 %d： %s 不建议使用：%s\n"
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "有问题的软件包规范：%s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "软件包已存在：%s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "行 %d：未知标签：%s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不能为空\n"
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不能为 \"/\"\n"
@@ -1237,193 +1209,161 @@ msgstr "%%{buildroot} 不能为 \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "问题来源： %s： %s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "没有 %u 补丁\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%补丁 没有对应的 \"Patch:\" 标记\n"
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "没有 %u 源码\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "spec文件内不存在 \"Source:\" 标签\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "解析 %%setup 时发生错误：%s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "行 %d：%%setup 中存在坏的参数：%s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "行 %d：错误的 %%setup 选项 %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "无效的补丁编号 %s：%s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "行 %d：第二个 %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr "不允许的版本控制命名"
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr "无效的依赖"
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr "版本要求"
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+#: build/parseReqs.c:189
+msgid "invalid dependency"
+msgstr "无效的依赖"
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "行 %d: %s: %s\n"
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "列 %d：触发器必须包含有 --：%s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "列 %d：解析 %s 时发生错误：%s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "行 %d：内部脚本必須以 “>” 結尾：%s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "行 %d：脚本程序必须以 “/” 开头：%s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "列 %d：第二个 %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "行 %d：不支持的内部脚本：%s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "行 %d: %s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "不能打开 %s：%s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "行 %d: Unclosed %%if\n"
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d：有一个 %%else 没有对应的 %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d：有一个 %%endif 没有对应的 %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "没有找到可供构建的兼容构架\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "软件包没有 %%description：%s\n"
@@ -1494,281 +1434,290 @@ msgstr "此行存在过多参数：%s\n"
 msgid "Processing policies: %s\n"
 msgstr "处理策略：%s\n"
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略无效的正则表达式 %s\n"
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "无法为 %s建立管道： %m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "无法执行%s：%s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "无法抽取分支 %s：%s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失败：%x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "无法写入所有的数据到 %s：%s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr "错误的操作"
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr "错误的格式"
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s 转换到长整型失败。\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr "空文件分类\n"
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "没有配置文件属性\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失败：%s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失败：%s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "文件 \"%s\" 辨识失败: 模式 %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在查找 %s：%s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "查找 %s 失败：\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "查询 spec 文件 %s 失败，无法解析\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 是一个 Delta RPM 并且无法直接被安装。\n"
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "软件包 %s 已被加入，跳过 %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "软件包 %s 已被加入，以 %s 替换\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(不是数字)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(非base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(无效类型)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(非blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(无效的xml 类型)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(不是OpenPGP 签名)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr "无效日期%u"
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "正常"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "已被替换"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "未安装"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "网络共享"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "错误颜色"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "丢失"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(未知)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(不是字符串)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已另存为 %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立为 %s \n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: 移除失败: %s\n"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr "目录"
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr "文件"
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
 msgstr ""
 
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
+msgstr "Fread 失败: %s"
+
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1897,16 +1846,15 @@ msgid "relocations must have a / following the ="
 msgstr "重定位必须有 / 跟在 = 之后"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr "安装全部文件，包含配置文件，否则配置文件会被跳过。"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"移除所有符合 <package> 的软件包(如果 <package> 被指定未多个软件包，常常会导致"
-"错误出现)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "移除所有符合 <package> 的软件包(如果 <package> 被指定未多个软件包，常常会导致错误出现)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1984,7 +1932,7 @@ msgstr "更新数据库，但不修改文件系统"
 msgid "do not verify package dependencies"
 msgstr "不验证软件包依赖"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "不验证文件摘要"
 
@@ -2104,182 +2052,162 @@ msgstr "升级软件包"
 msgid "reinstall package(s)"
 msgstr "重新安装软件包"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "查询/验证所有软件包"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm 检查签名模式"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "查询/验证文件属于的软件包"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "查询/验证组中的软件包"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "查询/验证一个软件包"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm 查询模式"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "查询/验证头的实例"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm 校验模式"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "查询/验证提供相关依赖的软件包"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "查询/验证提供相关依赖的软件包"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "查询/验证提供相关依赖的软件包"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "查询/验证提供相关依赖的软件包"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "查询/验证提供相关依赖的软件包"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "不使用 glob 参数"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "不把非软件包文件作为清单处理"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "列出所有配置文件"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "列出所有程序文档"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr "列出所有许可证文件"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "转储基本文件信息"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "列出软件包中的文件"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "跳过%%ghost 文件"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "显示列出文件的状态"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "不验证文件大小"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "不验证符号连接路径"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "不验证文件所有者"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "不验证文件组信息"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "不验证文件修改时间"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "不验证文件模式"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr "不验证文件兼容性"
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "不验证文件安全上下文"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "不验证软件包中文件"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "不验证包依赖"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "不执行验证脚本"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr " %s 缺失rpmlib的特性\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "期望源代码包，但找到二进制包\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "源代码包中没有找到 .spec 文件\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解压压缩文件 %s%s 失败：%s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr "  在文件"
 
@@ -2354,116 +2282,96 @@ msgstr "没有软件包和 %s 匹配：%s\n"
 msgid "no package requires %s\n"
 msgstr "没有软件包需要 %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "没有软件包需要 %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "没有软件包触发器 %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "没有软件包需要 %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "没有软件包需要 %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "没有软件包提供 %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "文件 %s：%s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "文件 %s 不属于任何软件包\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "无效的软件包编号：%s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "记录 %u 不能读取\n"
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "未安装软件包 %s \n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "未知标签：\"%s\"\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: 密钥 %d 导入失败。\n"
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：公钥 %d  不受到保护。\n"
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s：headerRead 函数执行失败：%s\n"
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s：Fread 函数执行失败：%s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "不正确"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "确定"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (丢失的密钥："
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (不受信任的密钥："
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: 打开失败：%s\n"
@@ -2488,195 +2396,144 @@ msgstr "无法更改根目录： %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "无法恢复根目录：%m\n"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "否"
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "是"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "软件包净负荷可以使用 bzip2 压缩。"
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr "软件包净负荷可以使用 xz 压缩。"
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr "软件包净负荷可以使用 lzma 压缩。"
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "软件包净负荷有\"./\" 前缀。"
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "软件包 name-version-release 没有隐含地提供。"
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "头标签总是排序后被加载。"
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "硬链接文件集没有被完整的安装。"
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "软件包脚本在安装过程中允许访问 rpm 数据库。"
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "lua 脚本的内部支持"
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr "支持超过 4G 的文件"
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "不验证软件包依赖"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-#, fuzzy
-msgid "Name required"
-msgstr "版本要求"
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-#, fuzzy
-msgid "Empty rich dependency"
-msgstr "无效的依赖"
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "未结束的 %c：%s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-#, fuzzy
-msgid "Junk after rich dependency"
-msgstr "无效的依赖"
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "用户%s 不存在 - 使用root\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "群组%s 不存在 - 使用root\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "Bad magic"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "错误/不可读的  头部"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "头部太大"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr "对于压缩文件来说文件太大了"
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "未知文件类型"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr "丢失文件"
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "摘要不匹配"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "内部错误"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "在头中不存在归档"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " 失败 - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
-msgstr ""
+msgstr "%s: (错误 0x%x)"
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "打开 %s 失败： %s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: 不是 rpm 软件包 (或者没有 manifest 文件)\n"
@@ -2708,42 +2565,42 @@ msgstr "依赖检测失败：\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: 不是 rpm 软件包 (或者没有manifest)：%s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "不能安装 %s \n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "获取%s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "跳过 %s - 传输失败\n"
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "软件包 %s 不能重定位\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "文件 %s 读取错误\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" 指定多个软件包：\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "无法打开 %s：%s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "正在安装 %s\n"
@@ -2769,12 +2626,12 @@ msgstr "读取失败：%s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "不是一个 rpm 软件包\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "正在等候 %s 锁定 %s\n"
@@ -2790,9 +2647,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr "解析符号 %s 失败 : %s\n"
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "%s 插件未载入\n"
+msgstr "插件 %%__%s_%s 未配置\n"
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2885,7 +2742,7 @@ msgstr "在 %s:%d 处丢失构架名称\n"
 #: lib/rpmrc.c:370
 #, c-format
 msgid "Incomplete data line at %s:%d\n"
-msgstr ""
+msgstr "不完整的资料行于 %s:%d\n"
 
 #: lib/rpmrc.c:375
 #, c-format
@@ -2936,75 +2793,56 @@ msgstr "坏的选项 “%s” 位于 %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "读取辅助载体失败, 是 /proc 没有挂载么？\n"
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "未知系统：%s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "请联系 %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "不能打开 %s 供读取：%m。\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "无法恢复当前目录：%m"
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 脚本支持未内建\n"
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "无法建立临时文件赖存储%s：%s\n"
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
-msgstr ""
+msgstr "无法复制文件描述: %s: %s\n"
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "无法读取图标 %s: %s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "无法恢复根目录：%m\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite 失败: %s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s 脚本执行失败，waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s 脚本执行失败，捕捉到信号： %d\n"
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s 脚本执行失败，退出状态码为 %d\n"
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "未知格式"
 
@@ -3016,142 +2854,127 @@ msgstr "安裝"
 msgid "erase"
 msgstr "删除"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "无法从 %s 打开软件包数据库\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的“（”存在于软件包标签中：%s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "丢失“（”在软件包标签 %s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "丢失“）”在软件包标签 %s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "读出公钥失败：%s\n"
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "事务"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(不是OpenPGP 签名)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr "sigh 载入: BAD"
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigh sigSize(%zd): BAD, fstat(2) 失败"
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "头"
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 摘要："
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "头 SHA1 摘要："
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "头"
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "验证签名：错误的参数 (%d %p %d %p %p)"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "已跳过"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "已失败"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
-msgstr ""
+msgstr "用户 %s 存在重复的用户名或 UID\n"
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
-msgstr ""
+msgstr "用户组 %s 存在重复的组名或 GID\n"
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr "没有状态"
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr "未知状态"
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "遗漏   %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "未满足的依赖关系 %s：\n"
@@ -3182,7 +3005,7 @@ msgstr "未知标签"
 
 #: lib/headerfmt.c:413
 msgid "] expected at end of array"
-msgstr ""
+msgstr "] 预期于数组结尾"
 
 #: lib/headerfmt.c:425
 msgid "unexpected ]"
@@ -3194,7 +3017,7 @@ msgstr "未预期的 }"
 
 #: lib/headerfmt.c:491
 msgid "? expected in expression"
-msgstr ""
+msgstr "? 预期于表达式中"
 
 #: lib/headerfmt.c:498
 msgid "{ expected after ? in expression"
@@ -3214,7 +3037,7 @@ msgstr ""
 
 #: lib/headerfmt.c:558
 msgid "| expected at end of expression"
-msgstr ""
+msgstr "| 预期于表达式结尾"
 
 #: lib/headerfmt.c:735
 msgid "array iterator used with different sized arrays"
@@ -3225,240 +3048,240 @@ msgstr "使用不同大小数组的数组的迭代器"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "没有设置 dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳过"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec 函数执行失败： %s\n"
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp 函数执行失败: %s\n"
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳过"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
-msgstr ""
+msgstr "rpmdb: 获取到损坏表头 #%u -- 跳过此项。\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：无法读取位于 0x%x 的表头\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "没有设置 dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "無法建立 %s 目录： %s\n"
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "无法加入原本位于 %u 的记录\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建数据库失败：原始数据库仍保持原状\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "用新的数据库取代旧的数据库失败！\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "用 %2$s 文件取代 %1$s 文件來恢复"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "移除目录失败 %s：%s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s 错误(%d) 源自 %s: %s\n"
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s 错误(%d): %s\n"
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "无法识别的数据库选项：\"%s\" 已忽略。\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s 有无效的数值，忽略\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s 有过大或者是过小的 long 数值，忽略\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s 有过大或者是过小的整数值，忽略\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "无法取得 %s 位于 %s/%s 的锁定\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "已共享"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "无效的索引类型 %x 于 %s/%s\n"
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
-msgstr ""
+msgstr "添加表头 #%d 记录时出错 (%d)\n\n"
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
-msgstr ""
+msgstr "移除表头 #%d 记录时出错 (%d)\n"
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
-msgstr ""
+msgstr "在分配新软件包进程时出错 (%d)\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "无法识别的数据库选项：\"%s\" 已忽略。\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s 有无效的数值，忽略\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s 有过大或者是过小的 long 数值，忽略\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s 有过大或者是过小的整数值，忽略\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "宏 %%%s 具有未结束的选项\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "宏 %%%s 主体未结束\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "宏 %%%s 中存在无效的名称 (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "宏 %%%s 中存在空内容\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "宏 %%%s 在结构之前需要空格\n"
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "宏 %%%s 展开失败\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "宏 %%%s 中存在无效的名称 (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "宏 %%%s 已经定义但是没有使用\n"
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中存在未知的选项 %1$c\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "宏扩展中存在太多层的递归。这有可能是由宏的递归声明引起的。\n"
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未结束的 %c：%s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在一个不可解析的宏之之后跟着 %%\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "载入宏文件 %s 失败"
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3478,31 +3301,31 @@ msgstr "文件 %s：%s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "文件 %s 小于 %u 字节\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "创建目录失败"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "lua 脚本中存在无效的语法：%s\n"
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "lua 脚本中存在无效的语法: %s\n"
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 脚本执行失败：%s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua文件中存在无效的语法 %s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hook 执行失败：%s\n"
@@ -3511,19 +3334,19 @@ msgstr "lua hook 执行失败：%s\n"
 msgid "[none]"
 msgstr "[无]"
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(没有错误)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "致命错误："
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "错误："
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "警告："
 
@@ -3532,121 +3355,99 @@ msgstr "警告："
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "内在分配 (%u 字节) 返回 NULL。\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, 密钥 ID %s"
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(无)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "临时文件创建失败 %s：%m\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "临时文件创建失败 %s：%m\n"
-
-#: sign/rpmgensig.c:85
-#, fuzzy, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr "临时文件创建失败 %s：%m\n"
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "無法建立 %s 目录： %s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite 失败: %s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush 失败：%s\n"
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr "不支持的 PGP 签名\n"
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "不支持的 PGP hash 算法 %u\n"
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "不支持的 PGP 公钥算法 %u\n"
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "无法exec %s: %s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "无法创建签名用的管道：%m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s: 打开失败：%s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr "fdopen 失败\n"
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "不能打开文件 %s：%s\n"
+msgstr "无法写入到管道\n"
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "无法打开 %%files 文件 %s: %m\n"
+msgstr "无法从文件 %s 读取: %s\n"
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg 执行失败 (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "写入签名时 gpg 验证失败\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "无法读取签名\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 函数执行失败：%s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "无法对 RPM v3 版本的软件包签名\n"
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已经包含了相同的签名，跳过\n"
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失败：%s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp 失败\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失败：%s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "替换 %s 失败：%s\n"
@@ -3659,99 +3460,3 @@ msgstr "%s：读取 manifest 文件失败：%s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "不验证报头+净负荷签名"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "输入密码："
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "密码正确。\n"
-
-#~ msgid "Pass phrase check failed or gpg key expired\n"
-#~ msgstr "密码检查失败或者 gpg 密钥过期\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "坏的属主/群组：%s\n"
-
-#~ msgid "line %d: Illegal char in: %s\n"
-#~ msgstr "行 %d：非法的字符在: %s 中\n"
-
-#~ msgid "Fread failed: %s"
-#~ msgstr "Fread 失败: %s"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "无法创建签名用的管道：%m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "无法写入净负荷到 %s: %s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "无法从 %s 读取净负荷：%s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "无法打开临时文件。\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "无法打开签名目标 %s: %s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "无法从 %s 获取头： %s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "无法将头写入 %s: %s\n"
-
-#~ msgid "do not perform any collection actions"
-#~ msgstr "请不要执行任何动作集"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "无法为 %s 解码策略\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "无法为 %s 建立临时文件：%s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "无法写入 %s 策略到文件 %s\n"
-
-#~ msgid "Failed to create semanage handle\n"
-#~ msgstr "无法创建semanage的句柄\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "无法连接到策略处理程序\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "无法开始事务策略：%s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "移除临时策略文件失败 %s：%s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "安装失败的策略模块：%s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "删除失败的策略模块：%s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "无法分支程序：%s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "无法执行 %s：%s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s 异常终止\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s 已失败，退出代码 %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "无法提交策略变化\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "无法扩大 restorecon 路径"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr "无法重新标记文件系统。文件可能标签有误\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr "无法重载文件环境。文件可能标签有误\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "无法从 %s 提取策略\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Christopher Meng <cickumqt@gmail.com>, 2012-2013
 # dongfengweixia88616b04c28344fa <dongfengweixiao@gmail.com>, 2012
@@ -19,14 +19,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2015-08-23 16:38+0000\n"
 "Last-Translator: 白铭骢 <jeffbaichina@members.fsf.org>\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/rpm-team/rpm/language/zh_CN/)\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/rpm-team/rpm/"
+"language/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -91,7 +92,7 @@ msgstr "验证选项（用 -V 或 --verify）："
 msgid "Install/Upgrade/Erase options:"
 msgstr "安装/升级/擦除选项："
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "所有 rpm 模式和可执行文件的通用选项："
@@ -112,7 +113,7 @@ msgstr "意外的查询格式"
 msgid "unexpected query source"
 msgstr "意外的查询源"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "仅能指定一个主模式"
 
@@ -147,8 +148,7 @@ msgid ""
 msgstr "--hash (-h) 选项只能在软件包安装和擦除时指定"
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr "--percent 选项只能在软件包安装和擦除时指定"
 
 #: rpmqv.c:179
@@ -213,7 +213,7 @@ msgstr "--nodeps 只能在软件包安装、擦除和检验时指定"
 msgid "--test may only be specified during package installation and erasure"
 msgstr "--test 只能在软件包安装和擦除时指定"
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的参数必须以 / 开头"
 
@@ -233,201 +233,248 @@ msgstr "未给出要查询的参数"
 msgid "no arguments given for verify"
 msgstr "未给出要检验的参数"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot 已经指定，忽略 %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "依据 <specfile> 从 %prep (解压缩源代码并应用补丁) 开始构建"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "依据 <specfile> 从 %build (%prep 之后编译) 开始构建"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "依据 <specfile> 从 %install (%prep、%build 后安装) 开始构建"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "依据 <specfile> 检验 %files 区域"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "依据 <specfile> 构建源代码和二进制软件包"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "依据 <specfile> 构建二进制软件包"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "依据 <specfile> 构建源代码软件包"
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "依据 <tarball> 从 %prep (解压源代码并应用补丁)开始构建"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "依据 <specfile> 从 %prep (解压缩源代码并应用补丁) 开始构建"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "依据 <tarball> 从 %build (%prep，之后编译)开始构建"
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "依据 <tarball> 从 %install (%prep、%build 然后安装)开始构建"
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "依据 <tarball> 检验 %files 区域"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "依据 <tarball> 构建源代码和二进制软件包"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr "依据 <tarball> 构建二进制软件包"
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr "依据 <tarball> 构建源代码软件包"
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "依据 <source package> 构建二进制软件包"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "依据 <specfile> 从 %build (%prep 之后编译) 开始构建"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "依据 <source package> 从 %install (%prep、%build 然后安装)开始构建"
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "依据 <specfile> 检验 %files 区域"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "依据 <source package> 构建二进制软件包"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "依据 <source package> 构建二进制软件包"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "依据 <specfile> 构建源代码软件包"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "依据 <tarball> 从 %prep (解压源代码并应用补丁)开始构建"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "依据 <tarball> 从 %build (%prep，之后编译)开始构建"
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "依据 <tarball> 从 %install (%prep、%build 然后安装)开始构建"
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "依据 <tarball> 检验 %files 区域"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "依据 <tarball> 构建源代码和二进制软件包"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr "依据 <tarball> 构建二进制软件包"
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr "依据 <tarball> 构建源代码软件包"
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "依据 <source package> 构建二进制软件包"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "重载构建根路径"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "无法打开当前目录：%m\n"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "完成后移除构建树"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "忽略 spec 文件中的 ExcludeArch 规则"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "除错文件状态机"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "不执行任何构建步骤 "
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "不检验构建依赖"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr "生成和 rpm v3 包管理(旧版本)兼容的软件包头"
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr "构建过程中不执行 %clean 步骤"
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "构建过程中不执行 %clean 步骤"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr "构建过程中不执行 %check 步骤"
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "不接受来自 specfile 的 i18N 字符串信息"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "完成时移除源代码"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "完成时移除 specfile"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "直接跳转到指定步骤 (仅限 c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "重载目标平台"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "适用于 [ <specfile> | <tarball> | <source package> ] 的构建选项："
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "构建依赖失败：\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "无法打开 spec 文件 %s: %s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "打开 tar 管道失败: %m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "一行中有多个文件： %s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "从 %s 读取 spec 文件失败\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "重命名 %s 为 %s 时失败：%m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "stat %s 失败：%m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "文件 %s 不是常规文件。\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "文件 %s 不像是 spec 文件。\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "构建目标平台：%s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "为目标%s构建\n"
@@ -476,49 +523,64 @@ msgstr "列出RPM密钥环中的密钥"
 msgid "Keyring options:"
 msgstr "密钥环选项："
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "没有指定参数"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "签名包"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "签名包(同--addsign)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "删除软件包签名"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "签名包"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "签名选项："
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "无法exec %s: %s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "你必须在你的宏文件中设置 \"%%_gpg_name\" \n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "输入密码："
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "密码正确。\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
+msgstr ""
 
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
-msgstr "密码检查失败或者 gpg 密钥过期\n"
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix 只能在安装新软件包时使用"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches 只能在软件包擦除时指定"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -536,7 +598,7 @@ msgstr "操纵 spec 生成的二进制 rpm 包(缺省值)"
 msgid "operate on source rpm generated by spec"
 msgstr "操纵 spec 生成的源 rpm 包"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "使用这种格式打印信息"
 
@@ -583,68 +645,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM 构建错误：\n"
+msgstr ""
+"\n"
+"\n"
+"RPM 构建错误：\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "== 语法解析错误\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "&& 语法解析错误\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "解析 || 时有语法错误\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "表达式解析错误\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "不匹配的 (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- 只用于数字\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! 只用于数字\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "类型必须匹配\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "* / 不支持字符串\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "- 不支持字符串\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "&& 和 || 不支持字符串\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "表达式语法错误\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "%s %s 中丢失 '(' \n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "%s(%s 中丢失 ')'\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "无效的 %s 令牌：%s\n"
@@ -654,46 +719,46 @@ msgstr "无效的 %s 令牌：%s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "%2$s %3$s 中丢失 %1$s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 后有非空白字符：%s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "语法错误：%s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "spec 文件权限不好：%s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "spec 目录权限不好：%s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr "异常的 locale 长度：\"%s\" 在%%lang(%s) 中\n"
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr "重复的 locale %s 在%%lang(%s) 中\n"
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "无效的 capability：%s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "无内建文件capability 支持\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "文件必须以 \"/\" 开头： %s\n"
@@ -703,149 +768,151 @@ msgstr "文件必须以 \"/\" 开头： %s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr "未知的文件摘要算法 %u, 回退到MD5\n"
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "被列出两次的文件：%s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr "读取符号连接 %s 失败：%s\n"
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "符号链接指向了 BuildRoot：%s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "路径在 buildroot 之外: %s\n"
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "没有找到目录：%s\n"
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "没有找到文件：%s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "此路径不是一个目录: %s\n"
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: 无法加载未知标签(%d)。\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: 公钥读取失败。\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: 不是带装甲的(armored)公钥。\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：编码失败\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "文件需要 \"/\" 开头：%s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob 不被允许：%s\n"
 
-#: build/files.c:1565
-#, c-format
-msgid "Directory not found by glob: %s\n"
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "目录未找到，所用 glob: %s\n"
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "文件未找到，所用 glob: %s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "无法打开 %%files 文件 %s: %m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "行：%s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr "空 %%file 文件 %s\n"
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr "读取 %%files 文件 %s 失败：%m\n"
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "文件未找到，所用 glob: %s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一行中有多个文件： %s\n"
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "坏文件：%s: %s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "坏的属主/群组：%s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "检查未打包文件：%s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "发现已安装(但未打包的)文件：\n%s"
+msgstr ""
+"发现已安装(但未打包的)文件：\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "处理文件：%s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二进制架构 (%d) 和软件包构架 (%d)不匹配。\n"
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 软件包中有架构相关的二进制文件\n"
 
@@ -874,79 +941,76 @@ msgstr "%s: 行: %s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "无法正规化主机名：%s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "无法重载签名头。\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "未知的净负荷压缩：%s\n"
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "无法创建不可改变的头区。\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "无法打开%s: %s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "无法写入软件包：%s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "无法写入临时头\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "不合法的CSA数据\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已写至：%s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在执行 \"%s\"：\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr " \"%s\" 执行失败。\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "软件包检查 \"%s\" 失败。\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "无法为软件包 %s 生成输出文件名: %s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "无法创建 %s: %s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "行 %d：第二个 %s\n"
@@ -997,19 +1061,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "行 %d：解析 %%description 时发生错误：%s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "行 %d：错误的选项 %s：%s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "列 %d：过多的名称：%s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "行 %d：套件不存在：%s\n"
@@ -1115,91 +1179,96 @@ msgid "line %d: Tag takes single token only: %s\n"
 msgstr "行 %d：标签只需要一个令牌： %s\n"
 
 #: build/parsePreamble.c:616
-#, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+#, fuzzy, c-format
+msgid "Illegal char '%c' (0x%x)"
 msgstr "行 %d：非法的字符 '%c' 在: %s 中\n"
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
-msgstr "行 %d：非法的字符在: %s 中\n"
-
-#: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
+#: build/parsePreamble.c:620
+#, fuzzy
+msgid "Illegal sequence \"..\""
 msgstr "行 %d：非法序列 \"..\" in: %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:625
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "行 %d: %s: %s\n"
+
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: 行: %s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "行 %d：有缺陷的标签：%s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "行 %d：空的标签：%s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "行 %d：前缀不能以 “/” 结尾：%s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "行 %d：Docdir 必须以 “/\" 開頭：%s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "行 %d:：Epoch field 必须是无符号数：%s\n"
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "行 %d：错误的 %s：限定符：%s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "行 %d：错误的 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "行 %d：只能支持noarch的子包：%s\n"
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "内部错误：虚假标签 %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "行 %d： %s 不建议使用：%s\n"
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "有问题的软件包规范：%s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "软件包已存在：%s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "行 %d：未知标签：%s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不能为空\n"
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不能为 \"/\"\n"
@@ -1209,161 +1278,193 @@ msgstr "%%{buildroot} 不能为 \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "问题来源： %s： %s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "没有 %u 补丁\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr "%%补丁 没有对应的 \"Patch:\" 标记\n"
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "没有 %u 源码\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "spec文件内不存在 \"Source:\" 标签\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "解析 %%setup 时发生错误：%s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "行 %d：%%setup 中存在坏的参数：%s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "行 %d：错误的 %%setup 选项 %s: %s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "无效的补丁编号 %s：%s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "行 %d：第二个 %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr "不允许的版本控制命名"
 
-#: build/parseReqs.c:173
-msgid "Version required"
-msgstr "版本要求"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
+msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr "无效的依赖"
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr "版本要求"
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr "行 %d: %s: %s\n"
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "列 %d：触发器必须包含有 --：%s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "列 %d：解析 %s 时发生错误：%s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "行 %d：内部脚本必須以 “>” 結尾：%s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "行 %d：脚本程序必须以 “/” 开头：%s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "列 %d：第二个 %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "行 %d：不支持的内部脚本：%s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "行 %d: %s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "不能打开 %s：%s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "行 %d: Unclosed %%if\n"
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d：有一个 %%else 没有对应的 %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d：有一个 %%endif 没有对应的 %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "没有找到可供构建的兼容构架\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "软件包没有 %%description：%s\n"
@@ -1434,290 +1535,281 @@ msgstr "此行存在过多参数：%s\n"
 msgid "Processing policies: %s\n"
 msgstr "处理策略：%s\n"
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略无效的正则表达式 %s\n"
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "无法为 %s建立管道： %m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "无法执行%s：%s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "无法抽取分支 %s：%s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失败：%x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "无法写入所有的数据到 %s：%s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr "错误的操作"
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr "错误的格式"
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s 转换到长整型失败。\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr "空文件分类\n"
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "没有配置文件属性\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失败：%s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失败：%s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "文件 \"%s\" 辨识失败: 模式 %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在查找 %s：%s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "查找 %s 失败：\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "查询 spec 文件 %s 失败，无法解析\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 是一个 Delta RPM 并且无法直接被安装。\n"
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "软件包 %s 已被加入，跳过 %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "软件包 %s 已被加入，以 %s 替换\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(不是数字)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(非base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(无效类型)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(非blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(无效的xml 类型)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(不是OpenPGP 签名)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr "无效日期%u"
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "正常"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "已被替换"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "未安装"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "网络共享"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "错误颜色"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "丢失"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(未知)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(不是字符串)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已另存为 %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立为 %s \n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: 移除失败: %s\n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr "目录"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr "文件"
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
-msgstr "Fread 失败: %s"
-
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1846,15 +1938,16 @@ msgid "relocations must have a / following the ="
 msgstr "重定位必须有 / 跟在 = 之后"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr "安装全部文件，包含配置文件，否则配置文件会被跳过。"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "移除所有符合 <package> 的软件包(如果 <package> 被指定未多个软件包，常常会导致错误出现)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"移除所有符合 <package> 的软件包(如果 <package> 被指定未多个软件包，常常会导致"
+"错误出现)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1932,7 +2025,7 @@ msgstr "更新数据库，但不修改文件系统"
 msgid "do not verify package dependencies"
 msgstr "不验证软件包依赖"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "不验证文件摘要"
 
@@ -2052,162 +2145,182 @@ msgstr "升级软件包"
 msgid "reinstall package(s)"
 msgstr "重新安装软件包"
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "查询/验证所有软件包"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm 检查签名模式"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "查询/验证文件属于的软件包"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "查询/验证组中的软件包"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "查询/验证一个软件包"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr ""
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr ""
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm 查询模式"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "查询/验证头的实例"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr ""
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr ""
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm 校验模式"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr ""
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "查询/验证提供相关依赖的软件包"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "查询/验证提供相关依赖的软件包"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "查询/验证提供相关依赖的软件包"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "查询/验证提供相关依赖的软件包"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "查询/验证提供相关依赖的软件包"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "不使用 glob 参数"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "不把非软件包文件作为清单处理"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "列出所有配置文件"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "列出所有程序文档"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr "列出所有许可证文件"
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "转储基本文件信息"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "列出软件包中的文件"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "跳过%%ghost 文件"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "显示列出文件的状态"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "不验证文件大小"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "不验证符号连接路径"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "不验证文件所有者"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "不验证文件组信息"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "不验证文件修改时间"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "不验证文件模式"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr "不验证文件兼容性"
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "不验证文件安全上下文"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "不验证软件包中文件"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "不验证包依赖"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "不执行验证脚本"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr " %s 缺失rpmlib的特性\n"
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "期望源代码包，但找到二进制包\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "源代码包中没有找到 .spec 文件\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解压压缩文件 %s%s 失败：%s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr "  在文件"
 
@@ -2282,96 +2395,116 @@ msgstr "没有软件包和 %s 匹配：%s\n"
 msgid "no package requires %s\n"
 msgstr "没有软件包需要 %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "没有软件包需要 %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "没有软件包触发器 %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "没有软件包需要 %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "没有软件包需要 %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "没有软件包提供 %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "文件 %s：%s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "文件 %s 不属于任何软件包\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "无效的软件包编号：%s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "记录 %u 不能读取\n"
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "未安装软件包 %s \n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "未知标签：\"%s\"\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: 密钥 %d 导入失败。\n"
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：公钥 %d  不受到保护。\n"
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s：headerRead 函数执行失败：%s\n"
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s：Fread 函数执行失败：%s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "不正确"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "确定"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (丢失的密钥："
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (不受信任的密钥："
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s: 打开失败：%s\n"
@@ -2396,144 +2529,195 @@ msgstr "无法更改根目录： %m\n"
 msgid "Unable to restore root directory: %m\n"
 msgstr "无法恢复根目录：%m\n"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "否"
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "是"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr ""
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr ""
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "软件包净负荷可以使用 bzip2 压缩。"
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr "软件包净负荷可以使用 xz 压缩。"
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr "软件包净负荷可以使用 lzma 压缩。"
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "软件包净负荷有\"./\" 前缀。"
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "软件包 name-version-release 没有隐含地提供。"
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "头标签总是排序后被加载。"
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr ""
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "硬链接文件集没有被完整的安装。"
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "软件包脚本在安装过程中允许访问 rpm 数据库。"
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "lua 脚本的内部支持"
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr "支持超过 4G 的文件"
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "不验证软件包依赖"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+#, fuzzy
+msgid "Name required"
+msgstr "版本要求"
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+#, fuzzy
+msgid "Empty rich dependency"
+msgstr "无效的依赖"
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "未结束的 %c：%s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+#, fuzzy
+msgid "Junk after rich dependency"
+msgstr "无效的依赖"
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "用户%s 不存在 - 使用root\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "群组%s 不存在 - 使用root\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "Bad magic"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "错误/不可读的  头部"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "头部太大"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr "对于压缩文件来说文件太大了"
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "未知文件类型"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr "丢失文件"
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "摘要不匹配"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "内部错误"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "在头中不存在归档"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " 失败 - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr "%s: (错误 0x%x)"
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "打开 %s 失败： %s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr "%s: 不是 rpm 软件包 (或者没有 manifest 文件)\n"
@@ -2565,42 +2749,42 @@ msgstr "依赖检测失败：\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s: 不是 rpm 软件包 (或者没有manifest)：%s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "不能安装 %s \n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "获取%s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr "跳过 %s - 传输失败\n"
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "软件包 %s 不能重定位\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "文件 %s 读取错误\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "\"%s\" 指定多个软件包：\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "无法打开 %s：%s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "正在安装 %s\n"
@@ -2626,12 +2810,12 @@ msgstr "读取失败：%s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "不是一个 rpm 软件包\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr "正在等候 %s 锁定 %s\n"
@@ -2789,60 +2973,79 @@ msgstr ""
 msgid "bad option '%s' at %s:%d\n"
 msgstr "坏的选项 “%s” 位于 %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr "读取辅助载体失败, 是 /proc 没有挂载么？\n"
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "未知系统：%s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "请联系 %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "不能打开 %s 供读取：%m。\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "无法恢复当前目录：%m"
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 脚本支持未内建\n"
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr "无法建立临时文件赖存储%s：%s\n"
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr "无法复制文件描述: %s: %s\n"
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "无法读取图标 %s: %s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "无法恢复根目录：%m\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite 失败: %s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr "%s 脚本执行失败，waitpid(%d) rc %d: %s\n"
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr "%s 脚本执行失败，捕捉到信号： %d\n"
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr "%s 脚本执行失败，退出状态码为 %d\n"
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "未知格式"
 
@@ -2854,127 +3057,146 @@ msgstr "安裝"
 msgid "erase"
 msgstr "删除"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "无法从 %s 打开软件包数据库\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的“（”存在于软件包标签中：%s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "丢失“（”在软件包标签 %s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "丢失“）”在软件包标签 %s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "读出公钥失败：%s\n"
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "事务"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(不是OpenPGP 签名)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr "sigh 载入: BAD"
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr "sigh sigSize(%zd): BAD, fstat(2) 失败"
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 摘要："
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "无法重载签名头。\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "头 SHA1 摘要："
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "头"
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 摘要："
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "头 SHA1 摘要："
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr "验证签名：错误的参数 (%d %p %d %p %p)"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "已跳过"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "已失败"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr "用户 %s 存在重复的用户名或 UID\n"
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr "用户组 %s 存在重复的组名或 GID\n"
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr "没有状态"
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr "未知状态"
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "遗漏   %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr "未满足的依赖关系 %s：\n"
@@ -3048,240 +3270,242 @@ msgstr "使用不同大小数组的数组的迭代器"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "没有设置 dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳过"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec 函数执行失败： %s\n"
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp 函数执行失败: %s\n"
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳过"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: 获取到损坏表头 #%u -- 跳过此项。\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：无法读取位于 0x%x 的表头\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "没有设置 dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "無法建立 %s 目录： %s\n"
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "无法加入原本位于 %u 的记录\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建数据库失败：原始数据库仍保持原状\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "用新的数据库取代旧的数据库失败！\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "用 %2$s 文件取代 %1$s 文件來恢复"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "移除目录失败 %s：%s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr "%s 错误(%d) 源自 %s: %s\n"
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr "%s 错误(%d): %s\n"
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "无法取得 %s 位于 %s/%s 的锁定\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "已共享"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "排他"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr "无效的索引类型 %x 于 %s/%s\n"
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr "添加表头 #%d 记录时出错 (%d)\n\n"
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr "移除表头 #%d 记录时出错 (%d)\n"
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "在分配新软件包进程时出错 (%d)\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "无法识别的数据库选项：\"%s\" 已忽略。\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s 有无效的数值，忽略\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s 有过大或者是过小的 long 数值，忽略\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s 有过大或者是过小的整数值，忽略\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "无法取得 %s 位于 %s/%s 的锁定\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "已共享"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "排他"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr "无效的索引类型 %x 于 %s/%s\n"
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+"添加表头 #%d 记录时出错 (%d)\n"
+"\n"
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr "移除表头 #%d 记录时出错 (%d)\n"
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "在分配新软件包进程时出错 (%d)\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "宏 %%%s 具有未结束的选项\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "宏 %%%s 主体未结束\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "宏 %%%s 中存在无效的名称 (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "宏 %%%s 中存在空内容\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "宏 %%%s 在结构之前需要空格\n"
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "宏 %%%s 展开失败\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "宏 %%%s 中存在无效的名称 (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "宏 %%%s 已经定义但是没有使用\n"
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中存在未知的选项 %1$c\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "宏扩展中存在太多层的递归。这有可能是由宏的递归声明引起的。\n"
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未结束的 %c：%s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在一个不可解析的宏之之后跟着 %%\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr "载入宏文件 %s 失败"
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3301,31 +3525,31 @@ msgstr "文件 %s：%s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "文件 %s 小于 %u 字节\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "创建目录失败"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "lua 脚本中存在无效的语法：%s\n"
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "lua 脚本中存在无效的语法: %s\n"
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 脚本执行失败：%s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua文件中存在无效的语法 %s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hook 执行失败：%s\n"
@@ -3334,19 +3558,19 @@ msgstr "lua hook 执行失败：%s\n"
 msgid "[none]"
 msgstr "[无]"
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(没有错误)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "致命错误："
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "错误："
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "警告："
 
@@ -3355,99 +3579,154 @@ msgstr "警告："
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "内在分配 (%u 字节) 返回 NULL。\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, 密钥 ID %s"
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(无)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "临时文件创建失败 %s：%m\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "临时文件创建失败 %s：%m\n"
+
+#: sign/rpmgensig.c:87
+#, fuzzy, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr "临时文件创建失败 %s：%m\n"
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "無法建立 %s 目录： %s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite 失败: %s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr "%s: Fflush 失败：%s\n"
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr "不支持的 PGP 签名\n"
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr "不支持的 PGP hash 算法 %u\n"
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr "不支持的 PGP 公钥算法 %u\n"
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "无法创建签名用的管道：%m"
+msgid "Could not exec %s: %s\n"
+msgstr "无法exec %s: %s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
 msgstr "fdopen 失败\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr "无法写入到管道\n"
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr "无法从文件 %s 读取: %s\n"
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg 执行失败 (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "写入签名时 gpg 验证失败\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "无法读取签名\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s：rpmWriteSignature 失败：%s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s：rpmReadSignature 函数执行失败：%s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "%s：headerRead 函数执行失败：%s\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp 失败\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "fdopen 失败\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "%s：headerRead 函数执行失败：%s\n"
+
+#: sign/rpmgensig.c:652
+#, fuzzy, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr "%s 已经包含了相同的签名，跳过\n"
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 函数执行失败：%s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "无法对 RPM v3 版本的软件包签名\n"
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已经包含了相同的签名，跳过\n"
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失败：%s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp 失败\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失败：%s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "替换 %s 失败：%s\n"
@@ -3460,3 +3739,24 @@ msgstr "%s：读取 manifest 文件失败：%s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "不验证报头+净负荷签名"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "输入密码："
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "密码正确。\n"
+
+#~ msgid "Pass phrase check failed or gpg key expired\n"
+#~ msgstr "密码检查失败或者 gpg 密钥过期\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "坏的属主/群组：%s\n"
+
+#~ msgid "line %d: Illegal char in: %s\n"
+#~ msgstr "行 %d：非法的字符在: %s 中\n"
+
+#~ msgid "Fread failed: %s"
+#~ msgstr "Fread 失败: %s"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "无法创建签名用的管道：%m"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Cheng-Chia Tseng <pswo10680@gmail.com>, 2011-2012
 # You-Cheng Hsieh <yochenhsieh@gmail.com>, 2012-2013
@@ -9,15 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2015-07-24 08:13+0200\n"
-"PO-Revision-Date: 2014-04-07 10:19+0000\n"
+"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/projects/p/rpm/"
-"language/zh_TW/)\n"
-"Language: zh_TW\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/rpm-team/rpm/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -82,7 +81,7 @@ msgstr "校驗選項 (使用 -V 或 --verify)："
 msgid "Install/Upgrade/Erase options:"
 msgstr "安裝/升級/抹除選項："
 
-#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "用於所有 rpm 模式和可執行檔案的共同選項："
@@ -103,7 +102,7 @@ msgstr "不可預料的查詢格式"
 msgid "unexpected query source"
 msgstr "不可預料的查詢來源"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:95
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
 msgid "only one major mode may be specified"
 msgstr "只能指定一個主要工作模式"
 
@@ -138,7 +137,8 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid "--percent may only be specified during package installation and erasure"
+msgid ""
+"--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -203,7 +203,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:615
+#: rpmqv.c:240 rpmbuild.c:550
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的引數必須以「/」開頭"
 
@@ -223,248 +223,201 @@ msgstr "沒有給定查詢引數"
 msgid "no arguments given for verify"
 msgstr "沒有給定校驗引數"
 
-#: rpmbuild.c:115
+#: rpmbuild.c:99
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot 已被指定，忽略 %s\n"
 
-#: rpmbuild.c:140
+#: rpmbuild.c:120
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "從 <specfile> 透過 %prep (解包源碼並套用修補程式) 來建置"
 
-#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
-#: rpmbuild.c:156 rpmbuild.c:159
+#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
+#: rpmbuild.c:136 rpmbuild.c:139
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:143
+#: rpmbuild.c:123
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
 
-#: rpmbuild.c:146
+#: rpmbuild.c:126
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "從 <specfile> 透過 %install (%prep，%build，然後安裝) 來建置"
 
-#: rpmbuild.c:149
+#: rpmbuild.c:129
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "從 <specfile> 驗證 %files 區段"
 
-#: rpmbuild.c:152
+#: rpmbuild.c:132
 msgid "build source and binary packages from <specfile>"
 msgstr "根據 <specfile> 建置源碼套件與二進位套件"
 
-#: rpmbuild.c:155
+#: rpmbuild.c:135
 msgid "build binary package only from <specfile>"
 msgstr "根據 <specfile> 只建置二進位套件"
 
-#: rpmbuild.c:158
+#: rpmbuild.c:138
 msgid "build source package only from <specfile>"
 msgstr "根據 <specfile> 只建置源碼套件"
 
-#: rpmbuild.c:162
-#, fuzzy, c-format
-msgid ""
-"build through %prep (unpack sources and apply patches) from <source package>"
-msgstr "從 <specfile> 透過 %prep (解包源碼並套用修補程式) 來建置"
+#: rpmbuild.c:142
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "從 <tarball> 透過 %prep (解包源碼和套用修補檔) 來建置"
 
-#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
-#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
+#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
+#: rpmbuild.c:158 rpmbuild.c:161
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:145
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
+
+#: rpmbuild.c:148
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
+
+#: rpmbuild.c:151
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "從 <tarball> 驗證 %files 區段"
+
+#: rpmbuild.c:154
+msgid "build source and binary packages from <tarball>"
+msgstr "從 <tarball> 中建置源碼套件與二進位套件"
+
+#: rpmbuild.c:157
+msgid "build binary package only from <tarball>"
+msgstr "從 <tarball> 中只建置二進位套件"
+
+#: rpmbuild.c:160
+msgid "build source package only from <tarball>"
+msgstr "從 <tarball> 中只建置源碼套件"
+
+#: rpmbuild.c:164
+msgid "build binary package from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:165 rpmbuild.c:168
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:165
-#, fuzzy
-msgid "build through %build (%prep, then compile) from <source package>"
-msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
-
-#: rpmbuild.c:168 rpmbuild.c:209
+#: rpmbuild.c:167
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "從 <source package> 透過 %install (%prep，%build，然後安裝) 來建置"
 
 #: rpmbuild.c:171
-#, fuzzy, c-format
-msgid "verify %files section from <source package>"
-msgstr "從 <specfile> 驗證 %files 區段"
-
-#: rpmbuild.c:174
-#, fuzzy
-msgid "build source and binary packages from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:177
-#, fuzzy
-msgid "build binary package only from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:180
-#, fuzzy
-msgid "build source package only from <source package>"
-msgstr "根據 <specfile> 只建置源碼套件"
-
-#: rpmbuild.c:184
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "從 <tarball> 透過 %prep (解包源碼和套用修補檔) 來建置"
-
-#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
-#: rpmbuild.c:200 rpmbuild.c:203
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:187
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
-
-#: rpmbuild.c:190
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
-
-#: rpmbuild.c:193
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "從 <tarball> 驗證 %files 區段"
-
-#: rpmbuild.c:196
-msgid "build source and binary packages from <tarball>"
-msgstr "從 <tarball> 中建置源碼套件與二進位套件"
-
-#: rpmbuild.c:199
-msgid "build binary package only from <tarball>"
-msgstr "從 <tarball> 中只建置二進位套件"
-
-#: rpmbuild.c:202
-msgid "build source package only from <tarball>"
-msgstr "從 <tarball> 中只建置源碼套件"
-
-#: rpmbuild.c:206
-msgid "build binary package from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:213
 msgid "override build root"
 msgstr "強制覆寫建置根目錄"
 
-#: rpmbuild.c:215
-#, fuzzy
-msgid "run build in current directory"
-msgstr "無法建立目錄"
-
-#: rpmbuild.c:217
+#: rpmbuild.c:173
 msgid "remove build tree when done"
 msgstr "完成後移除建置樹"
 
-#: rpmbuild.c:219
+#: rpmbuild.c:175
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "忽略 ExcludeArch：根據規格檔的指示"
 
-#: rpmbuild.c:221
+#: rpmbuild.c:177
 msgid "debug file state machine"
 msgstr "除錯檔案狀態機器"
 
-#: rpmbuild.c:223
+#: rpmbuild.c:179
 msgid "do not execute any stages of the build"
 msgstr "不執行建置程序裡的任何步驟"
 
-#: rpmbuild.c:225
+#: rpmbuild.c:181
 msgid "do not verify build dependencies"
 msgstr "不校驗建置相依關係"
 
-#: rpmbuild.c:227
+#: rpmbuild.c:183
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:231
+#: rpmbuild.c:187
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:233
-#, fuzzy, c-format
-msgid "do not execute %prep stage of the build"
-msgstr "不執行建置程序裡的任何步驟"
-
-#: rpmbuild.c:235
+#: rpmbuild.c:189
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:238
+#: rpmbuild.c:192
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "不接受來自規格檔的 i18N msgstr"
 
-#: rpmbuild.c:240
+#: rpmbuild.c:194
 msgid "remove sources when done"
 msgstr "完成後移除源碼檔案"
 
-#: rpmbuild.c:242
+#: rpmbuild.c:196
 msgid "remove specfile when done"
 msgstr "完成後移除規格檔"
 
-#: rpmbuild.c:244
+#: rpmbuild.c:198
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "直接跳到指定的階段 (只有用於 c,i)"
 
-#: rpmbuild.c:246 rpmspec.c:34
+#: rpmbuild.c:200 rpmspec.c:34
 msgid "override target platform"
 msgstr "無視目標平臺"
 
-#: rpmbuild.c:263
+#: rpmbuild.c:217
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "組建選項中使用 [ <specfile> | <tarball> | <source package> ]："
 
-#: rpmbuild.c:283
+#: rpmbuild.c:237
 msgid "Failed build dependencies:\n"
 msgstr "相依性建置失敗：\n"
 
-#: rpmbuild.c:301
+#: rpmbuild.c:255
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "無法開啟 %s 規格檔：%s\n"
 
-#: rpmbuild.c:364
+#: rpmbuild.c:317
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "無法開啟 tar 導管：%m\n"
 
-#: rpmbuild.c:379
-#, fuzzy, c-format
-msgid "Found more than one spec file in %s\n"
-msgstr "無法開啟 %s 規格檔：%s\n"
-
-#: rpmbuild.c:390
+#: rpmbuild.c:336
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "無法從 %s 讀取規格檔\n"
 
-#: rpmbuild.c:402
+#: rpmbuild.c:348
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "無法將 %s 重新命名為 %s：%m\n"
 
-#: rpmbuild.c:480
+#: rpmbuild.c:419
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "無法檢視 %s 的狀態：%m\n"
 
-#: rpmbuild.c:484
+#: rpmbuild.c:423
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s 不是通常的檔案。\n"
 
-#: rpmbuild.c:491
+#: rpmbuild.c:430
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s 似乎不是規格檔。\n"
 
-#: rpmbuild.c:557
+#: rpmbuild.c:496
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "建置目標平台：%s\n"
 
-#: rpmbuild.c:565
+#: rpmbuild.c:504
 #, c-format
 msgid "Building for target %s\n"
 msgstr "建置目標 %s\n"
@@ -513,7 +466,7 @@ msgstr "列出 RPM 鑰匙圈的金鑰"
 msgid "Keyring options:"
 msgstr "鑰匙圈選項："
 
-#: rpmkeys.c:64 rpmsign.c:80
+#: rpmkeys.c:64 rpmsign.c:154
 msgid "no arguments given"
 msgstr "沒有指定引數"
 
@@ -533,10 +486,29 @@ msgstr "刪除套件簽署"
 msgid "Signature options:"
 msgstr "簽署選項："
 
-#: rpmsign.c:52
+#: rpmsign.c:93 sign/rpmgensig.c:232
+#, c-format
+msgid "Could not exec %s: %s\n"
+msgstr "無法執行 %s：%s\n"
+
+#: rpmsign.c:118
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "您必須在您的巨集檔案中設定「%%_gpg_name」\n"
+
+#: rpmsign.c:123
+msgid "Enter pass phrase: "
+msgstr "輸入通關密語： "
+
+#: rpmsign.c:127
+#, c-format
+msgid "Pass phrase is good.\n"
+msgstr "通關密語良好。\n"
+
+#: rpmsign.c:133
+#, c-format
+msgid "Pass phrase check failed or gpg key expired\n"
+msgstr ""
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -554,7 +526,7 @@ msgstr "操作透過規格所建立的二進位 rpm (預設)"
 msgid "operate on source rpm generated by spec"
 msgstr "操作透過規格所建立的源碼 rpm"
 
-#: rpmspec.c:36 lib/poptQV.c:208
+#: rpmspec.c:36 lib/poptQV.c:192
 msgid "use the following query format"
 msgstr "使用以下的查詢格式"
 
@@ -601,71 +573,68 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-"\n"
-"\n"
-"RPM 建置錯誤：\n"
+msgstr "\n\nRPM 建置錯誤：\n"
 
-#: build/expression.c:215
+#: build/expression.c:216
 msgid "syntax error while parsing ==\n"
 msgstr "解析 == 時有語法錯誤\n"
 
-#: build/expression.c:245
+#: build/expression.c:246
 msgid "syntax error while parsing &&\n"
 msgstr "解析 && 時有語法錯誤\n"
 
-#: build/expression.c:254
+#: build/expression.c:255
 msgid "syntax error while parsing ||\n"
 msgstr "解析 || 時有語法錯誤\n"
 
-#: build/expression.c:304
+#: build/expression.c:305
 msgid "parse error in expression\n"
 msgstr "表述式解析錯誤\n"
 
-#: build/expression.c:336
+#: build/expression.c:337
 msgid "unmatched (\n"
 msgstr "不符合的 (\n"
 
-#: build/expression.c:368
+#: build/expression.c:369
 msgid "- only on numbers\n"
 msgstr "- 只能用於數字\n"
 
-#: build/expression.c:384
+#: build/expression.c:385
 msgid "! only on numbers\n"
 msgstr "! 只能用於數字\n"
 
-#: build/expression.c:426 build/expression.c:474 build/expression.c:532
-#: build/expression.c:624
+#: build/expression.c:427 build/expression.c:475 build/expression.c:533
+#: build/expression.c:625
 msgid "types must match\n"
 msgstr "類型必須符合\n"
 
-#: build/expression.c:439
+#: build/expression.c:440
 msgid "* / not suported for strings\n"
 msgstr "字串不支援 *、/\n"
 
-#: build/expression.c:490
+#: build/expression.c:491
 msgid "- not suported for strings\n"
 msgstr "字串不支援 -\n"
 
-#: build/expression.c:637
+#: build/expression.c:638
 msgid "&& and || not suported for strings\n"
 msgstr "字串不支援 && 和 ||\n"
 
-#: build/expression.c:669
+#: build/expression.c:671
 msgid "syntax error in expression\n"
 msgstr "表述式中有語法錯誤\n"
 
-#: build/files.c:282 build/files.c:456 build/files.c:670
+#: build/files.c:282 build/files.c:455 build/files.c:669
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "在 %s %s 中有遺漏的「(」\n"
 
-#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
+#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "在 %s(%s 中有遺漏的「)」\n"
 
-#: build/files.c:317 build/files.c:611
+#: build/files.c:317 build/files.c:610
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "無效的 %s 符記：%s\n"
@@ -675,46 +644,46 @@ msgstr "無效的 %s 符記：%s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "在 %2$s %3$s 中有缺失的 %1$s\n"
 
-#: build/files.c:471
+#: build/files.c:470
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 之後有非空白空格：%s\n"
 
-#: build/files.c:507
+#: build/files.c:506
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "不良語法：%s(%s)\n"
 
-#: build/files.c:516
+#: build/files.c:515
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "不良模式規格：%s(%s)\n"
 
-#: build/files.c:528
+#: build/files.c:527
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "不良 dirmode 規格：%s(%s)\n"
 
-#: build/files.c:632
+#: build/files.c:631
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:639
+#: build/files.c:638
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:754
+#: build/files.c:753
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "無效的功能：%s\n"
 
-#: build/files.c:764
+#: build/files.c:763
 msgid "File capability support not built in\n"
 msgstr "檔案功能支援未內建於\n"
 
-#: build/files.c:813
+#: build/files.c:812
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "檔案必須以「/」開頭：%s\n"
@@ -724,146 +693,149 @@ msgstr "檔案必須以「/」開頭：%s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:979
+#: build/files.c:955
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "曾列出兩次的檔案：%s\n"
 
-#: build/files.c:1094
+#: build/files.c:1070
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1102
+#: build/files.c:1078
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "指向 BuildRoot 的符號連結：%s -> %s\n"
 
-#: build/files.c:1244
+#: build/files.c:1220
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1284
+#: build/files.c:1260
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1285 lib/rpminstall.c:443
+#: build/files.c:1261
 #, c-format
 msgid "File not found: %s\n"
 msgstr "找不到檔案：%s\n"
 
-#: build/files.c:1297
+#: build/files.c:1273
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1488
+#: build/files.c:1464
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：無法呼叫不明的標籤 (%d)。\n"
 
-#: build/files.c:1494
+#: build/files.c:1470
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公鑰讀入失敗。\n"
 
-#: build/files.c:1498
+#: build/files.c:1474
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s：不是一個受保護的公鑰。\n"
 
-#: build/files.c:1507
+#: build/files.c:1483
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：編碼失敗\n"
 
-#: build/files.c:1552
+#: build/files.c:1528
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "檔案需要以「/」開頭：%s\n"
 
-#: build/files.c:1576
+#: build/files.c:1552
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1589
+#: build/files.c:1565
 #, c-format
 msgid "Directory not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:1590 build/files.c:1773 lib/rpminstall.c:445
+#: build/files.c:1566 lib/rpminstall.c:426
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "透過 glob 解析找不到檔案：%s\n"
 
-#: build/files.c:1627
+#: build/files.c:1603
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "無法開啟 %%files 檔案 %s：%m\n"
 
-#: build/files.c:1638
+#: build/files.c:1611
 #, c-format
 msgid "line: %s\n"
 msgstr "列：%s\n"
 
-#: build/files.c:1649
+#: build/files.c:1619
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1655
+#: build/files.c:1622
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1678
+#: build/files.c:1644
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1868
+#: build/files.c:1806
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1823
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2015
+#: build/files.c:1953
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不良檔案：%s：%s\n"
 
-#: build/files.c:2083
+#: build/files.c:1978 build/parsePrep.c:33
+#, c-format
+msgid "Bad owner/group: %s\n"
+msgstr "不良擁有者/群組：%s\n"
+
+#: build/files.c:2011
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "正在檢查未打包的檔案：%s\n"
 
-#: build/files.c:2096
+#: build/files.c:2024
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr ""
-"找到已安裝 (但未打包) 的檔案：\n"
-"%s"
+msgstr "找到已安裝 (但未打包) 的檔案：\n%s"
 
-#: build/files.c:2127
+#: build/files.c:2055
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "正在處理檔案：%s\n"
 
-#: build/files.c:2141
+#: build/files.c:2069
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2147
+#: build/files.c:2075
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 套件中有架構依賴二進位檔\n"
 
@@ -892,79 +864,79 @@ msgstr "%s: 列：%s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "無法標準化主機名稱：%s\n"
 
-#: build/pack.c:368
+#: build/pack.c:350
 msgid "Unable to reload signature header.\n"
 msgstr "無法重新載入簽署表頭。\n"
 
-#: build/pack.c:441
+#: build/pack.c:423
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:490
+#: build/pack.c:451
 msgid "Unable to create immutable header region.\n"
 msgstr "無法建立不可變的表頭區域。\n"
 
-#: build/pack.c:498
+#: build/pack.c:459
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/pack.c:510
+#: build/pack.c:471
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "無法寫入套件：%s\n"
 
-#: build/pack.c:534
+#: build/pack.c:495
 msgid "Unable to write temp header\n"
 msgstr "無法寫入臨時表頭\n"
 
-#: build/pack.c:543
+#: build/pack.c:504
 msgid "Bad CSA data\n"
 msgstr "不良 CSA 資料\n"
 
-#: build/pack.c:554 build/pack.c:573 sign/rpmgensig.c:294 sign/rpmgensig.c:614
-#: sign/rpmgensig.c:649
-#, fuzzy, c-format
+#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
+#: sign/rpmgensig.c:633
+#, c-format
 msgid "Could not seek in file %s: %s\n"
-msgstr "無法開啟 %%files 檔案 %s：%m\n"
+msgstr ""
 
-#: build/pack.c:565
-#, fuzzy, c-format
+#: build/pack.c:526
+#, c-format
 msgid "Fread failed in file %s: %s\n"
-msgstr "%s：Fread 失敗：%s\n"
+msgstr ""
 
-#: build/pack.c:599
+#: build/pack.c:560
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已寫入：%s\n"
 
-#: build/pack.c:618
+#: build/pack.c:579
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在執行「%s」：\n"
 
-#: build/pack.c:621
+#: build/pack.c:582
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」執行失敗。\n"
 
-#: build/pack.c:625
+#: build/pack.c:586
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "套件檢查「%s」失敗。\n"
 
-#: build/pack.c:672
+#: build/pack.c:633
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "無法產生套件 %s 的檔案名稱輸出：%s\n"
 
-#: build/pack.c:689
+#: build/pack.c:650
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "無法建立 %s：%s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "列 %d：第二個 %s\n"
@@ -1015,19 +987,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "列 %d：解析 %%description 時發生錯誤：%s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:306
+#: build/parseScript.c:232
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "列 %d：不良選項 %s：%s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:317
+#: build/parseScript.c:243
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "列 %d：過多名稱：%s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:325
+#: build/parseScript.c:251
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "列 %d：套件不存在：%s\n"
@@ -1134,94 +1106,90 @@ msgstr "列 %d：標籤只需單一符記：%s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "Illegal char '%c' (0x%x)"
+msgid "line %d: Illegal char '%c' in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:620
-msgid "Illegal sequence \"..\""
+#: build/parsePreamble.c:619
+#, c-format
+msgid "line %d: Illegal char in: %s\n"
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, fuzzy, c-format
-msgid "line %d: %s in: %s\n"
-msgstr "列 %d：第二個 %s\n"
+#, c-format
+msgid "line %d: Illegal sequence \"..\" in: %s\n"
+msgstr ""
 
-#: build/parsePreamble.c:628
-#, fuzzy, c-format
-msgid "%s in: %s\n"
-msgstr "%s: 列：%s\n"
-
-#: build/parsePreamble.c:713
+#: build/parsePreamble.c:710
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "列 %d：格式不良的標籤：%s\n"
 
-#: build/parsePreamble.c:721
+#: build/parsePreamble.c:718
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "列 %d：空的標籤：%s\n"
 
-#: build/parsePreamble.c:782
+#: build/parsePreamble.c:779
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "列 %d：前綴不能以「/」結尾：%s\n"
 
-#: build/parsePreamble.c:794
+#: build/parsePreamble.c:791
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "列 %d：Docdir 必須以「/」開頭：%s\n"
 
-#: build/parsePreamble.c:807
+#: build/parsePreamble.c:804
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:844
+#: build/parsePreamble.c:841
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "列 %d：不良 %s：修飾詞：%s\n"
 
-#: build/parsePreamble.c:878
+#: build/parsePreamble.c:875
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "列 %d：不良 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:888
+#: build/parsePreamble.c:885
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:903
+#: build/parsePreamble.c:897
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "內部錯誤：假造的標籤 %d\n"
 
-#: build/parsePreamble.c:992
+#: build/parsePreamble.c:985
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1053
+#: build/parsePreamble.c:1046
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不良套件規格：%s\n"
 
-#: build/parsePreamble.c:1062
+#: build/parsePreamble.c:1055
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "套件已經存在：%s\n"
 
-#: build/parsePreamble.c:1097
+#: build/parsePreamble.c:1090
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "列 %d：未知標籤：%s\n"
 
-#: build/parsePreamble.c:1129
+#: build/parsePreamble.c:1122
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1133
+#: build/parsePreamble.c:1126
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1231,193 +1199,161 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "不良源碼：%s：%s\n"
 
-#: build/parsePrep.c:70
+#: build/parsePrep.c:73
 #, c-format
 msgid "No patch number %u\n"
 msgstr "沒有修補編號 %u\n"
 
-#: build/parsePrep.c:72
+#: build/parsePrep.c:75
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:155
+#: build/parsePrep.c:152
 #, c-format
 msgid "No source number %u\n"
 msgstr "沒有源碼編號 %u\n"
 
-#: build/parsePrep.c:157
+#: build/parsePrep.c:154
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "規格檔內無「Source:」標籤\n"
 
-#: build/parsePrep.c:265
+#: build/parsePrep.c:261
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "解析 %%setup 時發生錯誤：%s\n"
 
-#: build/parsePrep.c:276
+#: build/parsePrep.c:272
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "列 %d：%%setup 中出現不良引數：%s\n"
 
-#: build/parsePrep.c:291
+#: build/parsePrep.c:287
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "列 %d：不良 %%setup 選項 %s：%s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:446
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:472
+#: build/parsePrep.c:459
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無效的修補編號 %s：%s\n"
 
-#: build/parsePrep.c:499
+#: build/parsePrep.c:486
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "列 %d：第二個 %%prep\n"
 
-#: build/parseReqs.c:35
+#: build/parseReqs.c:131
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:40
+#: build/parseReqs.c:156
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:208
-msgid "No rich dependencies allowed for this type"
-msgstr ""
-
-#: build/parseReqs.c:218 build/parseReqs.c:293
-msgid "invalid dependency"
-msgstr ""
-
-#: build/parseReqs.c:253 lib/rpmds.c:1441
+#: build/parseReqs.c:173
 msgid "Version required"
 msgstr ""
 
-#: build/parseReqs.c:269
-msgid "Only absolute paths are allowed in file triggers"
+#: build/parseReqs.c:189
+msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:282
-msgid "Trigger fired by the same package is already defined in spec file"
-msgstr ""
-
-#: build/parseReqs.c:310
+#: build/parseReqs.c:205
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:256
+#: build/parseScript.c:192
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "列 %d：觸發器必須包含 --：%s\n"
 
-#: build/parseScript.c:266 build/parseScript.c:339
+#: build/parseScript.c:202 build/parseScript.c:265
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "列 %d：解析 %s 時發生錯誤：%s\n"
 
-#: build/parseScript.c:278
+#: build/parseScript.c:214
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "列 %d：內部指令稿必須以「>」結尾：%s\n"
 
-#: build/parseScript.c:284
+#: build/parseScript.c:220
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "列 %d：指令稿程式必須以「/」開頭：%s\n"
 
-#: build/parseScript.c:298
-#, c-format
-msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
-
-#: build/parseScript.c:332
+#: build/parseScript.c:258
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "列 %d：第二個 %s\n"
 
-#: build/parseScript.c:374
+#: build/parseScript.c:300
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "列 %d：不支援的內部指令稿：%s\n"
 
-#: build/parseScript.c:392
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:187
+#: build/parseSpec.c:212
 #, c-format
 msgid "line %d: %s\n"
 msgstr "列 %d：%s\n"
 
-#: build/parseSpec.c:196
-#, c-format
-msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
-
-#: build/parseSpec.c:300
+#: build/parseSpec.c:255
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/parseSpec.c:334
+#: build/parseSpec.c:289
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:356
+#: build/parseSpec.c:311
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:361
+#: build/parseSpec.c:316
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:358
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:411
+#: build/parseSpec.c:366
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d：有個 %%else 沒有對應 %%if\n"
 
-#: build/parseSpec.c:422
+#: build/parseSpec.c:377
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d：有個 %%endif 沒有對應 %%if\n"
 
-#: build/parseSpec.c:440
+#: build/parseSpec.c:395
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:625
-#, c-format
-msgid "encoding %s not supported by system\n"
-msgstr ""
-
-#: build/parseSpec.c:654
-#, c-format
-msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
-msgstr ""
-
-#: build/parseSpec.c:799
+#: build/parseSpec.c:669
 msgid "No compatible architectures found for build\n"
 msgstr "找不到可供建置的相容架構\n"
 
-#: build/parseSpec.c:833
+#: build/parseSpec.c:703
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "套件沒有 %%description：%s\n"
@@ -1488,281 +1424,290 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:108
+#: build/rpmfc.c:110
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:205
+#: build/rpmfc.c:207
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "無法為 %s 建立導管：%m\n"
 
-#: build/rpmfc.c:230
+#: build/rpmfc.c:232
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "無法執行 %s：%s\n"
 
-#: build/rpmfc.c:235 lib/rpmscript.c:323
+#: build/rpmfc.c:237 lib/rpmscript.c:297
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "無法分支 %s：%s\n"
 
-#: build/rpmfc.c:318
+#: build/rpmfc.c:320
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失敗：%x\n"
 
-#: build/rpmfc.c:322
+#: build/rpmfc.c:324
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "無法寫入所有資料至 %s：%s\n"
 
-#: build/rpmfc.c:453
+#: build/rpmfc.c:455
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:472
+#: build/rpmfc.c:474
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:539
+#: build/rpmfc.c:540
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:845
+#: build/rpmfc.c:871
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s 轉換至 long integer 失敗。\n"
 
-#: build/rpmfc.c:915
+#: build/rpmfc.c:949
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:924
+#: build/rpmfc.c:958
 msgid "No file attributes configured\n"
 msgstr "無設定檔案特性\n"
 
-#: build/rpmfc.c:944
+#: build/rpmfc.c:978
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失敗：%s\n"
 
-#: build/rpmfc.c:950
+#: build/rpmfc.c:984
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失敗：%s\n"
 
-#: build/rpmfc.c:992
+#: build/rpmfc.c:1026
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "檔案「%s」辨識失敗：模式 %06o %s\n"
 
-#: build/rpmfc.c:1193
+#: build/rpmfc.c:1214
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在尋找 %s：%s\n"
 
-#: build/rpmfc.c:1202 build/rpmfc.c:1211
+#: build/rpmfc.c:1223 build/rpmfc.c:1232
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "找不到 %s：\n"
 
-#: build/spec.c:451
+#: build/spec.c:425
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s 規格檔查詢失敗，無法剖析\n"
 
-#: lib/depends.c:91
+#: lib/depends.c:82
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:95
+#: lib/depends.c:86
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:375
+#: lib/depends.c:365
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "套件 %s 已被加入，跳過 %s\n"
 
-#: lib/depends.c:376
+#: lib/depends.c:366
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "套件 %s 已被加入，以 %s 替換\n"
 
-#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
-#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
-#: lib/formats.c:545
+#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
+#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
+#: lib/formats.c:544
 msgid "(not a number)"
 msgstr "(不是數字)"
 
-#: lib/formats.c:126
+#: lib/formats.c:125
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:136
+#: lib/formats.c:135
 msgid "%a %b %d %Y"
 msgstr "%Y %b %d %a"
 
-#: lib/formats.c:315
+#: lib/formats.c:314
 msgid "(not base64)"
 msgstr "(不是 base64)"
 
-#: lib/formats.c:327
+#: lib/formats.c:326
 msgid "(invalid type)"
 msgstr "(無效型態)"
 
-#: lib/formats.c:350 lib/formats.c:430
+#: lib/formats.c:349 lib/formats.c:429
 msgid "(not a blob)"
 msgstr "(不是 blob)"
 
-#: lib/formats.c:385
+#: lib/formats.c:384
 msgid "(invalid xml type)"
 msgstr "(無效 xml 類型)"
 
-#: lib/formats.c:435
+#: lib/formats.c:434
 msgid "(not an OpenPGP signature)"
 msgstr "(不是個 OpenPGP 簽署)"
 
-#: lib/formats.c:447
+#: lib/formats.c:446
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:513
+#: lib/formats.c:512
 msgid "normal"
 msgstr "一般"
 
-#: lib/formats.c:516 lib/verify.c:375
+#: lib/formats.c:515 lib/verify.c:369
 msgid "replaced"
 msgstr "已替換"
 
-#: lib/formats.c:519 lib/verify.c:369
+#: lib/formats.c:518 lib/verify.c:363
 msgid "not installed"
 msgstr "未安裝"
 
-#: lib/formats.c:522 lib/verify.c:371
+#: lib/formats.c:521 lib/verify.c:365
 msgid "net shared"
 msgstr "已網路分享"
 
-#: lib/formats.c:525 lib/verify.c:373
+#: lib/formats.c:524 lib/verify.c:367
 msgid "wrong color"
 msgstr "錯誤色彩"
 
-#: lib/formats.c:528
+#: lib/formats.c:527
 msgid "missing"
 msgstr "遺失"
 
-#: lib/formats.c:531
+#: lib/formats.c:530
 msgid "(unknown)"
 msgstr "(未知)"
 
-#: lib/formats.c:566
+#: lib/formats.c:565
 msgid "(not a string)"
 msgstr "(不是字串)"
 
-#: lib/fsm.c:705
+#: lib/fsm.c:704
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已被另存為 %s\n"
 
-#: lib/fsm.c:757
+#: lib/fsm.c:756
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立為 %s \n"
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1029
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1031
+#: lib/fsm.c:1030
 msgid "file"
 msgstr ""
 
-#: lib/package.c:173 lib/package.c:276 lib/package.c:383
+#: lib/package.c:155
+#, c-format
+msgid "%s has unverifiable signature"
+msgstr ""
+
+#: lib/package.c:183 lib/package.c:297 lib/package.c:404
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:192
+#: lib/package.c:202
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:204
+#: lib/package.c:214
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:224
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:292
+#: lib/package.c:313
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:301
+#: lib/package.c:322
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:320
+#: lib/package.c:341
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:329
+#: lib/package.c:350
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:360
+#: lib/package.c:381
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:437
+#: lib/package.c:458
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:441
+#: lib/package.c:462
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:446
+#: lib/package.c:467
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:452
+#: lib/package.c:473
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:483
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:475
+#: lib/package.c:496
 msgid "hdr load: BAD"
+msgstr ""
+
+#: lib/package.c:648
+#, c-format
+msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid ""
-"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1891,16 +1836,15 @@ msgid "relocations must have a / following the ="
 msgstr "重新分配位置必須有個 / 跟在 = 之後"
 
 #: lib/poptI.c:114
-msgid "install all files, even configurations which might otherwise be skipped"
+msgid ""
+"install all files, even configurations which might otherwise be skipped"
 msgstr "安裝所有檔案，即使組態可能被略過"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if "
-"<package> specified multiple packages)"
-msgstr ""
-"移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤"
-"出現)"
+"remove all packages which match <package> (normally an error is generated if"
+" <package> specified multiple packages)"
+msgstr "移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤出現)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1978,7 +1922,7 @@ msgstr "更新資料庫，但不修改檔案系統"
 msgid "do not verify package dependencies"
 msgstr "不校驗套件相依性"
 
-#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
+#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
 msgid "don't verify digest of files"
 msgstr "不要校驗檔案的摘要"
 
@@ -2098,182 +2042,162 @@ msgstr "升級套件"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:67
 msgid "query/verify all packages"
 msgstr "查詢/校驗所有套件"
 
-#: lib/poptQV.c:77
+#: lib/poptQV.c:69
 msgid "rpm checksig mode"
 msgstr "rpm 檢查簽署模式"
 
-#: lib/poptQV.c:79
+#: lib/poptQV.c:71
 msgid "query/verify package(s) owning file"
 msgstr "查詢/校驗套件擁有的檔案"
 
-#: lib/poptQV.c:81
+#: lib/poptQV.c:73
 msgid "query/verify package(s) in group"
 msgstr "查詢/校驗套件所屬的群組"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:75
 msgid "query/verify a package file"
 msgstr "查詢/校驗一個套件檔案"
 
-#: lib/poptQV.c:86
+#: lib/poptQV.c:78
 msgid "query/verify package(s) with package identifier"
 msgstr "以套件的識別符查詢/校驗套件"
 
-#: lib/poptQV.c:88
+#: lib/poptQV.c:80
 msgid "query/verify package(s) with header identifier"
 msgstr "以表頭識別符查詢/校驗套件"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:83
 msgid "rpm query mode"
 msgstr "rpm 查詢模式"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:85
 msgid "query/verify a header instance"
 msgstr "查詢/驗證表頭實體"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:87
 msgid "query/verify package(s) from install transaction"
 msgstr "從安裝處理事項查詢/驗證套件"
 
-#: lib/poptQV.c:97
+#: lib/poptQV.c:89
 msgid "query the package(s) triggered by the package"
 msgstr "查詢套件所觸發的套件"
 
-#: lib/poptQV.c:99
+#: lib/poptQV.c:91
 msgid "rpm verify mode"
 msgstr "rpm 校驗模式"
 
-#: lib/poptQV.c:101
+#: lib/poptQV.c:93
 msgid "query/verify the package(s) which require a dependency"
 msgstr "查詢/校驗需要某些相依套件的套件"
 
-#: lib/poptQV.c:103
+#: lib/poptQV.c:95
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "查詢/校驗提供某些相依套件的套件"
 
-#: lib/poptQV.c:105
-#, fuzzy
-msgid "query/verify the package(s) which recommends a dependency"
-msgstr "查詢/校驗需要某些相依套件的套件"
-
-#: lib/poptQV.c:107
-#, fuzzy
-msgid "query/verify the package(s) which suggests a dependency"
-msgstr "查詢/校驗需要某些相依套件的套件"
-
-#: lib/poptQV.c:109
-#, fuzzy
-msgid "query/verify the package(s) which supplements a dependency"
-msgstr "查詢/校驗需要某些相依套件的套件"
-
-#: lib/poptQV.c:111
-#, fuzzy
-msgid "query/verify the package(s) which enhances a dependency"
-msgstr "查詢/校驗需要某些相依套件的套件"
-
-#: lib/poptQV.c:114
+#: lib/poptQV.c:98
 msgid "do not glob arguments"
 msgstr "不以 glob 解析引數"
 
-#: lib/poptQV.c:116
+#: lib/poptQV.c:100
 msgid "do not process non-package files as manifests"
 msgstr "不以 manifest 處理非套件檔案"
 
-#: lib/poptQV.c:188
+#: lib/poptQV.c:172
 msgid "list all configuration files"
 msgstr "列出所有組態檔案"
 
-#: lib/poptQV.c:190
+#: lib/poptQV.c:174
 msgid "list all documentation files"
 msgstr "列出所有文件檔案"
 
-#: lib/poptQV.c:192
+#: lib/poptQV.c:176
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:178
 msgid "dump basic file information"
 msgstr "傾印基本檔案資訊"
 
-#: lib/poptQV.c:198
+#: lib/poptQV.c:182
 msgid "list files in package"
 msgstr "列出套件內的檔案"
 
-#: lib/poptQV.c:203
+#: lib/poptQV.c:187
 #, c-format
 msgid "skip %%ghost files"
 msgstr "略過 %%ghost 檔案"
 
-#: lib/poptQV.c:210
+#: lib/poptQV.c:194
 msgid "display the states of the listed files"
 msgstr "顯示列出的檔案的狀態"
 
-#: lib/poptQV.c:228
+#: lib/poptQV.c:212
 msgid "don't verify size of files"
 msgstr "不校驗檔案大小"
 
-#: lib/poptQV.c:231
+#: lib/poptQV.c:215
 msgid "don't verify symlink path of files"
 msgstr "不校驗檔案的符號連結路徑"
 
-#: lib/poptQV.c:234
+#: lib/poptQV.c:218
 msgid "don't verify owner of files"
 msgstr "不校驗檔案的擁有者"
 
-#: lib/poptQV.c:237
+#: lib/poptQV.c:221
 msgid "don't verify group of files"
 msgstr "不校驗檔案的群組"
 
-#: lib/poptQV.c:240
+#: lib/poptQV.c:224
 msgid "don't verify modification time of files"
 msgstr "不校驗檔案的修改時間"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:227 lib/poptQV.c:230
 msgid "don't verify mode of files"
 msgstr "不校驗檔案的模式"
 
-#: lib/poptQV.c:249
+#: lib/poptQV.c:233
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:252
+#: lib/poptQV.c:236
 msgid "don't verify file security contexts"
 msgstr "不校驗檔案的安全情境"
 
-#: lib/poptQV.c:254
+#: lib/poptQV.c:238
 msgid "don't verify files in package"
 msgstr "不校驗套件內的檔案"
 
-#: lib/poptQV.c:256 tools/rpmgraph.c:218
+#: lib/poptQV.c:240 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "不校驗套件的相依關係"
 
-#: lib/poptQV.c:259 lib/poptQV.c:262
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't execute verify script(s)"
 msgstr "不執行校驗指令稿"
 
-#: lib/psm.c:146
+#: lib/psm.c:144
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:181
 msgid "source package expected, binary found\n"
 msgstr "預期是源碼套件，但卻找到二進位套件\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:192
 msgid "source package contains no .spec file\n"
 msgstr "源碼套件內未包含 .spec 檔案\n"
 
-#: lib/psm.c:605
+#: lib/psm.c:688
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解包封存檔失敗 %s%s：%s\n"
 
-#: lib/psm.c:606
+#: lib/psm.c:689
 msgid " on file "
 msgstr "  於檔案 "
 
@@ -2348,116 +2272,96 @@ msgstr "沒有套件符合 %s：%s\n"
 msgid "no package requires %s\n"
 msgstr "沒有套件需要 %s\n"
 
-#: lib/query.c:390
-#, fuzzy, c-format
-msgid "no package recommends %s\n"
-msgstr "沒有套件需要 %s\n"
-
-#: lib/query.c:397
-#, fuzzy, c-format
-msgid "no package suggests %s\n"
-msgstr "沒有套件會觸發 %s\n"
-
-#: lib/query.c:404
-#, fuzzy, c-format
-msgid "no package supplements %s\n"
-msgstr "沒有套件需要 %s\n"
-
-#: lib/query.c:411
-#, fuzzy, c-format
-msgid "no package enhances %s\n"
-msgstr "沒有套件需要 %s\n"
-
-#: lib/query.c:419
+#: lib/query.c:391
 #, c-format
 msgid "no package provides %s\n"
 msgstr "沒有套件提供 %s\n"
 
-#: lib/query.c:451
+#: lib/query.c:423
 #, c-format
 msgid "file %s: %s\n"
 msgstr "檔案 %s：%s\n"
 
-#: lib/query.c:454
+#: lib/query.c:426
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "檔案 %s 不被任何套件擁有\n"
 
-#: lib/query.c:465
+#: lib/query.c:437
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無效的套件編號：%s\n"
 
-#: lib/query.c:472
+#: lib/query.c:444
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:485 lib/rpminstall.c:680
+#: lib/query.c:457 lib/rpminstall.c:660
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "套件 %s 尚未安裝\n"
 
-#: lib/query.c:519
+#: lib/query.c:491
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "未知的標籤：「%s」\n"
 
-#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
+#: lib/rpmchecksig.c:44
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:65
+#: lib/rpmchecksig.c:48
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:110
+#: lib/rpmchecksig.c:93
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：匯入時讀取失敗(%d)。\n"
 
-#: lib/rpmchecksig.c:136 sign/rpmgensig.c:524
+#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:145
+#: lib/rpmchecksig.c:128
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:157 sign/rpmgensig.c:176
+#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s：Fread 失敗：%s\n"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "NOT OK"
 msgstr "不正確"
 
-#: lib/rpmchecksig.c:335
+#: lib/rpmchecksig.c:373
 msgid "OK"
 msgstr "正確"
 
-#: lib/rpmchecksig.c:337
+#: lib/rpmchecksig.c:375
 msgid " (MISSING KEYS:"
 msgstr " (遺失的金鑰："
 
-#: lib/rpmchecksig.c:339
+#: lib/rpmchecksig.c:377
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:340
+#: lib/rpmchecksig.c:378
 msgid " (UNTRUSTED KEYS:"
 msgstr " (未受信任的金鑰："
 
-#: lib/rpmchecksig.c:342
+#: lib/rpmchecksig.c:380
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:385 sign/rpmgensig.c:136
+#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s：開啟失敗：%s\n"
@@ -2482,192 +2386,144 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "NO "
 msgstr "否 "
 
-#: lib/rpmds.c:726
+#: lib/rpmds.c:547
 msgid "YES"
 msgstr "是"
 
-#: lib/rpmds.c:1203
+#: lib/rpmds.c:1000
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:、Provides:、以及 Obsoletes: 相依性支援版本。"
 
-#: lib/rpmds.c:1206
+#: lib/rpmds.c:1003
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "檔案名稱儲存為 (dirName、baseName、dirIndex) 字組，而非路徑。"
 
-#: lib/rpmds.c:1210
+#: lib/rpmds.c:1007
 msgid "package payload can be compressed using bzip2."
 msgstr "套件酬載可以使用 bzip2 壓縮。"
 
-#: lib/rpmds.c:1215
+#: lib/rpmds.c:1012
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1218
+#: lib/rpmds.c:1015
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1222
+#: lib/rpmds.c:1019
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "套件酬載檔案有「./」前綴。"
 
-#: lib/rpmds.c:1225
+#: lib/rpmds.c:1022
 msgid "package name-version-release is not implicitly provided."
 msgstr "套件的「名稱-版本-發行編號」沒有隱含性地提供。"
 
-#: lib/rpmds.c:1228
+#: lib/rpmds.c:1025
 msgid "header tags are always sorted after being loaded."
 msgstr "表頭標籤總在載入之後排序。"
 
-#: lib/rpmds.c:1231
+#: lib/rpmds.c:1028
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "指令稿片段解譯器可以使用來自表頭的引數。"
 
-#: lib/rpmds.c:1234
+#: lib/rpmds.c:1031
 msgid "a hardlink file set may be installed without being complete."
 msgstr "硬鏈結檔案組也許沒有被完整安裝。"
 
-#: lib/rpmds.c:1237
+#: lib/rpmds.c:1034
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "套件指令稿片段在安裝過程中可以存取 rpm 資料庫。"
 
-#: lib/rpmds.c:1241
+#: lib/rpmds.c:1038
 msgid "internal support for lua scripts."
 msgstr "lua 指令稿的內部支援。"
 
-#: lib/rpmds.c:1245
+#: lib/rpmds.c:1042
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1249
+#: lib/rpmds.c:1046
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1253
+#: lib/rpmds.c:1050
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1256
+#: lib/rpmds.c:1053
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1259
+#: lib/rpmds.c:1056
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmds.c:1262
-#, fuzzy
-msgid "support for rich dependencies."
-msgstr "不校驗套件相依性"
-
-#: lib/rpmds.c:1385
-#, c-format
-msgid "Unknown rich dependency op '%.*s'"
-msgstr ""
-
-#: lib/rpmds.c:1422
-msgid "Name required"
-msgstr ""
-
-#: lib/rpmds.c:1459
-msgid "Rich dependency does not start with '('"
-msgstr ""
-
-#: lib/rpmds.c:1467
-msgid "Missing argument to rich dependency op"
-msgstr ""
-
-#: lib/rpmds.c:1469
-msgid "Empty rich dependency"
-msgstr ""
-
-#: lib/rpmds.c:1483
-#, fuzzy, c-format
-msgid "Unterminated rich dependency: %s"
-msgstr "未終結的 %c：%s\n"
-
-#: lib/rpmds.c:1495
-msgid "Cannot chain different ops"
-msgstr ""
-
-#: lib/rpmds.c:1500
-msgid "Can only chain AND and OR ops"
-msgstr ""
-
-#: lib/rpmds.c:1592
-msgid "Junk after rich dependency"
-msgstr ""
-
-#: lib/rpmfi.c:798
+#: lib/rpmfi.c:780
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "使用者 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:805
+#: lib/rpmfi.c:787
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "群組 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:2194
+#: lib/rpmfi.c:2111
 msgid "Bad magic"
 msgstr "不良魔法數字"
 
-#: lib/rpmfi.c:2195
+#: lib/rpmfi.c:2112
 msgid "Bad/unreadable  header"
 msgstr "不良或無法讀取的表頭"
 
-#: lib/rpmfi.c:2218
+#: lib/rpmfi.c:2135
 msgid "Header size too big"
 msgstr "表頭大小過大"
 
-#: lib/rpmfi.c:2219
+#: lib/rpmfi.c:2136
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2220
+#: lib/rpmfi.c:2137
 msgid "Unknown file type"
 msgstr "未知檔案類型"
 
-#: lib/rpmfi.c:2221
+#: lib/rpmfi.c:2138
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2222
+#: lib/rpmfi.c:2139
 msgid "Digest mismatch"
 msgstr "摘要不符"
 
-#: lib/rpmfi.c:2223
+#: lib/rpmfi.c:2140
 msgid "Internal error"
 msgstr "內部錯誤"
 
-#: lib/rpmfi.c:2224
+#: lib/rpmfi.c:2141
 msgid "Archive file not in header"
 msgstr "在表頭中沒有封存檔"
 
-#: lib/rpmfi.c:2232
+#: lib/rpmfi.c:2149
 msgid " failed - "
 msgstr " 失敗 - "
 
-#: lib/rpmfi.c:2235
+#: lib/rpmfi.c:2152
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "開啟 %s 失敗：%s\n"
 
-#: lib/rpmgi.c:144
-#, c-format
-msgid "Max level of manifest recursion exceeded: %s\n"
-msgstr ""
-
-#: lib/rpmgi.c:155
+#: lib/rpmgi.c:136
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2699,42 +2555,42 @@ msgstr "相依關係失敗：\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s：不是 rpm 套件 (或套件 manifest)：%s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s 無法安裝\n"
 
-#: lib/rpminstall.c:484
+#: lib/rpminstall.c:464
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "正在擷取 %s\n"
 
-#: lib/rpminstall.c:496
+#: lib/rpminstall.c:476
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:562
+#: lib/rpminstall.c:542
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "套件 %s 不能重新分配位置\n"
 
-#: lib/rpminstall.c:593
+#: lib/rpminstall.c:573
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "讀取檔案 %s 時發生錯誤\n"
 
-#: lib/rpminstall.c:687
+#: lib/rpminstall.c:667
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "「%s」指定多個套件：\n"
 
-#: lib/rpminstall.c:726
+#: lib/rpminstall.c:706
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: lib/rpminstall.c:732
+#: lib/rpminstall.c:712
 #, c-format
 msgid "Installing %s\n"
 msgstr "正在安裝 %s\n"
@@ -2760,12 +2616,12 @@ msgstr "讀取失敗：%s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "並非 rpm 套件\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:137
+#: lib/rpmlock.c:118 lib/rpmlock.c:136
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:132
+#: lib/rpmlock.c:131
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2781,9 +2637,9 @@ msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
 #: lib/rpmplugins.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "Plugin %%__%s_%s not configured\n"
-msgstr "%s 插件未載入\n"
+msgstr ""
 
 #: lib/rpmplugins.c:199
 #, c-format
@@ -2927,75 +2783,56 @@ msgstr "不良選項「%s」位於 %s:%d\n"
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1411
+#: lib/rpmrc.c:1365
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "未知系統：%s\n"
 
-#: lib/rpmrc.c:1413
+#: lib/rpmrc.c:1367
 #, c-format
 msgid "Please contact %s\n"
 msgstr "請聯絡 %s\n"
 
-#: lib/rpmrc.c:1546
+#: lib/rpmrc.c:1500
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "無法開啟 %s 以供讀取：%m。\n"
 
-#: lib/rpmscript.c:137
-msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
-
-#: lib/rpmscript.c:142
+#: lib/rpmscript.c:122
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:153
+#: lib/rpmscript.c:133
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:281
+#: lib/rpmscript.c:263
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:316
+#: lib/rpmscript.c:290
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:343
-#, fuzzy, c-format
-msgid "Unable to reset nice value: %s"
-msgstr "無法讀取圖示 %s：%s\n"
-
-#: lib/rpmscript.c:354
-#, fuzzy, c-format
-msgid "Unable to reset I/O priority: %s"
-msgstr "無法讀取圖示 %s：%s\n"
-
-#: lib/rpmscript.c:382
-#, fuzzy, c-format
-msgid "Fwrite failed: %s"
-msgstr "%s: Fwrite 失敗：%s\n"
-
-#: lib/rpmscript.c:400
+#: lib/rpmscript.c:320
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:404
+#: lib/rpmscript.c:324
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:407
+#: lib/rpmscript.c:327
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:263
+#: lib/rpmtd.c:258
 msgid "Unknown format"
 msgstr "未知格式"
 
@@ -3007,142 +2844,127 @@ msgstr "安裝"
 msgid "erase"
 msgstr "抹除"
 
-#: lib/rpmts.c:99
+#: lib/rpmts.c:98
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "無法開啟套件資料庫 %s\n"
 
-#: lib/rpmts.c:198
+#: lib/rpmts.c:197
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的「(」存在於套件標籤中：%s\n"
 
-#: lib/rpmts.c:216
+#: lib/rpmts.c:215
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "套件標籤遺漏「(」：%s\n"
 
-#: lib/rpmts.c:224
+#: lib/rpmts.c:223
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "套件標籤遺漏「)」：%s\n"
 
-#: lib/rpmts.c:283
+#: lib/rpmts.c:279
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1139
+#: lib/rpmts.c:1062
 msgid "transaction"
 msgstr "處理事項"
 
-#: lib/signature.c:77
-#, c-format
-msgid "%s tag %u: BAD, invalid size %u"
-msgstr ""
-
-#: lib/signature.c:83
-#, c-format
-msgid "%s tag %u: BAD, invalid type %u"
-msgstr ""
-
-#: lib/signature.c:90
-#, fuzzy, c-format
-msgid "%s tag %u: BAD, invalid OpenPGP signature"
-msgstr "(不是個 OpenPGP 簽署)"
-
-#: lib/signature.c:159
+#: lib/signature.c:74
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:164
+#: lib/signature.c:79
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:170
+#: lib/signature.c:85
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:176
+#: lib/signature.c:91
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:191
+#: lib/signature.c:106
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:208
+#: lib/signature.c:123
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:218
+#: lib/signature.c:133
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:232
+#: lib/signature.c:146
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:248
+#: lib/signature.c:162
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:358
-msgid "Header "
-msgstr "表頭 "
-
-#: lib/signature.c:377
+#: lib/signature.c:235
 msgid "MD5 digest:"
 msgstr "MD5 摘要："
 
-#: lib/signature.c:380
+#: lib/signature.c:274
 msgid "Header SHA1 digest:"
 msgstr "表頭 SHA1 摘要："
 
-#: lib/signature.c:399
+#: lib/signature.c:316
+msgid "Header "
+msgstr "表頭 "
+
+#: lib/signature.c:357
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "skipped"
 msgstr "已跳過"
 
-#: lib/transaction.c:1360
+#: lib/transaction.c:1344
 msgid "failed"
 msgstr "已失敗"
 
-#: lib/verify.c:257
+#: lib/verify.c:251
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:278
+#: lib/verify.c:272
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:377
+#: lib/verify.c:371
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:379
+#: lib/verify.c:373
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:430
+#: lib/verify.c:424
 #, c-format
 msgid "missing   %c %s"
 msgstr "遺漏      %c %s"
 
-#: lib/verify.c:482
+#: lib/verify.c:476
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3216,240 +3038,240 @@ msgstr "用於不同大小陣列的陣列迭代器"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:166 lib/rpmdb.c:212
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:526
+#: lib/rpmdb.c:499
 msgid "no dbpath has been set\n"
 msgstr "尚未設定 dbpath\n"
 
-#: lib/rpmdb.c:1043
+#: lib/rpmdb.c:1013
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳過"
 
-#: lib/rpmdb.c:1061
+#: lib/rpmdb.c:1028
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "儲存記錄 #%2$d 到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/rpmdb.c:1172
+#: lib/rpmdb.c:1121
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1353
+#: lib/rpmdb.c:1302
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1516
+#: lib/rpmdb.c:1465
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳過"
 
-#: lib/rpmdb.c:1603
+#: lib/rpmdb.c:1550
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：已擷取損壞的表頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2135
+#: lib/rpmdb.c:2000
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：無法讀取位於 0x%x 的表頭\n"
 
-#: lib/rpmdb.c:2558
+#: lib/rpmdb.c:2300
 msgid "no dbpath has been set"
 msgstr "尚未設定 dbpath"
 
-#: lib/rpmdb.c:2576
+#: lib/rpmdb.c:2318
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2610
+#: lib/rpmdb.c:2352
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "在資料庫中有不良的表頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2623
+#: lib/rpmdb.c:2365
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "無法加入原本位於 %u 的記錄\n"
 
-#: lib/rpmdb.c:2639
+#: lib/rpmdb.c:2381
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建資料庫時失敗：原來的資料庫保持原狀\n"
 
-#: lib/rpmdb.c:2647
+#: lib/rpmdb.c:2389
 msgid "failed to replace old database with new database!\n"
 msgstr "以新的資料庫取代舊的資料庫時失敗！\n"
 
-#: lib/rpmdb.c:2649
+#: lib/rpmdb.c:2391
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "以 %2$s 的檔案取代 %1$s 的檔案來復原"
 
-#: lib/rpmdb.c:2660
+#: lib/rpmdb.c:2402
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "移除目錄時失敗 %s：%s\n"
 
-#: lib/backend/db3.c:96
+#: lib/backend/db3.c:36
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:99
+#: lib/backend/db3.c:39
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:282
-#, c-format
-msgid "unrecognized db option: \"%s\" ignored.\n"
-msgstr "無法辨識的資料庫選項：「%s」 已忽略。\n"
-
-#: lib/backend/db3.c:319
-#, c-format
-msgid "%s has invalid numeric value, skipped\n"
-msgstr "%s 有無效的數值，略過\n"
-
-#: lib/backend/db3.c:328
-#, c-format
-msgid "%s has too large or too small long value, skipped\n"
-msgstr "%s 有過大或過小的 long 數值，略過\n"
-
-#: lib/backend/db3.c:337
-#, c-format
-msgid "%s has too large or too small integer value, skipped\n"
-msgstr "%s 有過大或過小的整數值，略過\n"
-
-#: lib/backend/db3.c:797
+#: lib/backend/db3.c:592
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "shared"
 msgstr "已共享"
 
-#: lib/backend/db3.c:799
+#: lib/backend/db3.c:594
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:881
+#: lib/backend/db3.c:674
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1070
+#: lib/backend/db3.c:874
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1100
+#: lib/backend/db3.c:904
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1108
+#: lib/backend/db3.c:912
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1210
+#: lib/backend/db3.c:996
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1219
+#: lib/backend/db3.c:1008
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1274
+#: lib/backend/db3.c:1067
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "分配新套件實體時發生錯誤(%d)\n"
 
-#: rpmio/macro.c:283
+#: lib/backend/dbconfig.c:145
+#, c-format
+msgid "unrecognized db option: \"%s\" ignored.\n"
+msgstr "無法辨識的資料庫選項：「%s」 已忽略。\n"
+
+#: lib/backend/dbconfig.c:182
+#, c-format
+msgid "%s has invalid numeric value, skipped\n"
+msgstr "%s 有無效的數值，略過\n"
+
+#: lib/backend/dbconfig.c:191
+#, c-format
+msgid "%s has too large or too small long value, skipped\n"
+msgstr "%s 有過大或過小的 long 數值，略過\n"
+
+#: lib/backend/dbconfig.c:200
+#, c-format
+msgid "%s has too large or too small integer value, skipped\n"
+msgstr "%s 有過大或過小的整數值，略過\n"
+
+#: rpmio/macro.c:282
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:324
+#: rpmio/macro.c:323
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:495
+#: rpmio/macro.c:494
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:507 rpmio/macro.c:545
+#: rpmio/macro.c:506 rpmio/macro.c:544
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "巨集 %%%s 具有未終結的主體\n"
 
-#: rpmio/macro.c:564
+#: rpmio/macro.c:563
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%define)\n"
 
-#: rpmio/macro.c:569
+#: rpmio/macro.c:568
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "巨集 %%%s 具有空的主體\n"
 
-#: rpmio/macro.c:574
+#: rpmio/macro.c:573
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:578
+#: rpmio/macro.c:577
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "巨集 %%%s 展開時失敗\n"
 
-#: rpmio/macro.c:617
+#: rpmio/macro.c:616
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%undefine)\n"
 
-#: rpmio/macro.c:647
+#: rpmio/macro.c:645
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:730
+#: rpmio/macro.c:728
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中有未知的選項 %1$c\n"
 
-#: rpmio/macro.c:963
+#: rpmio/macro.c:958
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1032 rpmio/macro.c:1049
+#: rpmio/macro.c:1027 rpmio/macro.c:1044
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未終結的 %c：%s\n"
 
-#: rpmio/macro.c:1090
+#: rpmio/macro.c:1085
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在無法解析的巨集之後跟著一個 %%\n"
 
-#: rpmio/macro.c:1106
+#: rpmio/macro.c:1103
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1492
+#: rpmio/macro.c:1484
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3469,31 +3291,31 @@ msgstr "檔案 %s：%s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "檔案 %s 小於 %u 位元組\n"
 
-#: rpmio/rpmfileutil.c:601
+#: rpmio/rpmfileutil.c:600
 msgid "failed to create directory"
 msgstr "無法建立目錄"
 
-#: rpmio/rpmlua.c:523
+#: rpmio/rpmlua.c:514
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:541
+#: rpmio/rpmlua.c:532
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
+#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 指令稿失敗：%s\n"
 
-#: rpmio/rpmlua.c:560
+#: rpmio/rpmlua.c:551
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua 檔案內有無效語法：%s\n"
 
-#: rpmio/rpmlua.c:746
+#: rpmio/rpmlua.c:727
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3502,19 +3324,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:80
+#: rpmio/rpmlog.c:76
 msgid "(no error)"
 msgstr "(無錯誤)"
 
-#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
+#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
 msgid "fatal error: "
 msgstr "嚴重錯誤："
 
-#: rpmio/rpmlog.c:225
+#: rpmio/rpmlog.c:204
 msgid "error: "
 msgstr "錯誤："
 
-#: rpmio/rpmlog.c:226
+#: rpmio/rpmlog.c:205
 msgid "warning: "
 msgstr "警告："
 
@@ -3523,121 +3345,99 @@ msgstr "警告："
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "記憶體配置 (%u 位元組) 回傳 NULL。\n"
 
-#: rpmio/rpmpgp.c:1074
+#: rpmio/rpmpgp.c:1016
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1082
+#: rpmio/rpmpgp.c:1024
 msgid "(none)"
 msgstr "(無)"
 
-#: sign/rpmgensig.c:56
-#, fuzzy, c-format
-msgid "error creating temp directory %s: %m\n"
-msgstr "讀取檔案 %s 時發生錯誤\n"
-
-#: sign/rpmgensig.c:64
-#, fuzzy, c-format
-msgid "error creating fifo %s: %m\n"
-msgstr "讀取檔案 %s 時發生錯誤\n"
-
-#: sign/rpmgensig.c:85
-#, c-format
-msgid "error delete fifo %s: %m\n"
-msgstr ""
-
-#: sign/rpmgensig.c:93
-#, fuzzy, c-format
-msgid "error delete directory %s: %m\n"
-msgstr "移除目錄時失敗 %s：%s\n"
-
-#: sign/rpmgensig.c:170
+#: sign/rpmgensig.c:106
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite 失敗：%s\n"
 
-#: sign/rpmgensig.c:180
+#: sign/rpmgensig.c:116
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:208
+#: sign/rpmgensig.c:144
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:214
+#: sign/rpmgensig.c:150
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:227
+#: sign/rpmgensig.c:163
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:279
+#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
 #, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "無法執行 %s：%s\n"
+msgid "Couldn't create pipe for signing: %m"
+msgstr "無法建立簽署用的導管：%m"
 
-#: sign/rpmgensig.c:289
-#, fuzzy
-msgid "Fopen failed\n"
-msgstr "%s：開啟失敗：%s\n"
+#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
+msgid "fdopen failed\n"
+msgstr ""
 
-#: sign/rpmgensig.c:304
-#, fuzzy
+#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
 msgid "Could not write to pipe\n"
-msgstr "無法執行 %s：%s\n"
+msgstr ""
 
-#: sign/rpmgensig.c:311
-#, fuzzy, c-format
+#: sign/rpmgensig.c:284
+#, c-format
 msgid "Could not read from file %s: %s\n"
-msgstr "無法開啟 %%files 檔案 %s：%m\n"
+msgstr ""
 
-#: sign/rpmgensig.c:321
+#: sign/rpmgensig.c:294
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg 執行失敗 (%d)\n"
 
-#: sign/rpmgensig.c:363
+#: sign/rpmgensig.c:344
 msgid "gpg failed to write signature\n"
 msgstr "寫入簽署時 gpg 失敗\n"
 
-#: sign/rpmgensig.c:380
+#: sign/rpmgensig.c:361
 msgid "unable to read the signature\n"
 msgstr "無法讀取簽名\n"
 
-#: sign/rpmgensig.c:516
+#: sign/rpmgensig.c:500
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 失敗：%s"
 
-#: sign/rpmgensig.c:530
+#: sign/rpmgensig.c:514
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:572
+#: sign/rpmgensig.c:556
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:620 sign/rpmgensig.c:643
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失敗：%s\n"
 
-#: sign/rpmgensig.c:630
+#: sign/rpmgensig.c:614
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp 失敗\n"
 
-#: sign/rpmgensig.c:637
+#: sign/rpmgensig.c:621
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失敗：%s\n"
 
-#: sign/rpmgensig.c:662
+#: sign/rpmgensig.c:646
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3650,84 +3450,3 @@ msgstr "%s：讀取清單失敗：%s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "不驗證表頭+酬載簽署"
-
-#~ msgid "Enter pass phrase: "
-#~ msgstr "輸入通關密語： "
-
-#~ msgid "Pass phrase is good.\n"
-#~ msgstr "通關密語良好。\n"
-
-#~ msgid "Bad owner/group: %s\n"
-#~ msgstr "不良擁有者/群組：%s\n"
-
-#~ msgid "Couldn't create pipe for signing: %m"
-#~ msgstr "無法建立簽署用的導管：%m"
-
-#~ msgid "Unable to write payload to %s: %s\n"
-#~ msgstr "無法寫入酬載到 %s：%s\n"
-
-#~ msgid "Unable to read payload from %s: %s\n"
-#~ msgstr "無法從 %s 讀取酬載：%s\n"
-
-#~ msgid "Unable to open temp file.\n"
-#~ msgstr "無法開啟暫時檔案。\n"
-
-#~ msgid "Unable to open sigtarget %s: %s\n"
-#~ msgstr "無法開啟簽署目標 %s：%s\n"
-
-#~ msgid "Unable to read header from %s: %s\n"
-#~ msgstr "無法讀取 %s 的表頭：%s\n"
-
-#~ msgid "Unable to write header to %s: %s\n"
-#~ msgstr "無法寫入 %s 的表頭：%s\n"
-
-#~ msgid "Failed to decode policy for %s\n"
-#~ msgstr "無法解碼 %s 的方針\n"
-
-#~ msgid "Failed to create temporary file for %s: %s\n"
-#~ msgstr "無法為 %s 建立暫存檔：%s\n"
-
-#~ msgid "Failed to write %s policy to file %s\n"
-#~ msgstr "無法寫入 %s 方針至檔案 %s\n"
-
-#~ msgid "Failed to connect to policy handler\n"
-#~ msgstr "無法連接至方針處理器\n"
-
-#~ msgid "Failed to begin policy transaction: %s\n"
-#~ msgstr "無法開始方針處理事項：%s\n"
-
-#~ msgid "Failed to remove temporary policy file %s: %s\n"
-#~ msgstr "無法移除暫存方針檔 %s：%s\n"
-
-#~ msgid "Failed to install policy module: %s (%s)\n"
-#~ msgstr "無法安裝方針模組：%s (%s)\n"
-
-#~ msgid "Failed to remove policy module: %s\n"
-#~ msgstr "無法移除方針模組：%s\n"
-
-#~ msgid "Failed to fork process: %s\n"
-#~ msgstr "無法分支程序：%s\n"
-
-#~ msgid "Failed to execute %s: %s\n"
-#~ msgstr "無法執行 %s：%s\n"
-
-#~ msgid "%s terminated abnormally\n"
-#~ msgstr "%s 已異常終止\n"
-
-#~ msgid "%s failed with exit code %i\n"
-#~ msgstr "%s 已失敗並伴隨代碼 %i\n"
-
-#~ msgid "Failed to commit policy changes\n"
-#~ msgstr "無法提交方針變更\n"
-
-#~ msgid "Failed to expand restorecon path"
-#~ msgstr "無法擴展 restorecon 路徑"
-
-#~ msgid "Failed to relabel filesystem. Files may be mislabeled\n"
-#~ msgstr "無法將檔案系統重新標籤。檔案可能標籤有誤\n"
-
-#~ msgid "Failed to reload file contexts. Files may be mislabeled\n"
-#~ msgstr "無法重新載入檔案情境。檔案可能標籤有誤\n"
-
-#~ msgid "Failed to extract policy from %s\n"
-#~ msgstr "無法從 %s 抽出方針\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Free Software Foundation, Inc.
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Cheng-Chia Tseng <pswo10680@gmail.com>, 2011-2012
 # You-Cheng Hsieh <yochenhsieh@gmail.com>, 2012-2013
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2014-06-25 13:38+0300\n"
+"POT-Creation-Date: 2015-09-02 13:48+0200\n"
 "PO-Revision-Date: 2014-06-25 10:40+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/rpm-team/rpm/language/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/rpm-team/rpm/"
+"language/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: cliutils.c:21 lib/poptI.c:29
@@ -81,7 +82,7 @@ msgstr "校驗選項 (使用 -V 或 --verify)："
 msgid "Install/Upgrade/Erase options:"
 msgstr "安裝/升級/抹除選項："
 
-#: rpmqv.c:64 rpmbuild.c:223 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:37 rpmspec.c:48
+#: rpmqv.c:64 rpmbuild.c:269 rpmdb.c:44 rpmkeys.c:42 rpmsign.c:49 rpmspec.c:48
 #: tools/rpmdeps.c:32 tools/rpmgraph.c:222
 msgid "Common options for all rpm modes and executables:"
 msgstr "用於所有 rpm 模式和可執行檔案的共同選項："
@@ -102,7 +103,7 @@ msgstr "不可預料的查詢格式"
 msgid "unexpected query source"
 msgstr "不可預料的查詢來源"
 
-#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:169
+#: rpmqv.c:143 rpmdb.c:126 rpmkeys.c:82 rpmsign.c:141
 msgid "only one major mode may be specified"
 msgstr "只能指定一個主要工作模式"
 
@@ -137,8 +138,7 @@ msgid ""
 msgstr ""
 
 #: rpmqv.c:175
-msgid ""
-"--percent may only be specified during package installation and erasure"
+msgid "--percent may only be specified during package installation and erasure"
 msgstr ""
 
 #: rpmqv.c:179
@@ -203,7 +203,7 @@ msgstr ""
 msgid "--test may only be specified during package installation and erasure"
 msgstr ""
 
-#: rpmqv.c:240 rpmbuild.c:550
+#: rpmqv.c:240 rpmbuild.c:615
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的引數必須以「/」開頭"
 
@@ -223,201 +223,248 @@ msgstr "沒有給定查詢引數"
 msgid "no arguments given for verify"
 msgstr "沒有給定校驗引數"
 
-#: rpmbuild.c:99
+#: rpmbuild.c:115
 #, c-format
 msgid "buildroot already specified, ignoring %s\n"
 msgstr "buildroot 已被指定，忽略 %s\n"
 
-#: rpmbuild.c:120
+#: rpmbuild.c:140
 #, c-format
 msgid "build through %prep (unpack sources and apply patches) from <specfile>"
 msgstr "從 <specfile> 透過 %prep (解包源碼並套用修補程式) 來建置"
 
-#: rpmbuild.c:121 rpmbuild.c:124 rpmbuild.c:127 rpmbuild.c:130 rpmbuild.c:133
-#: rpmbuild.c:136 rpmbuild.c:139
+#: rpmbuild.c:141 rpmbuild.c:144 rpmbuild.c:147 rpmbuild.c:150 rpmbuild.c:153
+#: rpmbuild.c:156 rpmbuild.c:159
 msgid "<specfile>"
 msgstr "<specfile>"
 
-#: rpmbuild.c:123
+#: rpmbuild.c:143
 msgid "build through %build (%prep, then compile) from <specfile>"
 msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
 
-#: rpmbuild.c:126
+#: rpmbuild.c:146
 msgid "build through %install (%prep, %build, then install) from <specfile>"
 msgstr "從 <specfile> 透過 %install (%prep，%build，然後安裝) 來建置"
 
-#: rpmbuild.c:129
+#: rpmbuild.c:149
 #, c-format
 msgid "verify %files section from <specfile>"
 msgstr "從 <specfile> 驗證 %files 區段"
 
-#: rpmbuild.c:132
+#: rpmbuild.c:152
 msgid "build source and binary packages from <specfile>"
 msgstr "根據 <specfile> 建置源碼套件與二進位套件"
 
-#: rpmbuild.c:135
+#: rpmbuild.c:155
 msgid "build binary package only from <specfile>"
 msgstr "根據 <specfile> 只建置二進位套件"
 
-#: rpmbuild.c:138
+#: rpmbuild.c:158
 msgid "build source package only from <specfile>"
 msgstr "根據 <specfile> 只建置源碼套件"
 
-#: rpmbuild.c:142
-#, c-format
-msgid "build through %prep (unpack sources and apply patches) from <tarball>"
-msgstr "從 <tarball> 透過 %prep (解包源碼和套用修補檔) 來建置"
+#: rpmbuild.c:162
+#, fuzzy, c-format
+msgid ""
+"build through %prep (unpack sources and apply patches) from <source package>"
+msgstr "從 <specfile> 透過 %prep (解包源碼並套用修補程式) 來建置"
 
-#: rpmbuild.c:143 rpmbuild.c:146 rpmbuild.c:149 rpmbuild.c:152 rpmbuild.c:155
-#: rpmbuild.c:158 rpmbuild.c:161
-msgid "<tarball>"
-msgstr "<tarball>"
-
-#: rpmbuild.c:145
-msgid "build through %build (%prep, then compile) from <tarball>"
-msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
-
-#: rpmbuild.c:148
-msgid "build through %install (%prep, %build, then install) from <tarball>"
-msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
-
-#: rpmbuild.c:151
-#, c-format
-msgid "verify %files section from <tarball>"
-msgstr "從 <tarball> 驗證 %files 區段"
-
-#: rpmbuild.c:154
-msgid "build source and binary packages from <tarball>"
-msgstr "從 <tarball> 中建置源碼套件與二進位套件"
-
-#: rpmbuild.c:157
-msgid "build binary package only from <tarball>"
-msgstr "從 <tarball> 中只建置二進位套件"
-
-#: rpmbuild.c:160
-msgid "build source package only from <tarball>"
-msgstr "從 <tarball> 中只建置源碼套件"
-
-#: rpmbuild.c:164
-msgid "build binary package from <source package>"
-msgstr "從 <source package> 中建置二進位套件"
-
-#: rpmbuild.c:165 rpmbuild.c:168
+#: rpmbuild.c:163 rpmbuild.c:166 rpmbuild.c:169 rpmbuild.c:172 rpmbuild.c:175
+#: rpmbuild.c:178 rpmbuild.c:181 rpmbuild.c:207 rpmbuild.c:210
 msgid "<source package>"
 msgstr "<source package>"
 
-#: rpmbuild.c:167
+#: rpmbuild.c:165
+#, fuzzy
+msgid "build through %build (%prep, then compile) from <source package>"
+msgstr "從 <specfile> 透過 %build (%prep，然後編譯) 來建置"
+
+#: rpmbuild.c:168 rpmbuild.c:209
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr "從 <source package> 透過 %install (%prep，%build，然後安裝) 來建置"
 
 #: rpmbuild.c:171
+#, fuzzy, c-format
+msgid "verify %files section from <source package>"
+msgstr "從 <specfile> 驗證 %files 區段"
+
+#: rpmbuild.c:174
+#, fuzzy
+msgid "build source and binary packages from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:177
+#, fuzzy
+msgid "build binary package only from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:180
+#, fuzzy
+msgid "build source package only from <source package>"
+msgstr "根據 <specfile> 只建置源碼套件"
+
+#: rpmbuild.c:184
+#, c-format
+msgid "build through %prep (unpack sources and apply patches) from <tarball>"
+msgstr "從 <tarball> 透過 %prep (解包源碼和套用修補檔) 來建置"
+
+#: rpmbuild.c:185 rpmbuild.c:188 rpmbuild.c:191 rpmbuild.c:194 rpmbuild.c:197
+#: rpmbuild.c:200 rpmbuild.c:203
+msgid "<tarball>"
+msgstr "<tarball>"
+
+#: rpmbuild.c:187
+msgid "build through %build (%prep, then compile) from <tarball>"
+msgstr "從 <tarball> 透過 %build (%prep，然後編譯) 來建置"
+
+#: rpmbuild.c:190
+msgid "build through %install (%prep, %build, then install) from <tarball>"
+msgstr "從 <tarball> 透過 %install (%prep，%build，然後安裝) 來建置"
+
+#: rpmbuild.c:193
+#, c-format
+msgid "verify %files section from <tarball>"
+msgstr "從 <tarball> 驗證 %files 區段"
+
+#: rpmbuild.c:196
+msgid "build source and binary packages from <tarball>"
+msgstr "從 <tarball> 中建置源碼套件與二進位套件"
+
+#: rpmbuild.c:199
+msgid "build binary package only from <tarball>"
+msgstr "從 <tarball> 中只建置二進位套件"
+
+#: rpmbuild.c:202
+msgid "build source package only from <tarball>"
+msgstr "從 <tarball> 中只建置源碼套件"
+
+#: rpmbuild.c:206
+msgid "build binary package from <source package>"
+msgstr "從 <source package> 中建置二進位套件"
+
+#: rpmbuild.c:213
 msgid "override build root"
 msgstr "強制覆寫建置根目錄"
 
-#: rpmbuild.c:173
+#: rpmbuild.c:215
+#, fuzzy
+msgid "run build in current directory"
+msgstr "無法建立目錄"
+
+#: rpmbuild.c:217
 msgid "remove build tree when done"
 msgstr "完成後移除建置樹"
 
-#: rpmbuild.c:175
+#: rpmbuild.c:219
 msgid "ignore ExcludeArch: directives from spec file"
 msgstr "忽略 ExcludeArch：根據規格檔的指示"
 
-#: rpmbuild.c:177
+#: rpmbuild.c:221
 msgid "debug file state machine"
 msgstr "除錯檔案狀態機器"
 
-#: rpmbuild.c:179
+#: rpmbuild.c:223
 msgid "do not execute any stages of the build"
 msgstr "不執行建置程序裡的任何步驟"
 
-#: rpmbuild.c:181
+#: rpmbuild.c:225
 msgid "do not verify build dependencies"
 msgstr "不校驗建置相依關係"
 
-#: rpmbuild.c:183
+#: rpmbuild.c:227
 msgid "generate package header(s) compatible with (legacy) rpm v3 packaging"
 msgstr ""
 
-#: rpmbuild.c:187
+#: rpmbuild.c:231
 #, c-format
 msgid "do not execute %clean stage of the build"
 msgstr ""
 
-#: rpmbuild.c:189
+#: rpmbuild.c:233
+#, fuzzy, c-format
+msgid "do not execute %prep stage of the build"
+msgstr "不執行建置程序裡的任何步驟"
+
+#: rpmbuild.c:235
 #, c-format
 msgid "do not execute %check stage of the build"
 msgstr ""
 
-#: rpmbuild.c:192
+#: rpmbuild.c:238
 msgid "do not accept i18N msgstr's from specfile"
 msgstr "不接受來自規格檔的 i18N msgstr"
 
-#: rpmbuild.c:194
+#: rpmbuild.c:240
 msgid "remove sources when done"
 msgstr "完成後移除源碼檔案"
 
-#: rpmbuild.c:196
+#: rpmbuild.c:242
 msgid "remove specfile when done"
 msgstr "完成後移除規格檔"
 
-#: rpmbuild.c:198
+#: rpmbuild.c:244
 msgid "skip straight to specified stage (only for c,i)"
 msgstr "直接跳到指定的階段 (只有用於 c,i)"
 
-#: rpmbuild.c:200 rpmspec.c:34
+#: rpmbuild.c:246 rpmspec.c:34
 msgid "override target platform"
 msgstr "無視目標平臺"
 
-#: rpmbuild.c:217
+#: rpmbuild.c:263
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "組建選項中使用 [ <specfile> | <tarball> | <source package> ]："
 
-#: rpmbuild.c:237
+#: rpmbuild.c:283
 msgid "Failed build dependencies:\n"
 msgstr "相依性建置失敗：\n"
 
-#: rpmbuild.c:255
+#: rpmbuild.c:301
 #, c-format
 msgid "Unable to open spec file %s: %s\n"
 msgstr "無法開啟 %s 規格檔：%s\n"
 
-#: rpmbuild.c:317
+#: rpmbuild.c:364
 #, c-format
 msgid "Failed to open tar pipe: %m\n"
 msgstr "無法開啟 tar 導管：%m\n"
 
-#: rpmbuild.c:336
+#: rpmbuild.c:379
+#, fuzzy, c-format
+msgid "Found more than one spec file in %s\n"
+msgstr "無法開啟 %s 規格檔：%s\n"
+
+#: rpmbuild.c:390
 #, c-format
 msgid "Failed to read spec file from %s\n"
 msgstr "無法從 %s 讀取規格檔\n"
 
-#: rpmbuild.c:348
+#: rpmbuild.c:402
 #, c-format
 msgid "Failed to rename %s to %s: %m\n"
 msgstr "無法將 %s 重新命名為 %s：%m\n"
 
-#: rpmbuild.c:419
+#: rpmbuild.c:480
 #, c-format
 msgid "failed to stat %s: %m\n"
 msgstr "無法檢視 %s 的狀態：%m\n"
 
-#: rpmbuild.c:423
+#: rpmbuild.c:484
 #, c-format
 msgid "File %s is not a regular file.\n"
 msgstr "%s 不是通常的檔案。\n"
 
-#: rpmbuild.c:430
+#: rpmbuild.c:491
 #, c-format
 msgid "File %s does not appear to be a specfile.\n"
 msgstr "%s 似乎不是規格檔。\n"
 
-#: rpmbuild.c:496
+#: rpmbuild.c:557
 #, c-format
 msgid "Building target platforms: %s\n"
 msgstr "建置目標平台：%s\n"
 
-#: rpmbuild.c:504
+#: rpmbuild.c:565
 #, c-format
 msgid "Building for target %s\n"
 msgstr "建置目標 %s\n"
@@ -466,49 +513,64 @@ msgstr "列出 RPM 鑰匙圈的金鑰"
 msgid "Keyring options:"
 msgstr "鑰匙圈選項："
 
-#: rpmkeys.c:64 rpmsign.c:154
+#: rpmkeys.c:64 rpmsign.c:122
 msgid "no arguments given"
 msgstr "沒有指定引數"
 
-#: rpmsign.c:25
+#: rpmsign.c:30
 msgid "sign package(s)"
 msgstr "簽署套件"
 
-#: rpmsign.c:27
+#: rpmsign.c:32
 msgid "sign package(s) (identical to --addsign)"
 msgstr "簽署套件 (與 --addsign 含義相同)"
 
-#: rpmsign.c:29
+#: rpmsign.c:34
 msgid "delete package signatures"
 msgstr "刪除套件簽署"
 
-#: rpmsign.c:35
+#: rpmsign.c:36
+#, fuzzy
+msgid "sign package(s) files"
+msgstr "簽署套件"
+
+#: rpmsign.c:38
+msgid "use file signing key <key>"
+msgstr ""
+
+#: rpmsign.c:39
+msgid "<key>"
+msgstr ""
+
+#: rpmsign.c:41
+msgid "prompt for file signing key password"
+msgstr ""
+
+#: rpmsign.c:47
 msgid "Signature options:"
 msgstr "簽署選項："
 
-#: rpmsign.c:93 sign/rpmgensig.c:232
-#, c-format
-msgid "Could not exec %s: %s\n"
-msgstr "無法執行 %s：%s\n"
-
-#: rpmsign.c:118
+#: rpmsign.c:65
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "您必須在您的巨集檔案中設定「%%_gpg_name」\n"
 
-#: rpmsign.c:123
-msgid "Enter pass phrase: "
-msgstr "輸入通關密語： "
-
-#: rpmsign.c:127
+#: rpmsign.c:76
 #, c-format
-msgid "Pass phrase is good.\n"
-msgstr "通關密語良好。\n"
-
-#: rpmsign.c:133
-#, c-format
-msgid "Pass phrase check failed or gpg key expired\n"
+msgid ""
+"You must set \"$$_file_signing_key\" in your macro file or on the command "
+"line with --fskpath\n"
 msgstr ""
+
+#: rpmsign.c:82
+#, fuzzy
+msgid "--fskpass may only be specified when signing files"
+msgstr "--prefix 只能在安裝新軟體時使用"
+
+#: rpmsign.c:126
+#, fuzzy
+msgid "--fskpath may only be specified when signing files"
+msgstr "--allmatches 只能在套件抹除時指定"
 
 #: rpmspec.c:26
 msgid "parse spec file(s) to stdout"
@@ -526,7 +588,7 @@ msgstr "操作透過規格所建立的二進位 rpm (預設)"
 msgid "operate on source rpm generated by spec"
 msgstr "操作透過規格所建立的源碼 rpm"
 
-#: rpmspec.c:36 lib/poptQV.c:192
+#: rpmspec.c:36 lib/poptQV.c:208
 msgid "use the following query format"
 msgstr "使用以下的查詢格式"
 
@@ -573,68 +635,71 @@ msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr "\n\nRPM 建置錯誤：\n"
+msgstr ""
+"\n"
+"\n"
+"RPM 建置錯誤：\n"
 
-#: build/expression.c:216
+#: build/expression.c:215
 msgid "syntax error while parsing ==\n"
 msgstr "解析 == 時有語法錯誤\n"
 
-#: build/expression.c:246
+#: build/expression.c:245
 msgid "syntax error while parsing &&\n"
 msgstr "解析 && 時有語法錯誤\n"
 
-#: build/expression.c:255
+#: build/expression.c:254
 msgid "syntax error while parsing ||\n"
 msgstr "解析 || 時有語法錯誤\n"
 
-#: build/expression.c:305
+#: build/expression.c:304
 msgid "parse error in expression\n"
 msgstr "表述式解析錯誤\n"
 
-#: build/expression.c:337
+#: build/expression.c:336
 msgid "unmatched (\n"
 msgstr "不符合的 (\n"
 
-#: build/expression.c:369
+#: build/expression.c:368
 msgid "- only on numbers\n"
 msgstr "- 只能用於數字\n"
 
-#: build/expression.c:385
+#: build/expression.c:384
 msgid "! only on numbers\n"
 msgstr "! 只能用於數字\n"
 
-#: build/expression.c:427 build/expression.c:475 build/expression.c:533
-#: build/expression.c:625
+#: build/expression.c:426 build/expression.c:474 build/expression.c:532
+#: build/expression.c:624
 msgid "types must match\n"
 msgstr "類型必須符合\n"
 
-#: build/expression.c:440
+#: build/expression.c:439
 msgid "* / not suported for strings\n"
 msgstr "字串不支援 *、/\n"
 
-#: build/expression.c:491
+#: build/expression.c:490
 msgid "- not suported for strings\n"
 msgstr "字串不支援 -\n"
 
-#: build/expression.c:638
+#: build/expression.c:637
 msgid "&& and || not suported for strings\n"
 msgstr "字串不支援 && 和 ||\n"
 
-#: build/expression.c:671
+#: build/expression.c:669
 msgid "syntax error in expression\n"
 msgstr "表述式中有語法錯誤\n"
 
-#: build/files.c:282 build/files.c:455 build/files.c:669
+#: build/files.c:282 build/files.c:456 build/files.c:670
 #, c-format
 msgid "Missing '(' in %s %s\n"
 msgstr "在 %s %s 中有遺漏的「(」\n"
 
-#: build/files.c:292 build/files.c:591 build/files.c:679 build/files.c:738
+#: build/files.c:292 build/files.c:592 build/files.c:680 build/files.c:739
 #, c-format
 msgid "Missing ')' in %s(%s\n"
 msgstr "在 %s(%s 中有遺漏的「)」\n"
 
-#: build/files.c:317 build/files.c:610
+#: build/files.c:317 build/files.c:611
 #, c-format
 msgid "Invalid %s token: %s\n"
 msgstr "無效的 %s 符記：%s\n"
@@ -644,46 +709,46 @@ msgstr "無效的 %s 符記：%s\n"
 msgid "Missing %s in %s %s\n"
 msgstr "在 %2$s %3$s 中有缺失的 %1$s\n"
 
-#: build/files.c:470
+#: build/files.c:471
 #, c-format
 msgid "Non-white space follows %s(): %s\n"
 msgstr "%s() 之後有非空白空格：%s\n"
 
-#: build/files.c:506
+#: build/files.c:507
 #, c-format
 msgid "Bad syntax: %s(%s)\n"
 msgstr "不良語法：%s(%s)\n"
 
-#: build/files.c:515
+#: build/files.c:516
 #, c-format
 msgid "Bad mode spec: %s(%s)\n"
 msgstr "不良模式規格：%s(%s)\n"
 
-#: build/files.c:527
+#: build/files.c:528
 #, c-format
 msgid "Bad dirmode spec: %s(%s)\n"
 msgstr "不良 dirmode 規格：%s(%s)\n"
 
-#: build/files.c:631
+#: build/files.c:632
 #, c-format
 msgid "Unusual locale length: \"%s\" in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:638
+#: build/files.c:639
 #, c-format
 msgid "Duplicate locale %s in %%lang(%s)\n"
 msgstr ""
 
-#: build/files.c:753
+#: build/files.c:754
 #, c-format
 msgid "Invalid capability: %s\n"
 msgstr "無效的功能：%s\n"
 
-#: build/files.c:763
+#: build/files.c:764
 msgid "File capability support not built in\n"
 msgstr "檔案功能支援未內建於\n"
 
-#: build/files.c:812
+#: build/files.c:813
 #, c-format
 msgid "File must begin with \"/\": %s\n"
 msgstr "檔案必須以「/」開頭：%s\n"
@@ -693,149 +758,151 @@ msgstr "檔案必須以「/」開頭：%s\n"
 msgid "Unknown file digest algorithm %u, falling back to MD5\n"
 msgstr ""
 
-#: build/files.c:955
+#: build/files.c:979
 #, c-format
 msgid "File listed twice: %s\n"
 msgstr "曾列出兩次的檔案：%s\n"
 
-#: build/files.c:1070
+#: build/files.c:1094
 #, c-format
 msgid "reading symlink %s failed: %s\n"
 msgstr ""
 
-#: build/files.c:1078
+#: build/files.c:1102
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "指向 BuildRoot 的符號連結：%s -> %s\n"
 
-#: build/files.c:1220
+#: build/files.c:1244
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1260
+#: build/files.c:1284
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1261
+#: build/files.c:1285 lib/rpminstall.c:443
 #, c-format
 msgid "File not found: %s\n"
 msgstr "找不到檔案：%s\n"
 
-#: build/files.c:1273
+#: build/files.c:1297
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1464
+#: build/files.c:1488
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：無法呼叫不明的標籤 (%d)。\n"
 
-#: build/files.c:1470
+#: build/files.c:1494
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公鑰讀入失敗。\n"
 
-#: build/files.c:1474
+#: build/files.c:1498
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s：不是一個受保護的公鑰。\n"
 
-#: build/files.c:1483
+#: build/files.c:1507
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：編碼失敗\n"
 
-#: build/files.c:1528
+#: build/files.c:1552
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "檔案需要以「/」開頭：%s\n"
 
-#: build/files.c:1552
+#: build/files.c:1576
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:1565
+#: build/files.c:1588
 #, c-format
-msgid "Directory not found by glob: %s\n"
+msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:1566 lib/rpminstall.c:426
-#, c-format
-msgid "File not found by glob: %s\n"
+#: build/files.c:1590
+#, fuzzy, c-format
+msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "透過 glob 解析找不到檔案：%s\n"
 
-#: build/files.c:1603
+#: build/files.c:1624
 #, c-format
 msgid "Could not open %%files file %s: %m\n"
 msgstr "無法開啟 %%files 檔案 %s：%m\n"
 
-#: build/files.c:1611
+#: build/files.c:1635
 #, c-format
 msgid "line: %s\n"
 msgstr "列：%s\n"
 
-#: build/files.c:1619
+#: build/files.c:1646
 #, c-format
 msgid "Empty %%files file %s\n"
 msgstr ""
 
-#: build/files.c:1622
+#: build/files.c:1652
 #, c-format
 msgid "Error reading %%files file %s: %m\n"
 msgstr ""
 
-#: build/files.c:1644
+#: build/files.c:1675
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:1806
+#: build/files.c:1770 lib/rpminstall.c:445
+#, c-format
+msgid "File not found by glob: %s\n"
+msgstr "透過 glob 解析找不到檔案：%s\n"
+
+#: build/files.c:1865
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:1823
+#: build/files.c:1882
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:1953
+#: build/files.c:2012
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不良檔案：%s：%s\n"
 
-#: build/files.c:1978 build/parsePrep.c:33
-#, c-format
-msgid "Bad owner/group: %s\n"
-msgstr "不良擁有者/群組：%s\n"
-
-#: build/files.c:2011
+#: build/files.c:2080
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "正在檢查未打包的檔案：%s\n"
 
-#: build/files.c:2024
+#: build/files.c:2093
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
-msgstr "找到已安裝 (但未打包) 的檔案：\n%s"
+msgstr ""
+"找到已安裝 (但未打包) 的檔案：\n"
+"%s"
 
-#: build/files.c:2055
+#: build/files.c:2124
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "正在處理檔案：%s\n"
 
-#: build/files.c:2069
+#: build/files.c:2138
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:2075
+#: build/files.c:2144
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 套件中有架構依賴二進位檔\n"
 
@@ -864,79 +931,76 @@ msgstr "%s: 列：%s\n"
 msgid "Could not canonicalize hostname: %s\n"
 msgstr "無法標準化主機名稱：%s\n"
 
-#: build/pack.c:350
-msgid "Unable to reload signature header.\n"
-msgstr "無法重新載入簽署表頭。\n"
-
-#: build/pack.c:423
+#: build/pack.c:355
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:451
+#: build/pack.c:404
 msgid "Unable to create immutable header region.\n"
 msgstr "無法建立不可變的表頭區域。\n"
 
-#: build/pack.c:459
+#: build/pack.c:412
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/pack.c:471
+#: build/pack.c:424
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "無法寫入套件：%s\n"
 
-#: build/pack.c:495
+#: build/pack.c:448
 msgid "Unable to write temp header\n"
 msgstr "無法寫入臨時表頭\n"
 
-#: build/pack.c:504
+#: build/pack.c:457
 msgid "Bad CSA data\n"
 msgstr "不良 CSA 資料\n"
 
-#: build/pack.c:515 build/pack.c:534 sign/rpmgensig.c:267 sign/rpmgensig.c:598
-#: sign/rpmgensig.c:633
+#: build/pack.c:468 build/pack.c:487 sign/rpmgensig.c:293 sign/rpmgensig.c:513
+#: sign/rpmgensig.c:536 sign/rpmgensig.c:610 sign/rpmgensig.c:630
+#: sign/rpmgensig.c:786 sign/rpmgensig.c:821
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:526
+#: build/pack.c:479
 #, c-format
 msgid "Fread failed in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:560
+#: build/pack.c:513
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已寫入：%s\n"
 
-#: build/pack.c:579
+#: build/pack.c:532
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在執行「%s」：\n"
 
-#: build/pack.c:582
+#: build/pack.c:535
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」執行失敗。\n"
 
-#: build/pack.c:586
+#: build/pack.c:539
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "套件檢查「%s」失敗。\n"
 
-#: build/pack.c:633
+#: build/pack.c:586
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "無法產生套件 %s 的檔案名稱輸出：%s\n"
 
-#: build/pack.c:650
+#: build/pack.c:603
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "無法建立 %s：%s\n"
 
-#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:678
+#: build/parseBuildInstallClean.c:35 build/parsePreamble.c:681
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "列 %d：第二個 %s\n"
@@ -987,19 +1051,19 @@ msgid "line %d: Error parsing %%description: %s\n"
 msgstr "列 %d：解析 %%description 時發生錯誤：%s\n"
 
 #: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
-#: build/parseScript.c:232
+#: build/parseScript.c:306
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "列 %d：不良選項 %s：%s\n"
 
 #: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
-#: build/parseScript.c:243
+#: build/parseScript.c:317
 #, c-format
 msgid "line %d: Too many names: %s\n"
 msgstr "列 %d：過多名稱：%s\n"
 
 #: build/parseDescription.c:64 build/parseFiles.c:65 build/parsePolicies.c:62
-#: build/parseScript.c:251
+#: build/parseScript.c:325
 #, c-format
 msgid "line %d: Package does not exist: %s\n"
 msgstr "列 %d：套件不存在：%s\n"
@@ -1106,90 +1170,94 @@ msgstr "列 %d：標籤只需單一符記：%s\n"
 
 #: build/parsePreamble.c:616
 #, c-format
-msgid "line %d: Illegal char '%c' in: %s\n"
+msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:619
-#, c-format
-msgid "line %d: Illegal char in: %s\n"
+#: build/parsePreamble.c:620
+msgid "Illegal sequence \"..\""
 msgstr ""
 
 #: build/parsePreamble.c:625
-#, c-format
-msgid "line %d: Illegal sequence \"..\" in: %s\n"
-msgstr ""
+#, fuzzy, c-format
+msgid "line %d: %s in: %s\n"
+msgstr "列 %d：第二個 %s\n"
 
-#: build/parsePreamble.c:710
+#: build/parsePreamble.c:628
+#, fuzzy, c-format
+msgid "%s in: %s\n"
+msgstr "%s: 列：%s\n"
+
+#: build/parsePreamble.c:713
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "列 %d：格式不良的標籤：%s\n"
 
-#: build/parsePreamble.c:718
+#: build/parsePreamble.c:721
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "列 %d：空的標籤：%s\n"
 
-#: build/parsePreamble.c:779
+#: build/parsePreamble.c:782
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "列 %d：前綴不能以「/」結尾：%s\n"
 
-#: build/parsePreamble.c:791
+#: build/parsePreamble.c:794
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "列 %d：Docdir 必須以「/」開頭：%s\n"
 
-#: build/parsePreamble.c:804
+#: build/parsePreamble.c:807
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:841
+#: build/parsePreamble.c:844
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "列 %d：不良 %s：修飾詞：%s\n"
 
-#: build/parsePreamble.c:875
+#: build/parsePreamble.c:878
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "列 %d：不良 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:885
+#: build/parsePreamble.c:888
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:897
+#: build/parsePreamble.c:903
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "內部錯誤：假造的標籤 %d\n"
 
-#: build/parsePreamble.c:985
+#: build/parsePreamble.c:992
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1046
+#: build/parsePreamble.c:1053
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不良套件規格：%s\n"
 
-#: build/parsePreamble.c:1055
+#: build/parsePreamble.c:1062
 #, c-format
 msgid "Package already exists: %s\n"
 msgstr "套件已經存在：%s\n"
 
-#: build/parsePreamble.c:1090
+#: build/parsePreamble.c:1097
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "列 %d：未知標籤：%s\n"
 
-#: build/parsePreamble.c:1122
+#: build/parsePreamble.c:1129
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1126
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1199,161 +1267,193 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "不良源碼：%s：%s\n"
 
-#: build/parsePrep.c:73
+#: build/parsePrep.c:70
 #, c-format
 msgid "No patch number %u\n"
 msgstr "沒有修補編號 %u\n"
 
-#: build/parsePrep.c:75
+#: build/parsePrep.c:72
 #, c-format
 msgid "%%patch without corresponding \"Patch:\" tag\n"
 msgstr ""
 
-#: build/parsePrep.c:152
+#: build/parsePrep.c:155
 #, c-format
 msgid "No source number %u\n"
 msgstr "沒有源碼編號 %u\n"
 
-#: build/parsePrep.c:154
+#: build/parsePrep.c:157
 msgid "No \"Source:\" tag in the spec file\n"
 msgstr "規格檔內無「Source:」標籤\n"
 
-#: build/parsePrep.c:261
+#: build/parsePrep.c:265
 #, c-format
 msgid "Error parsing %%setup: %s\n"
 msgstr "解析 %%setup 時發生錯誤：%s\n"
 
-#: build/parsePrep.c:272
+#: build/parsePrep.c:276
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "列 %d：%%setup 中出現不良引數：%s\n"
 
-#: build/parsePrep.c:287
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "列 %d：不良 %%setup 選項 %s：%s\n"
 
-#: build/parsePrep.c:446
+#: build/parsePrep.c:459
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:459
+#: build/parsePrep.c:472
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無效的修補編號 %s：%s\n"
 
-#: build/parsePrep.c:486
+#: build/parsePrep.c:499
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "列 %d：第二個 %%prep\n"
 
-#: build/parseReqs.c:131
+#: build/parseReqs.c:35
 msgid "Dependency tokens must begin with alpha-numeric, '_' or '/'"
 msgstr ""
 
-#: build/parseReqs.c:156
+#: build/parseReqs.c:40
 msgid "Versioned file name not permitted"
 msgstr ""
 
-#: build/parseReqs.c:173
-msgid "Version required"
+#: build/parseReqs.c:208
+msgid "No rich dependencies allowed for this type"
 msgstr ""
 
-#: build/parseReqs.c:189
+#: build/parseReqs.c:218 build/parseReqs.c:293
 msgid "invalid dependency"
 msgstr ""
 
-#: build/parseReqs.c:205
+#: build/parseReqs.c:253 lib/rpmds.c:1438
+msgid "Version required"
+msgstr ""
+
+#: build/parseReqs.c:269
+msgid "Only absolute paths are allowed in file triggers"
+msgstr ""
+
+#: build/parseReqs.c:282
+msgid "Trigger fired by the same package is already defined in spec file"
+msgstr ""
+
+#: build/parseReqs.c:310
 #, c-format
 msgid "line %d: %s: %s\n"
 msgstr ""
 
-#: build/parseScript.c:192
+#: build/parseScript.c:256
 #, c-format
 msgid "line %d: triggers must have --: %s\n"
 msgstr "列 %d：觸發器必須包含 --：%s\n"
 
-#: build/parseScript.c:202 build/parseScript.c:265
+#: build/parseScript.c:266 build/parseScript.c:339
 #, c-format
 msgid "line %d: Error parsing %s: %s\n"
 msgstr "列 %d：解析 %s 時發生錯誤：%s\n"
 
-#: build/parseScript.c:214
+#: build/parseScript.c:278
 #, c-format
 msgid "line %d: internal script must end with '>': %s\n"
 msgstr "列 %d：內部指令稿必須以「>」結尾：%s\n"
 
-#: build/parseScript.c:220
+#: build/parseScript.c:284
 #, c-format
 msgid "line %d: script program must begin with '/': %s\n"
 msgstr "列 %d：指令稿程式必須以「/」開頭：%s\n"
 
-#: build/parseScript.c:258
+#: build/parseScript.c:298
+#, c-format
+msgid "line %d: Priorities are allowed only for file triggers : %s\n"
+msgstr ""
+
+#: build/parseScript.c:332
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "列 %d：第二個 %s\n"
 
-#: build/parseScript.c:300
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "列 %d：不支援的內部指令稿：%s\n"
 
-#: build/parseScript.c:317
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:212
+#: build/parseSpec.c:187
 #, c-format
 msgid "line %d: %s\n"
 msgstr "列 %d：%s\n"
 
-#: build/parseSpec.c:255
+#: build/parseSpec.c:209
+#, c-format
+msgid "Macro expanded in comment on line %d: %s\n"
+msgstr ""
+
+#: build/parseSpec.c:313
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/parseSpec.c:289
+#: build/parseSpec.c:347
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:311
+#: build/parseSpec.c:369
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:316
+#: build/parseSpec.c:374
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:358
+#: build/parseSpec.c:416
 #, c-format
 msgid "%s:%d: bad %%if condition\n"
 msgstr ""
 
-#: build/parseSpec.c:366
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Got a %%else with no %%if\n"
 msgstr "%s:%d：有個 %%else 沒有對應 %%if\n"
 
-#: build/parseSpec.c:377
+#: build/parseSpec.c:435
 #, c-format
 msgid "%s:%d: Got a %%endif with no %%if\n"
 msgstr "%s:%d：有個 %%endif 沒有對應 %%if\n"
 
-#: build/parseSpec.c:395
+#: build/parseSpec.c:453
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:669
+#: build/parseSpec.c:638
+#, c-format
+msgid "encoding %s not supported by system\n"
+msgstr ""
+
+#: build/parseSpec.c:667
+#, c-format
+msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
+msgstr ""
+
+#: build/parseSpec.c:812
 msgid "No compatible architectures found for build\n"
 msgstr "找不到可供建置的相容架構\n"
 
-#: build/parseSpec.c:703
+#: build/parseSpec.c:846
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "套件沒有 %%description：%s\n"
@@ -1424,290 +1524,281 @@ msgstr ""
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:110
+#: build/rpmfc.c:108
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:207
+#: build/rpmfc.c:205
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "無法為 %s 建立導管：%m\n"
 
-#: build/rpmfc.c:232
+#: build/rpmfc.c:230
 #, c-format
 msgid "Couldn't exec %s: %s\n"
 msgstr "無法執行 %s：%s\n"
 
-#: build/rpmfc.c:237 lib/rpmscript.c:297
+#: build/rpmfc.c:235 lib/rpmscript.c:323
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "無法分支 %s：%s\n"
 
-#: build/rpmfc.c:320
+#: build/rpmfc.c:318
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失敗：%x\n"
 
-#: build/rpmfc.c:324
+#: build/rpmfc.c:322
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "無法寫入所有資料至 %s：%s\n"
 
-#: build/rpmfc.c:455
+#: build/rpmfc.c:453
 msgid "bad operator"
 msgstr ""
 
-#: build/rpmfc.c:474
+#: build/rpmfc.c:472
 msgid "bad format"
 msgstr ""
 
-#: build/rpmfc.c:540
+#: build/rpmfc.c:539
 #, c-format
 msgid "invalid dependency (%s): %s\n"
 msgstr ""
 
-#: build/rpmfc.c:871
+#: build/rpmfc.c:845
 #, c-format
 msgid "Conversion of %s to long integer failed.\n"
 msgstr "%s 轉換至 long integer 失敗。\n"
 
-#: build/rpmfc.c:949
+#: build/rpmfc.c:915
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:958
+#: build/rpmfc.c:924
 msgid "No file attributes configured\n"
 msgstr "無設定檔案特性\n"
 
-#: build/rpmfc.c:978
+#: build/rpmfc.c:944
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失敗：%s\n"
 
-#: build/rpmfc.c:984
+#: build/rpmfc.c:950
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失敗：%s\n"
 
-#: build/rpmfc.c:1026
+#: build/rpmfc.c:992
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "檔案「%s」辨識失敗：模式 %06o %s\n"
 
-#: build/rpmfc.c:1214
+#: build/rpmfc.c:1193
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在尋找 %s：%s\n"
 
-#: build/rpmfc.c:1223 build/rpmfc.c:1232
+#: build/rpmfc.c:1202 build/rpmfc.c:1211
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "找不到 %s：\n"
 
-#: build/spec.c:425
+#: build/spec.c:451
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s 規格檔查詢失敗，無法剖析\n"
 
-#: lib/depends.c:82
+#: lib/depends.c:91
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:86
+#: lib/depends.c:95
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:365
+#: lib/depends.c:375
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "套件 %s 已被加入，跳過 %s\n"
 
-#: lib/depends.c:366
+#: lib/depends.c:376
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "套件 %s 已被加入，以 %s 替換\n"
 
-#: lib/formats.c:65 lib/formats.c:101 lib/formats.c:183 lib/formats.c:209
-#: lib/formats.c:262 lib/formats.c:280 lib/formats.c:473 lib/formats.c:506
-#: lib/formats.c:544
+#: lib/formats.c:65 lib/formats.c:102 lib/formats.c:184 lib/formats.c:210
+#: lib/formats.c:263 lib/formats.c:281 lib/formats.c:474 lib/formats.c:507
+#: lib/formats.c:545
 msgid "(not a number)"
 msgstr "(不是數字)"
 
-#: lib/formats.c:125
+#: lib/formats.c:126
 #, c-format
 msgid "%c"
 msgstr "%c"
 
-#: lib/formats.c:135
+#: lib/formats.c:136
 msgid "%a %b %d %Y"
 msgstr "%Y %b %d %a"
 
-#: lib/formats.c:314
+#: lib/formats.c:315
 msgid "(not base64)"
 msgstr "(不是 base64)"
 
-#: lib/formats.c:326
+#: lib/formats.c:327
 msgid "(invalid type)"
 msgstr "(無效型態)"
 
-#: lib/formats.c:349 lib/formats.c:429
+#: lib/formats.c:350 lib/formats.c:430
 msgid "(not a blob)"
 msgstr "(不是 blob)"
 
-#: lib/formats.c:384
+#: lib/formats.c:385
 msgid "(invalid xml type)"
 msgstr "(無效 xml 類型)"
 
-#: lib/formats.c:434
+#: lib/formats.c:435
 msgid "(not an OpenPGP signature)"
 msgstr "(不是個 OpenPGP 簽署)"
 
-#: lib/formats.c:446
+#: lib/formats.c:447
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:512
+#: lib/formats.c:513
 msgid "normal"
 msgstr "一般"
 
-#: lib/formats.c:515 lib/verify.c:369
+#: lib/formats.c:516 lib/verify.c:375
 msgid "replaced"
 msgstr "已替換"
 
-#: lib/formats.c:518 lib/verify.c:363
+#: lib/formats.c:519 lib/verify.c:369
 msgid "not installed"
 msgstr "未安裝"
 
-#: lib/formats.c:521 lib/verify.c:365
+#: lib/formats.c:522 lib/verify.c:371
 msgid "net shared"
 msgstr "已網路分享"
 
-#: lib/formats.c:524 lib/verify.c:367
+#: lib/formats.c:525 lib/verify.c:373
 msgid "wrong color"
 msgstr "錯誤色彩"
 
-#: lib/formats.c:527
+#: lib/formats.c:528
 msgid "missing"
 msgstr "遺失"
 
-#: lib/formats.c:530
+#: lib/formats.c:531
 msgid "(unknown)"
 msgstr "(未知)"
 
-#: lib/formats.c:565
+#: lib/formats.c:566
 msgid "(not a string)"
 msgstr "(不是字串)"
 
-#: lib/fsm.c:704
+#: lib/fsm.c:705
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已被另存為 %s\n"
 
-#: lib/fsm.c:756
+#: lib/fsm.c:757
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立為 %s \n"
 
-#: lib/fsm.c:1029
+#: lib/fsm.c:1030
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1030
+#: lib/fsm.c:1031
 msgid "file"
 msgstr ""
 
-#: lib/package.c:155
-#, c-format
-msgid "%s has unverifiable signature"
-msgstr ""
-
-#: lib/package.c:183 lib/package.c:297 lib/package.c:404
+#: lib/package.c:173 lib/package.c:276 lib/package.c:383
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:202
+#: lib/package.c:192
 msgid "hdr SHA1: BAD, not hex"
 msgstr ""
 
-#: lib/package.c:214
+#: lib/package.c:204
 msgid "hdr RSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:224
+#: lib/package.c:214
 msgid "hdr DSA: BAD, not binary"
 msgstr ""
 
-#: lib/package.c:313
+#: lib/package.c:292
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:322
+#: lib/package.c:301
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:341
+#: lib/package.c:320
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/package.c:350
+#: lib/package.c:329
 #, c-format
 msgid "region size: BAD, ril(%d) > il(%d)"
 msgstr ""
 
-#: lib/package.c:381
+#: lib/package.c:360
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
 
-#: lib/package.c:458
+#: lib/package.c:437
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:462
+#: lib/package.c:441
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/package.c:467
+#: lib/package.c:446
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/package.c:473
+#: lib/package.c:452
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/package.c:483
+#: lib/package.c:462
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/package.c:496
+#: lib/package.c:475
 msgid "hdr load: BAD"
-msgstr ""
-
-#: lib/package.c:648
-#, c-format
-msgid "Fread failed: %s"
 msgstr ""
 
 #: lib/poptALL.c:145
 #, c-format
-msgid "%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
+msgid ""
+"%s: error: more than one --pipe specified (incompatible popt aliases?)\n"
 msgstr ""
 
 #: lib/poptALL.c:175
@@ -1836,15 +1927,16 @@ msgid "relocations must have a / following the ="
 msgstr "重新分配位置必須有個 / 跟在 = 之後"
 
 #: lib/poptI.c:114
-msgid ""
-"install all files, even configurations which might otherwise be skipped"
+msgid "install all files, even configurations which might otherwise be skipped"
 msgstr "安裝所有檔案，即使組態可能被略過"
 
 #: lib/poptI.c:118
 msgid ""
-"remove all packages which match <package> (normally an error is generated if"
-" <package> specified multiple packages)"
-msgstr "移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤出現)"
+"remove all packages which match <package> (normally an error is generated if "
+"<package> specified multiple packages)"
+msgstr ""
+"移除所有符合 <package> 的套件 (如果 <package> 被指定為多個套件，常會導致錯誤"
+"出現)"
 
 #: lib/poptI.c:123
 msgid "relocate files in non-relocatable package"
@@ -1922,7 +2014,7 @@ msgstr "更新資料庫，但不修改檔案系統"
 msgid "do not verify package dependencies"
 msgstr "不校驗套件相依性"
 
-#: lib/poptI.c:179 lib/poptQV.c:207 lib/poptQV.c:209
+#: lib/poptI.c:179 lib/poptQV.c:223 lib/poptQV.c:225
 msgid "don't verify digest of files"
 msgstr "不要校驗檔案的摘要"
 
@@ -2042,162 +2134,182 @@ msgstr "升級套件"
 msgid "reinstall package(s)"
 msgstr ""
 
-#: lib/poptQV.c:67
+#: lib/poptQV.c:75
 msgid "query/verify all packages"
 msgstr "查詢/校驗所有套件"
 
-#: lib/poptQV.c:69
+#: lib/poptQV.c:77
 msgid "rpm checksig mode"
 msgstr "rpm 檢查簽署模式"
 
-#: lib/poptQV.c:71
+#: lib/poptQV.c:79
 msgid "query/verify package(s) owning file"
 msgstr "查詢/校驗套件擁有的檔案"
 
-#: lib/poptQV.c:73
+#: lib/poptQV.c:81
 msgid "query/verify package(s) in group"
 msgstr "查詢/校驗套件所屬的群組"
 
-#: lib/poptQV.c:75
+#: lib/poptQV.c:83
 msgid "query/verify a package file"
 msgstr "查詢/校驗一個套件檔案"
 
-#: lib/poptQV.c:78
+#: lib/poptQV.c:86
 msgid "query/verify package(s) with package identifier"
 msgstr "以套件的識別符查詢/校驗套件"
 
-#: lib/poptQV.c:80
+#: lib/poptQV.c:88
 msgid "query/verify package(s) with header identifier"
 msgstr "以表頭識別符查詢/校驗套件"
 
-#: lib/poptQV.c:83
+#: lib/poptQV.c:91
 msgid "rpm query mode"
 msgstr "rpm 查詢模式"
 
-#: lib/poptQV.c:85
+#: lib/poptQV.c:93
 msgid "query/verify a header instance"
 msgstr "查詢/驗證表頭實體"
 
-#: lib/poptQV.c:87
+#: lib/poptQV.c:95
 msgid "query/verify package(s) from install transaction"
 msgstr "從安裝處理事項查詢/驗證套件"
 
-#: lib/poptQV.c:89
+#: lib/poptQV.c:97
 msgid "query the package(s) triggered by the package"
 msgstr "查詢套件所觸發的套件"
 
-#: lib/poptQV.c:91
+#: lib/poptQV.c:99
 msgid "rpm verify mode"
 msgstr "rpm 校驗模式"
 
-#: lib/poptQV.c:93
+#: lib/poptQV.c:101
 msgid "query/verify the package(s) which require a dependency"
 msgstr "查詢/校驗需要某些相依套件的套件"
 
-#: lib/poptQV.c:95
+#: lib/poptQV.c:103
 msgid "query/verify the package(s) which provide a dependency"
 msgstr "查詢/校驗提供某些相依套件的套件"
 
-#: lib/poptQV.c:98
+#: lib/poptQV.c:105
+#, fuzzy
+msgid "query/verify the package(s) which recommends a dependency"
+msgstr "查詢/校驗需要某些相依套件的套件"
+
+#: lib/poptQV.c:107
+#, fuzzy
+msgid "query/verify the package(s) which suggests a dependency"
+msgstr "查詢/校驗需要某些相依套件的套件"
+
+#: lib/poptQV.c:109
+#, fuzzy
+msgid "query/verify the package(s) which supplements a dependency"
+msgstr "查詢/校驗需要某些相依套件的套件"
+
+#: lib/poptQV.c:111
+#, fuzzy
+msgid "query/verify the package(s) which enhances a dependency"
+msgstr "查詢/校驗需要某些相依套件的套件"
+
+#: lib/poptQV.c:114
 msgid "do not glob arguments"
 msgstr "不以 glob 解析引數"
 
-#: lib/poptQV.c:100
+#: lib/poptQV.c:116
 msgid "do not process non-package files as manifests"
 msgstr "不以 manifest 處理非套件檔案"
 
-#: lib/poptQV.c:172
+#: lib/poptQV.c:188
 msgid "list all configuration files"
 msgstr "列出所有組態檔案"
 
-#: lib/poptQV.c:174
+#: lib/poptQV.c:190
 msgid "list all documentation files"
 msgstr "列出所有文件檔案"
 
-#: lib/poptQV.c:176
+#: lib/poptQV.c:192
 msgid "list all license files"
 msgstr ""
 
-#: lib/poptQV.c:178
+#: lib/poptQV.c:194
 msgid "dump basic file information"
 msgstr "傾印基本檔案資訊"
 
-#: lib/poptQV.c:182
+#: lib/poptQV.c:198
 msgid "list files in package"
 msgstr "列出套件內的檔案"
 
-#: lib/poptQV.c:187
+#: lib/poptQV.c:203
 #, c-format
 msgid "skip %%ghost files"
 msgstr "略過 %%ghost 檔案"
 
-#: lib/poptQV.c:194
+#: lib/poptQV.c:210
 msgid "display the states of the listed files"
 msgstr "顯示列出的檔案的狀態"
 
-#: lib/poptQV.c:212
+#: lib/poptQV.c:228
 msgid "don't verify size of files"
 msgstr "不校驗檔案大小"
 
-#: lib/poptQV.c:215
+#: lib/poptQV.c:231
 msgid "don't verify symlink path of files"
 msgstr "不校驗檔案的符號連結路徑"
 
-#: lib/poptQV.c:218
+#: lib/poptQV.c:234
 msgid "don't verify owner of files"
 msgstr "不校驗檔案的擁有者"
 
-#: lib/poptQV.c:221
+#: lib/poptQV.c:237
 msgid "don't verify group of files"
 msgstr "不校驗檔案的群組"
 
-#: lib/poptQV.c:224
+#: lib/poptQV.c:240
 msgid "don't verify modification time of files"
 msgstr "不校驗檔案的修改時間"
 
-#: lib/poptQV.c:227 lib/poptQV.c:230
+#: lib/poptQV.c:243 lib/poptQV.c:246
 msgid "don't verify mode of files"
 msgstr "不校驗檔案的模式"
 
-#: lib/poptQV.c:233
+#: lib/poptQV.c:249
 msgid "don't verify capabilities of files"
 msgstr ""
 
-#: lib/poptQV.c:236
+#: lib/poptQV.c:252
 msgid "don't verify file security contexts"
 msgstr "不校驗檔案的安全情境"
 
-#: lib/poptQV.c:238
+#: lib/poptQV.c:254
 msgid "don't verify files in package"
 msgstr "不校驗套件內的檔案"
 
-#: lib/poptQV.c:240 tools/rpmgraph.c:218
+#: lib/poptQV.c:256 tools/rpmgraph.c:218
 msgid "don't verify package dependencies"
 msgstr "不校驗套件的相依關係"
 
-#: lib/poptQV.c:243 lib/poptQV.c:246
+#: lib/poptQV.c:259 lib/poptQV.c:262
 msgid "don't execute verify script(s)"
 msgstr "不執行校驗指令稿"
 
-#: lib/psm.c:144
+#: lib/psm.c:146
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:181
+#: lib/psm.c:183
 msgid "source package expected, binary found\n"
 msgstr "預期是源碼套件，但卻找到二進位套件\n"
 
-#: lib/psm.c:192
+#: lib/psm.c:194
 msgid "source package contains no .spec file\n"
 msgstr "源碼套件內未包含 .spec 檔案\n"
 
-#: lib/psm.c:688
+#: lib/psm.c:605
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解包封存檔失敗 %s%s：%s\n"
 
-#: lib/psm.c:689
+#: lib/psm.c:606
 msgid " on file "
 msgstr "  於檔案 "
 
@@ -2272,96 +2384,116 @@ msgstr "沒有套件符合 %s：%s\n"
 msgid "no package requires %s\n"
 msgstr "沒有套件需要 %s\n"
 
-#: lib/query.c:391
+#: lib/query.c:390
+#, fuzzy, c-format
+msgid "no package recommends %s\n"
+msgstr "沒有套件需要 %s\n"
+
+#: lib/query.c:397
+#, fuzzy, c-format
+msgid "no package suggests %s\n"
+msgstr "沒有套件會觸發 %s\n"
+
+#: lib/query.c:404
+#, fuzzy, c-format
+msgid "no package supplements %s\n"
+msgstr "沒有套件需要 %s\n"
+
+#: lib/query.c:411
+#, fuzzy, c-format
+msgid "no package enhances %s\n"
+msgstr "沒有套件需要 %s\n"
+
+#: lib/query.c:419
 #, c-format
 msgid "no package provides %s\n"
 msgstr "沒有套件提供 %s\n"
 
-#: lib/query.c:423
+#: lib/query.c:451
 #, c-format
 msgid "file %s: %s\n"
 msgstr "檔案 %s：%s\n"
 
-#: lib/query.c:426
+#: lib/query.c:454
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "檔案 %s 不被任何套件擁有\n"
 
-#: lib/query.c:437
+#: lib/query.c:465
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無效的套件編號：%s\n"
 
-#: lib/query.c:444
+#: lib/query.c:472
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:457 lib/rpminstall.c:660
+#: lib/query.c:485 lib/rpminstall.c:680
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "套件 %s 尚未安裝\n"
 
-#: lib/query.c:491
+#: lib/query.c:519
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "未知的標籤：「%s」\n"
 
-#: lib/rpmchecksig.c:44
+#: lib/rpmchecksig.c:49 lib/rpmchecksig.c:57
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:48
+#: lib/rpmchecksig.c:65
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:93
+#: lib/rpmchecksig.c:110
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：匯入時讀取失敗(%d)。\n"
 
-#: lib/rpmchecksig.c:119 sign/rpmgensig.c:508
+#: lib/rpmchecksig.c:136 sign/rpmgensig.c:710
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:128
+#: lib/rpmchecksig.c:145
 #, c-format
 msgid "%s: Immutable header region could not be read. Corrupted package?\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:140 sign/rpmgensig.c:112
+#: lib/rpmchecksig.c:157 sign/rpmgensig.c:177
 #, c-format
 msgid "%s: Fread failed: %s\n"
 msgstr "%s：Fread 失敗：%s\n"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "NOT OK"
 msgstr "不正確"
 
-#: lib/rpmchecksig.c:373
+#: lib/rpmchecksig.c:335
 msgid "OK"
 msgstr "正確"
 
-#: lib/rpmchecksig.c:375
+#: lib/rpmchecksig.c:337
 msgid " (MISSING KEYS:"
 msgstr " (遺失的金鑰："
 
-#: lib/rpmchecksig.c:377
+#: lib/rpmchecksig.c:339
 msgid ") "
 msgstr ") "
 
-#: lib/rpmchecksig.c:378
+#: lib/rpmchecksig.c:340
 msgid " (UNTRUSTED KEYS:"
 msgstr " (未受信任的金鑰："
 
-#: lib/rpmchecksig.c:380
+#: lib/rpmchecksig.c:342
 msgid ")"
 msgstr ")"
 
-#: lib/rpmchecksig.c:423 sign/rpmgensig.c:72
+#: lib/rpmchecksig.c:385 sign/rpmgensig.c:138
 #, c-format
 msgid "%s: open failed: %s\n"
 msgstr "%s：開啟失敗：%s\n"
@@ -2386,144 +2518,192 @@ msgstr ""
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "NO "
 msgstr "否 "
 
-#: lib/rpmds.c:547
+#: lib/rpmds.c:726
 msgid "YES"
 msgstr "是"
 
-#: lib/rpmds.c:1000
+#: lib/rpmds.c:1203
 msgid "PreReq:, Provides:, and Obsoletes: dependencies support versions."
 msgstr "PreReq:、Provides:、以及 Obsoletes: 相依性支援版本。"
 
-#: lib/rpmds.c:1003
+#: lib/rpmds.c:1206
 msgid "file name(s) stored as (dirName,baseName,dirIndex) tuple, not as path."
 msgstr "檔案名稱儲存為 (dirName、baseName、dirIndex) 字組，而非路徑。"
 
-#: lib/rpmds.c:1007
+#: lib/rpmds.c:1210
 msgid "package payload can be compressed using bzip2."
 msgstr "套件酬載可以使用 bzip2 壓縮。"
 
-#: lib/rpmds.c:1012
+#: lib/rpmds.c:1215
 msgid "package payload can be compressed using xz."
 msgstr ""
 
-#: lib/rpmds.c:1015
+#: lib/rpmds.c:1218
 msgid "package payload can be compressed using lzma."
 msgstr ""
 
-#: lib/rpmds.c:1019
+#: lib/rpmds.c:1222
 msgid "package payload file(s) have \"./\" prefix."
 msgstr "套件酬載檔案有「./」前綴。"
 
-#: lib/rpmds.c:1022
+#: lib/rpmds.c:1225
 msgid "package name-version-release is not implicitly provided."
 msgstr "套件的「名稱-版本-發行編號」沒有隱含性地提供。"
 
-#: lib/rpmds.c:1025
+#: lib/rpmds.c:1228
 msgid "header tags are always sorted after being loaded."
 msgstr "表頭標籤總在載入之後排序。"
 
-#: lib/rpmds.c:1028
+#: lib/rpmds.c:1231
 msgid "the scriptlet interpreter can use arguments from header."
 msgstr "指令稿片段解譯器可以使用來自表頭的引數。"
 
-#: lib/rpmds.c:1031
+#: lib/rpmds.c:1234
 msgid "a hardlink file set may be installed without being complete."
 msgstr "硬鏈結檔案組也許沒有被完整安裝。"
 
-#: lib/rpmds.c:1034
+#: lib/rpmds.c:1237
 msgid "package scriptlets may access the rpm database while installing."
 msgstr "套件指令稿片段在安裝過程中可以存取 rpm 資料庫。"
 
-#: lib/rpmds.c:1038
+#: lib/rpmds.c:1241
 msgid "internal support for lua scripts."
 msgstr "lua 指令稿的內部支援。"
 
-#: lib/rpmds.c:1042
+#: lib/rpmds.c:1245
 msgid "file digest algorithm is per package configurable"
 msgstr ""
 
-#: lib/rpmds.c:1046
+#: lib/rpmds.c:1249
 msgid "support for POSIX.1e file capabilities"
 msgstr ""
 
-#: lib/rpmds.c:1050
+#: lib/rpmds.c:1253
 msgid "package scriptlets can be expanded at install time."
 msgstr ""
 
-#: lib/rpmds.c:1053
+#: lib/rpmds.c:1256
 msgid "dependency comparison supports versions with tilde."
 msgstr ""
 
-#: lib/rpmds.c:1056
+#: lib/rpmds.c:1259
 msgid "support files larger than 4GB"
 msgstr ""
 
-#: lib/rpmfi.c:780
+#: lib/rpmds.c:1262
+#, fuzzy
+msgid "support for rich dependencies."
+msgstr "不校驗套件相依性"
+
+#: lib/rpmds.c:1384
+#, c-format
+msgid "Unknown rich dependency op '%.*s'"
+msgstr ""
+
+#: lib/rpmds.c:1419
+msgid "Name required"
+msgstr ""
+
+#: lib/rpmds.c:1456
+msgid "Rich dependency does not start with '('"
+msgstr ""
+
+#: lib/rpmds.c:1464
+msgid "Missing argument to rich dependency op"
+msgstr ""
+
+#: lib/rpmds.c:1466
+msgid "Empty rich dependency"
+msgstr ""
+
+#: lib/rpmds.c:1480
+#, fuzzy, c-format
+msgid "Unterminated rich dependency: %s"
+msgstr "未終結的 %c：%s\n"
+
+#: lib/rpmds.c:1492
+msgid "Cannot chain different ops"
+msgstr ""
+
+#: lib/rpmds.c:1497
+msgid "Can only chain AND and OR ops"
+msgstr ""
+
+#: lib/rpmds.c:1587
+msgid "Junk after rich dependency"
+msgstr ""
+
+#: lib/rpmfi.c:813
 #, c-format
 msgid "user %s does not exist - using root\n"
 msgstr "使用者 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:787
+#: lib/rpmfi.c:820
 #, c-format
 msgid "group %s does not exist - using root\n"
 msgstr "群組 %s 不存在 - 現使用 root 代替\n"
 
-#: lib/rpmfi.c:2111
+#: lib/rpmfi.c:2236
 msgid "Bad magic"
 msgstr "不良魔法數字"
 
-#: lib/rpmfi.c:2112
+#: lib/rpmfi.c:2237
 msgid "Bad/unreadable  header"
 msgstr "不良或無法讀取的表頭"
 
-#: lib/rpmfi.c:2135
+#: lib/rpmfi.c:2260
 msgid "Header size too big"
 msgstr "表頭大小過大"
 
-#: lib/rpmfi.c:2136
+#: lib/rpmfi.c:2261
 msgid "File too large for archive"
 msgstr ""
 
-#: lib/rpmfi.c:2137
+#: lib/rpmfi.c:2262
 msgid "Unknown file type"
 msgstr "未知檔案類型"
 
-#: lib/rpmfi.c:2138
+#: lib/rpmfi.c:2263
 msgid "Missing file(s)"
 msgstr ""
 
-#: lib/rpmfi.c:2139
+#: lib/rpmfi.c:2264
 msgid "Digest mismatch"
 msgstr "摘要不符"
 
-#: lib/rpmfi.c:2140
+#: lib/rpmfi.c:2265
 msgid "Internal error"
 msgstr "內部錯誤"
 
-#: lib/rpmfi.c:2141
+#: lib/rpmfi.c:2266
 msgid "Archive file not in header"
 msgstr "在表頭中沒有封存檔"
 
-#: lib/rpmfi.c:2149
+#: lib/rpmfi.c:2274
 msgid " failed - "
 msgstr " 失敗 - "
 
-#: lib/rpmfi.c:2152
+#: lib/rpmfi.c:2277
 #, c-format
 msgid "%s: (error 0x%x)"
 msgstr ""
 
-#: lib/rpmgi.c:49 lib/rpminstall.c:115 lib/rpminstall.c:308
+#: lib/rpmgi.c:55 lib/rpminstall.c:115 lib/rpminstall.c:308
 #: lib/rpminstall.c:337 tools/rpmgraph.c:92 tools/rpmgraph.c:129
 #, c-format
 msgid "open of %s failed: %s\n"
 msgstr "開啟 %s 失敗：%s\n"
 
-#: lib/rpmgi.c:136
+#: lib/rpmgi.c:144
+#, c-format
+msgid "Max level of manifest recursion exceeded: %s\n"
+msgstr ""
+
+#: lib/rpmgi.c:155
 #, c-format
 msgid "%s: not an rpm package (or package manifest)\n"
 msgstr ""
@@ -2555,42 +2735,42 @@ msgstr "相依關係失敗：\n"
 msgid "%s: not an rpm package (or package manifest): %s\n"
 msgstr "%s：不是 rpm 套件 (或套件 manifest)：%s\n"
 
-#: lib/rpminstall.c:357 lib/rpminstall.c:722 tools/rpmgraph.c:112
+#: lib/rpminstall.c:357 lib/rpminstall.c:742 tools/rpmgraph.c:112
 #, c-format
 msgid "%s cannot be installed\n"
 msgstr "%s 無法安裝\n"
 
-#: lib/rpminstall.c:464
+#: lib/rpminstall.c:484
 #, c-format
 msgid "Retrieving %s\n"
 msgstr "正在擷取 %s\n"
 
-#: lib/rpminstall.c:476
+#: lib/rpminstall.c:496
 #, c-format
 msgid "skipping %s - transfer failed\n"
 msgstr ""
 
-#: lib/rpminstall.c:542
+#: lib/rpminstall.c:562
 #, c-format
 msgid "package %s is not relocatable\n"
 msgstr "套件 %s 不能重新分配位置\n"
 
-#: lib/rpminstall.c:573
+#: lib/rpminstall.c:593
 #, c-format
 msgid "error reading from file %s\n"
 msgstr "讀取檔案 %s 時發生錯誤\n"
 
-#: lib/rpminstall.c:667
+#: lib/rpminstall.c:687
 #, c-format
 msgid "\"%s\" specifies multiple packages:\n"
 msgstr "「%s」指定多個套件：\n"
 
-#: lib/rpminstall.c:706
+#: lib/rpminstall.c:726
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: lib/rpminstall.c:712
+#: lib/rpminstall.c:732
 #, c-format
 msgid "Installing %s\n"
 msgstr "正在安裝 %s\n"
@@ -2616,12 +2796,12 @@ msgstr "讀取失敗：%s (%d)\n"
 msgid "not an rpm package\n"
 msgstr "並非 rpm 套件\n"
 
-#: lib/rpmlock.c:118 lib/rpmlock.c:136
+#: lib/rpmlock.c:118 lib/rpmlock.c:137
 #, c-format
 msgid "can't create %s lock on %s (%s)\n"
 msgstr ""
 
-#: lib/rpmlock.c:131
+#: lib/rpmlock.c:132
 #, c-format
 msgid "waiting for %s lock on %s\n"
 msgstr ""
@@ -2779,60 +2959,79 @@ msgstr "%s 遺漏架構位於 %s:%d\n"
 msgid "bad option '%s' at %s:%d\n"
 msgstr "不良選項「%s」位於 %s:%d\n"
 
-#: lib/rpmrc.c:959
+#: lib/rpmrc.c:964
 msgid "Failed to read auxiliary vector, /proc not mounted?\n"
 msgstr ""
 
-#: lib/rpmrc.c:1365
+#: lib/rpmrc.c:1416
 #, c-format
 msgid "Unknown system: %s\n"
 msgstr "未知系統：%s\n"
 
-#: lib/rpmrc.c:1367
+#: lib/rpmrc.c:1418
 #, c-format
 msgid "Please contact %s\n"
 msgstr "請聯絡 %s\n"
 
-#: lib/rpmrc.c:1500
+#: lib/rpmrc.c:1551
 #, c-format
 msgid "Unable to open %s for reading: %m.\n"
 msgstr "無法開啟 %s 以供讀取：%m。\n"
 
-#: lib/rpmscript.c:122
+#: lib/rpmscript.c:137
+msgid "No exec() called after fork() in lua scriptlet\n"
+msgstr ""
+
+#: lib/rpmscript.c:142
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:133
+#: lib/rpmscript.c:153
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
-#: lib/rpmscript.c:263
+#: lib/rpmscript.c:281
 #, c-format
 msgid "Couldn't create temporary file for %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:290
+#: lib/rpmscript.c:316
 #, c-format
 msgid "Couldn't duplicate file descriptor: %s: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:320
+#: lib/rpmscript.c:343
+#, fuzzy, c-format
+msgid "Unable to reset nice value: %s"
+msgstr "無法讀取圖示 %s：%s\n"
+
+#: lib/rpmscript.c:354
+#, fuzzy, c-format
+msgid "Unable to reset I/O priority: %s"
+msgstr "無法讀取圖示 %s：%s\n"
+
+#: lib/rpmscript.c:382
+#, fuzzy, c-format
+msgid "Fwrite failed: %s"
+msgstr "%s: Fwrite 失敗：%s\n"
+
+#: lib/rpmscript.c:400
 #, c-format
 msgid "%s scriptlet failed, waitpid(%d) rc %d: %s\n"
 msgstr ""
 
-#: lib/rpmscript.c:324
+#: lib/rpmscript.c:404
 #, c-format
 msgid "%s scriptlet failed, signal %d\n"
 msgstr ""
 
-#: lib/rpmscript.c:327
+#: lib/rpmscript.c:407
 #, c-format
 msgid "%s scriptlet failed, exit status %d\n"
 msgstr ""
 
-#: lib/rpmtd.c:258
+#: lib/rpmtd.c:263
 msgid "Unknown format"
 msgstr "未知格式"
 
@@ -2844,127 +3043,146 @@ msgstr "安裝"
 msgid "erase"
 msgstr "抹除"
 
-#: lib/rpmts.c:98
+#: lib/rpmts.c:99
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "無法開啟套件資料庫 %s\n"
 
-#: lib/rpmts.c:197
+#: lib/rpmts.c:198
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的「(」存在於套件標籤中：%s\n"
 
-#: lib/rpmts.c:215
+#: lib/rpmts.c:216
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "套件標籤遺漏「(」：%s\n"
 
-#: lib/rpmts.c:223
+#: lib/rpmts.c:224
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "套件標籤遺漏「)」：%s\n"
 
-#: lib/rpmts.c:279
+#: lib/rpmts.c:283
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1062
+#: lib/rpmts.c:1139
 msgid "transaction"
 msgstr "處理事項"
 
-#: lib/signature.c:74
+#: lib/signature.c:78
+#, c-format
+msgid "%s tag %u: BAD, invalid size %u"
+msgstr ""
+
+#: lib/signature.c:84
+#, c-format
+msgid "%s tag %u: BAD, invalid type %u"
+msgstr ""
+
+#: lib/signature.c:91
+#, fuzzy, c-format
+msgid "%s tag %u: BAD, invalid OpenPGP signature"
+msgstr "(不是個 OpenPGP 簽署)"
+
+#: lib/signature.c:160
 #, c-format
 msgid "sigh size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:79
+#: lib/signature.c:165
 msgid "sigh magic: BAD"
 msgstr ""
 
-#: lib/signature.c:85
+#: lib/signature.c:171
 #, c-format
 msgid "sigh tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:91
+#: lib/signature.c:177
 #, c-format
 msgid "sigh data: BAD, no. of  bytes(%d) out of range"
 msgstr ""
 
-#: lib/signature.c:106
+#: lib/signature.c:192
 #, c-format
 msgid "sigh blob(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/signature.c:123
+#: lib/signature.c:209
 #, c-format
 msgid "sigh tag[%d]: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/signature.c:133
+#: lib/signature.c:219
 msgid "sigh load: BAD"
 msgstr ""
 
-#: lib/signature.c:146
+#: lib/signature.c:233
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/signature.c:162
+#: lib/signature.c:249
 #, c-format
 msgid "sigh sigSize(%zd): BAD, fstat(2) failed"
 msgstr ""
 
-#: lib/signature.c:235
-msgid "MD5 digest:"
-msgstr "MD5 摘要："
+#: lib/signature.c:369
+msgid "Unable to reload signature header.\n"
+msgstr "無法重新載入簽署表頭。\n"
 
-#: lib/signature.c:274
-msgid "Header SHA1 digest:"
-msgstr "表頭 SHA1 摘要："
-
-#: lib/signature.c:316
+#: lib/signature.c:445
 msgid "Header "
 msgstr "表頭 "
 
-#: lib/signature.c:357
+#: lib/signature.c:464
+msgid "MD5 digest:"
+msgstr "MD5 摘要："
+
+#: lib/signature.c:467
+msgid "Header SHA1 digest:"
+msgstr "表頭 SHA1 摘要："
+
+#: lib/signature.c:486
 #, c-format
 msgid "Verify signature: BAD PARAMETERS (%d %p %d %p %p)"
 msgstr ""
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "skipped"
 msgstr "已跳過"
 
-#: lib/transaction.c:1344
+#: lib/transaction.c:1360
 msgid "failed"
 msgstr "已失敗"
 
-#: lib/verify.c:251
+#: lib/verify.c:257
 #, c-format
 msgid "Duplicate username or UID for user %s\n"
 msgstr ""
 
-#: lib/verify.c:272
+#: lib/verify.c:278
 #, c-format
 msgid "Duplicate groupname or GID for group %s\n"
 msgstr ""
 
-#: lib/verify.c:371
+#: lib/verify.c:377
 msgid "no state"
 msgstr ""
 
-#: lib/verify.c:373
+#: lib/verify.c:379
 msgid "unknown state"
 msgstr ""
 
-#: lib/verify.c:424
+#: lib/verify.c:430
 #, c-format
 msgid "missing   %c %s"
 msgstr "遺漏      %c %s"
 
-#: lib/verify.c:476
+#: lib/verify.c:482
 #, c-format
 msgid "Unsatisfied dependencies for %s:\n"
 msgstr ""
@@ -3038,240 +3256,240 @@ msgstr "用於不同大小陣列的陣列迭代器"
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:160 lib/rpmdb.c:206
+#: lib/rpmdb.c:166 lib/rpmdb.c:212
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:499
+#: lib/rpmdb.c:526
 msgid "no dbpath has been set\n"
 msgstr "尚未設定 dbpath\n"
 
-#: lib/rpmdb.c:1013
+#: lib/rpmdb.c:1043
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳過"
 
-#: lib/rpmdb.c:1028
+#: lib/rpmdb.c:1061
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "儲存記錄 #%2$d 到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/rpmdb.c:1121
+#: lib/rpmdb.c:1172
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1302
+#: lib/rpmdb.c:1353
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1465
+#: lib/rpmdb.c:1516
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳過"
 
-#: lib/rpmdb.c:1550
+#: lib/rpmdb.c:1603
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：已擷取損壞的表頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2000
+#: lib/rpmdb.c:2135
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：無法讀取位於 0x%x 的表頭\n"
 
-#: lib/rpmdb.c:2300
+#: lib/rpmdb.c:2528
 msgid "no dbpath has been set"
 msgstr "尚未設定 dbpath"
 
-#: lib/rpmdb.c:2318
+#: lib/rpmdb.c:2546
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2352
+#: lib/rpmdb.c:2580
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "在資料庫中有不良的表頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2365
+#: lib/rpmdb.c:2593
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "無法加入原本位於 %u 的記錄\n"
 
-#: lib/rpmdb.c:2381
+#: lib/rpmdb.c:2609
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建資料庫時失敗：原來的資料庫保持原狀\n"
 
-#: lib/rpmdb.c:2389
+#: lib/rpmdb.c:2617
 msgid "failed to replace old database with new database!\n"
 msgstr "以新的資料庫取代舊的資料庫時失敗！\n"
 
-#: lib/rpmdb.c:2391
+#: lib/rpmdb.c:2619
 #, c-format
 msgid "replace files in %s with files from %s to recover"
 msgstr "以 %2$s 的檔案取代 %1$s 的檔案來復原"
 
-#: lib/rpmdb.c:2402
+#: lib/rpmdb.c:2630
 #, c-format
 msgid "failed to remove directory %s: %s\n"
 msgstr "移除目錄時失敗 %s：%s\n"
 
-#: lib/backend/db3.c:36
+#: lib/backend/db3.c:96
 #, c-format
 msgid "%s error(%d) from %s: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:39
+#: lib/backend/db3.c:99
 #, c-format
 msgid "%s error(%d): %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:592
-#, c-format
-msgid "cannot get %s lock on %s/%s\n"
-msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
-
-#: lib/backend/db3.c:594
-msgid "shared"
-msgstr "已共享"
-
-#: lib/backend/db3.c:594
-msgid "exclusive"
-msgstr "排他"
-
-#: lib/backend/db3.c:674
-#, c-format
-msgid "invalid index type %x on %s/%s\n"
-msgstr ""
-
-#: lib/backend/db3.c:874
-#, c-format
-msgid "error(%d) getting \"%s\" records from %s index: %s\n"
-msgstr ""
-
-#: lib/backend/db3.c:904
-#, c-format
-msgid "error(%d) storing record \"%s\" into %s\n"
-msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
-
-#: lib/backend/db3.c:912
-#, c-format
-msgid "error(%d) removing record \"%s\" from %s\n"
-msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
-
-#: lib/backend/db3.c:996
-#, c-format
-msgid "error(%d) adding header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1008
-#, c-format
-msgid "error(%d) removing header #%d record\n"
-msgstr ""
-
-#: lib/backend/db3.c:1067
-#, c-format
-msgid "error(%d) allocating new package instance\n"
-msgstr "分配新套件實體時發生錯誤(%d)\n"
-
-#: lib/backend/dbconfig.c:145
+#: lib/backend/db3.c:282
 #, c-format
 msgid "unrecognized db option: \"%s\" ignored.\n"
 msgstr "無法辨識的資料庫選項：「%s」 已忽略。\n"
 
-#: lib/backend/dbconfig.c:182
+#: lib/backend/db3.c:319
 #, c-format
 msgid "%s has invalid numeric value, skipped\n"
 msgstr "%s 有無效的數值，略過\n"
 
-#: lib/backend/dbconfig.c:191
+#: lib/backend/db3.c:328
 #, c-format
 msgid "%s has too large or too small long value, skipped\n"
 msgstr "%s 有過大或過小的 long 數值，略過\n"
 
-#: lib/backend/dbconfig.c:200
+#: lib/backend/db3.c:337
 #, c-format
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s 有過大或過小的整數值，略過\n"
 
-#: rpmio/macro.c:282
+#: lib/backend/db3.c:797
+#, c-format
+msgid "cannot get %s lock on %s/%s\n"
+msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
+
+#: lib/backend/db3.c:799
+msgid "shared"
+msgstr "已共享"
+
+#: lib/backend/db3.c:799
+msgid "exclusive"
+msgstr "排他"
+
+#: lib/backend/db3.c:881
+#, c-format
+msgid "invalid index type %x on %s/%s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1070
+#, c-format
+msgid "error(%d) getting \"%s\" records from %s index: %s\n"
+msgstr ""
+
+#: lib/backend/db3.c:1100
+#, c-format
+msgid "error(%d) storing record \"%s\" into %s\n"
+msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
+
+#: lib/backend/db3.c:1108
+#, c-format
+msgid "error(%d) removing record \"%s\" from %s\n"
+msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
+
+#: lib/backend/db3.c:1210
+#, c-format
+msgid "error(%d) adding header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1219
+#, c-format
+msgid "error(%d) removing header #%d record\n"
+msgstr ""
+
+#: lib/backend/db3.c:1274
+#, c-format
+msgid "error(%d) allocating new package instance\n"
+msgstr "分配新套件實體時發生錯誤(%d)\n"
+
+#: rpmio/macro.c:283
 #, c-format
 msgid "%3d>%*s(empty)"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:323
+#: rpmio/macro.c:324
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:494
+#: rpmio/macro.c:495
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:506 rpmio/macro.c:544
+#: rpmio/macro.c:507 rpmio/macro.c:545
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "巨集 %%%s 具有未終結的主體\n"
 
-#: rpmio/macro.c:563
+#: rpmio/macro.c:564
 #, c-format
 msgid "Macro %%%s has illegal name (%%define)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%define)\n"
 
-#: rpmio/macro.c:568
+#: rpmio/macro.c:569
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "巨集 %%%s 具有空的主體\n"
 
-#: rpmio/macro.c:573
+#: rpmio/macro.c:574
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:577
+#: rpmio/macro.c:578
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "巨集 %%%s 展開時失敗\n"
 
-#: rpmio/macro.c:616
+#: rpmio/macro.c:617
 #, c-format
 msgid "Macro %%%s has illegal name (%%undefine)\n"
 msgstr "巨集 %%%s 具有無效的名稱 (%%undefine)\n"
 
-#: rpmio/macro.c:645
+#: rpmio/macro.c:647
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:728
+#: rpmio/macro.c:730
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中有未知的選項 %1$c\n"
 
-#: rpmio/macro.c:958
+#: rpmio/macro.c:963
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1027 rpmio/macro.c:1044
+#: rpmio/macro.c:1032 rpmio/macro.c:1049
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未終結的 %c：%s\n"
 
-#: rpmio/macro.c:1085
+#: rpmio/macro.c:1090
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在無法解析的巨集之後跟著一個 %%\n"
 
-#: rpmio/macro.c:1103
+#: rpmio/macro.c:1106
 #, c-format
 msgid "failed to load macro file %s"
 msgstr ""
 
-#: rpmio/macro.c:1484
+#: rpmio/macro.c:1492
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3291,31 +3509,31 @@ msgstr "檔案 %s：%s\n"
 msgid "File %s is smaller than %u bytes\n"
 msgstr "檔案 %s 小於 %u 位元組\n"
 
-#: rpmio/rpmfileutil.c:600
+#: rpmio/rpmfileutil.c:601
 msgid "failed to create directory"
 msgstr "無法建立目錄"
 
-#: rpmio/rpmlua.c:514
+#: rpmio/rpmlua.c:523
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:532
+#: rpmio/rpmlua.c:541
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:537 rpmio/rpmlua.c:556
+#: rpmio/rpmlua.c:546 rpmio/rpmlua.c:565
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 指令稿失敗：%s\n"
 
-#: rpmio/rpmlua.c:551
+#: rpmio/rpmlua.c:560
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua 檔案內有無效語法：%s\n"
 
-#: rpmio/rpmlua.c:727
+#: rpmio/rpmlua.c:746
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3324,19 +3542,19 @@ msgstr ""
 msgid "[none]"
 msgstr ""
 
-#: rpmio/rpmlog.c:76
+#: rpmio/rpmlog.c:80
 msgid "(no error)"
 msgstr "(無錯誤)"
 
-#: rpmio/rpmlog.c:201 rpmio/rpmlog.c:202 rpmio/rpmlog.c:203
+#: rpmio/rpmlog.c:222 rpmio/rpmlog.c:223 rpmio/rpmlog.c:224
 msgid "fatal error: "
 msgstr "嚴重錯誤："
 
-#: rpmio/rpmlog.c:204
+#: rpmio/rpmlog.c:225
 msgid "error: "
 msgstr "錯誤："
 
-#: rpmio/rpmlog.c:205
+#: rpmio/rpmlog.c:226
 msgid "warning: "
 msgstr "警告："
 
@@ -3345,99 +3563,154 @@ msgstr "警告："
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "記憶體配置 (%u 位元組) 回傳 NULL。\n"
 
-#: rpmio/rpmpgp.c:1016
+#: rpmio/rpmpgp.c:1074
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1024
+#: rpmio/rpmpgp.c:1082
 msgid "(none)"
 msgstr "(無)"
 
-#: sign/rpmgensig.c:106
+#: sign/rpmgensig.c:58
+#, fuzzy, c-format
+msgid "error creating temp directory %s: %m\n"
+msgstr "讀取檔案 %s 時發生錯誤\n"
+
+#: sign/rpmgensig.c:66
+#, fuzzy, c-format
+msgid "error creating fifo %s: %m\n"
+msgstr "讀取檔案 %s 時發生錯誤\n"
+
+#: sign/rpmgensig.c:87
+#, c-format
+msgid "error delete fifo %s: %m\n"
+msgstr ""
+
+#: sign/rpmgensig.c:95
+#, fuzzy, c-format
+msgid "error delete directory %s: %m\n"
+msgstr "移除目錄時失敗 %s：%s\n"
+
+#: sign/rpmgensig.c:171
 #, c-format
 msgid "%s: Fwrite failed: %s\n"
 msgstr "%s: Fwrite 失敗：%s\n"
 
-#: sign/rpmgensig.c:116
+#: sign/rpmgensig.c:181
 #, c-format
 msgid "%s: Fflush failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:144
+#: sign/rpmgensig.c:207
 msgid "Unsupported PGP signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:150
+#: sign/rpmgensig.c:213
 #, c-format
 msgid "Unsupported PGP hash algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:163
+#: sign/rpmgensig.c:226
 #, c-format
 msgid "Unsupported PGP pubkey algorithm %u\n"
 msgstr ""
 
-#: sign/rpmgensig.c:198 sign/rpmgensig.c:204
+#: sign/rpmgensig.c:278
 #, c-format
-msgid "Couldn't create pipe for signing: %m"
-msgstr "無法建立簽署用的導管：%m"
+msgid "Could not exec %s: %s\n"
+msgstr "無法執行 %s：%s\n"
 
-#: sign/rpmgensig.c:247 sign/rpmgensig.c:261
-msgid "fdopen failed\n"
-msgstr ""
+#: sign/rpmgensig.c:288
+#, fuzzy
+msgid "Fopen failed\n"
+msgstr "%s：開啟失敗：%s\n"
 
-#: sign/rpmgensig.c:253 sign/rpmgensig.c:277
+#: sign/rpmgensig.c:303
 msgid "Could not write to pipe\n"
 msgstr ""
 
-#: sign/rpmgensig.c:284
+#: sign/rpmgensig.c:310
 #, c-format
 msgid "Could not read from file %s: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:294
+#: sign/rpmgensig.c:320
 #, c-format
 msgid "gpg exec failed (%d)\n"
 msgstr "gpg 執行失敗 (%d)\n"
 
-#: sign/rpmgensig.c:344
+#: sign/rpmgensig.c:362
 msgid "gpg failed to write signature\n"
 msgstr "寫入簽署時 gpg 失敗\n"
 
-#: sign/rpmgensig.c:361
+#: sign/rpmgensig.c:379
 msgid "unable to read the signature\n"
 msgstr "無法讀取簽名\n"
 
-#: sign/rpmgensig.c:500
+#: sign/rpmgensig.c:530
+#, fuzzy
+msgid "generateSignature failed\n"
+msgstr "%s：rpmWriteSignature 失敗：%s\n"
+
+#: sign/rpmgensig.c:544
+#, fuzzy
+msgid "rpmReadSignature failed\n"
+msgstr "%s：rpmReadSignature 失敗：%s"
+
+#: sign/rpmgensig.c:571
+msgid "missing libimaevm\n"
+msgstr ""
+
+#: sign/rpmgensig.c:590
+#, fuzzy
+msgid "headerReload failed\n"
+msgstr "執行失敗\n"
+
+#: sign/rpmgensig.c:597 sign/rpmgensig.c:802
+msgid "rpmMkTemp failed\n"
+msgstr "rpmMkTemp 失敗\n"
+
+#: sign/rpmgensig.c:604 sign/rpmgensig.c:636
+#, fuzzy
+msgid "copyFile failed\n"
+msgstr "執行失敗\n"
+
+#: sign/rpmgensig.c:622
+#, fuzzy
+msgid "headerWrite failed\n"
+msgstr "執行失敗\n"
+
+#: sign/rpmgensig.c:652
+#, c-format
+msgid "%s already contains identical file signatures\n"
+msgstr ""
+
+#: sign/rpmgensig.c:702
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 失敗：%s"
 
-#: sign/rpmgensig.c:514
+#: sign/rpmgensig.c:716
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:556
+#: sign/rpmgensig.c:744
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:604 sign/rpmgensig.c:627
+#: sign/rpmgensig.c:792 sign/rpmgensig.c:815
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失敗：%s\n"
 
-#: sign/rpmgensig.c:614
-msgid "rpmMkTemp failed\n"
-msgstr "rpmMkTemp 失敗\n"
-
-#: sign/rpmgensig.c:621
+#: sign/rpmgensig.c:809
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失敗：%s\n"
 
-#: sign/rpmgensig.c:646
+#: sign/rpmgensig.c:834
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3450,3 +3723,15 @@ msgstr "%s：讀取清單失敗：%s\n"
 #: tools/rpmgraph.c:220
 msgid "don't verify header+payload signature"
 msgstr "不驗證表頭+酬載簽署"
+
+#~ msgid "Enter pass phrase: "
+#~ msgstr "輸入通關密語： "
+
+#~ msgid "Pass phrase is good.\n"
+#~ msgstr "通關密語良好。\n"
+
+#~ msgid "Bad owner/group: %s\n"
+#~ msgstr "不良擁有者/群組：%s\n"
+
+#~ msgid "Couldn't create pipe for signing: %m"
+#~ msgstr "無法建立簽署用的導管：%m"

--- a/rpmio/rpmkeyring.h
+++ b/rpmio/rpmkeyring.h
@@ -64,7 +64,7 @@ rpmKeyring rpmKeyringLink(rpmKeyring keyring);
  */
 rpmPubkey rpmPubkeyNew(const uint8_t *pkt, size_t pktlen);
 
-/** \ingroupt rpmkeyring
+/** \ingroup rpmkeyring
  * Return array of subkeys belonging to maikey
  * param mainkey	main rpmPubkey
  * param count		count of returned subkeys

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -521,6 +521,9 @@ static rpmRC replaceSigDigests(FD_t fd, const char *rpm, Header *sigp,
 	archiveSize = headerGetNumber(*sigp, RPMSIGTAG_LONGARCHIVESIZE);
     }
 
+    /* Set reserved space to 0 */
+    addMacro(NULL, "__gpg_reserved_space", NULL, 0, RMIL_GLOBAL);
+
     /* Replace old digests in sigh */
     rc = rpmGenerateSignature(SHA1, MD5, sigTargetSize, archiveSize, fd);
     if (rc != RPMRC_OK) {

--- a/sign/rpmsign.h
+++ b/sign/rpmsign.h
@@ -19,7 +19,6 @@ struct rpmSignArgs {
  * Sign a package
  * @param path		path to package
  * @param args		signing parameters (or NULL for defaults)
- * @param passPhrase	passphrase for the signing key
  * @return		0 on success
  */
 int rpmPkgSign(const char *path, const struct rpmSignArgs * args);


### PR DESCRIPTION
fixes file triggers

which are otherwise broken when using a chroot (which is the case of a DVD installer such as DrakX or Anaconda, or when using urpmi with either --root or --urpmi-root option)