### PR TITLE
Use C.UTF-8 locale, if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ Makefile.in.in
 /rpmsign
 /rpmsort
 /rpmspec
+/scripts/check-buildroot
+/scripts/check-files
+/scripts/check-rpaths-worker
+/scripts/find-debuginfo.sh
 /scripts/macros.perl
 /scripts/macros.php
 /scripts/macros.python

--- a/build/files.c
+++ b/build/files.c
@@ -2297,7 +2297,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     appendStringBuf(docScript, sdenv);
     appendStringBuf(docScript, "=$RPM_BUILD_ROOT");
     appendLineStringBuf(docScript, sd->dirname);
-    appendLineStringBuf(docScript, "export LC_ALL=C");
+    appendLineStringBuf(docScript, ("export LC_ALL=%s", C_LOCALE));
     appendStringBuf(docScript, "export ");
     appendLineStringBuf(docScript, sdenv);
     appendLineStringBuf(docScript, mkdocdir);

--- a/configure.ac
+++ b/configure.ac
@@ -743,6 +743,21 @@ AM_CONDITIONAL([USE_BUNDLED_FTS_KLUDGE], [test "$ac_cv_header_fts_h" = no])
 
 AC_LIBOBJ(fnmatch)
 
+dnl Check whether the system has support for C.UTF-8 locale.
+AC_PATH_PROG(FALSEPROG, false)
+AC_PATH_PROG(LOCALEPROG, locale, $FALSEPROG)
+AC_PROG_EGREP
+AC_MSG_CHECKING([whether C.UTF-8 locale is present])
+if test `$LOCALEPROG -a | $EGREP '^C\.utf8' > /dev/null; echo \$?` == 0; then
+	echo "yes"
+	AC_DEFINE(C_LOCALE, "C.UTF-8", [C locale to use)])
+	AC_SUBST(C_LOCALE, C.UTF-8)
+else
+	echo "no"
+	AC_DEFINE(C_LOCALE, "C", [C locale to use)])
+	AC_SUBST(C_LOCALE, C)
+fi
+
 dnl check if python is requested
 AC_ARG_ENABLE(python, [AS_HELP_STRING([--enable-python],[build rpm python bindings])],
 [case "$enable_python" in
@@ -1037,6 +1052,10 @@ AC_CONFIG_FILES([Makefile
 	doc/Makefile
 	python/Makefile
  	luaext/Makefile
+	scripts/check-buildroot
+	scripts/check-files
+	scripts/check-rpaths-worker
+	scripts/find-debuginfo.sh
  	tests/Makefile
  	plugins/Makefile
 	python/setup.py

--- a/macros.in
+++ b/macros.in
@@ -782,7 +782,7 @@ package or when debugging this package.\
   RPM_PACKAGE_VERSION=\"%{VERSION}\"\
   RPM_PACKAGE_RELEASE=\"%{RELEASE}\"\
   export RPM_PACKAGE_NAME RPM_PACKAGE_VERSION RPM_PACKAGE_RELEASE\
-  LANG=C\
+  LANG=@C_LOCALE@\
   export LANG\
   unset CDPATH DISPLAY ||:\
   %{?buildroot:RPM_BUILD_ROOT=\"%{u2p:%{buildroot}}\"\
@@ -1060,7 +1060,7 @@ package or when debugging this package.\
 #	%{perl_sitearch}/Image
 #	%dir %{perl_sitearch}/auto/Image
 #
-%requires_eq()	%(LC_ALL="C" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
+%requires_eq()	%(LC_ALL="@C_LOCALE@" echo '%*' | xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
 %perl_sitearch	%(eval "`%{__perl} -V:installsitearch`"; echo $installsitearch)
 %perl_sitelib	%(eval "`%{__perl} -V:installsitelib`"; echo $installsitelib)
 %perl_vendorarch %(eval "`%{__perl} -V:installvendorarch`"; echo $installvendorarch)

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -846,8 +846,8 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
     t = setlocale(LC_CTYPE, NULL);
     if (t)
     	old_ctype = xstrdup(t);
-    (void) setlocale(LC_COLLATE, "C");
-    (void) setlocale(LC_CTYPE, "C");
+    (void) setlocale(LC_COLLATE, C_LOCALE);
+    (void) setlocale(LC_CTYPE, C_LOCALE);
 #endif
 	
     if (av != NULL)

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -128,7 +128,7 @@ rpm	alias --filetriggers --filetriggerscripts \
 	--POPTdesc=$"list filetrigger scriptlets from package(s)"
 
 rpm	alias --last --qf '%|INSTALLTIME?{%{INSTALLTIME}}:{000000000}| %{NVRA} %|INSTALLTIME?{%{INSTALLTIME:date}}:{(not installed)}|\n' \
-	--pipe "LC_NUMERIC=C sort -r -n | sed 's,^[0-9]\+ ,,' | awk '{printf(\"%-45s %-s\n\", $1, substr($0,length($1)+2))}' " \
+	--pipe "LC_NUMERIC=@C_LOCALE@ sort -r -n | sed 's,^[0-9]\+ ,,' | awk '{printf(\"%-45s %-s\n\", $1, substr($0,length($1)+2))}' " \
 	--POPTdesc=$"list package(s) by install time, most recent first"
 
 rpm	alias --dupes   --qf '%|SOURCERPM?{%{name}.%{arch}}:{%|ARCH?{%{name}}:{%{name}-%{version}}|}|\n' --pipe "sort | uniq -d" \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,10 +9,10 @@ EXTRA_DIST = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-shared brp-strip-static-archive \
-	check-files check-prereqs \
-	check-buildroot check-rpaths check-rpaths-worker \
+	check-files.in check-prereqs \
+	check-buildroot.in check-rpaths check-rpaths-worker.in \
 	debuginfo.prov \
-	find-debuginfo.sh find-lang.sh \
+	find-debuginfo.sh.in find-lang.sh \
 	perl.prov perl.req pythondeps.sh pythondistdeps.py \
 	rpmdb_loadcvt rpm.daily rpm.log rpm.supp rpm2cpio.sh \
 	tgpg vpkg-provides.sh \

--- a/scripts/check-buildroot.in
+++ b/scripts/check-buildroot.in
@@ -28,7 +28,7 @@ trap "rm -f $tmp" EXIT
 find "$RPM_BUILD_ROOT" \! \( \
     -name '*.pyo' -o -name '*.pyc' -o -name '*.elc' -o -name '.packlist' \
     \) -type f -print0 | \
-    LANG=C xargs -0r grep -F "$RPM_BUILD_ROOT" >$tmp
+    LANG=@C_LOCALE@ xargs -0r grep -F "$RPM_BUILD_ROOT" >$tmp
 
 test -s "$tmp" && {
     cat "$tmp"

--- a/scripts/check-files.in
+++ b/scripts/check-files.in
@@ -27,6 +27,6 @@ trap "rm -f \"${FILES_DISK}\"" 0 2 3 5 10 13 15
 
 # Find non-directory files in the build root and compare to the manifest.
 # TODO: regex chars in last sed(1) expression should be escaped
-find "${RPM_BUILD_ROOT}" -type f -o -type l | LC_ALL=C sort > "${FILES_DISK}"
-LC_ALL=C sort | diff -d "${FILES_DISK}" - | sed -n 's|^< '"${RPM_BUILD_ROOT}"'\(.*\)$|   \1|gp'
+find "${RPM_BUILD_ROOT}" -type f -o -type l | LC_ALL=@C_LOCALE@ sort > "${FILES_DISK}"
+LC_ALL=@C_LOCALE@ sort | diff -d "${FILES_DISK}" - | sed -n 's|^< '"${RPM_BUILD_ROOT}"'\(.*\)$|   \1|gp'
 

--- a/scripts/check-rpaths-worker.in
+++ b/scripts/check-rpaths-worker.in
@@ -97,8 +97,8 @@ old_IFS=$IFS
 
 for i; do
     pos=0
-    rpath=$(readelf -d "$i" 2>/dev/null | LANG=C grep '(RPATH).*:') || continue
-    rpath=$(echo "$rpath" | LANG=C sed -e 's!.*(RPATH).*: \[\(.*\)\]!\1!p;d')
+    rpath=$(readelf -d "$i" 2>/dev/null | LANG=@C_LOCALE@ grep '(RPATH).*:') || continue
+    rpath=$(echo "$rpath" | LANG=@C_LOCALE@ sed -e 's!.*(RPATH).*: \[\(.*\)\]!\1!p;d')
     tmp=aux:$rpath:/lib/aux || :
     IFS=:
     set -- $tmp

--- a/scripts/find-debuginfo.sh.in
+++ b/scripts/find-debuginfo.sh.in
@@ -545,7 +545,7 @@ if [ -s "$SOURCEFILE" ]; then
   # e.g. <internal>, <built-in>, <__thread_local_inner macros>.
   # Some compilers generate them as if they are part of the working
   # directory (which is why we match against ^ or /).
-  LC_ALL=C sort -z -u "$SOURCEFILE" | grep -E -v -z '(^|/)<[a-z _-]+>$' |
+  LC_ALL=@C_LOCALE@ sort -z -u "$SOURCEFILE" | grep -E -v -z '(^|/)<[a-z _-]+>$' |
   (cd "${debug_base_name}"; cpio -pd0mL "${RPM_BUILD_ROOT}${debug_dest_name}")
   # stupid cpio creates new directories in mode 0700,
   # and non-standard modes may be inherented from original directories, fixup
@@ -633,7 +633,7 @@ if ((nout > 0)); then
   # Now add the right %dir lines to each output list.
   (cd "${RPM_BUILD_ROOT}"; find usr/lib/debug -type d) |
   sed 's#^.*$#\\@^/&/@{h;s@^.*$@%dir /&@p;g;}#' |
-  LC_ALL=C sort -ur > "${LISTFILE}.dirs.sed"
+  LC_ALL=@C_LOCALE@ sort -ur > "${LISTFILE}.dirs.sed"
   i=0
   while ((i < nout)); do
     sed -n -f "${LISTFILE}.dirs.sed" "${outs[$i]}" | sort -u > "${outs[$i]}.new"


### PR DESCRIPTION
Since some distributions ship a glibc with support for the C.UTF-8 locale.  This commit adds a check in configure for it and sets it as a default if it is available on the system.

There are more and more applications coming up, which imply support for UTF-8 encoding present in the runtime enviroment, during tests for instance.  So rpm should provide support for such cases out of the box.  And since the new C.UTF-8 locale is fully backwards compatible with the tradional ASCII-based C locale, there are no incompatibilities to expect.

If there is no support for this new locale, e.g. not using a glibc version having it present, we keep the old C locale by default.