### PR TITLE
configure.ac: correct stack protector check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ if test "$GCC" = yes; then
     echo
     for flag in $cflags_to_try; do
         CFLAGS="$CFLAGS $flag -Werror"
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],[
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[alloca(100);]])],[
                 echo "   $flag"
                 RPMCFLAGS="$RPMCFLAGS $flag"
         ],[])


### PR DESCRIPTION
If a used toolchain accepts the `-fstack-protector` option but does not
provide a stack smashing protector implementation (ex. libssp), linking
will fail:

 .libs/rpmio.o: In function `Fdescr':
 rpmio.c:(.text+0x672): undefined reference to `__stack_chk_fail_local'
 .libs/rpmio.o: In function `Fdopen':
 rpmio.c:(.text+0xce9): undefined reference to `__stack_chk_fail_local'
 .libs/rpmio.o: In function `ufdCopy':
 rpmio.c:(.text+0x10f7): undefined reference to `__stack_chk_fail_local'
 ...

This is a result of testing for `-fstack-protector` support using a main
that GCC does not inject guards. GCC's manual notes that stack protector
code is only added when "[functions] that call alloca, and functions
with buffers larger than 8 bytes" [1]. This commit adjusts the stack
protector check to allocate memory on the stack (via `alloca`).

[1]: https://gcc.gnu.org/onlinedocs/gcc-4.4.2/gcc/Optimize-Options.html

Signed-off-by: James Knight <james.knight@rockwellcollins.com>