### PR TITLE
Read the full date from RPM changelog

### DIFF
--- a/doc/rpm.8
+++ b/doc/rpm.8
@@ -63,7 +63,7 @@ rpm \- RPM Package Manager
 .SS "query-options"
 .PP
 General:
- [\fB--changelog\fR]  [\fB--dupes\fR] [\fB-i,--info\fR]
+ [\fB--changelog\fR] [\fB--changes\fR]  [\fB--dupes\fR] [\fB-i,--info\fR]
  [\fB--last\fR] [\fB--qf,--queryformat \fIQUERYFMT\fB\fR] [\fB--xml\fR]
 .PP
 Dependencies:
@@ -625,6 +625,9 @@ Query all packages that enhance \fICAPABILITY\fR.
 .TP
 \fB--changelog\fR
 Display change information for the package.
+.TP
+\fB--changes\fR
+Display change information for the package with full time stamps.
 .TP
 \fB-c, --configfiles\fR
 List only configuration files (implies \fB-l\fR).

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -107,6 +107,9 @@ Description :\n%{DESCRIPTION}\n' \
 rpm	alias --changelog --qf '[* %{CHANGELOGTIME:day} %{CHANGELOGNAME}\n%{CHANGELOGTEXT}\n\n]' \
 	--POPTdesc=$"list change logs for this package"
 
+rpm	alias --changes --qf '[* %{CHANGELOGTIME:date} %{CHANGELOGNAME}\n%{CHANGELOGTEXT}\n\n]' \
+	--POPTdesc=$"list changes for this package with full time stamps"
+
 rpm	alias --xml --qf '[%{*:xml}\n]' \
 	--POPTdesc=$"list metadata in xml"
 


### PR DESCRIPTION
As of 57f94a582602f0353cdb17a02dc12c4461d4f32d, it's now possible to have proper changelogs with dates and times properly set.

Thus, it makes sense to offer `--changes` to offer this information.