### PR TITLE
Fix preun scriptlet failure not aborting rpm erase

### DIFF
--- a/lib/psm.c
+++ b/lib/psm.c
@@ -757,8 +757,10 @@ static rpmRC rpmPackageErase(rpmts ts, rpmpsm psm)
 	    if (rc) break;
 	}
 
-	if (!(rpmtsFlags(ts) & RPMTRANS_FLAG_NOPREUN))
+	if (!(rpmtsFlags(ts) & RPMTRANS_FLAG_NOPREUN)) {
 	    rc = runInstScript(psm, RPMTAG_PREUN);
+	    if (rc) break;
+	}
 
 	if (!(rpmtsFlags(ts) & RPMTRANS_FLAG_NOTRIGGERUN)) {
 	    /* Run file triggers in this package other package(s) set off. */


### PR DESCRIPTION
Since commit f4a49c3d446bb180ca6b30a4337065fb6511e641 ( Unceremoniously
eliminate rpmpsmNext() ), when a preun scriptlet is failing, rpm continues to
be erased. Handling return code of runInstScript.