### PR TITLE
add brp helper scripts from mandriva's spec-helper

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -78,6 +78,7 @@
     %{?!dont_remove_rpath:		[ -n "$DONT_REMOVE_RPATH" ]	|| %{_rpmconfigdir}/brp-remove-rpath} \
     %{?!dont_fix_file_permissions: 	[ -n "$DONT_FIX_FILE_PERMISSIONS" ] || %{_rpmconfigdir}/brp-fix_file_permissions} \
     %{?!dont_fix_desktop_files:		[ -n "$DONT_FIX_DESKTOP_FILES" ]    || %{_rpmconfigdir}/brp-fix-desktop-files} \
+    %{?!dont_fix_pkgconfig:		[ -n "$DONT_FIX_PKGCONFIG" ]	|| %{_rpmconfigdir}/brp-fix-pkgconfig} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -81,6 +81,7 @@
     %{?!dont_fix_pkgconfig:		[ -n "$DONT_FIX_PKGCONFIG" ]	|| %{_rpmconfigdir}/brp-fix-pkgconfig} \
     %{?!dont_symlinks_libs:		[ -n "$DONT_SYMLINK_LIBS" ]	|| %{_rpmconfigdir}/brp-lib-symlinks} \
     %{?!dont_check_elf_files_for_unused_libraries}:	[ -n "$DONT_CHECK_ELF_FILES_FOR_UNUSED_LIBRARIES" ]	|| %{_rpmconfigdir}/brp-check-elf-files-for-unused-libraries} \
+    %{?!dont_check_elf_files_for_undefined_symbols}:	[ -n "$DONT_CHECK_ELF_FILES_FOR_UNDEFINED_SYMBOLS" ]	||  %{_rpmconfigdir}/brp-check-elf-files-for-undefined-symbols} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -66,10 +66,10 @@
 %__arch_install_post   @ARCH_INSTALL_POST@
 
 %__os_install_post    \
-    %{_rpmconfigdir}/brp-compress \
-    %{_rpmconfigdir}/brp-strip %{__strip} \
-    %{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
-    %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
+    %{?!dont_compress:			[ -n "$DONT_COMPRESS" ]		|| %{_rpmconfigdir}/brp-compress} \
+    %{?!dont_strip:			[ -n "$DONT_STRIP" ]		|| %{_rpmconfigdir}/brp-strip %{__strip}} \
+    %{?!dont_strip_static_archive:	[ -n "$DONT_STRIP_STATIC_ARCHIVE" ] || %{_rpmconfigdir}/brp-strip-static-archive %{__strip}} \
+    %{?!dont_strip_comment_note:	[ -n "$DONT_STRIP_COMMENT_NOTE" ] || %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump}} \
     %{?!dont_clean_files:		[ -n "$DONT_CLEAN_FILES" ]	|| %{_rpmconfigdir}/brp-clean-files} \
     %{?!dont_remove_info_dir:		[ -n "$DONT_REMOVE_INFO_DIR" ]	|| %{_rpmconfigdir}/brp-remove-info-dir} \
     %{?!dont_relink_symlinks:		[ -n "$DONT_RELINK_SYMLINKS" ]	|| %{_rpmconfigdir}/brp-relink-symlinks} \

--- a/platform.in
+++ b/platform.in
@@ -79,6 +79,7 @@
     %{?!dont_fix_file_permissions: 	[ -n "$DONT_FIX_FILE_PERMISSIONS" ] || %{_rpmconfigdir}/brp-fix_file_permissions} \
     %{?!dont_fix_desktop_files:		[ -n "$DONT_FIX_DESKTOP_FILES" ]    || %{_rpmconfigdir}/brp-fix-desktop-files} \
     %{?!dont_fix_pkgconfig:		[ -n "$DONT_FIX_PKGCONFIG" ]	|| %{_rpmconfigdir}/brp-fix-pkgconfig} \
+    %{?!dont_symlinks_libs:		[ -n "$DONT_SYMLINK_LIBS" ]	|| %{_rpmconfigdir}/brp-lib-symlinks} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -80,6 +80,7 @@
     %{?!dont_fix_desktop_files:		[ -n "$DONT_FIX_DESKTOP_FILES" ]    || %{_rpmconfigdir}/brp-fix-desktop-files} \
     %{?!dont_fix_pkgconfig:		[ -n "$DONT_FIX_PKGCONFIG" ]	|| %{_rpmconfigdir}/brp-fix-pkgconfig} \
     %{?!dont_symlinks_libs:		[ -n "$DONT_SYMLINK_LIBS" ]	|| %{_rpmconfigdir}/brp-lib-symlinks} \
