### PR TITLE
Support optionally creating backup files with %autopatch or %autosetup

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1086,8 +1086,8 @@ package or when debugging this package.\
 
 # Plain patch (-m is unused)
 %__scm_setup_patch(q) %{nil}
-%__scm_apply_patch(qp:m:)\
-%{__patch} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags}
+%__scm_apply_patch(qp:m:b:)\
+%{__patch} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags} %{-b:-b --suffix=%{-b*}}
 
 # Mercurial (aka hg)
 %__scm_setup_hg(q)\
@@ -1136,11 +1136,11 @@ package or when debugging this package.\
 %{__bzr} commit %{-q} -m %{-m*}
 
 # Single patch application
-%apply_patch(qp:m:)\
+%apply_patch(qp:m:b:)\
 %{lua:\
 local file = rpm.expand("%{1}")\
 if posix.access(file, "r") then\
-    local options = rpm.expand("%{-q} %{-p:-p%{-p*}} %{-m:-m%{-m*}}")\
+    local options = rpm.expand("%{-q} %{-p:-p%{-p*}} %{-b:%{-b*}} %{-m:-m%{-m*}}")\
     local scm_apply = rpm.expand("%__scm_apply_%{__scm}")\
     print(rpm.expand("%{uncompress:"..file.."} | "..scm_apply.." "..options.."\\n"))\
 else\
@@ -1148,11 +1148,11 @@ else\
 end}
 
 # Automatically apply all patches
-%autopatch(vp:)\
+%autopatch(vp:B)\
 %{lua:\
 local options = rpm.expand("%{!-v:-q} %{-p:-p%{-p*}} ")\
 for i, p in ipairs(patches) do\
-    print(rpm.expand("%apply_patch -m %{basename:"..p.."}  "..options..p.."\\n"))\
+    print(rpm.expand("%apply_patch -m %{basename:"..p.."}  "..options..rpm.expand("%{-B:-b"..string.format(".%04d", patches_num[p]).."~}").." "..p.. "\\n"))\
 end}
 
 # One macro to (optionally) do it all.

--- a/macros.in
+++ b/macros.in
@@ -1159,12 +1159,13 @@ end}
 # -S<scm name>	Sets the used patch application style, eg '-S git' enables
 #           	usage of git repository and per-patch commits.
 # -N		Disable automatic patch application
-# -p<num>	Use -p<num> for patch application	
-%autosetup(a:b:cDn:TvNS:p:)\
+# -p<num>	Use -p<num> for patch application
+# -B		Enable patch backup with automatically generated suffixes
+%autosetup(a:b:cDn:TvNS:p:B)\
 %setup %{-a} %{-b} %{-c} %{-D} %{-n} %{-T} %{!-v:-q}\
 %{-S:%global __scm %{-S*}}\
 %{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
-%{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}
+%{!-N:%autopatch %{-v} %{-p:-p%{-p*}} %{-B}}
 
 # \endverbatim
 #*/


### PR DESCRIPTION
There are plenty of people who prefer to have backup files created when applying patches, for one reason or another. In #109, @proyvind proposed it to be enabled by default.

This pull request tweaks that PR so that it is *not* enabled by default, but still available by adding `-B`. In addition, the switch is now supported in `%autosetup`.

Obsoletes #109.