### PR TITLE
Working '%__scm_apply_quilt' macro.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1107,7 +1107,7 @@ done \
 %__scm_setup_quilt(q) %{nil}
 %__scm_apply_quilt(qp:m:)\
 %{__cat} > %{-m*}.quilt\
-%{__quilt} import %{-p:-p%{-p*}} %{-m*}.quilt && %{__quilt} push\
+%{__quilt} import %{-p:-p%{-p*}} %{-m*}.quilt && %{__quilt} push %{-q}\
 %{__rm} -f %{-m*}.quilt
 
 # Bzr

--- a/macros.in
+++ b/macros.in
@@ -1106,7 +1106,9 @@ done \
 # Quilt
 %__scm_setup_quilt(q) %{nil}
 %__scm_apply_quilt(qp:m:)\
-%{__quilt} import %{-p:-p%{-p*}} %{1} && %{__quilt} push
+%{__cat} > %{-m*}.quilt\
+%{__quilt} import %{-p:-p%{-p*}} %{-m*}.quilt && %{__quilt} push\
+%{__rm} -f %{-m*}.quilt
 
 # Bzr
 %__scm_setup_bzr(q)\


### PR DESCRIPTION
This macro is called in `%apply_patch` as the recipient of a pipe. Unfortunately, `quilt import` only works on 'real' files and does not read from `STDIN` (like `quilt import -`). We can circumvent this restriction with a temporary file(name).

This modified macro has successfully been tested on Kubuntu 12.04.5 with 'quilt 0.50' and Linux Mint 17.2 with 'quilt 0.61', both with 'debbuild 16.1.6' (https://github.com/ascherer/debbuild).