### PR TITLE
Rename to pythonX.Ydist, read .dist-info, support legacy pythoneggs()(), and cleanups

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -7,7 +7,7 @@
 # This program is free software. It may be redistributed and/or modified under
 # the terms of the LGPL version 2.1 (or later).
 #
-# RPM python (egg) dependency generator.
+# RPM python dependency generator, using .egg-info/.egg-link/.dist-info data
 #
 
 from __future__ import print_function
@@ -18,14 +18,17 @@ from distutils.sysconfig import get_python_lib
 
 
 opts, args = getopt(
-    argv[1:], 'hPRrCOE:',
-    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'extras'])
+    argv[1:], 'hPRrCOEMml:',
+    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'extras', 'majorver-provides', 'majorver-prov-with-legacy' , 'legacy'])
 
 Provides = False
 Requires = False
 Recommends = False
 Conflicts = False
 Extras = False
+Provides_PyMajorVer_Variant = False
+legacy_Provides = False
+legacy = False
 
 for o, a in opts:
     if o in ('-h', '--help'):
@@ -35,6 +38,9 @@ for o, a in opts:
         print('-r, --recommends\tPrint Recommends')
         print('-C, --conflicts\tPrint Conflicts')
         print('-E, --extras\tPrint Extras ')
+        print('-M, --majorver-provides\tPrint extra Provides with Python major version only')
+        print('-m, --majorver-prov-with-legacy\tPrint extra Provides with Python major version only and extra legacy Provides')
+        print('-l, --legacy\tPrint extra legacy pythonegg Provides/Requires instead (also enables --majorver-provides)')
         exit(1)
     elif o in ('-P', '--provides'):
         Provides = True
@@ -46,6 +52,14 @@ for o, a in opts:
         Conflicts = True
     elif o in ('-E', '--extras'):
         Extras = True
+    elif o in ('-M', '--majorver-provides'):
+        Provides_PyMajorVer_Variant = True
+    elif o in ('-m', '--majorver-prov-with-legacy'):
+        Provides_PyMajorVer_Variant = True
+        legacy_Provides = True
+    elif o in ('-l', '--legacy'):
+        legacy = True
+        Provides_PyMajorVer_Variant = True
 
 if Requires:
     py_abi = True
@@ -77,13 +91,15 @@ for f in files:
     lower_dir = dirname(lower)
     if lower_dir.endswith('.egg') or \
             lower_dir.endswith('.egg-info') or \
-            lower_dir.endswith('.egg-link'):
+            lower_dir.endswith('.egg-link') or \
+            lower_dir.endswith('.dist-info'):
         lower = lower_dir
         f = dirname(f)
-    # Determine provide, requires, conflicts & recommends based on egg metadata
+    # Determine provide, requires, conflicts & recommends based on egg/dist metadata
     if lower.endswith('.egg') or \
             lower.endswith('.egg-info') or \
-            lower.endswith('.egg-link'):
+            lower.endswith('.egg-link') or \
+            lower.endswith('.dist-info'):
         # This import is very slow, so only do it if needed
         from pkg_resources import Distribution, FileMetadata, PathMetadata
         dist_name = basename(f)
@@ -94,25 +110,38 @@ for f in files:
             path_item = f
             metadata = FileMetadata(f)
         dist = Distribution.from_location(path_item, dist_name, metadata)
-        # Get the Python major version
-        pyver_major = dist.py_version.split('.')[0]
+        if Provides_PyMajorVer_Variant and Provides:
+            # Get the Python major version
+            pyver_major = dist.py_version.split('.')[0]
         if Provides:
-            # If egg metadata says package name is python, we provide python(abi)
+            # If egg/dist metadata says package name is python, we provide python(abi)
             if dist.key == 'python':
                 name = 'python(abi)'
                 if name not in py_deps:
                     py_deps[name] = []
                 py_deps[name].append(('==', dist.py_version))
-            name = 'python{}egg({})'.format(pyver_major, dist.key)
+            name = 'python{}dist({})'.format(dist.py_version, dist.key)
             if name not in py_deps:
                 py_deps[name] = []
+            if Provides_PyMajorVer_Variant:
+                pymajor_name = 'python{}dist({})'.format(pyver_major, dist.key)
+                if pymajor_name not in py_deps:
+                    py_deps[pymajor_name] = []
+            if legacy or legacy_Provides:
+                legacy_name = 'pythonegg({})({})'.format(pyver_major, dist.key)
+                if legacy_name not in py_deps:
+                    py_deps[legacy_name] = []
             if dist.version:
                 spec = ('==', dist.version)
                 if spec not in py_deps[name]:
                     py_deps[name].append(spec)
