### PR TITLE
rpm/transaction: move from __future__ to the top

### DIFF
--- a/python/rpm/transaction.py
+++ b/python/rpm/transaction.py
@@ -1,3 +1,5 @@
+from __future__ import with_statement
+
 import sys
 import rpm
 from rpm._rpm import ts as TransactionSetCore
@@ -6,7 +8,6 @@ if sys.version_info[0] == 3:
     _string_types = str,
 else:
     _string_types = basestring,
-    from __future__ import with_statement
 
 
 # TODO: migrate relevant documentation from C-side


### PR DESCRIPTION
```python
*** Error compiling '/builddir/build/BUILDROOT/rpm-4.13.0_alpha-239g190fa42.fc24.x86_64/usr/lib64/python3.5/site-packages/rpm/transaction.py'...
  File "/usr/lib64/python3.5/transaction.py", line 9
SyntaxError: from __future__ imports must occur at the beginning of the file
```

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>