### PR TITLE
fix path to external beecrypt include dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,7 @@ if test "$with_crypto" = beecrypt ; then
     ],[
       AC_MSG_ERROR([missing required library 'beecrypt'])
     ])
+    WITH_BEECRYPT_INCLUDE="-I${includedir}/beecrypt"
     AC_CHECK_HEADER([beecrypt/api.h], [AC_DEFINE(HAVE_BEECRYPT_API_H, 1, [Define to 1 if you have the <beecrypt/api.h> header file.])
     ])
   fi


### PR DESCRIPTION
beecrypt are storing headers under /usr/include/beecrypt by default (which is also where the configure.ac check looks for as well), but while passing internal beecrypt build to default header search path, it fails to do so for external beecrypt (ie. -I/usr/include/beecrypt).

