### PR TITLE
Fix non-standard inherented modes of directories in debuginfo

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -490,9 +490,10 @@ if [ -s "$SOURCEFILE" ]; then
   mkdir -p "${RPM_BUILD_ROOT}${debug_dest_name}"
   LC_ALL=C sort -z -u "$SOURCEFILE" | grep -E -v -z '(<internal>|<built-in>)$' |
   (cd "${debug_base_name}"; cpio -pd0mL "${RPM_BUILD_ROOT}${debug_dest_name}")
-  # stupid cpio creates new directories in mode 0700, fixup
+  # stupid cpio creates new directories in mode 0700,
+  # and non-standard modes may be inherented from original directories, fixup
   find "${RPM_BUILD_ROOT}${debug_dest_name}" -type d -print0 |
-  xargs --no-run-if-empty -0 chmod a+rx
+  xargs --no-run-if-empty -0 chmod 0755
 fi
 
 if [ -d "${RPM_BUILD_ROOT}/usr/lib" -o -d "${RPM_BUILD_ROOT}/usr/src" ]; then


### PR DESCRIPTION
In case that binary compiled from source generated in /tmp, a
/usr/src/debug/tmp directory will be created with the same mode as
/tmp, a.k.a 777, which should be avoided.

Fixes: RhBug:641022