### PR TITLE
Do not store digests of ghost files

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1169,7 +1169,7 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	}
 	
 	buf[0] = '\0';
-	if (S_ISREG(flp->fl_mode))
+	if (S_ISREG(flp->fl_mode) && !(flp->flags & RPMFILE_GHOST))
 	    (void) rpmDoDigest(digestalgo, flp->diskPath, 1, 
 			       (unsigned char *)buf, NULL);
 	headerPutString(h, RPMTAG_FILEDIGESTS, buf);


### PR DESCRIPTION
Do not store digests of ghost files
when the files exist during build time.
The hash will never be used for verification anyway.

This helps making packages build more reproducibly.

To test use
```
echo $RANDOM > %{buildroot}/var/cache/ghostfile
%files
%ghost /var/cache/ghostfile
```
and check with `rpm -qp --dump $RPM`