+                    if Provides_PyMajorVer_Variant:
+                        py_deps[pymajor_name].append(spec)
+                    if legacy or legacy_Provides:
+                        py_deps[legacy_name].append(spec)
         if Requires or (Recommends and dist.extras):
             name = 'python(abi)'
-            # If egg metadata says package name is python, we don't add dependency on python(abi)
+            # If egg/dist metadata says package name is python, we don't add dependency on python(abi)
             if dist.key == 'python':
                 py_abi = False
                 if name in py_deps:
@@ -131,9 +160,12 @@ for f in files:
                         if dep in deps:
                             depsextras.remove(dep)
                 deps = depsextras
-            # add requires/recommends based on egg metadata
+            # add requires/recommends based on egg/dist metadata
             for dep in deps:
-                name = 'python{}egg({})'.format(pyver_major, dep.key)
+                if legacy:
+                    name = 'pythonegg({})({})'.format(pyver_major, dep.key)
+                else:
+                    name = 'python{}dist({})'.format(dist.py_version, dep.key)
                 for spec in dep.specs:
                     if spec[0] != '!=':
                         if name not in py_deps:
@@ -142,7 +174,7 @@ for f in files:
                             py_deps[name].append(spec)
                 if not dep.specs:
                     py_deps[name] = []
-        # Unused, for automatic sub-package generation based on 'extras' from egg metadata
+        # Unused, for automatic sub-package generation based on 'extras' from egg/dist metadata
         # TODO: implement in rpm later, or...?
         if Extras:
             deps = dist.requires()
@@ -150,7 +182,7 @@ for f in files:
             print(extras)
             for extra in extras:
                 print('%%package\textras-{}'.format(extra))
-                print('Summary:\t{} extra for {} python egg'.format(extra, dist.key))
+                print('Summary:\t{} extra for {} python package'.format(extra, dist.key))
                 print('Group:\t\tDevelopment/Python')
                 depsextras = dist.requires(extras=[extra])
                 for dep in reversed(depsextras):
@@ -164,7 +196,7 @@ for f in files:
                         else:
                             print('Requires:\t{} {} {}'.format(dep.key, spec[0], spec[1]))
                 print('%%description\t{}'.format(extra))
-                print('{} extra for {} python egg'.format(extra, dist.key))
+                print('{} extra for {} python package'.format(extra, dist.key))
                 print('%%files\t\textras-{}\n'.format(extra))
         if Conflicts:
             # Should we really add conflicts for extras?

--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -18,8 +18,8 @@ from distutils.sysconfig import get_python_lib
 
 
 opts, args = getopt(
-    argv[1:], 'hPRrCOEMml:',
-    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'extras', 'majorver-provides', 'majorver-prov-with-legacy' , 'legacy'])
+    argv[1:], 'hPRrCOEMLl:',
+    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'extras', 'majorver-provides', 'legacy-provides' , 'legacy'])
 
 Provides = False
 Requires = False
@@ -38,7 +38,7 @@ for o, a in opts:
         print('-r, --recommends\tPrint Recommends')
         print('-C, --conflicts\tPrint Conflicts')
         print('-E, --extras\tPrint Extras ')
-        print('-m, --majorver-provides\tPrint extra Provides with Python major version only')
+        print('-M, --majorver-provides\tPrint extra Provides with Python major version only')
         print('-L, --legacy-provides\tPrint extra legacy pythonegg Provides')
         print('-l, --legacy\tPrint legacy pythonegg Provides/Requires instead')
         exit(1)
@@ -52,7 +52,7 @@ for o, a in opts:
         Conflicts = True
     elif o in ('-E', '--extras'):
         Extras = True
-    elif o in ('-m', '--majorver-provides'):
+    elif o in ('-M', '--majorver-provides'):
         Provides_PyMajorVer_Variant = True
     elif o in ('-L', '--legacy-provides'):
         legacy_Provides = True
@@ -108,7 +108,7 @@ for f in files:
             path_item = f
             metadata = FileMetadata(f)
         dist = Distribution.from_location(path_item, dist_name, metadata)
