### PR TITLE
Print exit code with rpm -vv (from @n3npq, #195)

### DIFF
--- a/rpmqv.c
+++ b/rpmqv.c
@@ -354,5 +354,7 @@ int main(int argc, char *argv[])
 
     rpmcliFini(optCon);
 
+    rpmlog(RPMLOG_DEBUG, "exit code: %d\n", ec);
+
     return RETVAL(ec);
 }

--- a/rpmqv.c
+++ b/rpmqv.c
@@ -354,7 +354,7 @@ int main(int argc, char *argv[])
 
     rpmcliFini(optCon);
 
-    rpmlog(RPMLOG_DEBUG, "exit code: %d\n", ec);
+    rpmlog(RPMLOG_DEBUG, "Exit status: %d\n", ec);
 
     return RETVAL(ec);
 }


### PR DESCRIPTION
This trivial patch helps diagnose rpm behavior while developing or testing. From @n3npq.

Fixes #195.