### PR TITLE
Allow SOURCE_DATE_EPOCH to override file timestamps

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -214,6 +214,11 @@ package or when debugging this package.\
 #	to the timestamp of the topmost changelog entry
 %source_date_epoch_from_changelog 0
 
+#	If true, make sure that timestamps in built rpms
+#	are not later than the value of SOURCE_DATE_EPOCH.
+#	Is ignored when SOURCE_DATE_EPOCH is not set.
+%clamp_mtime_to_source_date_epoch 0
+
 #	The directory where newly built binary packages will be written.
 %_rpmdir		%{_topdir}/RPMS
 


### PR DESCRIPTION
Limit the maximum date to SOURCE_DATE_EPOCH, if defined
similar to the tar --clamp-mtime option

based on a patch by `Nicolas Vigier <boklm at torproject.org>`

together with previously merged
#143 
b8a54d6a1e9bb6140b6b47e23dc707e4b967537e from @boklm
22588250baa1bfa5c00f57d39329d0c144fc8112

This allows rpmbuild to produce bit-by-bit identical rpms on different hosts when setting rpmmacros to
```
%_buildhost reproducible
%source_date_epoch_from_changelog Y
%clamp_mtime_to_source_date_epoch Y
```

macro is needed, because not everyone might want it, as it is known to affect python packages that include .pyc files which reference the original timestamp. Those will still work but re-compile on demand.