### PR TITLE
Add support for ARM 64bit (aarch64) - Add arm32 and arm64 macros

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1012,8 +1012,16 @@ package or when debugging this package.\
 %ix86   i386 i486 i586 i686 pentium3 pentium4 athlon geode
 
 #------------------------------------------------------------------------------
+# arch macro for all 32-bit ARM processors
+%arm32  armv3l armv4b armv4l armv4tl armv5tel armv5tejl armv6l armv6hl armv7l armv7hl armv7hnl
+
+#------------------------------------------------------------------------------
+# arch macro for all 64-bit ARM processors
+%arm64  aarch64
+
+#------------------------------------------------------------------------------
 # arch macro for all supported ARM processors
-%arm	armv3l armv4b armv4l armv4tl armv5tel armv5tejl armv6l armv6hl armv7l armv7hl armv7hnl
+%arm    %{arm32} %{arm64}
 
 #------------------------------------------------------------------------------
 # arch macro for 32-bit MIPS processors


### PR DESCRIPTION
Arm 64bit architectures have been around for a while and we'd like to distinguish arm32 vs arm64 in spec files as well. The usage of %arm macro is not that rare: in RPM .spec files of my working set (tizen.org), there are 112 occurrences of aarch64 and 163 occurrences of %arm or %{arm}. 


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>