### PR TITLE
Add support for RISC-V

### DIFF
--- a/installplatform
+++ b/installplatform
@@ -174,6 +174,12 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2`; do
 	CANONARCH=m68k
 	CANONCOLOR=0
 	;;
+    riscv64)
+	ISANAME=riscv
+	ISABITS=64
+	CANONARCH=riscv64
+	CANONCOLOR=3
+	;;
     noarch)
 	CANONARCH=noarch
 	CANONCOLOR=0

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1216,6 +1216,17 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 	}
 #	endif	/* arm*-linux */
 
+#	if defined(__linux__) && defined(__riscv__)
+	if (rstreq(un.machine, "riscv")) {
+		if (sizeof(long) == 4)
+			strcpy(un.machine, "riscv32");
+		else if (sizeof(long) == 8)
+			strcpy(un.machine, "riscv64");
+		else if (sizeof(long) == 16)
+			strcpy(un.machine, "riscv128");
+	}
+#	endif	/* riscv */
+
 #	if defined(__GNUC__) && defined(__alpha__)
 	{
 	    unsigned long amask, implver;

--- a/rpmrc.in
+++ b/rpmrc.in
@@ -99,6 +99,8 @@ optflags: sh4a -O2 -g -mieee
 
 optflags: aarch64 -O2 -g
 
+optflags: riscv64 -O2 -g
+
 #############################################################
 # Architecture colors
 
@@ -146,6 +148,8 @@ archcolor: sh3 1
 archcolor: sh4 1
 
 archcolor: aarch64 2
+
+archcolor: riscv64 2
 
 #############################################################
 # Canonical arch names and numbers
@@ -242,6 +246,9 @@ arch_canon:	mipsr6: mipsr6	20
 arch_canon:	mipsr6el: mipsr6el	20
 arch_canon:	mips64r6: mips64r6	21
 arch_canon:	mips64r6el: mips64r6el	21
+
+arch_canon:	riscv: riscv64	22
+arch_canon:	riscv64: riscv64	22
 
 #############################################################
 # Canonical OS names and numbers
@@ -368,6 +375,9 @@ buildarchtranslate: sh4a: sh4
 
 buildarchtranslate: aarch64: aarch64
 
+buildarchtranslate: riscv: riscv64
+buildarchtranslate: riscv64: riscv64
+
 #############################################################
 # Architecture compatibility
 
@@ -473,6 +483,9 @@ arch_compat: sh4a: sh4
 
 arch_compat: aarch64: noarch
 
+arch_compat: riscv: noarch
+arch_compat: riscv64: noarch
+
 os_compat:   IRIX64: IRIX
 os_compat: solaris2.7: solaris2.3 solaris2.4 solaris2.5 solaris2.6
 os_compat: solaris2.6: solaris2.3 solaris2.4 solaris2.5
@@ -505,6 +518,9 @@ os_compat: Darwin: MacOSX
 buildarch_compat: ia64: noarch
 
 buildarch_compat: aarch64: noarch
+
+buildarch_compat: riscv: noarch
+buildarch_compat: riscv64: noarch
 
 buildarch_compat: athlon: i686
 buildarch_compat: geode: i586


### PR DESCRIPTION
These patches add support for the RISC-V architecture.

For further information, see https://fedoraproject.org/wiki/Architectures/RISC-V