### PR TITLE
Support pbzip command for multicore environment

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -74,7 +74,7 @@ to configure and libselinux development environment installed. SELinux
 is available from
     http://www.nsa.gov/selinux/
 
-It may be desired to install bzip2, gzip, and xz/lzma so that RPM can use these
+It may be desired to install bzip2, pbzip2, gzip, and xz/lzma so that RPM can use these
 formats.  Gzip is necessary to build packages that contain compressed
 tar balls, these are quite common on the Internet.
 These are available from

--- a/build/pack.c
+++ b/build/pack.c
@@ -368,6 +368,11 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
 	    /* Add prereq on rpm version that understands bzip2 payloads */
 	    (void) rpmlibNeedsFeature(pkg, "PayloadIsBzip2", "3.0.5-1");
 #endif
+#if HAVE_PBZLIB_H
+	} else if (rstreq(s+1, "pbzdio")) {
+	    compr = "pbzip2";
+	    (void) rpmlibNeedsFeature(pkg, "PayloadIsPBzip2", "4.14.0-1");
+#endif
 #if HAVE_LZMA_H
 	} else if (rstreq(s+1, "xzdio")) {
 	    compr = "xz";

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -189,6 +189,9 @@ static char *doUntar(rpmSpec spec, uint32_t c, int quietly)
 	case COMPRESSED_BZIP2:
 	    t = "%{__bzip2} -dc";
 	    break;
+	case COMPRESSED_PBZIP2:
+	    t = "%{__pbzip2} -dc";
+	    break;
 	case COMPRESSED_ZIP:
 	    if (rpmIsVerbose() && !quietly)
 		t = "%{__unzip}";

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,7 @@ dnl Find some common programs
 dnl
 AC_PATH_PROGS(__7ZIP, [7zip 7za 7z], /usr/bin/7za, $MYPATH)
 AC_PATH_PROG(__BZIP2, bzip2, /usr/bin/bzip2, $MYPATH)
+AC_PATH_PROG(__PBZIP2, pbzip2, /usr/bin/pbzip2, $MYPATH)
 AC_PATH_PROG(__CAT, cat, /bin/cat, $MYPATH)
 AC_PATH_PROG(__CHGRP, chgrp, /bin/chgrp, $MYPATH)
 AC_PATH_PROG(__CHMOD, chmod, /bin/chmod, $MYPATH)

--- a/doc/manual/builddependencies
+++ b/doc/manual/builddependencies
@@ -72,6 +72,7 @@ Here's what's in yyy (\<packagename\>::\<filename\> format):
 	binutils-2.9.1.0.23-7::/usr/lib/libbfd-2.9.1.0.24.so 
 	binutils-2.9.1.0.23-7::/usr/lib/libopcodes-2.9.1.0.24.so 
 	bzip2-0.9.5c-1::/usr/lib/libbz2.so.0 
+	pbzip2-1.1.9::/usr/lib/libbz2.so.1
 	dev-2.7.10-2::/dev/null 
 	diffutils-2.7-16::/usr/bin/cmp 
 	egcs-1.1.2-25::/usr/bin/gcc 

--- a/doc/manual/macros
+++ b/doc/manual/macros
@@ -80,6 +80,7 @@ to perform useful operations. The current list is
 				cat <file>		# if not compressed
 				gzip -dc <file>		# if gzip'ed
 				bzip2 -dc <file>	# if bzip'ed
+				pbzip2 -dc <file>	# if pbzip'ed
 	%{expand:...}	like eval, expand ... to <body> and (re-)expand <body>
 
 	%{S:...}	expand ... to <source> file name

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1227,6 +1227,11 @@ static const struct rpmlibProvides_s rpmlibProvides[] = {
 	(RPMSENSE_RPMLIB|RPMSENSE_EQUAL),
     N_("package payload can be compressed using bzip2.") },
 #endif
+#if HAVE_PBZLIB_H
+    { "rpmlib(PayloadIsPBzip2)",		"4.14.0-1",
+	(RPMSENSE_RPMLIB|RPMSENSE_EQUAL),
+    N_("package payload can be compressed using pbzip2.") },
+#endif
 #if HAVE_LZMA_H
     { "rpmlib(PayloadIsXz)",		"5.2-1",
 	(RPMSENSE_RPMLIB|RPMSENSE_EQUAL),

--- a/macros.in
+++ b/macros.in
@@ -25,6 +25,7 @@
 %__7zip			@__7ZIP@
 %__awk			@AWK@
 %__bzip2		@__BZIP2@
+%__pbzip2		@__PBZIP2@
 %__cat			@__CAT@
 %__chgrp		@__CHGRP@
 %__chmod		@__CHMOD@

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -861,6 +861,9 @@ doFoo(MacroBuf mb, int negate, const char * f, size_t fn,
 	case COMPRESSED_BZIP2:
 	    sprintf(be, "%%__bzip2 -dc %s", b);
 	    break;
+	case COMPRESSED_PBZIP2:
+	    sprintf(be, "%%__pbzip2 -dc %s", b);
+	    break;
 	case COMPRESSED_ZIP:
 	    sprintf(be, "%%__unzip %s", b);
 	    break;

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -342,6 +342,9 @@ int rpmFileIsCompressed(const char * file, rpmCompressedMagic * compressed)
     if ((magic[0] == 'B') && (magic[1] == 'Z') &&
         (magic[2] == 'h')) {
 	*compressed = COMPRESSED_BZIP2;
+    } else if ((magic[0] == 'P') && (magic[1] == 'B') &&
+	       (magic[2] == 'Z')) {			/* pbzip2 */
+	*compressed = COMPRESSED_PBZIP2;
     } else if ((magic[0] == 'P') && (magic[1] == 'K') &&
 	 (((magic[2] == 3) && (magic[3] == 4)) ||
 	  ((magic[2] == '0') && (magic[3] == '0')))) {	/* pkzip */

--- a/rpmio/rpmfileutil.h
+++ b/rpmio/rpmfileutil.h
@@ -27,7 +27,8 @@ typedef enum rpmCompressedMagic_e {
     COMPRESSED_LZIP		= 6,	/*!< lzip can handle */
     COMPRESSED_LRZIP		= 7,	/*!< lrzip can handle */
     COMPRESSED_7ZIP		= 8,	/*!< 7zip can handle */
-    COMPRESSED_GEM		= 9	/*!< gem can handle */
+    COMPRESSED_GEM		= 9,	/*!< gem can handle */
+    COMPRESSED_PBZIP2		= 10	/*!< pbzip2 can handle */
 } rpmCompressedMagic;
 
 /** \ingroup rpmfileutil

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -143,6 +143,7 @@ static const FDIO_t fdio;
 static const FDIO_t ufdio;
 static const FDIO_t gzdio;
 static const FDIO_t bzdio;
+static const FDIO_t pbzdio;
 static const FDIO_t xzdio;
 static const FDIO_t lzdio;
 
@@ -703,6 +704,79 @@ static const FDIO_t bzdio = &bzdio_s ;
 #endif	/* HAVE_BZLIB_H */
 
 /* =============================================================== */
+/* Support for PBZIP2 library.  */
+#if HAVE_PBZLIB_H
+
+#include <bzlib.h>
+
+static FD_t pbzdFdopen(FD_t fd, int fdno, const char * fmode)
+{
+    PBZFILE *pbzfile = PBZ2_pbzdopen(fdno, fmode);
+
+    if (pbzfile == NULL)
+	return NULL;
+
+    fdSetFdno(fd, -1);		/* XXX skip the fdio close */
+    fdPush(fd, pbzdio, pbzfile, fdno);		/* Push pbzdio onto stack */
+    return fd;
+}
+
+static int pbzdFlush(FDSTACK_t fps)
+{
+    return PBZ2_pbzflush(fps->fp);
+}
+
+static ssize_t pbzdRead(FDSTACK_t fps, void * buf, size_t count)
+{
+    PBZFILE *pbzfile = fps->fp;
+    ssize_t rc = 0;
+
+    if (pbzfile)
+	rc = PBZ2_pbzread(pbzfile, buf, count);
+    if (rc == -1) {
+	int zerror = 0;
+	if (pbzfile) {
+	    fps->errcookie = PBZ2_pbzerror(pbzfile, &zerror);
+	}
+    }
+    return rc;
+}
+
+static ssize_t pbzdWrite(FDSTACK_t fps, const void * buf, size_t count)
+{
+    PBZFILE *pbzfile = fps->fp;
+    ssize_t rc;
+
+    rc = PBZ2_pbzwrite(pbzfile, (void *)buf, count);
+    if (rc == -1) {
+	int zerror = 0;
+	fps->errcookie = PBZ2_pbzerror(pbzfile, &zerror);
+    }
+    return rc;
+}
+
+static int pbzdClose(FDSTACK_t fps)
+{
+    PBZFILE *pbzfile = fps->fp;
+
+    if (pbzfile == NULL) return -2;
+
+    /* pbzclose() doesn't return errors */
+    PBZ2_pbzclose(pbzfile);
+
+    return 0;
+}
+
+static const struct FDIO_s pbzdio_s = {
+  "pbzdio", "pbzip2",
+  pbzdRead, pbzdWrite, NULL, pbzdClose,
+  NULL, pbzdFdopen, pbzdFlush, NULL, zfdError, zfdStrerr
+};
+static const FDIO_t pbzdio = &pbzdio_s ;
+
+#endif	/* HAVE_PBZLIB_H */
+
+/* =============================================================== */
 /* Support for LZMA library.  */
 
 #ifdef HAVE_LZMA_H
@@ -1232,6 +1306,9 @@ static FDIO_t findIOT(const char *name)
 	&gzdio_s,
 #if HAVE_BZLIB_H
 	&bzdio_s,
+#endif
+#if HAVE_PBZLIB_H
+	&pbzdio_s,
 #endif
 #if HAVE_LZMA_H
 	&xzdio_s,

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -82,6 +82,7 @@ static struct pgpValTbl_s const pgpCompressionTbl[] = {
     { PGPCOMPRESSALGO_ZIP,	"ZIP" },
     { PGPCOMPRESSALGO_ZLIB, 	"ZLIB" },
     { PGPCOMPRESSALGO_BZIP2, 	"BZIP2" },
+    { PGPCOMPRESSALGO_PBZIP2, 	"PBZIP2" },
     { -1,			"Unknown compression algorithm" },
 };
 

--- a/rpmio/rpmpgp.h
+++ b/rpmio/rpmpgp.h
@@ -229,7 +229,8 @@ typedef enum pgpCompressAlgo_e {
     PGPCOMPRESSALGO_NONE	=  0,	/*!< Uncompressed */
     PGPCOMPRESSALGO_ZIP		=  1,	/*!< ZIP */
     PGPCOMPRESSALGO_ZLIB	=  2,	/*!< ZLIB */
-    PGPCOMPRESSALGO_BZIP2	=  3	/*!< BZIP2 */
+    PGPCOMPRESSALGO_BZIP2	=  3,	/*!< BZIP2 */
+    PGPCOMPRESSALGO_PBZIP2	=  4	/*!< PBZIP2 */
 } pgpCompressAlgo;
 
 /** \ingroup rpmpgp


### PR DESCRIPTION
This commit is to support pbzip2 command for parallel (de) compression
with 'rpmbuild' command. The pbzip2 is compatible with the existing bzip2.

* Todo: The next step is adding pbzip2 content in .po files.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>