### PR TITLE
rpmplugins: don't print error if return code is RPMRC_NOTFOUND

### DIFF
--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -215,8 +215,9 @@ static rpmRC rpmpluginsCallInit(rpmPlugin plugin, rpmts ts)
     plugin_init_func hookFunc;
     RPMPLUGINS_SET_HOOK_FUNC(init);
     if (hookFunc)
-	if ((rc = hookFunc(plugin, ts)) != RPMRC_OK)
-	    rpmlog(RPMLOG_ERR, "Plugin %s: hook init failed\n", plugin->name);
+        rc = hookFunc(plugin, ts);
+        if (rc != RPMRC_OK && rc != RPMRC_NOTFOUND)
+            rpmlog(RPMLOG_ERR, "Plugin %s: hook init failed\n", plugin->name);
     return rc;
 }
 


### PR DESCRIPTION
For example, in simple docer container there is no systemd, so
systemd_inhibit plugin returns RPMRC_NOTFOUND in _init() which
automatically disables plugin (!= RPMRC_OK).

So let's say that if plugin returns RPMRC_NOTFOUND during init()
it's just signal to disable plugin and not show error.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>