### PR TITLE
Allow armsfp arches on armhfp ones (rhbz#1440974)

### DIFF
--- a/rpmrc.in
+++ b/rpmrc.in
@@ -458,8 +458,8 @@ arch_compat: armv4tl: armv4l
 arch_compat: armv4l: armv3l
 arch_compat: armv3l: noarch
 arch_compat: armv7hnl: armv7hl
-arch_compat: armv7hl: armv6hl
-arch_compat: armv6hl: noarch
+arch_compat: armv7hl: armv6hl armv7l
+arch_compat: armv6hl: armv6l noarch
 
 arch_compat: m68k: noarch
 

--- a/rpmrc.in
+++ b/rpmrc.in
@@ -451,8 +451,8 @@ arch_compat: parisc: noarch
 arch_compat: armv4b: noarch
 arch_compat: armv7l: armv6l
 arch_compat: armv6l: armv5tejl
-arch_compat: armv5tejl: armv5tel armv5tl
-arch_compat: armv5tel: armv4tl armv5tl
+arch_compat: armv5tejl: armv5tel
+arch_compat: armv5tel: armv5tl
 arch_compat: armv5tl: armv4tl
 arch_compat: armv4tl: armv4l
 arch_compat: armv4l: armv3l


### PR DESCRIPTION
In order to build chroots using Mock on armhfp hosts for armsfp targets, rpm needs to allow installing packages for armsfp architectures on an armhfp host.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1440974

Related PR for libsolv: https://github.com/openSUSE/libsolv/pull/192