### PR TITLE
Allow better usage of %trace mode in rpmspec -P

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -305,7 +305,7 @@ printMacro(MacroBuf mb, const char * s, const char * se)
     /* Substitute caret at end-of-macro position */
     fprintf(stderr, "%3d>%*s%%%.*s^", mb->depth,
 	(2 * mb->depth + 1), "", (int)(se - s), s);
-    if (se[1] != '\0' && (senl - (se+1)) > 0)
+    if (se[0] != '\0' && se[1] != '\0' && (senl - (se+1)) > 0)
 	fprintf(stderr, "%-.*s%s", (int)(senl - (se+1)), se+1, ellipsis);
     fprintf(stderr, "\n");
 }

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -278,8 +278,6 @@ static void
 printMacro(MacroBuf mb, const char * s, const char * se)
 {
     const char *senl;
-    const char *ellipsis;
-    int choplen;
 
     if (s >= se) {	/* XXX just in case */
 	fprintf(stderr, _("%3d>%*s(empty)"), mb->depth,
@@ -294,19 +292,11 @@ printMacro(MacroBuf mb, const char * s, const char * se)
     for (senl = se; *senl && !iseol(*senl); senl++)
 	{};
 
-    /* Limit trailing non-trace output */
-    choplen = 61 - (2 * mb->depth);
-    if ((senl - s) > choplen) {
-	senl = s + choplen;
-	ellipsis = "...";
-    } else
-	ellipsis = "";
-
     /* Substitute caret at end-of-macro position */
     fprintf(stderr, "%3d>%*s%%%.*s^", mb->depth,
 	(2 * mb->depth + 1), "", (int)(se - s), s);
     if (se[0] != '\0' && se[1] != '\0' && (senl - (se+1)) > 0)
-	fprintf(stderr, "%-.*s%s", (int)(senl - (se+1)), se+1, ellipsis);
+	fprintf(stderr, "%-.*s", (int)(senl - (se+1)), se+1);
     fprintf(stderr, "\n");
 }
 
@@ -319,9 +309,6 @@ printMacro(MacroBuf mb, const char * s, const char * se)
 static void
 printExpansion(MacroBuf mb, const char * t, const char * te)
 {
-    const char *ellipsis;
-    int choplen;
-
     if (!(te > t)) {
 	rpmlog(RPMLOG_DEBUG, _("%3d<%*s(empty)\n"), mb->depth, (2 * mb->depth + 1), "");
 	return;
@@ -330,7 +317,6 @@ printExpansion(MacroBuf mb, const char * t, const char * te)
     /* Shorten output which contains newlines */
     while (te > t && iseol(te[-1]))
 	te--;
-    ellipsis = "";
     if (mb->depth > 0) {
 	const char *tenl;
 
@@ -338,17 +324,11 @@ printExpansion(MacroBuf mb, const char * t, const char * te)
 	while ((tenl = strchr(t, '\n')) && tenl < te)
 	    t = ++tenl;
 
-	/* Limit expand output */
-	choplen = 61 - (2 * mb->depth);
-	if ((te - t) > choplen) {
-	    te = t + choplen;
-	    ellipsis = "...";
-	}
     }
 
     rpmlog(RPMLOG_DEBUG,"%3d<%*s", mb->depth, (2 * mb->depth + 1), "");
     if (te > t)
-	rpmlog(RPMLOG_DEBUG, "%.*s%s", (int)(te - t), t, ellipsis);
+	rpmlog(RPMLOG_DEBUG, "%.*s", (int)(te - t), t);
     rpmlog(RPMLOG_DEBUG, "\n");
 }
 

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -165,6 +165,8 @@ rpm	alias --ftpproxy	--define '_httpproxy !#:+'
 rpm	alias --httpport	--define '_httpport !#:+'
 #	[--httpproxy <host>]	"hostname or IP of http proxy"
 rpm	alias --httpproxy	--define '_httpproxy !#:+'
+#	[--trace]		"trace macro expansion"
+rpm	alias --trace		--eval '%trace'
 
 # Minimally preserve commonly used switches from cli split-up
 rpm	exec --addsign		rpmsign --addsign
@@ -198,6 +200,8 @@ rpmbuild alias --buildpolicy --define '__os_install_post %{_rpmconfigdir}/brp-!#
 rpmbuild alias --sign \
 	--pipe 'rpm --addsign `grep ".*: .*\.rpm$"|cut -d: -f2` < "/dev/"`ps -p $$ -o tty | tail -n 1`' \
 	--POPTdesc=$"generate GPG signature (deprecated, use command rpmsign instead)"
+#	[--trace]		"trace macro expansion"
+rpmbuild alias --trace		--eval '%trace'
 
 rpmsign alias --key-id  --define '_gpg_name !#:+' \
 	--POPTdesc=$"key id/name to sign with" \
@@ -222,5 +226,7 @@ rpmspec	alias --buildconflicts	--srpm --conflicts \
 	--POPTdesc=$"list capabilities conflicting with build of this package"
 rpmspec	alias --buildrequires	--srpm --requires \
 	--POPTdesc=$"list capabilities required to build this package"
+#	[--trace]		"trace macro expansion"
+rpmspec alias --trace		--eval '%trace'
 # \endverbatim
 #*/


### PR DESCRIPTION
This removes an old hack to make %trace output fit on small screens, as well as adding a --trace macro to rpm commands to make it easier to use.

Note that this patch series includes the independently useful patch that I've added separately as https://github.com/rpm-software-management/rpm/pull/160 , simply because otherwise there would be a merge collision between the two pull requests.