### PR TITLE
Add x86_64 for Darwin (Mac OS X) in rpmrc.c, enabling x86_64 target

### DIFF
--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1026,10 +1026,14 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 	    sprintf(un.sysname,"aix%s.%s", un.version, un.release);
 	}
 	else if(rstreq(un.sysname, "Darwin")) { 
-#ifdef __ppc__
+#if defined(__ppc__)
 	    strcpy(un.machine, "ppc");
-#else ifdef __i386__
+#elif defined(__i386__)
 	    strcpy(un.machine, "i386");
+#elif defined(__x86_64__)
+	    strcpy(un.machine, "x86_64");
+#else
+	    #warning "No architecture defined! Automatic detection may not work!"
 #endif 
 	}
 	else if (rstreq(un.sysname, "SunOS")) {


### PR DESCRIPTION
This pull request adds support for x86_64 for Darwin (Mac OS X) and adjusts the logic slightly so that in the event an architecture is not defined, it throws a warning.

Depending on how the architecture is set up, RPM may or may not properly detect it, which is why this is a warning instead of an error.