-        if Provides_PyMajorVer_Variant and Provides:
+        if (Provides_PyMajorVer_Variant or legacy_Provides or legacy) and Provides:
             # Get the Python major version
             pyver_major = dist.py_version.split('.')[0]
         if Provides:

--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -38,9 +38,9 @@ for o, a in opts:
         print('-r, --recommends\tPrint Recommends')
         print('-C, --conflicts\tPrint Conflicts')
         print('-E, --extras\tPrint Extras ')
-        print('-M, --majorver-provides\tPrint extra Provides with Python major version only')
-        print('-m, --majorver-prov-with-legacy\tPrint extra Provides with Python major version only and extra legacy Provides')
-        print('-l, --legacy\tPrint extra legacy pythonegg Provides/Requires instead (also enables --majorver-provides)')
+        print('-m, --majorver-provides\tPrint extra Provides with Python major version only')
+        print('-L, --legacy-provides\tPrint extra legacy pythonegg Provides')
+        print('-l, --legacy\tPrint legacy pythonegg Provides/Requires instead')
         exit(1)
     elif o in ('-P', '--provides'):
         Provides = True
@@ -52,14 +52,12 @@ for o, a in opts:
         Conflicts = True
     elif o in ('-E', '--extras'):
         Extras = True
-    elif o in ('-M', '--majorver-provides'):
+    elif o in ('-m', '--majorver-provides'):
         Provides_PyMajorVer_Variant = True
-    elif o in ('-m', '--majorver-prov-with-legacy'):
-        Provides_PyMajorVer_Variant = True
+    elif o in ('-L', '--legacy-provides'):
         legacy_Provides = True
     elif o in ('-l', '--legacy'):
         legacy = True
-        Provides_PyMajorVer_Variant = True
 
 if Requires:
     py_abi = True
@@ -120,9 +118,10 @@ for f in files:
                 if name not in py_deps:
                     py_deps[name] = []
                 py_deps[name].append(('==', dist.py_version))
-            name = 'python{}dist({})'.format(dist.py_version, dist.key)
-            if name not in py_deps:
-                py_deps[name] = []
+            if not legacy:
+                name = 'python{}dist({})'.format(dist.py_version, dist.key)
+                if name not in py_deps:
+                    py_deps[name] = []
             if Provides_PyMajorVer_Variant:
                 pymajor_name = 'python{}dist({})'.format(pyver_major, dist.key)
                 if pymajor_name not in py_deps:
@@ -134,7 +133,8 @@ for f in files:
             if dist.version:
                 spec = ('==', dist.version)
                 if spec not in py_deps[name]:
-                    py_deps[name].append(spec)
+                    if not legacy:
+                        py_deps[name].append(spec)
                     if Provides_PyMajorVer_Variant:
                         py_deps[pymajor_name].append(spec)
                     if legacy or legacy_Provides:

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -51,11 +51,6 @@ for o, a in opts:
     elif o in ('-E', '--extras'):
         Extras = True
 
-
-def is_exe(fpath):
-    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-
 if Requires:
     py_abi = True
 else:

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -19,13 +19,12 @@ from distutils.sysconfig import get_python_lib
 
 opts, args = getopt(
     argv[1:], 'hPRrCOE:',
-    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'obsoletes', 'extras'])
+    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'extras'])
 
 Provides = False
 Requires = False
 Recommends = False
 Conflicts = False
-Obsoletes = False
 Extras = False
 
 for o, a in opts:
@@ -35,7 +34,6 @@ for o, a in opts:
         print('-R, --requires\tPrint Requires')
         print('-r, --recommends\tPrint Recommends')
         print('-C, --conflicts\tPrint Conflicts')
-        print('-O, --obsoletes\tPrint Obsoletes (unused)')
         print('-E, --extras\tPrint Extras ')
         exit(1)
     elif o in ('-P', '--provides'):
@@ -46,8 +44,6 @@ for o, a in opts:
         Recommends = True
     elif o in ('-C', '--conflicts'):
         Conflicts = True
-    elif o in ('-O', '--obsoletes'):
-        Obsoletes = True
     elif o in ('-E', '--extras'):
         Extras = True
 

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -15,8 +15,6 @@ from getopt import getopt
 from os.path import basename, dirname, isdir, sep
 from sys import argv, stdin, version
 from distutils.sysconfig import get_python_lib
