### PR TITLE
fixes for OS X

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -230,9 +230,9 @@ rpmvar_DATA =
 
 install-exec-hook:
 	@rm -f $(DESTDIR)$(bindir)/rpmquery
-	@LN_S@ ../../bin/rpm $(DESTDIR)$(bindir)/rpmquery
+	@LN_S@ rpm $(DESTDIR)$(bindir)/rpmquery
 	@rm -f $(DESTDIR)$(bindir)/rpmverify
-	@LN_S@ ../../bin/rpm $(DESTDIR)$(bindir)/rpmverify
+	@LN_S@ rpm $(DESTDIR)$(bindir)/rpmverify
 
 install-data-local:
 	DESTDIR="$(DESTDIR)" pkglibdir="$(rpmconfigdir)" \

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -6,6 +6,7 @@
 #include "system.h"
 
 #include <errno.h>
+#include <libgen.h>
 
 #include <rpm/header.h>
 #include <rpm/rpmlog.h>

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1,6 +1,7 @@
 #include "system.h"
 
 #include <errno.h>
+#include <libgen.h>
 #include <sys/select.h>
 #include <sys/wait.h>
 #include <signal.h>

--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,7 @@ dnl Checks for library functions.
 AC_CHECK_FUNCS(putenv)
 AC_CHECK_FUNCS(mempcpy)
 AC_CHECK_FUNCS(fdatasync)
+AC_CHECK_DECLS(fdatasync, [], [], [#include <unistd.h>])
 AC_CHECK_FUNCS(lutimes)
 AC_CHECK_FUNCS(mergesort)
 AC_CHECK_FUNCS(getauxval)

--- a/lib/backend/db3.c
+++ b/lib/backend/db3.c
@@ -10,6 +10,7 @@ static int _debug = 1;	/* XXX if < 0 debugging, > 0 unusual error returns */
 #include <sys/wait.h>
 #include <popt.h>
 #include <db.h>
+#include <signal.h>
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmmacro.h>

--- a/lib/header.c
+++ b/lib/header.c
@@ -107,6 +107,7 @@ static const size_t headerMaxbytes = (32*1024*1024);
 	(((_e)->info.tag >= RPMTAG_HEADERIMAGE) && ((_e)->info.tag < RPMTAG_HEADERREGIONS))
 #define	ENTRY_IN_REGION(_e)	((_e)->info.offset < 0)
 
+#ifndef htonll
 /* Convert a 64bit value to network byte order. */
 RPM_GNUC_CONST
 static uint64_t htonll(uint64_t n)
@@ -119,6 +120,7 @@ static uint64_t htonll(uint64_t n)
 #endif
     return n;
 }
+#endif
 
 Header headerLink(Header h)
 {

--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -4,7 +4,6 @@
  */
 
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmcli.h>
 #include <rpm/rpmlib.h>		/* rpmEVR, rpmReadConfigFiles etc */
@@ -261,12 +260,6 @@ rpmcliInit(int argc, char *const argv[], struct poptOption * optionsTable)
     const char *ctx, *execPath;
 
     setprogname(argv[0]);       /* Retrofit glibc __progname */
-
-    /* XXX glibc churn sanity */
-    if (__progname == NULL) {
-	if ((__progname = strrchr(argv[0], '/')) != NULL) __progname++;
-	else __progname = argv[0];
-    }
 
 #if defined(ENABLE_NLS)
     (void) setlocale(LC_ALL, "" );

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -5,6 +5,7 @@
 #include "system.h"
 
 #include <inttypes.h>
+#include <libgen.h>
 
 #include <rpm/rpmlib.h>		/* rpmMachineScore, rpmReadPackageFile */
 #include <rpm/rpmmacro.h>	/* XXX for rpmExpand */

--- a/misc/fnmatch.c
+++ b/misc/fnmatch.c
@@ -17,7 +17,9 @@
    Boston, MA 02111-1307, USA.  */
 
 # include "system.h"
+# include <ctype.h>
 # include <stdlib.h>
+# include <string.h>
 
 /* Find the first occurrence of C in S or the final NUL byte.  */
 static inline char *

--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -1,7 +1,6 @@
 /* rpmarchive: spit out the main archive portion of a package */
 
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile .. */
 #include <rpm/rpmfi.h>

--- a/rpm2cpio.c
+++ b/rpm2cpio.c
@@ -1,7 +1,6 @@
 /* rpmarchive: spit out the main archive portion of a package */
 
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile .. */
 #include <rpm/rpmtag.h>

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -1,5 +1,4 @@
 #include "system.h"
-const char *__progname;
 
 #include <errno.h>
 #include <libgen.h>

--- a/rpmqv.c
+++ b/rpmqv.c
@@ -1,5 +1,4 @@
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmcli.h>
 #include <rpm/rpmlib.h>			/* RPMSIGTAG, rpmReadPackageFile .. */

--- a/rpmspec.c
+++ b/rpmspec.c
@@ -1,5 +1,4 @@
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmcli.h>
 #include <rpm/rpmbuild.h>

--- a/system.h
+++ b/system.h
@@ -78,6 +78,10 @@ char * stpncpy(char * dest, const char * src, size_t n);
 #endif
 #endif
 
+#if defined(HAVE_FDATASYNC) && !HAVE_DECL_FDATASYNC
+extern int fdatasync(int fildes);
+#endif
+
 #include "rpmio/rpmutil.h"
 /* compatibility macros to avoid a mass-renaming all over the codebase */
 #define xmalloc(_size) rmalloc((_size))

--- a/system.h
+++ b/system.h
@@ -90,20 +90,7 @@ extern int fdatasync(int fildes);
 #define xstrdup(_str) rstrdup((_str))
 #define _free(_ptr) rfree((_ptr))
 
-/* Retrofit glibc __progname */
-#if defined __GLIBC__ && __GLIBC__ >= 2
-#if __GLIBC_MINOR__ >= 1
-#define	__progname	__assert_program_name
-#endif
-#define	setprogname(pn)
-#else
-#define	__progname	program_name
-#define	setprogname(pn)	\
-  { if ((__progname = strrchr(pn, '/')) != NULL) __progname++; \
-    else __progname = pn;		\
-  }
-#endif
-extern const char *__progname;
+#define __progname getprogname()
 
 /* Take care of NLS matters.  */
 #if ENABLE_NLS

--- a/tools/rpmdeps.c
+++ b/tools/rpmdeps.c
@@ -1,5 +1,4 @@
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmbuild.h>
 #include <rpm/argv.h>

--- a/tools/rpmgraph.c
+++ b/tools/rpmgraph.c
@@ -1,5 +1,4 @@
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmcli.h>
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile */


### PR DESCRIPTION
Here is a set of patches to make rpm build cleanly on OS X.

Patches 1, 2, 3 should be pretty straightforward and safe.

Patch 4 looks like an outright bug.  Maybe it works on other platforms because the rpm packaging of rpm fixes it up somehow.

Patch 5 is more a hack to get it working, not something ready for portable use yet.

I had originally tried to send these by email but couldn't get them through. Let me know if you want them split into separate pull requests.