### PR TITLE
Override ghost+dir filesizes

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1112,6 +1112,9 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	headerPutString(h, RPMTAG_FILEGROUPNAME,
 			rpmstrPoolStr(fl->pool, flp->gname));
 
+	if((flp->flags & RPMFILE_GHOST) || S_ISDIR(flp->fl_mode)) {
+	    flp->fl_size = 128*1024; // pessimistic constant to allow reproducible rpms
+	}
 	/* Only use 64bit filesizes tag if required. */
 	if (fl->largeFiles) {
 	    rpm_loff_t rsize64 = (rpm_loff_t)flp->fl_size;


### PR DESCRIPTION
for directories and ghost files we do not want to
record their size in binary rpms
to make builds more reproducible.

See https://reproducible-builds.org/ for why this matters.

Note: I'm not sure if this is the best/correct way to do this, but at least it made the packages build bit-identical where they did not before.

To test add to %install section:
```
cd %{buildroot}/some/packaged/dir
for i in $(seq 1 $RANDOM) ; do touch xxx$i ; done
rm xxx*
```

and check with `rpm -qp --dump $RPM`