### PR TITLE
Add a new option --alldeps to rpmdeps

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -691,7 +691,6 @@ static rpm_color_t rpmfcColor(const char * fmstr)
 
 void rpmfcPrint(const char * msg, rpmfc fc, FILE * fp)
 {
-    rpm_color_t fcolor;
     int ndx;
     int dx;
     int fx;
@@ -703,21 +702,23 @@ void rpmfcPrint(const char * msg, rpmfc fc, FILE * fp)
 
     if (fc)
     for (fx = 0; fx < fc->nfiles; fx++) {
-	rpmsid cx = fc->fcdictx[fx] + 1; /* id's are one off */
-	fcolor = fc->fcolor[fx];
-	ARGV_t fattrs = fc->fattrs[fx];
-
 	fprintf(fp, "%3d %s", fx, fc->fn[fx]);
-	if (fcolor != RPMFC_BLACK)
+	if (_rpmfc_debug) {
+	    rpmsid cx = fc->fcdictx[fx] + 1; /* id's are one off */
+	    rpm_color_t fcolor = fc->fcolor[fx];
+	    ARGV_t fattrs = fc->fattrs[fx];
+
+	    if (fcolor != RPMFC_BLACK)
 		fprintf(fp, "\t0x%x", fc->fcolor[fx]);
-	else
+	    else
 		fprintf(fp, "\t%s", rpmstrPoolStr(fc->cdict, cx));
-	if (fattrs) {
-	    char *attrs = argvJoin(fattrs, ",");
-	    fprintf(fp, " [%s]", attrs);
-	    free(attrs);
-	} else {
-	    fprintf(fp, " [none]");
+	    if (fattrs) {
+		char *attrs = argvJoin(fattrs, ",");
+		fprintf(fp, " [%s]", attrs);
+		free(attrs);
+	    } else {
+		fprintf(fp, " [none]");
+	    }
 	}
 	fprintf(fp, "\n");
 

--- a/build/rpmfc.h
+++ b/build/rpmfc.h
@@ -45,7 +45,6 @@ typedef const struct rpmfcTokens_s * rpmfcToken;
 
 /** \ingroup rpmfc
  * Print results of file classification.
- * @todo Remove debugging routine.
  * @param msg		message prefix (NULL for none)
  * @param fc		file classifier
  * @param fp		output file handle (NULL for stderr)

--- a/tools/rpmdeps.c
+++ b/tools/rpmdeps.c
@@ -23,6 +23,8 @@ static int print_conflicts;
 
 static int print_obsoletes;
 
+static int print_alldeps;
+
 static void rpmdsPrint(const char * msg, rpmds ds, FILE * fp)
 {
     if (fp == NULL) fp = stderr;
@@ -56,6 +58,8 @@ static struct poptOption optionsTable[] = {
  { "conflicts", '\0', POPT_ARG_VAL, &print_conflicts, -1,
         NULL, NULL },
  { "obsoletes", '\0', POPT_ARG_VAL, &print_obsoletes, -1,
+        NULL, NULL },
+ { "alldeps", '\0', POPT_ARG_VAL, &print_alldeps, -1,
         NULL, NULL },
 
    POPT_AUTOALIAS
@@ -100,25 +104,27 @@ main(int argc, char *argv[])
     if (rpmfcClassify(fc, av, NULL) || rpmfcApply(fc))
 	goto exit;
 
-    if (_rpmfc_debug)
-	rpmfcPrint(NULL, fc, NULL);
+    if (print_alldeps || _rpmfc_debug)
+	rpmfcPrint(NULL, fc, print_alldeps ? stdout : NULL);
 
-    if (print_provides)
-	rpmdsPrint(NULL, rpmfcProvides(fc), stdout);
-    if (print_requires)
-	rpmdsPrint(NULL, rpmfcRequires(fc), stdout);
-    if (print_recommends)
-	rpmdsPrint(NULL, rpmfcRecommends(fc), stdout);
-    if (print_suggests)
-	rpmdsPrint(NULL, rpmfcSuggests(fc), stdout);
-    if (print_supplements)
-	rpmdsPrint(NULL, rpmfcSupplements(fc), stdout);
-    if (print_enhances)
-	rpmdsPrint(NULL, rpmfcEnhances(fc), stdout);
-    if (print_conflicts)
-	rpmdsPrint(NULL, rpmfcConflicts(fc), stdout);
-    if (print_obsoletes)
-	rpmdsPrint(NULL, rpmfcObsoletes(fc), stdout);
+    if (!print_alldeps) {
+	if (print_provides)
+	    rpmdsPrint(NULL, rpmfcProvides(fc), stdout);
+	if (print_requires)
+	    rpmdsPrint(NULL, rpmfcRequires(fc), stdout);
+	if (print_recommends)
+	    rpmdsPrint(NULL, rpmfcRecommends(fc), stdout);
+	if (print_suggests)
+	    rpmdsPrint(NULL, rpmfcSuggests(fc), stdout);
+	if (print_supplements)
+	    rpmdsPrint(NULL, rpmfcSupplements(fc), stdout);
+	if (print_enhances)
+	    rpmdsPrint(NULL, rpmfcEnhances(fc), stdout);
+	if (print_conflicts)
+	    rpmdsPrint(NULL, rpmfcConflicts(fc), stdout);
+	if (print_obsoletes)
+	    rpmdsPrint(NULL, rpmfcObsoletes(fc), stdout);
+    }
 
     ec = 0;
 


### PR DESCRIPTION
This is an alternative solution to the part in https://github.com/rpm-software-management/rpm/pull/216 that was rejected.

Rather than changing the behavior of the existing `--rpmfcdebug` option, this adds a new option `--all-per-file`, which outputs the same information as `--rpmfcdebug` does, but to stdout. 

The reason why this is needed and why not to just use `rpmdeps --rpmfcdebug ... 2>&1` is that if there is an error, the error message would then end up on stdout as well and never be shown to the user who then has no idea why the command failed (assuming that stdout is caught by some other process that uses the output from `rpmdeps` as its input).

I am not very happy about the option name, `--all-per-file`, but it was the best I could come up with to indicate that it outputs all dependencies per input file. Feel free to suggest alternatives.
