### PR TITLE
selinux: use string_to_security_class() instead of class ID

### DIFF
--- a/plugins/selinux.c
+++ b/plugins/selinux.c
@@ -106,7 +106,7 @@ static rpmRC selinux_scriptlet_fork_post(rpmPlugin plugin,
 	goto exit;
     if (getfilecon(path, &fcon) < 0)
 	goto exit;
-    if (security_compute_create(mycon, fcon, SECCLASS_PROCESS, &newcon) < 0)
+    if (security_compute_create(mycon, fcon, string_to_security_class("process"), &newcon) < 0)
 	goto exit;
 
     if (rstreq(mycon, newcon)) {


### PR DESCRIPTION
SELinux recommends to use string_to_security_class() instead of referencing
class IDs directly. This also fixes a build issue for systems that don't
include flask.h by default.

References:
https://selinuxproject.org/page/NB_Imp_SELinux-aware_Apps#Implementing_SELinux-aware_Applications_2
https://github.com/SELinuxProject/selinux/commit/76913d8adb61b5afe28fd3b4ce91feab29e284dd