+    %{?!dont_check_elf_files_for_unused_libraries}:	[ -n "$DONT_CHECK_ELF_FILES_FOR_UNUSED_LIBRARIES" ]	|| %{_rpmconfigdir}/brp-check-elf-files-for-unused-libraries} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -77,6 +77,7 @@
     %{?!dont_fix_eol:			[ -n "$DONT_FIX_EOL" ]		|| %{_rpmconfigdir}/brp-fix-eol} \
     %{?!dont_remove_rpath:		[ -n "$DONT_REMOVE_RPATH" ]	|| %{_rpmconfigdir}/brp-remove-rpath} \
     %{?!dont_fix_file_permissions: 	[ -n "$DONT_FIX_FILE_PERMISSIONS" ] || %{_rpmconfigdir}/brp-fix_file_permissions} \
+    %{?!dont_fix_desktop_files:		[ -n "$DONT_FIX_DESKTOP_FILES" ]    || %{_rpmconfigdir}/brp-fix-desktop-files} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -73,6 +73,7 @@
     %{?!dont_clean_files:		[ -n "$DONT_CLEAN_FILES" ]	|| %{_rpmconfigdir}/brp-clean-files} \
     %{?!dont_remove_info_dir:		[ -n "$DONT_REMOVE_INFO_DIR" ]	|| %{_rpmconfigdir}/brp-remove-info-dir} \
     %{?!dont_relink_symlinks:		[ -n "$DONT_RELINK_SYMLINKS" ]	|| %{_rpmconfigdir}/brp-relink-symlinks} \
+    %{?!dont_remove_libtool_files:	[ -n "$DONT_REMOVE_LIBTOOL_FILES" ] || %{_rpmconfigdir}/brp-remove-libtool-files} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -74,6 +74,7 @@
     %{?!dont_remove_info_dir:		[ -n "$DONT_REMOVE_INFO_DIR" ]	|| %{_rpmconfigdir}/brp-remove-info-dir} \
     %{?!dont_relink_symlinks:		[ -n "$DONT_RELINK_SYMLINKS" ]	|| %{_rpmconfigdir}/brp-relink-symlinks} \
     %{?!dont_remove_libtool_files:	[ -n "$DONT_REMOVE_LIBTOOL_FILES" ] || %{_rpmconfigdir}/brp-remove-libtool-files} \
+    %{?!dont_fix_eol:			[ -n "$DONT_FIX_EOL" ]		|| %{_rpmconfigdir}/brp-fix-eol} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -75,6 +75,7 @@
     %{?!dont_relink_symlinks:		[ -n "$DONT_RELINK_SYMLINKS" ]	|| %{_rpmconfigdir}/brp-relink-symlinks} \
     %{?!dont_remove_libtool_files:	[ -n "$DONT_REMOVE_LIBTOOL_FILES" ] || %{_rpmconfigdir}/brp-remove-libtool-files} \
     %{?!dont_fix_eol:			[ -n "$DONT_FIX_EOL" ]		|| %{_rpmconfigdir}/brp-fix-eol} \
+    %{?!dont_remove_rpath:		[ -n "$DONT_REMOVE_RPATH" ]	|| %{_rpmconfigdir}/brp-remove-rpath} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -72,6 +72,7 @@
     %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
     %{?!dont_clean_files:		[ -n "$DONT_CLEAN_FILES" ]	|| %{_rpmconfigdir}/brp-clean-files} \
     %{?!dont_remove_info_dir:		[ -n "$DONT_REMOVE_INFO_DIR" ]	|| %{_rpmconfigdir}/brp-remove-info-dir} \
