### PR TITLE
Add %mutable and %noupdate update policies (#152)

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -836,6 +836,10 @@ static VFA_t const virtualAttrs[] = {
     { "%license",	RPMFILE_LICENSE },
     { "%pubkey",	RPMFILE_PUBKEY },
     { "%missingok",	RPMFILE_MISSINGOK },
+    { "%mutable",	RPMFILE_MUTABLE },
+    { "%noupdate",	RPMFILE_NOUPDATE },
+    { "%updatepolicy(mutable)",	RPMFILE_MUTABLE },
+    { "%updatepolicy(noupdate)",	RPMFILE_NOUPDATE },
     { NULL, 0 }
 };
 

--- a/lib/rpmfi_internal.h
+++ b/lib/rpmfi_internal.h
@@ -73,6 +73,31 @@ rpmFileAction rpmfilesDecideFate(rpmfiles ofi, int oix,
 				   rpmfiles nfi, int nix,
                                    int skipMissing);
 
+
+/** \ingroup rpmfi
+ * Return action which should be done with the %mutable file
+ * @param		new file info set
+ * @param		new file index
+ * @param		old file info set
+ * @param		old file index
+ * @return		action name
+ */
+RPM_GNUC_INTERNAL
+rpmFileAction rpmfilesSetMutableAction(rpmfiles ofi, int oix,
+				   rpmfiles nfi, int nix);
+
+/** \ingroup rpmfi
+ * Return action which should be done with the %noupdate file
+ * @param		new file info set
+ * @param		new file index
+ * @param		old file info set
+ * @param		old file index
+ * @return		action name
+ */
+RPM_GNUC_INTERNAL
+rpmFileAction rpmfilesSetNoupdateAction(rpmfiles ofi, int oix,
+				   rpmfiles nfi, int nix);
+
 RPM_GNUC_INTERNAL
 int rpmfilesConfigConflict(rpmfiles fi, int ix);
 

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -60,6 +60,8 @@ enum rpmfileAttrs_e {
     RPMFILE_README	= (1 <<  8),	/*!< from %%readme */
     /* bits 9-10 unused */
     RPMFILE_PUBKEY	= (1 << 11),	/*!< from %%pubkey */
+    RPMFILE_MUTABLE	= (1 << 12),	/*!< from %%mutable or %updatepolicy(mutable) */
+    RPMFILE_NOUPDATE	= (1 << 13),	/*!< from %%noupdate or %updatepolicy(noupdate) */
 };
 
 typedef rpmFlags rpmfileAttrs;

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -414,6 +414,7 @@ static void handleInstInstalledFile(const rpmts ts, rpmte p, rpmfiles fi, int fx
 {
     rpmfs fs = rpmteGetFileStates(p);
     int isCfgFile = ((rpmfilesFFlags(otherFi, ofx) | rpmfilesFFlags(fi, fx)) & RPMFILE_CONFIG);
+    rpmFileAction action;
 
     if (XFA_SKIPPING(rpmfsGetAction(fs, fx)))
 	return;
@@ -471,10 +472,22 @@ static void handleInstInstalledFile(const rpmts ts, rpmte p, rpmfiles fi, int fx
     /* Determine config file disposition, skipping missing files (if any). */
     if (isCfgFile) {
 	int skipMissing = ((rpmtsFlags(ts) & RPMTRANS_FLAG_ALLFILES) ? 0 : 1);
-	rpmFileAction action;
 	action = rpmfilesDecideFate(otherFi, ofx, fi, fx, skipMissing);
 	rpmfsSetAction(fs, fx, action);
+
+    } else {
+       if (rpmfilesFFlags(fi, fx) & RPMFILE_MUTABLE) {
+	    action = rpmfilesSetMutableAction(otherFi, ofx, fi, fx);
+	    rpmfsSetAction(fs, fx, action);
+
+	} else {
+	    if (rpmfilesFFlags(fi, fx) & RPMFILE_NOUPDATE) {
+		action = rpmfilesSetNoupdateAction(otherFi, ofx, fi, fx);
+		rpmfsSetAction(fs, fx, action);
+	    }
+	}
     }
+
     rpmfilesSetFReplacedSize(fi, fx, rpmfilesFSize(otherFi, ofx));
 }
 

--- a/tests/data/SPECS/updpolicy.spec
+++ b/tests/data/SPECS/updpolicy.spec
@@ -1,0 +1,38 @@
+# avoid depending on rpm configuration
+%define _sysconfdir /etc
+
+%{!?filetype: %global filetype file}
+
+Name:		update-policy-test%{?sub:-%{sub}}
+Version:	%{ver}
+Release:	1
+Summary:	Testing update policy
+
+Group:		Testing
+License:	GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}
+case %{filetype} in
+file)
+    echo "%{filedata}" > $RPM_BUILD_ROOT/%{_sysconfdir}/policy.conf
+    ;;
+link)
+    ln -s "%{filedata}" $RPM_BUILD_ROOT/%{_sysconfdir}/policy.conf
+    ;;
+dir)
+    mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/policy.conf
+    ;;
+esac
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%{?fileattr} %{_sysconfdir}/policy.conf

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -354,3 +354,257 @@ runroot rpm -e testdoc
 [],
 [])
 AT_CLEANUP
