### PR TITLE
Fix fakechroot wrong URL.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -179,7 +179,7 @@ and then install with:
     make install
 
 Rpm comes with an automated self-test suite. The test-suite relies heavily
-on fakechroot (https://github.com/fakechroot/) and cannot be executed
+on fakechroot (https://github.com/dex4er/fakechroot/) and cannot be executed
 without it. Provided that fakechroot was found during configure,
 it can be executed after a successful build with:
 


### PR DESCRIPTION
Rename old `fakechrrot` URL in `INSTALL`.
This closes https://github.com/rpm-software-management/rpm/issues/243

http://pkgs.fedoraproject.org/cgit/rpms/fakechroot.git/tree/fakechroot.spec
> URL:            https://github.com/dex4er/fakechroot
