### PR TITLE
Fix pkgconfig reference to Lua in Libs.private

### DIFF
--- a/rpm.pc.in
+++ b/rpm.pc.in
@@ -12,4 +12,4 @@ URL: http://rpm.org
 # Conflicts:
 Cflags: -I${includedir}
 Libs: -L${libdir} -lrpm -lrpmio
-Libs.private: -lpopt -lrt -lpthread @WITH_LZMA_LIB@ @WITH_DB_LIB@ @WITH_BZ2_LIB@ @WITH_ZLIB_LIB@ @WITH_BEECRYPT_LIB@ @WITH_NSS_LIB@ @WITH_LUA_LIB@
+Libs.private: -lpopt -lrt -lpthread @WITH_LZMA_LIB@ @WITH_DB_LIB@ @WITH_BZ2_LIB@ @WITH_ZLIB_LIB@ @WITH_BEECRYPT_LIB@ @WITH_NSS_LIB@ @LUA_LIBS@


### PR DESCRIPTION
The reference in `rpm.pc.in` is invalid and never gets filled in. By changing it to the correct reference for `configure.ac` substitution, it should work as expected.