### PR TITLE
Support Apache Subversion as SCM in the BUILD arena.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,8 @@ AC_PATH_PROG(__GIT, git, /usr/bin/git, $MYPATH)
 AC_PATH_PROG(__HG, hg, /usr/bin/hg, $MYPATH)
 AC_PATH_PROG(__BZR, bzr, /usr/bin/bzr, $MYPATH)
 AC_PATH_PROG(__QUILT, quilt, /usr/bin/quilt, $MYPATH)
+AC_PATH_PROG(__SVN, svn, /usr/bin/svn, $MYPATH)
+AC_PATH_PROG(__SVNADMIN, svnadmin, /usr/bin/svnadmin, $MYPATH)
 
 AC_PATH_PROG(__FAKECHROOT, fakechroot, no, $MYPATH)
 AM_CONDITIONAL(HAVE_FAKECHROOT, [test "$__FAKECHROOT" != "no"])

--- a/macros.in
+++ b/macros.in
@@ -1125,19 +1125,16 @@ done \
 %{__svn} mkdir %{-q} -m "Create directory structure." file://`pwd`/.svnrepos/trunk\
 %{__svn} checkout %{-q} file://`pwd`/.svnrepos/trunk ./\
 %{__svn} add %{-q} --force ./\
-%{__svn} commit %{-q} -m "Initial import."\
-%{__svn} up %{-q}
+%{__svn} commit %{-q} -m "Initial import." && %{__svn} update %{-q}
 
 # Subversion 1.6 doesn't have its own command to apply patches
 #%__scm_apply_svn(qp:m:)\
 #%{__patch} %{-p:-p%{-p*}} %{-q:-s}\
-#%{__svn} commit %{-q} -m %{-m*}\
-#%{__svn} up %{-q}
+#%{__svn} commit %{-q} -m %{-m*} && %{__svn} update %{-q}
 # Subversion 1.7 learned to apply patches
 %__scm_apply_svn(qp:m:)\
 %{__svn} patch %{-p:--strip %{-p*}} %{-q} %{1}\
-%{__svn} commit %{-q} -m %{-m*}\
-%{__svn} up %{-q}
+%{__svn} commit %{-q} -m %{-m*} && %{__svn} update %{-q}
 
 # Single patch application
 %apply_patch(qp:m:)\

--- a/macros.in
+++ b/macros.in
@@ -73,6 +73,8 @@
 %__hg			@__HG@
 %__bzr			@__BZR@
 %__quilt		@__QUILT@
+%__svn			@__SVN@
+%__svnadmin		@__SVNADMIN@
 
 #==============================================================================
 # ---- Build system path macros.
@@ -1118,8 +1120,6 @@ done \
 %{__bzr} commit %{-q} -m %{-m*}
 
 # Subversion
-%__svn /usr/bin/svn
-%__svnadmin /usr/bin/svnadmin
 %__scm_setup_svn(q)\
 %{__svnadmin} create .svnrepos\
 %{__svn} mkdir %{-q} -m "Create directory structure." file://`pwd`/.svnrepos/trunk\
@@ -1128,7 +1128,7 @@ done \
 %{__svn} commit %{-q} -m "Initial import."\
 %{__svn} up %{-q}
 
-# Subversion 1.6 doesn't have its own command to appy patches
+# Subversion 1.6 doesn't have its own command to apply patches
 #%__scm_apply_svn(qp:m:)\
 #%{__patch} %{-p:-p%{-p*}} %{-q:-s}\
 #%{__svn} commit %{-q} -m %{-m*}\

--- a/macros.in
+++ b/macros.in
@@ -1117,6 +1117,28 @@ done \
 %{__patch} %{-p:-p%{-p*}} %{-q:-s}\
 %{__bzr} commit %{-q} -m %{-m*}
 
