### PR TITLE
pkgconfigdeps: disable dependency resolver where supported

### DIFF
--- a/scripts/pkgconfigdeps.sh
+++ b/scripts/pkgconfigdeps.sh
@@ -16,6 +16,9 @@ $pkgconfig --atleast-pkgconfig-version="0.24" || {
     exit 0
 }
 
+# Under pkgconf, disables dependency resolver
+export PKG_CONFIG_MAXIMUM_TRAVERSE_DEPTH=1
+
 case $1 in
 -P|--provides)
     while read filename ; do


### PR DESCRIPTION
pkgconf (alternative to freedesktop's pkgconfig implementation)
uses this flag to stop resolving dependencies after some level.
In our case, we are not interested in checking dependencies from
buildroot at all, we just generating top-level dependency list.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1401463
Reported-by: Martin Sehnoutka <msehnout@redhat.com>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>