### PR TITLE
rpm2archive: return EXIT_SUCCESS on successful processing of package

### DIFF
--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -204,5 +204,9 @@ int main(int argc, char *argv[])
 
     ts = rpmtsFree(ts);
 
-    return rc;
+    /* On a succesful processing of a package,
+     * it returns RPMERR_ITER_END. Most things
+     * expect EXIT_SUCCESS instead,
+     * so let's return that. */
+    return rc == RPMERR_ITER_END ? EXIT_SUCCESS : rc;
 }


### PR DESCRIPTION
This PR changes `rpm2archive` so that in the event `RPMERR_ITER_END` is returned back from `process_package()`, it will consider it successful and return `EXIT_SUCCESS`.

Thus, shell scripts will be able to use rpm2archive the same way as most tools.