### PR TITLE
make sure not to dereference NULL pointer

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1117,7 +1117,8 @@ void checkInstalledFiles(rpmts ts, uint64_t fileCount, fingerPrintCache fpc)
 		    break;
 		case TR_REMOVED:
 		    if (!beingRemoved) {
-			if (*rpmtdGetChar(&ostates) == RPMFILE_STATE_NORMAL)
+			char *rfs = rpmtdGetChar(&ostates);
+			if (((rfs && *rfs)) == RPMFILE_STATE_NORMAL)
 			    rpmfsSetAction(fs, recs[j].fileno, FA_SKIP);
 		    }
 		    break;


### PR DESCRIPTION
This seems odd to me, on one hand if one were to dereference the value
of rpmtdChar(ostate), and it being RPMFILE_STATE_NORMAL, it's the same
value as the NULL pointer..

Just wanting to fix segfaults now rather than digging deep within
code, so this might not be the right solution nor understanding for
the problem, but..