### PR TITLE
Change the shebang of pythondistdeps.py to Python 3

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright 2010 Per Øyvind Karlsen <proyvind@moondrake.org>


### PR DESCRIPTION
The `pythondistdeps.py` file is still carrying a Python 2 shebang (`/usr/bin/python`).

In Fedora we already patch it to Python 3, so I'm proposing to make the same change in upstream as well. Python 2 is EOL in 2 years and 11 months.