### PR TITLE
Add support for new package declarations in Perl 5.12+

### DIFF
--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -129,9 +129,9 @@ sub process_file {
     # package name so we report all namespaces except some common
     # false positives as if they were provided packages (really ugly).
 
-    if (m/^\s*package\s+([_:a-zA-Z0-9]+)\s*;/) {
+    if (m/^\s*package\s+([_:a-zA-Z0-9]+)\s*(?:v?([0-9_.]+)\s*)?[;{]/) {
       $package = $1;
-      undef $version;
+      $version = $2;
       if ($package eq 'main') {
         undef $package;
       } else {
@@ -139,7 +139,7 @@ sub process_file {
         # the package definition is broken up over multiple blocks.
         # In that case, don't stomp a previous $VERSION we might have
         # found.  (See BZ#214496.)
-        $require{$package} = undef unless (exists $require{$package});
+        $require{$package} = $version unless (exists $require{$package});
       }
     }
 


### PR DESCRIPTION
This is a [patch](https://build.opensuse.org/package/view_file/Base:System/rpm/perlprov-package.diff) we apply to rpm in openSUSE. It allows the `perl.prov` script to detect new variants of Perl package declarations that have been added in recent years.

In [Perl 5.12](https://metacpan.org/pod/distribution/perl/pod/perl5120delta.pod#New-package-NAME-VERSION-syntax) we got version numbers as part of the package declaration.
```perl
package Foo 1.0;

package Bar v1.0.0;
```

And in [Perl 5.14](https://metacpan.org/pod/distribution/perl/pod/perl5140delta.pod#package-block-syntax) we got the package block syntax.
```perl
package Foo {...}

package Bar 1.0 {...}

package Baz v1.0.0 {...}
```

We noticed this problem recently because [Dist::Zilla](https://metacpan.org/source/RJBS/Dist-Zilla-6.009/lib/Dist/Zilla.pm#L1), a popular Perl module, started using a version number as part of the package declaration and `perl(Dist::Zilla)` could no longer be resolved.