### PR TITLE
Ft2

### DIFF
--- a/lib/psm.c
+++ b/lib/psm.c
@@ -850,11 +850,11 @@ rpmRC rpmpsmRun(rpmts ts, rpmte te, pkgGoal goal)
 		rc = runInstScript(psm, goal);
 		break;
 	    case PKG_TRANSFILETRIGGERIN:
-		rc = runImmedFileTriggers(ts, te, RPMSENSE_TRIGGERIN,
+		rc = runImmedFileTriggersInChroot(ts, te, RPMSENSE_TRIGGERIN,
 					    RPMSCRIPT_TRANSFILETRIGGER, 0);
 		break;
 	    case PKG_TRANSFILETRIGGERUN:
-		rc = runImmedFileTriggers(ts, te, RPMSENSE_TRIGGERUN,
+		rc = runImmedFileTriggersInChroot(ts, te, RPMSENSE_TRIGGERUN,
 					    RPMSCRIPT_TRANSFILETRIGGER, 0);
 		break;
 	    default:

--- a/lib/rpmtriggers.c
+++ b/lib/rpmtriggers.c
@@ -599,3 +599,13 @@ rpmRC runImmedFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
 
     return (nerrors == 0) ? RPMRC_OK : RPMRC_FAIL;
 }
+
+rpmRC runImmedFileTriggersInChroot(rpmts ts, rpmte te, rpmsenseFlags sense,
+			    rpmscriptTriggerModes tm, int priorityClass)
+{
+    if (rpmChrootIn() == 0) {
+	runImmedFileTriggers(ts, te, sense, tm, priorityClass);
+	/* XXX an error here would require a full abort */
+	(void) rpmChrootOut();
+    }
+}

--- a/lib/rpmtriggers.c
+++ b/lib/rpmtriggers.c
@@ -530,6 +530,9 @@ rpmRC runFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
     /* Sort triggers by priority, offset, trigger index */
     rpmtriggersSortAndUniq(triggers);
 
+    if (rpmChrootIn() != 0)
+	return RPMRC_FAIL;
+
     /* Handle stored triggers */
     for (i = 0; i < triggers->count; i++) {
 	if (priorityClass == 1) {
@@ -550,6 +553,8 @@ rpmRC runFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
 	headerFree(trigH);
     }
     rpmtriggersFree(triggers);
+    /* XXX an error here would require a full abort */
+    (void) rpmChrootOut();
 
     return (nerrors == 0) ? RPMRC_OK : RPMRC_FAIL;
 }

--- a/lib/rpmtriggers.h
+++ b/lib/rpmtriggers.h
@@ -76,6 +76,22 @@ rpmRC runFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
  */
 rpmRC runImmedFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
 			    rpmscriptTriggerModes tm, int upper);
+
+/* Run file triggers in this te other package(s) set off (but goes in chroot first).
+ * This is used for transaction file triggers.
+ * @param ts		transaction set
+ * @param te		transaction entry
+ * @param sense		defines which triggers should be set off (triggerin,
+ *			triggerun, triggerpostun)
+ * @param triggerClass	1 to run triggers that should be executed before
+ *			standard scriptlets
+ *			2 to run triggers that should be executed after
+ *			standard scriptlets
+ *			0 to run all triggers
+ * @param tm		trigger mode, (filetrigger/transfiletrigger)
+ */
+rpmRC runImmedFileTriggersInChroot(rpmts ts, rpmte te, rpmsenseFlags sense,
+			    rpmscriptTriggerModes tm, int upper);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
fix file triggers

which are otherwise broken when using a chroot (which is the case of a DVD installer such as DrakX or Anaconda, or when using urpmi with either --root or --urpmi-root option)