### PR TITLE
Return error exit status when make check is failed.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -138,7 +138,7 @@ check_DATA += testing$(bindir)/rpmbuild
 
 if HAVE_FAKECHROOT
 check-local: $(check_DATA)
-	$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS) ||:
+	$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS)
 else
 check-local:
 	echo "you need to have fakechroot installed"


### PR DESCRIPTION
Right now `make check` returns success exit status: 0 when the tests are failed.

```
$ make check
...
## ------------- ##
## Test results. ##
## ------------- ##

ERROR: All 358 tests were run,
21 failed (2 expected failures).
## ------------------------- ##
## rpmtests.log was created. ##
## ------------------------- ##
...
```

```
$ echo $?
0
```

Because the logic to succeed forcely is added below commit.
But I think that it is not good. Because we can not detect failed tests for example in `rpm.spec` check section.

https://github.com/rpm-software-management/rpm/commit/52bc67436f5bc28d2bd08a9fd3498cf16d5817bb

After this modification, `make check` returns error exit status.

```
$ make check
...
## ------------- ##
## Test results. ##
## ------------- ##  

ERROR: All 358 tests were run,
21 failed (2 expected failures).
## ------------------------- ##
## rpmtests.log was created. ##
## ------------------------- ##
...
```

```
$ echo $?
2
```
