### PR TITLE
python: remove redundant suffix in python module name in metadata

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -55,7 +55,7 @@ rpmsign_mod = Extension('rpm._rpms',
                    extra_link_args = additional_link_args
                   )
 
-setup(name='@PACKAGE_NAME@-python',
+setup(name='@PACKAGE_NAME@',
       version='@VERSION@',
       description='Python bindings for @PACKAGE_NAME@',
       maintainer_email='@PACKAGE_BUGREPORT@',


### PR DESCRIPTION
No one is quite sure why there's a redundant `-python` suffix, but the module isn't named that, and typically we want the name in the metadata to be the same as the name of the module.

This has no effect on Python code itself, as it doesn't change the name of the installed module used in import statements, and since we've never published to PyPi, it's not something that can be sanely referenced for 'pip' and other similar tools in a useful manner.