### PR TITLE
Add all the BSDs that support setprogname() and getprogname()

### DIFF
--- a/system.h
+++ b/system.h
@@ -98,7 +98,7 @@ extern int fdatasync(int fildes);
 
    setprogname(*pn) must be the first call in main() in order to set the name
    as soon as possible. */
-#if defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__APPLE__)
 /* `man setprogname' v. May 21, 2011 (NetBSD 6.1) says:
    Portable programs that wish to use getprogname() should call setprogname()
    in main(). In some systems (like NetBSD) it can be set only once and it is


### PR DESCRIPTION
NetBSD and OS X aren't the only BSD derivatives with support for `setprogname()` and `getprogname()`, so this PR adds the definitions for the rest of them.