### PR TITLE
set SOURCE_DATE_EPOCH from changelog

### DIFF
--- a/build/parseChangelog.c
+++ b/build/parseChangelog.c
@@ -207,6 +207,7 @@ static rpmRC addChangelog(Header h, ARGV_const_t sb)
     time_t trimtime = rpmExpandNumeric("%{?_changelog_trimtime}");
     char *date, *name, *text, *next;
     int date_words;      /* number of words in date string */
+    int want_sde = rpmExpandNumeric("%{?source_date_epoch_from_changelog}");
 
     s = sp = argvJoin(sb, "");
 
@@ -286,6 +287,13 @@ static rpmRC addChangelog(Header h, ARGV_const_t sb)
 	    *s-- = '\0';
 	}
 	
+	if (want_sde && getenv("SOURCE_DATE_EPOCH") == NULL) {
+	    char sdestr[22];
+	    snprintf(sdestr, sizeof(sdestr), "%lli", (long long)time);
+	    //rpmlog(RPMLOG_NOTICE, _("setting %s=%s\n"), "SOURCE_DATE_EPOCH", sdestr); FIXME: this message broke rpmspec tests 008 and 295
+	    setenv("SOURCE_DATE_EPOCH", sdestr, 0);
+	    want_sde = 0;
+	}
 	if ( !trimtime || time >= trimtime ) {
 	    addChangelogEntry(h, time, name, text);
 	} else break;

--- a/macros.in
+++ b/macros.in
@@ -210,6 +210,10 @@ package or when debugging this package.\
 #	Any older entry is not packaged in binary packages.
 %_changelog_trimtime	0
 
+#	If true, set the SOURCE_DATE_EPOCH environment variable
+#	to the timestamp of the topmost changelog entry
+%source_date_epoch_from_changelog 0
+
 #	The directory where newly built binary packages will be written.
 %_rpmdir		%{_topdir}/RPMS
 


### PR DESCRIPTION
set SOURCE_DATE_EPOCH from changelog timestamp if requested by macro
to allow for more reproducible builds of packages.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

note: if changelog has only dates without times, time component will always be 12:00:00
but that is usually fine