### PR TITLE
'quilt push' has option '-q'.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1106,7 +1106,7 @@ done \
 # Quilt
 %__scm_setup_quilt(q) %{nil}
 %__scm_apply_quilt(qp:m:)\
-%{__quilt} import %{-p:-p%{-p*}} %{1} && %{__quilt} push
+%{__quilt} import %{-p:-p%{-p*}} %{1} && %{__quilt} push %{-q}
 
 # Bzr
 %__scm_setup_bzr(q)\


### PR DESCRIPTION
Use macro `%{-q}` to react to `%autosetup [-v]`.

Tested with RPM 4.13, Lua 5.1, Quilt 0.61 on Linux Mint 17.2.