### PR TITLE
configure.ac: reference zlib when checking libmagic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -316,6 +316,8 @@ AC_CHECK_HEADER([magic.h], [
       WITH_MAGIC_LIB="-lmagic"
     ],[
       AC_MSG_ERROR([missing required library 'libmagic']) 
+    ],[
+      -l${zlib}
     ])
 ],[
       AC_MSG_ERROR([missing required header magic.h]) 


### PR DESCRIPTION
When attempting to check for `magic_open` in libmagic (aka file),
linking can fail as libmagic and zlib may have been statically built:

    configure:20636: .../arm-linux-gcc -std=gnu99 -o conftest ... conftest.c -lmagic  -lpthread  >&5
    conftest.c:42:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
    ...
    .../sysroot/usr/lib/libmagic.a(compress.o): In function `uncompresszlib':
    compress.c:(.text+0x190): undefined reference to `inflateInit_'
    compress.c:(.text+0x1a8): undefined reference to `inflateInit2_'
    compress.c:(.text+0x1bc): undefined reference to `inflate'
    compress.c:(.text+0x1d4): undefined reference to `inflateEnd'
    compress.c:(.text+0x1fc): undefined reference to `zError'
    collect2: error: ld returned 1 exit status
    ...
    configure:20645: result: no
    configure:20654: error: missing required library 'libmagic'

The following adds the rpm-dependent zlib library to ensure the check
for `magic_open` can find the dependent decompression methods.

Signed-off-by: James Knight <james.knight@rockwellcollins.com>