### PR TITLE
macros: make rpmsig's gpg command alterable

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -606,6 +606,7 @@ package or when debugging this package.\
 	gpg --no-verbose --no-armor \
 	%{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
 	--no-secmem-warning \
+	%{?_gpg_sign_cmd_extra_args:%{_gpg_sign_cmd_extra_args}} \
 	-u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
 
 # XXX rpm >= 4.1 verifies signatures internally


### PR DESCRIPTION
The current version of gpg2 asks for password using a curses dialogue
or a GTK dialogue. Both methods breaks automation of package signing.

If we want to be asked the old way on terminal, we must run gpg2 with
additional arguments '--pinentry-mode loopback' (and gpg-agent must be
allow looping back (--allow-loopback) - allowed by default since 2.1.13).

Currently there is no other way how to tweak gpg command line than
creating a wrapper script and redefining %__gpg macro.

The wrapper script method can lead to use of wrong version of gpg
binary, hence, this patch adds possibility to specify additional command
lines argument passed on gpg's command line.

Signed-off-by: Jakub Filak <jfilak@redhat.com>