### PR TITLE
build: better warning for non-unique %files section

### DIFF
--- a/build/parseFiles.c
+++ b/build/parseFiles.c
@@ -73,9 +73,9 @@ int parseFiles(rpmSpec spec)
      * Warn but preserve behavior, except for leaking memory.
      */
     if (pkg->fileList != NULL) {
-	rpmlog(RPMLOG_WARNING, _("line %d: second %%files\n"), spec->lineNum);
+	rpmlog(RPMLOG_WARNING, _("line %d: multiple %%files for package '%s'\n"),
+	       spec->lineNum, rpmstrPoolStr(pkg->pool, pkg->name));
 	pkg->fileList = argvFree(pkg->fileList);
-	
     }
 
     for (arg=1; arg<argc; arg++) {


### PR DESCRIPTION
Background story is in rhbz#1374138, having the warning better
spelled before would simplify macro debugging a lot in that case.