### PR TITLE
rpm2cpio and rpm2archive: don't write archive data to a terminal.

### DIFF
--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -120,7 +120,11 @@ static int process_package(rpmts ts, char * filename)
     archive_write_set_format_pax_restricted(a);
 
     if (!strcmp(filename, "-")) {
-	archive_write_open_fd(a, 1);
+	if (isatty(STDOUT_FILENO)) {
+	    fprintf(stderr, "%s: refusing to output archive data to a terminal.\n");
+	    exit(EXIT_FAILURE);
+	}
+	archive_write_open_fd(a, STDOUT_FILENO);
     } else {
 	char * outname = rstrscat(NULL, filename, ".tgz", NULL);
 	archive_write_open_filename(a, outname);

--- a/rpm2cpio.c
+++ b/rpm2cpio.c
@@ -38,6 +38,10 @@ int main(int argc, char *argv[])
 		(argc == 1 ? "<stdin>" : argv[1]), Fstrerror(fdi));
 	exit(EXIT_FAILURE);
     }
+    if (isatty(STDOUT_FILENO)) {
+	fprintf(stderr, "%s: refusing to output cpio data to a terminal.\n");
+	exit(EXIT_FAILURE);
+    }
     fdo = fdDup(STDOUT_FILENO);
 
     {	rpmts ts = rpmtsCreate();


### PR DESCRIPTION
rpm2cpio and rpm2archive happily write binary data to the output
terminal.  This happens, for example, when I'm typing a command such as
"rpm2cpio foo.rpm | less" and I make a typo, hitting <Return> instead of
the pipe key.  This often results in hilarious (if bewildering) font and
character encoding changes.  On some systems, this can even result in
installation of relatively arbitrary rpms!

Nobody has ever meant to do this, and it's easy to prevent, so that's
what this patch does.

Signed-off-by: Peter Jones <pjones@redhat.com>
Reviewed-by: Adam Jackson <ajax@redhat.com>