### PR TITLE
build: fgetc returns int, not char.

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -323,7 +323,7 @@ retry:
 
     /* Make sure we have something in the read buffer */
     if (!(ofi->readPtr && *(ofi->readPtr))) {
-	char c;
+	int c;
 	int i = 0;
 
 	while((c = fgetc(ofi->fp)) != EOF) {


### PR DESCRIPTION
Returning the value into a char is a mistake on all platforms, but is
particularly bad on RISC-V.  On that platform (like ARM) char is
unsigned.  Therefore EOF (-1) is returned as 255, and the subsequent
test 'c == EOF' ('255 == -1') fails causing an infinite loop.

Signed-off-by: Richard W.M. Jones <rjones@redhat.com>