### PR TITLE
configure.ac: use link instead of compile for gcc flags test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ if test "$GCC" = yes; then
     echo
     for flag in $cflags_to_try; do
         CFLAGS="$CFLAGS $flag -Werror"
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[
                 echo "   $flag"
                 RPMCFLAGS="$RPMCFLAGS $flag"
         ],[])


### PR DESCRIPTION
The logic that tests whether gcc supports or not certain flags uses
AC_COMPILE_IFELSE(). However, when checking for stack smashing
protection support, an AC_LINK_IFELSE() test is needed, since the
build might work but not the link stage if certain libraries are
missing for proper stack smashing protection support.

Therefore, this commit switches to use AC_LINK_IFELSE().

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
Signed-off-by: James Knight <james.d.knight@live.com>