### PR TITLE
fix %doc with glob with some locales

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1715,6 +1715,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     appendStringBuf(docScript, sdenv);
     appendStringBuf(docScript, "=$RPM_BUILD_ROOT");
     appendLineStringBuf(docScript, sd->dirname);
+    appendLineStringBuf(docScript, "export LC_ALL=C");
     appendStringBuf(docScript, "export ");
     appendLineStringBuf(docScript, sdenv);
     appendLineStringBuf(docScript, mkdocdir);


### PR DESCRIPTION
Some spec files fail to build under some locales, when %doc is used with glob.
eg:

%build
touch author AUTHORS Ch cha
%files
%doc [A-Z]*

Which results in:

LANG=fr LC_COLLATE=fr LC_ALL=fr rpmbuild -ba SPECS/null.spec
(...)
error: Installed (but unpackaged) file(s) found:
   /usr/share/doc/null/cha
   /usr/share/doc/null/debugfiles.list
   /usr/share/doc/null/debuglinks.list
   /usr/share/doc/null/debugsources.list

RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/share/doc/null/cha
   /usr/share/doc/null/debugfiles.list
   /usr/share/doc/null/debuglinks.list
   /usr/share/doc/null/debugsources.list

Which is obviously not expected...