### PR TITLE
Permit dynamic selection of SCM.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1148,7 +1148,7 @@ end}
 %autosetup(a:b:cDn:TvNS:p:)\
 %setup %{-a} %{-b} %{-c} %{-D} %{-n} %{-T} %{!-v:-q}\
 %{-S:%global __scm %{-S*}}\
-%{-S:%{expand:%__scm_setup_%{-S*} %{!-v:-q}}}\
+%{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
 %{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}
 
 # \endverbatim


### PR DESCRIPTION
Invoking `%__scm_setup_%{__scm}` _without_ looking at option `-S` in the specfile, but taking the current definition of `%__scm` into account (_including_ the preceeding evaluation of `-S`), permits dynamic selection of the SCM on the commandline:
```
   rpmbuild --define="__scm SCM"
```
Default SCM `patch` already has a convenient `%__scm_setup_patch %{nil}` definition (which is currently _only_ used with the curious, indeed redundant `%autosetup -S patch` invocation in the specfile).

Tested with rpmbuild 4.13 and git, patch, quilt, svn on Linux Mint 17.2.