### PR TITLE
Do not expand macro in a comment.

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -240,6 +240,13 @@ static int copyNextLineFromOFI(rpmSpec spec, OFI_t *ofi, int strip)
 	spec->lbuf[spec->lbufOff] = '\0';
 	ofi->readPtr = from;
 
+	/* Do not expand macros if it is commented */
+	if ((strip & STRIP_COMMENTS) && spec->lbuf[0] == '#') {
+		spec->lbufOff = 0;
+		spec->nextline = spec->lbuf;
+		return 0;
+	}
+
 	/* Check if we need another line before expanding the buffer. */
 	for (const char *p = spec->lbuf; *p; p++) {
 	    switch (*p) {


### PR DESCRIPTION
Although %% can disable macro expansion, requiring to add another %
to % in a commented-out lines is not intuitive to most developers and
we are observing many mistakes in spec files.

With multi-line macros, expanding macros in a comment is disasterous
and is hard to find the errors for developers who do not know that
using % in # may be disasterous, which is very not common for other
scripting languages.

Because expanding a single-line macro in a comment has no effect on
the behaviors of rpm-build and expanding multi-line macro in a comment
has no value as a scripting syntax, I'd like to suggest that we do not
expand macros in a comment.

Related issue: #121 

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>