+# Subversion
+%__svn /usr/bin/svn
+%__svnadmin /usr/bin/svnadmin
+%__scm_setup_svn(q)\
+%{__svnadmin} create .svnrepos\
+%{__svn} mkdir %{-q} -m "Create directory structure." file://`pwd`/.svnrepos/trunk\
+%{__svn} checkout %{-q} file://`pwd`/.svnrepos/trunk ./\
+%{__svn} add %{-q} --force ./\
+%{__svn} commit %{-q} -m "Initial import."\
+%{__svn} up %{-q}
+
+# Subversion 1.6 doesn't have its own command to appy patches
+#%__scm_apply_svn(qp:m:)\
+#%{__patch} %{-p:-p%{-p*}} %{-q:-s}\
+#%{__svn} commit %{-q} -m %{-m*}\
+#%{__svn} up %{-q}
+# Subversion 1.7 learned to apply patches
+%__scm_apply_svn(qp:m:)\
+%{__svn} patch %{-p:--strip %{-p*}} %{-q} %{1}\
+%{__svn} commit %{-q} -m %{-m*}\
+%{__svn} up %{-q}
+
 # Single patch application
 %apply_patch(qp:m:)\
 %{lua:\
@@ -1147,28 +1169,6 @@ end}
 %{-S:%global __scm %{-S*}}\
 %{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
 %{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}
-
-# Subversion
-%__svn /usr/bin/svn
-%__svnadmin /usr/bin/svnadmin
-%__scm_setup_svn(q)\
-%{__svnadmin} create .svnrepos\
-%{__svn} mkdir %{-q} -m "Create directory structure." file://%{_builddir}/%{buildsubdir}/.svnrepos/trunk\
-%{__svn} checkout %{-q} file://%{_builddir}/%{buildsubdir}/.svnrepos/trunk ./\
-%{__svn} add %{-q} --force ./\
-%{__svn} commit %{-q} -m "Initial import."\
-%{__svn} up %{-q}
-
-# Subversion 1.6 doesn't have its own command to appy patches
-%__scm_apply_svn(qp:m:)\
-%{__patch} %{-p:-p%{-p*}} %{-q:-s}\
-%{__svn} commit %{-q} -m %{-m*}\
-%{__svn} up %{-q}
-# Subversion 1.7 learned to apply patches
-#%__scm_apply_svn(qp:m:)\
-#%{__svn} patch %{-p:--strip %{-p*}} %{-q} %{_sourcedir}/%{-m*}\
-#%{__svn} commit %{-q} -m %{-m*}\
-#%{__svn} up %{-q}
 
 # \endverbatim
 #*/

--- a/macros.in
+++ b/macros.in
@@ -1166,7 +1166,8 @@ end}
 %{__svn} up %{-q}
 # Subversion 1.7 learned to apply patches
 #%__scm_apply_svn(qp:m:)\
-#%{__svn} patch %{-p:--strip %{-p*}} %{-q}\
+#%{__svn} patch %{-p:--strip %{-p*}} %{-q} %{_sourcedir}/%{-m*}\
+#%{__svn} commit %{-q} -m %{-m*}\
 #%{__svn} up %{-q}
 
 # \endverbatim

--- a/macros.in
+++ b/macros.in
@@ -1148,5 +1148,26 @@ end}
 %{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
 %{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}
 
+# Subversion
+%__svn /usr/bin/svn
+%__svnadmin /usr/bin/svnadmin
+%__scm_setup_svn(q)\
+%{__svnadmin} create .svnrepos\
+%{__svn} mkdir %{-q} -m "Create directory structure." file://%{_builddir}/%{buildsubdir}/.svnrepos/trunk\
+%{__svn} checkout %{-q} file://%{_builddir}/%{buildsubdir}/.svnrepos/trunk ./\
+%{__svn} add %{-q} --force ./\
+%{__svn} commit %{-q} -m "Initial import."\
+%{__svn} up %{-q}
+
+# Subversion 1.6 doesn't have its own command to appy patches
+%__scm_apply_svn(qp:m:)\
+%{__patch} %{-p:-p%{-p*}} %{-q:-s}\
+%{__svn} commit %{-q} -m %{-m*}\
+%{__svn} up %{-q}
+# Subversion 1.7 learned to apply patches
+#%__scm_apply_svn(qp:m:)\
+#%{__svn} patch %{-p:--strip %{-p*}} %{-q}\
+#%{__svn} up %{-q}
+
 # \endverbatim
 #*/

--- a/macros.in
+++ b/macros.in
@@ -1127,11 +1127,6 @@ done \
 %{__svn} add %{-q} --force ./\
 %{__svn} commit %{-q} -m "Initial import." && %{__svn} update %{-q}
 
-# Subversion 1.6 doesn't have its own command to apply patches
-#%__scm_apply_svn(qp:m:)\
-#%{__patch} %{-p:-p%{-p*}} %{-q:-s}\
-#%{__svn} commit %{-q} -m %{-m*} && %{__svn} update %{-q}
-# Subversion 1.7 learned to apply patches
 %__scm_apply_svn(qp:m:)\
 %{__svn} patch %{-p:--strip %{-p*}} %{-q} %{1}\
 %{__svn} commit %{-q} -m %{-m*} && %{__svn} update %{-q}


### PR DESCRIPTION
This PR adds macro support for the [Apache Subversion](https://subversion.apache.org/) SCM:
```
%autosetup -S svn
```
The SCM macros `%__scm_setup_svn(q)` and `%__scm_apply_svn(qp:m:)` (two versions) were developed and tested with **debbuild 16.1.7** and **subversion 1.6.17** on Kubuntu 12.04. See https://github.com/ascherer/debbuild for information.

Later they were refined, tested, and fixed with **rpmbuild 4.13** (4.12.90) and **subversion 1.8.8** on Linux Mint 17.2. 

<del>You should use the 'old' version (svn pre-1.7) of `%__scm_apply_svn(qp:m:)`, if you have **compressed patches**; this version is fully piped, while</del> the 'new' form (svn 1.7+) uses `svn patch`, which works directly with the patch file (`%{1}`) and expects this to be in 'unified diff' format, thereby losing some flexibility. 