+    %{?!dont_relink_symlinks:		[ -n "$DONT_RELINK_SYMLINKS" ]	|| %{_rpmconfigdir}/brp-relink-symlinks} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -70,6 +70,7 @@
     %{_rpmconfigdir}/brp-strip %{__strip} \
     %{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
     %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
+    %{?!dont_clean_files:		[ -n "$DONT_CLEAN_FILES" ]	|| %{_rpmconfigdir}/brp-clean-files} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -76,6 +76,7 @@
     %{?!dont_remove_libtool_files:	[ -n "$DONT_REMOVE_LIBTOOL_FILES" ] || %{_rpmconfigdir}/brp-remove-libtool-files} \
     %{?!dont_fix_eol:			[ -n "$DONT_FIX_EOL" ]		|| %{_rpmconfigdir}/brp-fix-eol} \
     %{?!dont_remove_rpath:		[ -n "$DONT_REMOVE_RPATH" ]	|| %{_rpmconfigdir}/brp-remove-rpath} \
+    %{?!dont_fix_file_permissions: 	[ -n "$DONT_FIX_FILE_PERMISSIONS" ] || %{_rpmconfigdir}/brp-fix_file_permissions} \
 %{nil}
 
 %__spec_install_post\

--- a/platform.in
+++ b/platform.in
@@ -71,6 +71,7 @@
     %{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
     %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
     %{?!dont_clean_files:		[ -n "$DONT_CLEAN_FILES" ]	|| %{_rpmconfigdir}/brp-clean-files} \
+    %{?!dont_remove_info_dir:		[ -n "$DONT_REMOVE_INFO_DIR" ]	|| %{_rpmconfigdir}/brp-remove-info-dir} \
 %{nil}
 
 %__spec_install_post\

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST = \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
-	brp-fix-file-permissions brp-fix-desktop-files \
+	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -32,7 +32,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
-	brp-fix-file-permissions brp-fix-desktop-files \
+	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST = \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
 	brp-lib-symlinks brp-check-elf-files-for-unused-libraries \
+	brp-check-elf-files-for-undefined-symbols \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -35,6 +36,7 @@ rpmconfig_SCRIPTS = \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
 	brp-lib-symlinks brp-check-elf-files-for-unused-libraries \
+	brp-check-elf-files-for-undefined-symbols \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST = \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
-	brp-fix-file-permissions \
+	brp-fix-file-permissions brp-fix-desktop-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -32,7 +32,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
-	brp-fix-file-permissions \
+	brp-fix-file-permissions brp-fix-desktop-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -11,6 +11,7 @@ EXTRA_DIST = \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
+	brp-lib-symlinks \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -33,6 +34,7 @@ rpmconfig_SCRIPTS = \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
+	brp-lib-symlinks \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -11,7 +11,7 @@ EXTRA_DIST = \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
-	brp-lib-symlinks \
+	brp-lib-symlinks brp-check-elf-files-for-unused-libraries \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -34,7 +34,7 @@ rpmconfig_SCRIPTS = \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	brp-fix-file-permissions brp-fix-desktop-files brp-fix-pkgconfig \
-	brp-lib-symlinks \
+	brp-lib-symlinks brp-check-elf-files-for-unused-libraries \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
-	brp-clean-files brp-remove-info-dir \
+	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -28,7 +28,7 @@ rpmconfig_SCRIPTS = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
-	brp-clean-files brp-remove-info-dir \
+	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
-	brp-remove-libtool-files \
+	brp-remove-libtool-files brp-fix-eol \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -30,7 +30,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
-	brp-remove-libtool-files \
+	brp-remove-libtool-files brp-fix-eol \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST = \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
+	brp-remove-libtool-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -29,6 +30,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
+	brp-remove-libtool-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
-	brp-clean-files \
+	brp-clean-files brp-remove-info-dir \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -28,7 +28,7 @@ rpmconfig_SCRIPTS = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
-	brp-clean-files \
+	brp-clean-files brp-remove-info-dir \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -10,6 +10,7 @@ EXTRA_DIST = \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
+	brp-fix-file-permissions \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -31,6 +32,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
 	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
+	brp-fix-file-permissions \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
-	brp-remove-libtool-files brp-fix-eol \
+	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -30,7 +30,7 @@ rpmconfig_SCRIPTS = \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
 	brp-clean-files brp-remove-info-dir brp-relink-symlinks \
-	brp-remove-libtool-files brp-fix-eol \
+	brp-remove-libtool-files brp-fix-eol brp-remove-rpath \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
+	brp-clean-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -27,6 +28,7 @@ rpmconfig_SCRIPTS = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
+	brp-clean-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/brp-check-elf-files-for-undefined-symbols
+++ b/scripts/brp-check-elf-files-for-undefined-symbols
@@ -1,14 +1,20 @@
 #!/bin/sh
-# Check elf files for undefined symbols
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+# Created On	: Wed Dec 19 13:22:11 2012
+#		: Pascal "Pixel" Rigaux <pixel@mandriva.com>
+#		: (original perl implementation, 2008)
+# Description	: Check ELF files and report any undefined symbols found.
+#
+# Copyright (C) 2012 by Per Øyvind Karlsen <peroyvind@mandriva.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
-if [ -z "$RPM_BUILD_ROOT" ]; then
-    echo "No build root defined" >&2
-    exit 1
-fi
-
-if [ ! -d "$RPM_BUILD_ROOT" ]; then
-    echo "Invalid build root" >&2
-    exit 1
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+    exit 0
 fi
 
 LIB="`rpm --eval %{_lib}`"

--- a/scripts/brp-check-elf-files-for-undefined-symbols
+++ b/scripts/brp-check-elf-files-for-undefined-symbols
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Check elf files for undefined symbols
+
+if [ -z "$RPM_BUILD_ROOT" ]; then
+    echo "No build root defined" >&2
+    exit 1
+fi
+
+if [ ! -d "$RPM_BUILD_ROOT" ]; then
+    echo "Invalid build root" >&2
+    exit 1
+fi
+
+LIB="`rpm --eval %{_lib}`"
+export LD_LIBRARY_PATH="$RPM_BUILD_ROOT/$LIB:$RPM_BUILD_ROOT/usr/$LIB"
+
+find "$RPM_BUILD_ROOT" -type f -name \*.so\*  -a \
+	\( ! -path $RPM_BUILD_ROOT/usr/lib/debug/\* -a \
+	   ! -path $RPM_BUILD_ROOT/usr/src/debug/\* \) \
+	-print0 |
+xargs  --no-run-if-empty -0 file -N -L |
+grep -e '\.so.*: ELF.*shared' |
+while read match; do
+path="`echo $match | sed -e 's#\(\.so.*\): ELF.*shared.*#\1#'`"
+syspath="`echo $path | sed -e \"s#^$RPM_BUILD_ROOT##\"`"
+unused_libs="`ldd -u -r $path 2> /dev/null | grep /`"
+undefined_symbols="`ldd -r $path 2>&1 | grep '^undefined symbol: '| sed -e 's#^undefined symbol:##g' -e \"s#($path).*##g\" | tr -d '\n' | tr -d '\t'`"
+if [ -n "$undefined_symbols" ]; then
+    echo "Warning: undefined symbols in $syspath:$undefined_symbols" >&2
+fi
+done

--- a/scripts/brp-check-elf-files-for-unused-libraries
+++ b/scripts/brp-check-elf-files-for-unused-libraries
@@ -1,5 +1,16 @@
 #!/bin/sh
-# Check elf files for unused libraries linked (underlinking)
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+#		: Pascal "Pixel" Rigaux <pixel@mandriva.com>
+#		: (original perl implementation, 2008)
+# Created On	: Wed Dec 19 13:22:11 2012
+# Description	: Check elf files for unused libraries linked (overlinking).
+#
+# Copyright (C) 2012 by Per Øyvind Karlsen <peroyvind@mandriva.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
 if [ -z "$RPM_BUILD_ROOT" ]; then
     echo "No build root defined" >&2

--- a/scripts/brp-check-elf-files-for-unused-libraries
+++ b/scripts/brp-check-elf-files-for-unused-libraries
@@ -12,14 +12,9 @@
 # Public License (GPL) version 2 or later.
 #---------------------------------------------------------------
 
-if [ -z "$RPM_BUILD_ROOT" ]; then
-    echo "No build root defined" >&2
-    exit 1
-fi
-
-if [ ! -d "$RPM_BUILD_ROOT" ]; then
-    echo "Invalid build root" >&2
-    exit 1
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+    exit 0
 fi
 
 LIB="`rpm --eval %{_lib}`"

--- a/scripts/brp-check-elf-files-for-unused-libraries
+++ b/scripts/brp-check-elf-files-for-unused-libraries
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Check elf files for unused libraries linked (underlinking)
+
+if [ -z "$RPM_BUILD_ROOT" ]; then
+    echo "No build root defined" >&2
+    exit 1
+fi
+
+if [ ! -d "$RPM_BUILD_ROOT" ]; then
+    echo "Invalid build root" >&2
+    exit 1
+fi
+
+LIB="`rpm --eval %{_lib}`"
+export LD_LIBRARY_PATH="$RPM_BUILD_ROOT/$LIB:$RPM_BUILD_ROOT/usr/$LIB"
+
+find "$RPM_BUILD_ROOT" -type f \( -executable -o -name \*.so\* \) -a \
+	\( ! -path $RPM_BUILD_ROOT/usr/lib/debug/\* -a \
+	   ! -path $RPM_BUILD_ROOT/usr/src/debug/\* \) \
+	-print0 |
+xargs  --no-run-if-empty -0 file -N -L |
+grep -e '\.so.*: ELF.*shared' -e ': ELF.*executable' |
+while read match; do
+path="`echo $match | sed -e 's#\(\.so.*\): ELF.*shared.*#\1#' -e 's#: ELF.*executable.*##'`"
+syspath="`echo $path | sed -e \"s#^$RPM_BUILD_ROOT##\"`"
+if echo $match | grep -q -e ': ELF'; then
+    unused_libs="`ldd -u -r $path 2> /dev/null | grep /`"
+    if [ -n "$unused_libs" ]; then
+	echo "Warning: unused libraries in $syspath: " >&2
+	echo "$unused_libs" >&2
+    fi
+fi
+done

--- a/scripts/brp-clean-files
+++ b/scripts/brp-clean-files
@@ -1,14 +1,19 @@
 #!/bin/sh
-# remove backup files
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+#		: Chmouel Boudjnah (original perl implementation, 2000)
+# Created On	: Wed Dec 19 06:34:17 2012
+# Description	: Remove backup files and other files undesirable to package.
+#
+# Copyright (C) 2012 by Per Øyvind Karlsen <proyvind@mandriva.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
-if [ -z "$RPM_BUILD_ROOT" ]; then
-    echo "No build root defined" >&2
-    exit 1
-fi
-
-if [ ! -d "$RPM_BUILD_ROOT" ]; then
-    echo "Invalid build root" >&2
-    exit 1
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+    exit 0
 fi
 
 if [ -n "$1" ]; then

--- a/scripts/brp-clean-files
+++ b/scripts/brp-clean-files
@@ -1,0 +1,37 @@
+#!/bin/sh
+# remove backup files
+
+if [ -z "$RPM_BUILD_ROOT" ]; then
+    echo "No build root defined" >&2
+    exit 1
+fi
+
+if [ ! -d "$RPM_BUILD_ROOT" ]; then
+    echo "Invalid build root" >&2
+    exit 1
+fi
+
+if [ -n "$1" ]; then
+    DIRECTORY=$(echo $1 | sed -e "s#^$RPM_BUILD_ROOT##g")
+    if [ ! -d "$RPM_BUILD_ROOT$DIRECTORY" ]; then
+	exit 0
+    fi
+fi
+
+find "$RPM_BUILD_ROOT$DIRECTORY" \( -type f -o -type l \) \( \
+	-name '#*#' -o \
+	-name \*.orig -o \
+	-name \*~ -o \
+	-name DEADJOE -o \
+	-name .cvsignore -o \
+	-name \*.orig -o \
+	-name \*.rej -o \
+	-name \*.bak -o \
+	-name \*.SUMS -o \
+	-name TAGS -o \
+	-name .deps -o \
+	-name .P -o \
+	-name core \) \
+	-delete
+
+find "$RPM_BUILD_ROOT$DIRECTORY" -type d -name CVS | xargs rm -rf

--- a/scripts/brp-fix-desktop-files
+++ b/scripts/brp-fix-desktop-files
@@ -1,6 +1,14 @@
 #!/bin/sh
-# Fix .desktop files to be compliant with XDG specification
-
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Denis Silakov <dsilakov@rosalab.ru>
+# Created On	: Tue Dec 25 21:36:27 2012
+# Description	: Fix .desktop files to be compliant with XDG specification.
+#
+# Copyright (C) 2012 by Denis Silakov <dsilakov@rosalabs.ru>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-fix-desktop-files
+++ b/scripts/brp-fix-desktop-files
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Fix .desktop files to be compliant with XDG specification
+
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+# Find .desktop files
+find "$RPM_BUILD_ROOT" -name "*.desktop" -a ! -type d -print | while read f
+do
+    # Add trailing semicolons to lines starting with 'Actions=' or 'MimeType='
+    # if these lines do not end with '='
+    sed -e 's/^\(Actions=.*\|MimeType=.*\|OnlyShowIn=.*\|Categories=.*\)\([[:alnum:]]\)[[:space:]]*$/\1\2;/' -i "$f"
+done
+

--- a/scripts/brp-fix-eol
+++ b/scripts/brp-fix-eol
@@ -1,5 +1,15 @@
 #!/bin/sh
-# convert end of line patterns from DOS to UNIX
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+#		: Guillaume Rousse (orginal perl implementation)
+# Created On	: Wed Dec 19 06:58:37 2012
+# Description	: Convert end of line patterns from DOS to UNIX.
+#
+# Copyright (C) 2012 by Per Øyvind Karlsen <peroyvind@mandriva.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-fix-eol
+++ b/scripts/brp-fix-eol
@@ -1,0 +1,16 @@
+#!/bin/sh
+# convert end of line patterns from DOS to UNIX
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+find "$RPM_BUILD_ROOT" -type f | while read f; do
+    if [ -n "$EXCLUDE_FROM_EOL_CONVERSION" ]; then
+	basename "$f" | grep -q -P "$EXCLUDE_FROM_EOL_CONVERSION" && continue
+    fi
+    grep -q -Ilsr $'\r$' "$f" && sed -e 's/\r$//' -i "$f"
+done
+
+exit 0

--- a/scripts/brp-fix-file-permissions
+++ b/scripts/brp-fix-file-permissions
@@ -1,4 +1,14 @@
 #!/bin/sh
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+# Created On	: Sat Mar 10 21:17:48 2012
+# Description	: Ensure DSOs and mono lib/executables have right permissions.
+
+# Copyright (C) 2012 by Per Øyvind Karlsen <peroyvind@mandriva.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-fix-file-permissions
+++ b/scripts/brp-fix-file-permissions
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+find "$RPM_BUILD_ROOT" \
+    ! -path "${RPM_BUILD_ROOT}/usr/lib/debug/*" \
+    ! -path "${RPM_BUILD_ROOT}/usr/doc/*" \
+    ! -path "${RPM_BUILD_ROOT}/usr/share/doc/*" \
+    -type f \( -name \*.exe -o -name \*.dll -o -name \*.so\* \) -print0 |
+xargs  --no-run-if-empty -0 file -N -F ' //magic:' |
+grep -e "Mono/.Net assembly" -e "ELF.*shared object" |
+sed -e 's# //magic:.*##g' |
+while read path; do
+    PERMS=$(stat -c '%a' "$path")
+    if [ $PERMS -lt 755 ]; then
+	chmod 755 "$path"
+    fi
+done
+
+if [ -d "${RPM_BUILD_ROOT}/usr/share/info/" ]; then
+    find "${RPM_BUILD_ROOT}/usr/share/info/" \
+	-type f -print0 |
+    xargs  --no-run-if-empty -0 chmod 644
+fi
+
+if [ -d "${RPM_BUILD_ROOT}/usr/share/man/" ]; then
+    find "${RPM_BUILD_ROOT}/usr/share/man/" \
+	-type f -print0 |
+    xargs  --no-run-if-empty -0 chmod 644
+fi

--- a/scripts/brp-fix-pkgconfig
+++ b/scripts/brp-fix-pkgconfig
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# fix pkgconfig files to trim slashes, as ie. libdir=/usr/lib64/ rather than
+# libdir=/usr/lib64 will make pkg-config --libs return -L/usr/lib64
+#
+# (c) Per Øyvind Karlsen <proyvind@moondrake.org> 2015
+# (c) Andrey Bondrov <andrey.bondrov@rosalab.ru> 2016
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+    exit 0
+fi
+
+for pc in $(find "$RPM_BUILD_ROOT" -name \*.pc); do
+    export PKG_CONFIG_PATH="$(dirname $pc)"
+    pcfile="$(basename $pc)"
+    pcmodule="$(echo $pcfile|cut -d. -f1)"
+    for variable in $(pkg-config --print-variables "$pcmodule"); do
+	dir=$(pkg-config --variable="$variable" "$pcmodule")
+	if [[ -n "$dir" && "$dir" != "`realpath $dir`" ]]; then
+	    parentdir=$(dirname ${dir})
+	    subdir=$(basename ${dir})
+	    regexp="-e s|\(${variable}=.*/${subdir}\)/.*\$|\1|g -e s|\/\$||g -e s|\/\/|/|g"
+	    sed $regexp -i $pc
+	fi
+    done
+done

--- a/scripts/brp-fix-pkgconfig
+++ b/scripts/brp-fix-pkgconfig
@@ -1,10 +1,15 @@
 #!/bin/sh
-#
-# fix pkgconfig files to trim slashes, as ie. libdir=/usr/lib64/ rather than
-# libdir=/usr/lib64 will make pkg-config --libs return -L/usr/lib64
-#
-# (c) Per Øyvind Karlsen <proyvind@moondrake.org> 2015
-# (c) Andrey Bondrov <andrey.bondrov@rosalab.ru> 2016
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+# Created On	: Tue Oct 27 20:11:52 2015
+# Description	: Fix pkgconfig files to have extra slashes trimmed.
+
+# Copyright (C) 2015 by Per Øyvind Karlsen <peroyvind@mandriva.org>,
+# (C) 2016 Andrey Bondrov <andrey.bondrov@rosalab.ru>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL) version 2 or later.
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-fix-pkgconfig
+++ b/scripts/brp-fix-pkgconfig
@@ -19,7 +19,7 @@ fi
 for pc in $(find "$RPM_BUILD_ROOT" -name \*.pc); do
     export PKG_CONFIG_PATH="$(dirname $pc)"
     pcfile="$(basename $pc)"
-    pcmodule="$(echo $pcfile|cut -d. -f1)"
+    pcmodule="$(echo $pcfile|sed -e 's#.pc$##g')"
     for variable in $(pkg-config --print-variables "$pcmodule"); do
 	dir=$(pkg-config --variable="$variable" "$pcmodule")
 	if [[ -n "$dir" && "$dir" != "`realpath $dir`" ]]; then

--- a/scripts/brp-lib-symlinks
+++ b/scripts/brp-lib-symlinks
@@ -1,15 +1,13 @@
 #!/bin/sh
 #---------------------------------------------------------------
-# Project         : Linux-Mandrake
-# Module          : spec-helper
-# File            : lib_symlinks
-# Author          : Frederic Lepied
-# Created On      : Tue Nov  7 08:33:05 2000
-# Description	  : Run ldconfig to create symlinks to libraries.
+# Origin	: Linux-Mandrake
+# Author	: Frederic Lepied
+# Created On	: Tue Nov  7 08:33:05 2000
+# Description	: Run ldconfig to create symlinks to libraries.
 #
 # Copyright (C) 2000 by Frederic Lepied <flepied@mandrakesoft.com>
 # Redistribution of this file is permitted under the terms of the GNU
-# Public License (GPL)
+# Public License (GPL).
 #---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.

--- a/scripts/brp-lib-symlinks
+++ b/scripts/brp-lib-symlinks
@@ -7,7 +7,7 @@
 #
 # Copyright (C) 2000 by Frederic Lepied <flepied@mandrakesoft.com>
 # Redistribution of this file is permitted under the terms of the GNU
-# Public License (GPL).
+# Public License (GPL) version 2 or later.
 #---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.

--- a/scripts/brp-lib-symlinks
+++ b/scripts/brp-lib-symlinks
@@ -1,0 +1,27 @@
+#!/bin/sh
+#---------------------------------------------------------------
+# Project         : Linux-Mandrake
+# Module          : spec-helper
+# File            : lib_symlinks
+# Author          : Frederic Lepied
+# Created On      : Tue Nov  7 08:33:05 2000
+# Description	  : Run ldconfig to create symlinks to libraries.
+#
+# Copyright (C) 2000 by Frederic Lepied <flepied@mandrakesoft.com>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL)
+#---------------------------------------------------------------
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+libs=`find "$RPM_BUILD_ROOT" -type d \
+   -a "(" -name lib -o -name lib64 ")" \
+   -a ! "(" -path '*/usr/src/debug*' -o -path '*/usr/lib/debug*' ")" \
+   `
+
+if [ -n "$libs" -o -n "$EXTRA_LIBS_TO_SYMLINK" ]; then
+    /sbin/ldconfig -n -N $libs $EXTRA_LIBS_TO_SYMLINK
+fi

--- a/scripts/brp-relink-symlinks
+++ b/scripts/brp-relink-symlinks
@@ -1,4 +1,16 @@
 #!/bin/sh
+#---------------------------------------------------------------
+# Origin	: Linux-Mandrake
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+#		: Frederic Lepied <flepied@mandrakesoft.com>
+#		: (original implementation, Mon Nov 13 07:17:42 2000)
+# Created On	: Tue Sep 25 01:53:16 2012
+# Description	: Automatically relativize symlinks
+#
+# Copyright (C) 2012 by Per Øyvind Karlsen <proyvind@mandriva.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL).
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-relink-symlinks
+++ b/scripts/brp-relink-symlinks
@@ -9,7 +9,7 @@
 #
 # Copyright (C) 2012 by Per Øyvind Karlsen <proyvind@mandriva.org>
 # Redistribution of this file is permitted under the terms of the GNU
-# Public License (GPL).
+# Public License (GPL) version 2 or later.
 #---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.

--- a/scripts/brp-relink-symlinks
+++ b/scripts/brp-relink-symlinks
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+find "$RPM_BUILD_ROOT" \
+    -type l -print0 | xargs --no-run-if-empty -0 ls 2>/dev/null |
+while read symlink; do
+    path="`readlink -f \"$symlink\"`"
+
+    echo $path | grep -q -E '^(/dev|/sys|/proc)' && continue
+    # absolute path needs to be made into an absolute path relative to buildroot
+    echo $path | grep -q -E '^/' && path="$RPM_BUILD_ROOT$path"
+
+    if stat "$path" &> /dev/null; then
+	rm "$symlink"
+	# ln will try follow symlink if source exists as symlink, so let's move
+	# it out of the way first, then back afterwards
+	stat "$path" &> /dev/null && mv "$path" "$path.origlink"
+	output="`ln -svr \"$path\" \"$symlink\" 2>&1`"
+	stat "$path.origlink" &> /dev/null && mv "$path.origlink" "$path"
+	if ! stat "$symlink" &> /dev/null; then
+	    echo "symlink relativization failed:" >&2
+	    echo "$output" >&2
+	    ls --color -l "$symlink" >&2
+	fi
+    fi
+done

--- a/scripts/brp-remove-info-dir
+++ b/scripts/brp-remove-info-dir
@@ -1,4 +1,14 @@
 #!/bin/sh
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+# Created On	: Tue Dec 6 06:56:49 2011
+# Description	: Automatically remove /usr/share/dir if created during install
+#
+# Copyright (C) 2011 by Per Øyvind <peroyvind@mandrake.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL).
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-remove-info-dir
+++ b/scripts/brp-remove-info-dir
@@ -7,7 +7,7 @@
 #
 # Copyright (C) 2011 by Per Øyvind <peroyvind@mandrake.org>
 # Redistribution of this file is permitted under the terms of the GNU
-# Public License (GPL).
+# Public License (GPL) version 2 or later.
 #---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.

--- a/scripts/brp-remove-info-dir
+++ b/scripts/brp-remove-info-dir
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+INFODIR=`rpm --eval %{_infodir}/dir`
+
+dir="$RPM_BUILD_ROOT/$INFODIR"
+
+if [ -f $dir -a ! -f "$RPM_BUILD_ROOT/sbin/install-info" -a ! -f "$RPM_BUILD_ROOT/usr/sbin/install-info" ]; then
+    rm -f $dir
+fi
+

--- a/scripts/brp-remove-libtool-files
+++ b/scripts/brp-remove-libtool-files
@@ -7,7 +7,7 @@
 #
 # Copyright (C) 2011 by Per Øyvind <peroyvind@mandrake.org>
 # Redistribution of this file is permitted under the terms of the GNU
-# Public License (GPL).
+# Public License (GPL) version 2 or later.
 #---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.

--- a/scripts/brp-remove-libtool-files
+++ b/scripts/brp-remove-libtool-files
@@ -1,4 +1,14 @@
 #!/bin/sh
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+# Created On	: Tue Dec 6 06:56:49 2011
+# Description	: Automatically remove undesired libtool .la library files
+#
+# Copyright (C) 2011 by Per Øyvind <peroyvind@mandrake.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL).
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-remove-libtool-files
+++ b/scripts/brp-remove-libtool-files
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+find "$RPM_BUILD_ROOT" \( -type f -o -type l \) -name \*.la  -print0 |
+xargs  --no-run-if-empty -0 file -N -L |
+grep "libtool library file" |
+sed -e 's#: libtool library file.*##g' |
+while read path; do
+    rm -f "$path"
+done

--- a/scripts/brp-remove-rpath
+++ b/scripts/brp-remove-rpath
@@ -19,7 +19,7 @@ if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
 fi
 
 # make sure we have chrpath in our search path, otherwise wuzz out
-type chrpath || exit 0
+type chrpath &>/dev/null || echo 'chrpath' not found, skipping; exit 0
 
 find "$RPM_BUILD_ROOT" \
     ! -path "${RPM_BUILD_ROOT}/usr/lib/debug/*" \

--- a/scripts/brp-remove-rpath
+++ b/scripts/brp-remove-rpath
@@ -1,8 +1,17 @@
 #!/bin/sh
-
-# This script makes sure to remove any standard library search paths from rpath
-# or runpath tags as they're not only redundant, but will break overriding
-# search paths. Search paths of the tag that's not standard will be kept intact.
+#---------------------------------------------------------------
+# Origin	: Mandriva Linux
+# Author	: Per Øyvind Karlsen <proyvind@moondrake.org>
+# Created On	: Thu Feb 21 02:44:18 2013
+# Description	: Make sure to remove any standard library search paths from
+#		: rpath/runpath tags as they're not only redundant, but will
+#		: break overriding search paths.
+#		: Search paths of the tag that's not standard will be kept intact.
+#
+# Copyright (C) 2013 by Per Øyvind <peroyvind@mandrake.org>
+# Redistribution of this file is permitted under the terms of the GNU
+# Public License (GPL).
+#---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then

--- a/scripts/brp-remove-rpath
+++ b/scripts/brp-remove-rpath
@@ -10,7 +10,7 @@
 #
 # Copyright (C) 2013 by Per Øyvind <peroyvind@mandrake.org>
 # Redistribution of this file is permitted under the terms of the GNU
-# Public License (GPL).
+# Public License (GPL) version 2 or later.
 #---------------------------------------------------------------
 
 # If using normal root, avoid changing anything.

--- a/scripts/brp-remove-rpath
+++ b/scripts/brp-remove-rpath
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# This script makes sure to remove any standard library search paths from rpath
+# or runpath tags as they're not only redundant, but will break overriding
+# search paths. Search paths of the tag that's not standard will be kept intact.
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+# make sure we have chrpath in our search path, otherwise wuzz out
+type chrpath || exit 0
+
+find "$RPM_BUILD_ROOT" \
+    ! -path "${RPM_BUILD_ROOT}/usr/lib/debug/*" \
+    ! -path "${RPM_BUILD_ROOT}/usr/doc/*" \
+    ! -path "${RPM_BUILD_ROOT}/usr/share/doc/*" \
+    -type f  -print0 |
+xargs  --no-run-if-empty -0 file -N -F ' //magic:' |
+grep -e "ELF" |
+sed -e 's# //magic:.*##g' |
+while read path; do
+    RPATH=$(chrpath -l "$path" 2>/dev/null| grep -e RUNPATH -e RPATH|sed -e 's#.*RPATH=##g' -e 's#.*RUNPATH=##g')
+    [ -z "$RPATH" ] && continue
+    NEWRPATH=
+    for RDIR in $(echo $RPATH|cut -d: --output-delimiter=" " -f1-); do
+	    case $RDIR in
+		/lib|/lib32|/libx32|/lib64) 			echo removing $RDIR from rpath;;
+		/usr/lib|/usr/lib32|/usr/libx32|/usr/lib64)	echo removing $RDIR from rpath;;
+    *)      if [ -z "$NEWRPATH" ]; then
+		NEWRPATH="$RDIR"
+	    else
+		NEWRPATH="$NEWRPATH:$RDIR"
+	    fi
+	    ;;
+	esac
+    done
+
+    if [ "$NEWRPATH" = "$RPATH" ]; then
+	    continue
+    elif [ -z "$NEWRPATH" ]; then
+        chrpath -d "$path"
+        echo "Removing rpath ($RPATH) from $path"
+    else
+        chrpath -r "$NEWRPATH" "$path"
+        echo "Removed parts of rpath ($RPATH) from $path, new rpath is $NEWRPATH"
+    fi
+done


### PR DESCRIPTION
I've added most of the helper scripts, there's a few remaining and some I'll have to consider whether to kill off in stead before done.

Anyways, I'm making a preliminary pull request as a request for comments.

Notice how all these scripts can either be disabled by setting an environment variable or defining a rpm variable in contrast to the existing brp-* scripts.

As this has been an absolute necessity to disable some of these for some packages in cooker, I really think these should be kept, also equivalent disablers added for the existing brp- scripts invoked as well..