### PR TITLE
Three fixes for rpmdeps

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -230,8 +230,8 @@ package or when debugging this package.\
 # Their purpouse is to set up global filtering for all packages. If you need
 # to set up specific filtering for your package use %__requires_exclude_from
 # and %__provides_exclude_from instead.
-%__global_requires_exclude_from		%{_docdir}
-%__global_provides_exclude_from		%{_docdir}
+%__global_requires_exclude_from		%{?_docdir:%{_docdir}}
+%__global_provides_exclude_from		%{?_docdir:%{_docdir}}
 
 #	The path to the gzip executable (legacy, use %{__gzip} instead).
 %_gzipbin		%{__gzip}

--- a/tools/rpmdeps.c
+++ b/tools/rpmdeps.c
@@ -101,7 +101,7 @@ main(int argc, char *argv[])
 	goto exit;
 
     if (_rpmfc_debug)
-	rpmfcPrint(NULL, fc, NULL);
+	rpmfcPrint(NULL, fc, stdout);
 
     if (print_provides)
 	rpmdsPrint(NULL, rpmfcProvides(fc), stdout);

--- a/tools/rpmdeps.c
+++ b/tools/rpmdeps.c
@@ -101,7 +101,7 @@ main(int argc, char *argv[])
 	goto exit;
 
     if (_rpmfc_debug)
-	rpmfcPrint(buf, fc, NULL);
+	rpmfcPrint(NULL, fc, NULL);
 
     if (print_provides)
 	rpmdsPrint(NULL, rpmfcProvides(fc), stdout);


### PR DESCRIPTION
The first commit fixes the use of an uninitialized buffer in rpmdeps and should be trivial to merge.

The second commit changes `rpmdeps --rpmfcdebug` to output to stdout. This makes more sense when using it as the sole output from rpmdeps, as the output will no longer mix with any warnings sent to stderr. I guess it may make less sense if --rpmfcdebug is used together with any of the other output options, e.g., --provides or --requires. It would be possible to send the output from --rpmfcdebug to either stderr or stdout depending on if any other output options are used or not, but that may be more confusing than beneficial.

The third commit avoids a warning about %{_docdir} when running rpmdeps directly.