### PR TITLE
Additional fixes for getprogname()/setprogname() on BSD systems

### DIFF
--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -142,7 +142,7 @@ static void rpmcliAllArgCallback( poptContext con,
 	if (rpmcliPipeOutput) {
 	    fprintf(stderr,
 		    _("%s: error: more than one --pipe specified "
-		      "(incompatible popt aliases?)\n"), __progname);
+		      "(incompatible popt aliases?)\n"), xgetprogname());
 	    exit(EXIT_FAILURE);
 	}
 	rpmcliPipeOutput = xstrdup(arg);

--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -1,7 +1,6 @@
 /* rpmarchive: spit out the main archive portion of a package */
 
 #include "system.h"
-const char *__progname;
 
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile .. */
 #include <rpm/rpmfi.h>

--- a/system.h
+++ b/system.h
@@ -98,7 +98,7 @@ extern int fdatasync(int fildes);
 
    setprogname(*pn) must be the first call in main() in order to set the name
    as soon as possible. */
-#if defined(__NetBSD__)
+#if defined(__NetBSD__) || defined(__APPLE__)
 /* `man setprogname' v. May 21, 2011 (NetBSD 6.1) says:
    Portable programs that wish to use getprogname() should call setprogname()
    in main(). In some systems (like NetBSD) it can be set only once and it is


### PR DESCRIPTION
Fix some things that were missed in 61109446ac67ca8f3d96a5592814561db908d83c, and add OS X support for that change.