-from subprocess import Popen, PIPE, STDOUT
-import os
 
 
 opts, args = getopt(
@@ -61,13 +59,6 @@ for o, a in opts:
 def is_exe(fpath):
     return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
-typelib_check = False
-
-if is_exe("/usr/lib/rpm/gi-find-deps.sh") and is_exe("/usr/bin/g-ir-dep-tool"):
-    if not buildroot:
-        pass
-    else:
-        typelib_check = True
 
 if Requires:
     py_abi = True
@@ -94,13 +85,6 @@ for f in files:
                 spec = ('==', f.split(lib)[1].split(sep)[0])
                 if spec not in py_deps[name]:
                     py_deps[name].append(spec)
-        # Pipe files to find typelib requires
-        if typelib_check:
-            p = Popen(['/usr/lib/rpm/gi-find-deps.sh', '-R', str(buildroot)], stdout=PIPE, stdin=PIPE, stderr=STDOUT)
-            (stdoutdata, stderrdata) = p.communicate(input=str(f)+"\n")
-
-            if stdoutdata and stdoutdata:
-                py_deps[stdoutdata.strip()] = ""
 
     # XXX: hack to workaround RPM internal dependency generator not passing directories
     lower_dir = dirname(lower)

--- a/scripts/pythoneggs.py
+++ b/scripts/pythoneggs.py
@@ -18,8 +18,8 @@ from distutils.sysconfig import get_python_lib
 
 
 opts, args = getopt(
-    argv[1:], 'hPRrCOEb:',
-    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'obsoletes', 'extras', 'buildroot='])
+    argv[1:], 'hPRrCOE:',
+    ['help', 'provides', 'requires', 'recommends', 'conflicts', 'obsoletes', 'extras'])
 
 Provides = False
 Requires = False
@@ -27,7 +27,6 @@ Recommends = False
 Conflicts = False
 Obsoletes = False
 Extras = False
-buildroot = None
 
 for o, a in opts:
     if o in ('-h', '--help'):
@@ -38,7 +37,6 @@ for o, a in opts:
         print('-C, --conflicts\tPrint Conflicts')
         print('-O, --obsoletes\tPrint Obsoletes (unused)')
         print('-E, --extras\tPrint Extras ')
-        print('-b, --buildroot\tBuildroot for package ')
         exit(1)
     elif o in ('-P', '--provides'):
         Provides = True
@@ -52,8 +50,6 @@ for o, a in opts:
         Obsoletes = True
     elif o in ('-E', '--extras'):
         Extras = True
-    elif o in ('-b', '--buildroot'):
-        buildroot = a
 
 
 def is_exe(fpath):


### PR DESCRIPTION
#### This PR contains both #35 and #46
After reviewing the changes from @soig in #46, I've merged it into a new pull request, after doing some tweaking and git sorcery. This obsoletes #35 and #46.

This PR differs from #49 in that it doesn't include the attr file to enable the dependency generator by default. I believe enabling this by default will likely require more discussion.

#### From #35
Per the recommendation of Nick Coghlan and Toshio Kuratomi, `pythonXegg(M)` is being renamed to `pythonX.Ydist(M)`.

An option has also been added to add a `pythonXdist(M)` Provides for distributions that may prefer to have it. The option `--majorver-provides` is intended for use if only one Python stack per major version will be available at a given time, as unexpected depsolver results may occur if there are multiple independent Python stacks per major version available.

Consequently, it will not be on by default when using the generator for generating Provides.

Additionally, .egg-info data is being replaced with .dist-info data, so we need to handle that case, too.

See for more details:
https://lists.fedoraproject.org/archives/list/python-devel%40lists.fedoraproject.org/thread/SQBSAS4T25HK5YJBNBSFDD7KDQWDELL6/

Also, @soig brought up on rpm-maint that Mageia currently uses `pythonegg(X)(M)` (e.g. `pythonegg(3)(rpm)` for python3 rpm bindings package) in their Python packages to pull in Python dependencies and requested a way to not break Mageia.

After discussing with @ffesti about it, Mageia's `pythonegg(X)(M)` will be supported by adding `--legacy` as a switch to generate legacy Provides to maintain compatibility with Mageia's existing usage and to give them a path to transition from this usage over time.

This switch will also enable `pythonXdist(M)` format to allow for a transition, as the conditions for using `pythonXdist(M)` are the same as `pythonegg(X)(M)`.

#### From @soig's #46 
This clean up pythonegg and make it usable.