### PR TITLE
Error if a macro in a comment is expanded to multiple lines

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -207,10 +207,23 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
 	    bufB++;
 	}
 
-	if (*bufA != '\0' || *bufB != '\0')
+	if (*bufA != '\0' || *bufB != '\0') {
+            char *s = lbuf;
+            /* If expanded macro, lbuf, is multiline, it is error. */
+            while (*s) {
+                if (*s == '\n') {
+                    rpmlog(RPMLOG_ERR,
+                        _("Macro expanded to multiple lines in comment on line %d: %s\n"),
+                        spec->lineNum, bufA);
+                    return 1;
+                }
+                s++;
+            }
+
 	    rpmlog(RPMLOG_WARNING,
 		_("Macro expanded in comment on line %d: %s\n"),
 		spec->lineNum, bufA);
+        }
     }
 
     free(spec->lbuf);


### PR DESCRIPTION
Multi-line macro expansion in a comment has side effects
as mentioned in the PR #123. However, because there are
cases where a macro is needed to be expanded at a line
starting with # (e.g., shebang), let's emit an error
in a case where it is expected to cause side effects while
we do not expect to have any useful effects.

Related issue: #121

This is an alternative to #123 according to the comment from
@pmatilai in #123.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>