### PR TITLE
Build scriptlets handling: pass exit status of last execution regardless

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -798,7 +798,7 @@ package or when debugging this package.\
 
 
 #%___build_body		%{nil}
-%___build_post		exit 0
+%___build_post		exit $?
 
 %___build_template	#!%{___build_shell}\
 %{___build_pre}\


### PR DESCRIPTION
Since the introduction of "errexit" option of build-scriptlets-handling
(covering mainly prep, build, install, and check phases) shell execution
(sh -e) in d9a3f08d8, it was also for some undocumented reasons
accompanied with "exit 0" enforced scriptlet epilogue, now in the form
of ___build_post macro.

Per POSIX specification[1] (and using the terms devises), these two
provisions combined provide mostly the desired bail-out-ready execution
behaviour for:

- simple command
- last command in an AND-OR list

i.e., when these fail (non-zero exit status), the shell itself in turn
exits, carrying the exit status through its boundary, consequently
failing rpmbuild process as such.

Where such a propagation does _not_ occur and why does the behaviour
leave more to be desired, is a matter of the latter "exit 0" construct.
Generally, there are structured shell commands not compatible with
that bail-out-ready execution principle, like:

- all commands but last in an AND-OR list

even though these still can leave non-zero status behind, so yet one
would expect the equal expressivity with the former group if run at
the very end of the scriptlet.  Unfortunately, this is effectively
prevented with that "exit 0" tail appended to the scriptlet body.

We could redefine ___build_post macro as "%{nil}", but that would drop
the useful feedback for debugging (e.g. build.log from koji Fedora's
build system), hence let it just simply handover the last exit status
of the executing environment prior to that point (implicit zero if
nothing was executed).

Motivation example:

> %check
> { ./run-tests && touch .CHECKED; } | sed -n '/^test/p'
> [ -f .CHECKED ] && rm -f -- .CHECKED

When ./run-tests returns non-zero exit status and hence the second line,
when executed, also leaves non-zero exit status behind
- prior to this change:
  second line will not fail the run (the test subcommand is not the
  last command in an AND-OR list for "errexit" option to take effect),
  one would need to, e.g.,  append "|| false" to that line
- after this change:
  second line will fail the run, not because of "errexit" option
  (as explained), but simply because of its non-zero exit status being
  propagated down the road with "exit $?" (as if this last command
  wasn't there at all, but see the argument against complete removal)

[1] http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>