### PR TITLE
Add support for debugsource subpackages and split debuginfo subpackages

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -544,6 +544,13 @@ static void fillOutMainPackage(Header h)
 
 /**
  */
+void copyInheritedTags(Header h, Header fromh)
+{
+    headerCopyTags(fromh, h, (rpmTagVal *)copyTagsDuringParse);
+}
+
+/**
+ */
 static rpmRC readIcon(Header h, const char * file)
 {
     char *fn = NULL;
@@ -1197,8 +1204,7 @@ int parsePreamble(rpmSpec spec, int initialPackage)
     }
 
     if (pkg != spec->packages) {
-	headerCopyTags(spec->packages->header, pkg->header,
-			(rpmTagVal *)copyTagsDuringParse);
+	copyInheritedTags(pkg->header, spec->packages->header);
     }
 
     if (checkForRequired(pkg->header, NVR)) {

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -572,7 +572,7 @@ static void initSourceHeader(rpmSpec spec)
 }
 
 /* Add extra provides to package.  */
-static void addPackageProvides(Package pkg)
+void addPackageProvides(Package pkg)
 {
     const char *arch, *name;
     char *evr, *isaprov;

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -452,6 +452,13 @@ rpmRC addReqProvPkg(void *cbdata, rpmTagVal tagN,
 		    int index);
 
 /** \ingroup rpmbuild
+ * Add self-provides to package.
+ * @param pkg		package
+ */
+RPM_GNUC_INTERNAL
+void addPackageProvides(Package pkg);
+
+/** \ingroup rpmbuild
  * Add rpmlib feature dependency.
  * @param pkg		package
  * @param feature	rpm feature name (i.e. "rpmlib(Foo)" for feature Foo)
@@ -463,6 +470,16 @@ int rpmlibNeedsFeature(Package pkg, const char * feature, const char * featureEV
 
 RPM_GNUC_INTERNAL
 rpmRC checkForEncoding(Header h, int addtag);
+
+
+/** \ingroup rpmbuild
+ * Copy tags inherited by subpackages from the source header to the target header
+ * @param h		target header
+ * @param fromh		source header
+ */
+RPM_GNUC_INTERNAL
+void copyInheritedTags(Header h, Header fromh);
+
 #ifdef __cplusplus
 }
 #endif

--- a/macros.in
+++ b/macros.in
@@ -183,13 +183,12 @@
     %{?_unique_debug_srcs:--unique-debug-src-base "%{name}-%{VERSION}-%{RELEASE}.%{_arch}"} \\\
     %{?_find_debuginfo_dwz_opts} \\\
     %{?_find_debuginfo_opts} \\\
+    %{?_debugsource_packages:-S debugsourcefiles.list} \\\
     "%{_builddir}/%{?buildsubdir}"\
 %{nil}
 
 #	Template for debug information sub-package.
-%debug_package \
-%ifnarch noarch\
-%global __debug_package 1\
+%_debuginfo_template \
 %package debuginfo\
 Summary: Debug information for package %{name}\
 Group: Development/Debug\
@@ -201,6 +200,26 @@ Debug information is useful when developing applications that use this\
 package or when debugging this package.\
 %files debuginfo -f debugfiles.list\
 %defattr(-,root,root)\
+%{nil}
+
+%_debugsource_template \
+%package debugsource\
+Summary: Debug sources for package %{name}\
+Group: Development/Debug\
+AutoReqProv: 0\
+%description debugsource\
+This package provides debug sources for package %{name}.\
+Debug sources are useful when developing applications that use this\
+package or when debugging this package.\
+%files debugsource -f debugsourcefiles.list\
+%defattr(-,root,root)\
+%{nil}
+
+%debug_package \
+%ifnarch noarch\
+%global __debug_package 1\
+%_debuginfo_template\
+%{?_debugsource_packages:%_debugsource_template}\
 %endif\
 %{nil}
 
@@ -526,6 +545,9 @@ package or when debugging this package.\
 # --unique-debug-src-base "%{name}" to find-debuginfo.sh to name the
 # directory under /usr/debug/src as <name>-<ver>-<rel>.<arch>
 %_unique_debug_srcs	1
+
+# Whether rpm should put debug source files into its own subpackage
+#%_debugsource_packages	1
 
 #
 # Use internal dependency generator rather than external helpers?

--- a/macros.in
+++ b/macros.in
@@ -549,6 +549,9 @@ package or when debugging this package.\
 # Whether rpm should put debug source files into its own subpackage
 #%_debugsource_packages	1
 
+# Whether rpm should create extra debuginfo packages for each subpackage
+#%_debuginfo_subpackages 1
+
 #
 # Use internal dependency generator rather than external helpers?
 %_use_internal_dependency_generator	1

--- a/macros.in
+++ b/macros.in
@@ -172,7 +172,18 @@
 #	the script.  See the script for details.
 #
 %__debug_install_post   \
-   %{_rpmconfigdir}/find-debuginfo.sh %{?_smp_mflags} %{?_missing_build_ids_terminate_build:--strict-build-id} %{?_no_recompute_build_ids:-n} %{?_include_minidebuginfo:-m} %{?_include_gdb_index:-i} %{?_unique_build_ids:--ver-rel "%{VERSION}-%{RELEASE}"} %{?_unique_debug_names:--unique-debug-arch "%{_arch}"} %{?_unique_debug_srcs:--unique-debug-src-base "%{name}"} %{?_find_debuginfo_dwz_opts} %{?_find_debuginfo_opts} "%{_builddir}/%{?buildsubdir}"\
+    %{_rpmconfigdir}/find-debuginfo.sh \\\
+    %{?_smp_mflags} \\\
+    %{?_missing_build_ids_terminate_build:--strict-build-id} \\\
+    %{?_no_recompute_build_ids:-n} \\\
+    %{?_include_minidebuginfo:-m} \\\
+    %{?_include_gdb_index:-i} \\\
+    %{?_unique_build_ids:--build-id-seed "%{VERSION}-%{RELEASE}"} \\\
+    %{?_unique_debug_names:--unique-debug-suffix "-%{VERSION}-%{RELEASE}.%{_arch}"} \\\
+    %{?_unique_debug_srcs:--unique-debug-src-base "%{name}-%{VERSION}-%{RELEASE}.%{_arch}"} \\\
+    %{?_find_debuginfo_dwz_opts} \\\
+    %{?_find_debuginfo_opts} \\\
+    "%{_builddir}/%{?buildsubdir}"\
 %{nil}
 
 #	Template for debug information sub-package.


### PR DESCRIPTION
This adds support for SUSE style debuginfo packages. Due to the changes in rpm upstream the patch had to be pretty much rewritten from scratch.

As the new functionality is off per default the patch cannot break anything.