### PR TITLE
Makefile.maint: use git-rev-list

### DIFF
--- a/Makefile.maint
+++ b/Makefile.maint
@@ -1,7 +1,7 @@
 include Makefile
 
 snapshot: ChangeLog
-	@$(MAKE) dist VERSION=$(VERSION)-git`git log --pretty=oneline|wc -l`
+	@$(MAKE) dist VERSION=$(VERSION)-git`git rev-list --count HEAD`
 
 release: ChangeLog dist
 


### PR DESCRIPTION
No need to query all commits and count lines of output, we can just ask git to provide information directly.