### PR TITLE
Couple fixes in rpmdb (double free, and rpmdbCheckTerminate return code)

### DIFF
--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -315,7 +315,7 @@ int rpmdbCheckTerminate(int terminate)
     sigset_t newMask, oldMask;
     static int terminating = 0;
 
-    if (terminating) return 0;
+    if (terminating) return terminating;
 
     (void) sigfillset(&newMask);		/* block all signals */
     (void) sigprocmask(SIG_BLOCK, &newMask, &oldMask);

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -454,6 +454,12 @@ int rpmdbClose(rpmdb db)
     if (db == NULL)
 	goto exit;
 
+    prev = &rpmdbRock;
+    while ((next = *prev) != NULL && next != db)
+	prev = &next->db_next;
+    if (!next)
+	goto exit;
+
     (void) rpmdbUnlink(db);
 
     if (db->nrefs > 0)
@@ -474,9 +480,6 @@ int rpmdbClose(rpmdb db)
     db->db_indexes = _free(db->db_indexes);
     db->db_descr = _free(db->db_descr);
 
-    prev = &rpmdbRock;
-    while ((next = *prev) != NULL && next != db)
-	prev = &next->db_next;
     if (next) {
         *prev = next->db_next;
 	next->db_next = NULL;
@@ -1085,7 +1088,8 @@ rpmdbMatchIterator rpmdbFreeIterator(rpmdbMatchIterator mi)
     if (next) {
 	*prev = next->mi_next;
 	next->mi_next = NULL;
-    }
+    } else
+	return NULL;
 
     pkgdbOpen(mi->mi_db, 0, &dbi);
 
@@ -2085,7 +2089,8 @@ rpmdbIndexIterator rpmdbIndexIteratorFree(rpmdbIndexIterator ii)
     if (next) {
         *prev = next->ii_next;
         next->ii_next = NULL;
-    }
+    } else
+	return NULL;
 
     ii->ii_dbc = dbiCursorFree(ii->ii_dbi, ii->ii_dbc);
     ii->ii_dbi = NULL;


### PR DESCRIPTION
This code:
```c
#include <rpm/rpmdb.h>
#include <rpm/rpmts.h>
#include <rpm/rpmlib.h>
#include <signal.h>

class A {
    private:
        rpmts ts;
        rpmdbMatchIterator mi;
    public:
        A() {
            rpmReadConfigFiles(NULL, NULL);
            ts = rpmtsCreate();
            mi = rpmtsInitIterator(ts, RPMDBI_PACKAGES, NULL, 0);
        };
        ~A() {
            rpmdbFreeIterator(mi);
            rpmtsFree(ts);
        };
};

A a;

int main() {
    raise(SIGTERM);
    rpmdbCheckSignals();
    return 0;
}
```
tries to free `MatchIterator` again in `atexit` destructor.

```
Program received signal SIGSEGV, Segmentation fault.
#0  0x00007ffff7b57c17 in ?? () from /usr/lib64/librpm.so.7
#1  0x00007ffff7b5fbaa in rpmdbFreeIterator () from /usr/lib64/librpm.so.7
#2  0x00000000004009b6 in A::~A (this=0x601080 <a>, __in_chrg=<optimized out>) at t.cc:17
#3  0x00007ffff77d1ca8 in __run_exit_handlers (status=1, listp=0x7ffff7b395d8 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true) at exit.c:82
#4  0x00007ffff77d1cf5 in __GI_exit (status=<optimized out>) at exit.c:104
#5  0x00007ffff7b5f513 in rpmdbCheckSignals () from /usr/lib64/librpm.so.7
#6  0x00000000004008e9 in main () at t.cc:26
```

I tried `if (rpmdbCheckTerminate(0) == 0) rpmdbFreeIterator(mi);`, but `rpmdbCheckTerminate` return code is not reliable.