### PR TITLE
let debuginfo packages provide the build-id

### DIFF
--- a/fileattrs/Makefile.am
+++ b/fileattrs/Makefile.am
@@ -5,8 +5,8 @@ include $(top_srcdir)/rpm.am
 fattrsdir = $(rpmconfigdir)/fileattrs
 
 fattrs_DATA = \
-	appdata.attr desktop.attr elf.attr font.attr libtool.attr perl.attr \
-	perllib.attr pkgconfig.attr python.attr ocaml.attr script.attr \
+	appdata.attr debuginfo.attr desktop.attr elf.attr font.attr libtool.attr \
+	perl.attr perllib.attr pkgconfig.attr python.attr ocaml.attr script.attr \
 	mono.attr
 
 EXTRA_DIST = $(fattrs_DATA)

--- a/fileattrs/debuginfo.attr
+++ b/fileattrs/debuginfo.attr
@@ -1,0 +1,2 @@
+%__debuginfo_provides %{_rpmconfigdir}/debuginfo.prov
+%__debuginfo_path ^/usr/lib/debug/

--- a/macros.in
+++ b/macros.in
@@ -188,7 +188,8 @@
 %package debuginfo\
 Summary: Debug information for package %{name}\
 Group: Development/Debug\
-AutoReqProv: 0\
+AutoReq: 0\
+AutoProv: 1\
 %description debuginfo\
 This package provides debug information for package %{name}.\
 Debug information is useful when developing applications that use this\

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -10,6 +10,7 @@ EXTRA_DIST = \
 	brp-strip-shared brp-strip-static-archive \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
+	debuginfo.prov \
 	find-debuginfo.sh find-lang.sh \
 	perl.prov perl.req pythondeps.sh pythondistdeps.py \
 	rpmdb_loadcvt rpm.daily rpm.log rpm.supp rpm2cpio.sh \
@@ -29,6 +30,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip-shared brp-strip-static-archive \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
+	debuginfo.prov \
 	find-lang.sh find-requires find-provides \
 	perl.prov perl.req pythondeps.sh pythondistdeps.py \
 	mono-find-requires mono-find-provides \

--- a/scripts/debuginfo.prov
+++ b/scripts/debuginfo.prov
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+while read instfile; do
+  case "$instfile" in
+    */usr/lib/debug/.build-id/*.debug)
+      if [ -f "$instfile" ]; then
+        BUILDID=$(echo "$instfile" | sed -ne 's|.*/usr/lib/debug/.build-id/\([0-9a-f]\+\)/\([0-9a-f]\+\)\.debug|\1\2|p')
+        if [ -n "$BUILDID" ]; then
+          echo "debuginfo(build-id) = $BUILDID"
+        fi
+      fi
+      ;;
+  esac
+done


### PR DESCRIPTION
This patch lets debuginfo packages provide build-id like follows:

 debuginfo(build-id) = c63cb23876c5fa85f36beaff58f8557e1bf22517

Originally this patch was written by Jan Blunck <jblunck@suse.de>.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>