+
+
+# ------------------------------
+# Test mutable file
+AT_SETUP([mutable file - only works as root!])
+AT_KEYWORDS([mutable policy link])
+AT_CHECK([
+AT_XFAIL_IF([test `whoami` != root ])
+RPMDB_CLEAR
+RPMDB_INIT
+cf="${RPMTEST}"/etc/policy.conf
+rm -rf "${cf}" "${cf}".rpm*
+rm -rf "${TOPDIR}"
+
+for v in 1.0 2.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype file" \
+        --define "filedata old_contents" \
+        --define "fileattr %mutable" \
+          /data/SPECS/updpolicy.spec
+done
+
+for v in 3.0 4.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype file" \
+        --define "filedata new_contents" \
+        --define "fileattr %mutable" \
+          /data/SPECS/updpolicy.spec
+done
+
+
+#test update mutable file without changes and with changed contents
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-1.0-1.noarch.rpm
+cat "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-2.0-1.noarch.rpm
+cat "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-3.0-1.noarch.rpm
+cat "${cf}"
+echo "CHANGE" > "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-4.0-1.noarch.rpm
+cat "${cf}"
+
+runroot rpm -e update-policy-test
+test ! -f "${cf}" && echo OK1
+
+
+#test update mutable file with changed mode
+runroot rpm -U /build/RPMS/noarch/update-policy-test-2.0-1.noarch.rpm
+cat "${cf}"
+chmod a+x "${cf}"
+runroot rpm -U /build/RPMS/noarch/update-policy-test-3.0-1.noarch.rpm
+cat "${cf}"
+runroot rpm -e update-policy-test
+test ! -f "${cf}" && echo OK2
+],
+[],
+[old_contents
+old_contents
+new_contents
+CHANGE
+OK1
+old_contents
+old_contents
+OK2
+],
+[])
+AT_CLEANUP
+
+
+# ------------------------------
+# Test mutable link
+AT_SETUP([mutable link])
+AT_KEYWORDS([mutable policy link])
+AT_CHECK([
+RPMDB_CLEAR
+RPMDB_INIT
+cf="${RPMTEST}"/etc/policy.conf
+rm -rf "${cf}" "${cf}".rpm*
+rm -rf "${TOPDIR}"
+
+for v in 1.0 2.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype link" \
+        --define "filedata old_contents" \
+        --define "fileattr %mutable" \
+          /data/SPECS/updpolicy.spec
+done
+
+for v in 3.0 4.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype link" \
+        --define "filedata new_contents" \
+        --define "fileattr %mutable" \
+          /data/SPECS/updpolicy.spec
+done
+
+
+#test update mutable link without changes and with changed contents
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-1.0-1.noarch.rpm
+readlink "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-2.0-1.noarch.rpm
+readlink "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-3.0-1.noarch.rpm
+readlink "${cf}"
+ln -sf "CHANGE" "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-4.0-1.noarch.rpm
+readlink "${cf}"
+
+runroot rpm -e update-policy-test
+test ! -L "${cf}" && echo OK1
+],
+[],
+[old_contents
+old_contents
+new_contents
+CHANGE
+OK1
+],
+[])
+AT_CLEANUP
+
+
+
+
+
+# ------------------------------
+# Test noupdate file
+AT_SETUP([noupdate file])
+AT_KEYWORDS([noupdate policy link])
+AT_CHECK([
+RPMDB_CLEAR
+RPMDB_INIT
+cf="${RPMTEST}"/etc/policy.conf
+rm -rf "${cf}" "${cf}".rpm*
+rm -rf "${TOPDIR}"
+
+for v in 1.0 2.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype file" \
+        --define "filedata old_contents" \
+        --define "fileattr %noupdate" \
+          /data/SPECS/updpolicy.spec
+done
+
+for v in 3.0 4.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype file" \
+        --define "filedata new_contents" \
+        --define "fileattr %noupdate" \
+          /data/SPECS/updpolicy.spec
+done
+
+
+#test update mutable file without changes and with changed contents
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-1.0-1.noarch.rpm
+cat "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-2.0-1.noarch.rpm
+cat "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-3.0-1.noarch.rpm
+cat "${cf}"
+echo "CHANGE" > "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-4.0-1.noarch.rpm
+cat "${cf}"
+
+runroot rpm -e update-policy-test
+test ! -f "${cf}" && echo OK1
+
+],
+[],
+[old_contents
+old_contents
+old_contents
+CHANGE
+OK1
+],
+[])
+AT_CLEANUP
+
+
+# ------------------------------
+# Test noupdate link
+AT_SETUP([noupdate link])
+AT_KEYWORDS([noupdate policy link])
+AT_CHECK([
+RPMDB_CLEAR
+RPMDB_INIT
+cf="${RPMTEST}"/etc/policy.conf
+rm -rf "${cf}" "${cf}".rpm*
+rm -rf "${TOPDIR}"
+
+for v in 1.0 2.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype link" \
+        --define "filedata old_contents" \
+        --define "fileattr %noupdate" \
+          /data/SPECS/updpolicy.spec
+done
+
+for v in 3.0 4.0; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver ${v}" \
+        --define "filetype link" \
+        --define "filedata new_contents" \
+        --define "fileattr %noupdate" \
+          /data/SPECS/updpolicy.spec
+done
+
+
+#test update mutable link without changes and with changed contents
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-1.0-1.noarch.rpm
+readlink "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-2.0-1.noarch.rpm
+readlink "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-3.0-1.noarch.rpm
+readlink "${cf}"
+ln -sf "CHANGE" "${cf}"
+
+runroot rpm -U /build/RPMS/noarch/update-policy-test-4.0-1.noarch.rpm
+readlink "${cf}"
+
+runroot rpm -e update-policy-test
+test ! -L "${cf}" && echo OK1
+],
+[],
+[old_contents
+old_contents
+old_contents
+CHANGE
+OK1
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
%mutable
- is defined for files and links. It means update until modified.

In more details:
- if a file/link is the same as in new package then touch it,
- if a file/link is the same as in old package then upgrade it as "normal" file/link,
- else do nothing.

%noupdate
- is defined for all file types used internally by rpm. It is for cases, where packager wants just the initial content, never to be touched by rpm again.

In more details:
- if the file does not exist, then create it,
- if the file exists, then do nothing.