### PR TITLE
Add macro to force fsync() on close()

### DIFF
--- a/doc/rpm.8
+++ b/doc/rpm.8
@@ -102,7 +102,7 @@ Scripts and triggers:
  [\fB--oldpackage\fR] [\fB--percent\fR] [\fB--prefix \fINEWPATH\fB\fR]
  [\fB--relocate \fIOLDPATH\fB=\fINEWPATH\fB\fR]
  [\fB--replacefiles\fR] [\fB--replacepkgs\fR]
- [\fB--test\fR]
+ [\fB--test\fR] [\fB--force-fsync-on-close\fR]
 
 .SH "DESCRIPTION"
 .PP
@@ -373,6 +373,14 @@ on this system.
 \fB--test\fR
 Do not install the package, simply check for and report
 potential conflicts.
+.TP
+\fB--force-fsync-on-close\fR
+For each file written out on disk during RPM installation, force an fsync() on
+the filedescriptor before close()ing it. This can help spread IO load more
+evenly, not let RPM dominate IO queues, and prevent evicting too much of the
+diskcache. This can be useful on database-like systems, but will probably not
+be acceptable on rotational media. Can be enabled with the
+\fI_force_fsync_on_close\fR macro.
 .SS "ERASE OPTIONS"
 .PP
 The general form of an rpm erase command is 

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -1116,6 +1116,23 @@ int Fseek(FD_t fd, off_t offset, int whence)
     return rc;
 }
 
+int Fsync(FD_t fd)
+{
+    int rc = 0, ec = 0;
+
+    if (fd == NULL)
+	return -1;
+
+    for (FDSTACK_t fps = fd->fps; fps != NULL; fps = fps->prev) {
+	if (fps->fdno >= 0) {
+            rc = fsync(fps->fdno);
+	    if (ec == 0 && rc)
+		ec = rc;
+	}
+    }
+    return ec;
+}
+
 int Fclose(FD_t fd)
 {
     int rc = 0, ec = 0;

--- a/rpmio/rpmio.h
+++ b/rpmio/rpmio.h
@@ -57,7 +57,12 @@ off_t Ftell(FD_t fd);
 /** \ingroup rpmio
  * fclose(3) clone.
  */
-int Fclose( FD_t fd);
+int Fclose(FD_t fd);
+
+/** \ingroup rpmio
+ * fsync(3) clone.
+ */
+int Fsync(FD_t fd);
 
 /** \ingroup rpmio
  */

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -167,6 +167,8 @@ rpm	alias --httpport	--define '_httpport !#:+'
 rpm	alias --httpproxy	--define '_httpproxy !#:+'
 #	[--trace]		"trace macro expansion"
 rpm	alias --trace		--eval '%trace'
+#       [--force-fsync-on-close]
+rpm     alias --force-fsync-on-close --define '_force_fsync_on_close 1'
 
 # Minimally preserve commonly used switches from cli split-up
 rpm	exec --addsign		rpmsign --addsign


### PR DESCRIPTION
This patch adds a new macro that has rpm call fsync() before each close(). The
feature is off by default since most people will not want this, and is turned
on either with a macro or command-line flag.

There are a few reasons for wanting this:

1. To ensure that an RPM installation never fulls IO queues so much that
the production workload has to wait for it to be flushed when calling sync()
(think of databases)

2. For systems with very large numbers of disks to limit the amount of diskcache
an RPM installation can cause eviction of to limit IO thrash.

At Facebook, for the described workloads, we've found significant improvement on
our IO load when turning on this feature. Exact numbers are a bit hard to
quantify, but we are working on them. We see less threads of production
databases stacking up when yum/rpm/dnf are running, for example.

One word of caution: this will give good results on SSDs, but using this on
rotational disks won't make you happy.