### PR TITLE
Use fuzz settings for %autopatch/%autosetup

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1085,7 +1085,7 @@ done \
 # Plain patch (-m is unused)
 %__scm_setup_patch(q) %{nil}
 %__scm_apply_patch(qp:m:)\
-%{__patch} %{-p:-p%{-p*}} %{-q:-s}
+%{__patch} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz}
 
 # Mercurial (aka hg)
 %__scm_setup_hg(q)\


### PR DESCRIPTION
In the `%apply_patches` that inspired `%autopatch`, patch application respects the fuzz settings that are used for `%patch`. `%autopatch` and `%autosetup` weren't using this, which led to an inconsistent patch application behavior.