### PR TITLE
Generalize primary (uid/gid=0) user & group for platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1017,4 +1017,8 @@ AC_CONFIG_FILES([Makefile
  	plugins/Makefile
 	python/setup.py
   ])
+user_with_uid0=$(awk -F: '$3==0 {print $1}' /etc/passwd)
+group_with_gid0=$(awk -F: '$3==0 {print $1}' /etc/group)
+AC_DEFINE_UNQUOTED([UID_0_USER],["$username_with_uid0"],[Get the user name having userid 0])
+AC_DEFINE_UNQUOTED([GID_0_GROUP],["$groupname_with_gid0"],[Get the group name having groupid 0])
 AC_OUTPUT

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -801,14 +801,14 @@ int rpmfilesStat(rpmfiles fi, int ix, int flags, struct stat *sb)
 	if (user && rpmugUid(user, &sb->st_uid)) {
 	    if (warn)
 		rpmlog(RPMLOG_WARNING,
-			_("user %s does not exist - using root\n"), user);
+			_("user %s does not exist - using %s\n"), user, UID_0_USER);
 	    sb->st_mode &= ~S_ISUID;	  /* turn off suid bit */
 	}
 
 	if (group && rpmugGid(group, &sb->st_gid)) {
 	    if (warn)
 		rpmlog(RPMLOG_WARNING,
-			_("group %s does not exist - using root\n"), group);
+			_("group %s does not exist - using %s\n"), group, GID_0_GROUP);
 	    sb->st_mode &= ~S_ISGID;	/* turn off sgid bit */
 	}
 

--- a/lib/rpmug.c
+++ b/lib/rpmug.c
@@ -31,7 +31,7 @@ int rpmugUid(const char * thisUname, uid_t * uid)
     if (!thisUname) {
 	lastUnameLen = 0;
 	return -1;
-    } else if (rstreq(thisUname, "root")) {
+    } else if (rstreq(thisUname, UID_0_USER)) {
 	*uid = 0;
 	return 0;
     }
@@ -74,7 +74,7 @@ int rpmugGid(const char * thisGname, gid_t * gid)
     if (thisGname == NULL) {
 	lastGnameLen = 0;
 	return -1;
-    } else if (rstreq(thisGname, "root")) {
+    } else if (rstreq(thisGname, GID_0_GROUP)) {
 	*gid = 0;
 	return 0;
     }
@@ -116,7 +116,7 @@ const char * rpmugUname(uid_t uid)
 	lastUid = (uid_t) -1;
 	return NULL;
     } else if (uid == (uid_t) 0) {
-	return "root";
+	return UID_0_USER;
     } else if (uid == lastUid) {
 	return lastUname;
     } else {
@@ -147,7 +147,7 @@ const char * rpmugGname(gid_t gid)
 	lastGid = (gid_t) -1;
 	return NULL;
     } else if (gid == (gid_t) 0) {
-	return "root";
+	return GID_0_GROUP;
     } else if (gid == lastGid) {
 	return lastGname;
     } else {
@@ -170,9 +170,9 @@ const char * rpmugGname(gid_t gid)
 
 static void loadLibs(void)
 {
-    (void) getpwnam("root");
+    (void) getpwnam(UID_0_USER);
     endpwent();
-    (void) getgrnam("root");
+    (void) getgrnam(GID_0_GROUP);
     endgrent();
     (void) gethostbyname("localhost");
 }


### PR DESCRIPTION
Platforms like AIX has system instead of root as the primary group (gid=0). This patch generalize these stuffs rather than hard coding in the code. This PR is opened to incorporate the changes needed after the review of another PR https://github.com/rpm-software-management/rpm/pull/215