### PR TITLE
Make source package detection less error prone.

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -735,11 +735,13 @@ rpmRC packageSources(rpmSpec spec, char **cookie)
 {
     Package sourcePkg = spec->sourcePackage;
     rpmRC rc;
+    uint32_t one = 1;
 
     /* Add some cruft */
     headerPutString(sourcePkg->header, RPMTAG_RPMVERSION, VERSION);
     headerPutString(sourcePkg->header, RPMTAG_BUILDHOST, buildHost());
     headerPutUint32(sourcePkg->header, RPMTAG_BUILDTIME, getBuildTime(), 1);
+    headerPutUint32(sourcePkg->header, RPMTAG_SOURCEPACKAGE, &one, 1);
 
     /* XXX this should be %_srpmdir */
     {	char *fn = rpmGetPath("%{_srcrpmdir}/", spec->sourceRpmName,NULL);

--- a/lib/header.c
+++ b/lib/header.c
@@ -1028,6 +1028,16 @@ int headerIsEntry(Header h, rpmTagVal tag)
    	
 }
 
+/* simple heuristic to find out if the header is from * a source rpm
+ * or not: source rpms contain at least the spec file and have all
+ * files in one directory with an empty name.
+ */
+int headerIsSourceHeuristic(Header h)
+{
+    indexEntry entry = findEntry(h, RPMTAG_DIRNAMES, RPM_STRING_ARRAY_TYPE);
+    return entry && entry->info.count == 1 && entry->data && !*(const char *)entry->data;
+}
+
 /** \ingroup header
  * Retrieve data from header entry.
  * Relevant flags (others are ignored), if neither is set allocation

--- a/lib/header_internal.h
+++ b/lib/header_internal.h
@@ -91,6 +91,8 @@ RPM_GNUC_INTERNAL
 void headerMergeLegacySigs(Header h, Header sigh);
 RPM_GNUC_INTERNAL
 void applyRetrofits(Header h, int leadtype);
+RPM_GNUC_INTERNAL
+int headerIsSourceHeuristic(Header h);
 #ifdef __cplusplus
 }   
 #endif

--- a/lib/package.c
+++ b/lib/package.c
@@ -224,20 +224,27 @@ exit:
 
 void applyRetrofits(Header h, int leadtype)
 {
-    /* Retrofit RPMTAG_SOURCEPACKAGE to srpms for compatibility */
-    if (leadtype == RPMLEAD_SOURCE && headerIsSource(h)) {
-	if (!headerIsEntry(h, RPMTAG_SOURCEPACKAGE)) {
+    /*
+     * Make sure that either RPMTAG_SOURCERPM or RPMTAG_SOURCEPACKAGE
+     * is set. Use a simple heuristic to find the type if both are unset.
+     */
+    if (!headerIsEntry(h, RPMTAG_SOURCERPM) && !headerIsEntry(h, RPMTAG_SOURCEPACKAGE)) {
+	/* the heuristic needs the compressed file list */
+	if (headerIsEntry(h, RPMTAG_OLDFILENAMES))
+	    headerConvert(h, HEADERCONV_COMPRESSFILELIST);
+	if (headerIsSourceHeuristic(h)) {
+	    /* Retrofit RPMTAG_SOURCEPACKAGE to srpms for compatibility */
 	    uint32_t one = 1;
 	    headerPutUint32(h, RPMTAG_SOURCEPACKAGE, &one, 1);
+	} else {
+	    /*
+	     * Make sure binary rpms have RPMTAG_SOURCERPM set as that's
+	     * what we use for differentiating binary vs source elsewhere.
+	     */
+	    headerPutString(h, RPMTAG_SOURCERPM, "(none)");
 	}
     }
-    /*
-     * Try to make sure binary rpms have RPMTAG_SOURCERPM set as that's
-     * what we use for differentiating binary vs source elsewhere.
-     */
-    if (!headerIsEntry(h, RPMTAG_SOURCEPACKAGE) && headerIsSource(h)) {
-	headerPutString(h, RPMTAG_SOURCERPM, "(none)");
-    }
+
     /*
      * Convert legacy headers on the fly. Not having immutable region
      * equals a truly ancient package, do full retrofit. OTOH newer


### PR DESCRIPTION
Use a simple heuristic instead of looking at the lead type when we can't decided if a header is from a source package or not. 