### PR TITLE
make sure not to dereference NULL pointer

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1117,7 +1117,8 @@ void checkInstalledFiles(rpmts ts, uint64_t fileCount, fingerPrintCache fpc)
 		    break;
 		case TR_REMOVED:
 		    if (!beingRemoved) {
-			if (*rpmtdGetChar(&ostates) == RPMFILE_STATE_NORMAL)
+			char *rfs = rpmtdGetChar(&ostates);
+			if (rfs && (*rfs == RPMFILE_STATE_NORMAL))
 			    rpmfsSetAction(fs, recs[j].fileno, FA_SKIP);
 		    }
 		    break;

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1120,6 +1120,9 @@ void checkInstalledFiles(rpmts ts, uint64_t fileCount, fingerPrintCache fpc)
 			char *rfs = rpmtdGetChar(&ostates);
 			if (rfs && (*rfs == RPMFILE_STATE_NORMAL))
 			    rpmfsSetAction(fs, recs[j].fileno, FA_SKIP);
+			else
+			    rpmlog(RPMLOG_ERR, "Error reading tag container. File action for %s skipped\n",
+				    rpmfilesFN(fi, 0));
 		    }
 		    break;
 		}


### PR DESCRIPTION
This bug made me really puzzled and I don't wanna dig further around to
try wrap my head around to confirm that this fix is actually the right
one, nor if I even understand the problem or not.

I encountered it repeatedly right away, when installing a mageia
installation from rpm5 based omv-cooker into chroot.

I've not really tried installing a fresh rpm.org environment into a
chroot using rpm.org, but I'd imagine some differences in headers,
triggers what I found even more puzzling even more sloppy coding that
made me extremely uncertain and confused..

rpmtdType() may return -1, which means that rpmtdGetChar() may return
NULL, which as it's possible for this to actually happen, we need to
handle it gracefully without trying to derereference a NULL pointer
uncoditionally..

I was extremely confused about how noone else had encountered this right
away, which I did, but that would explain things using reasoning
without confirming. Internals of rpm.org are wastly different from what
used to with rpm5.org...