### PR TITLE
Correctly detect Transmeta Crusoe as i686

### DIFF
--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -815,6 +815,14 @@ static inline int RPMClass(void)
 	
 	cpu = (tfms>>8)&15;
 	
+	if (cpu == 5
+	    && cpuid_ecx(0) == '68xM'
+	    && cpuid_edx(0) == 'Teni'
+	    && (cpuid_edx(1) & ((1<<8)|(1<<15))) == ((1<<8)|(1<<15))) {
+		sigaction(SIGILL, &oldsa, NULL);
+		return 6;	/* has CX8 and CMOV */
+	}
+
 	sigaction(SIGILL, &oldsa, NULL);
 
 #define USER686 ((1<<4) | (1<<8) | (1<<15))

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1111,6 +1111,12 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 #		endif
 #	endif
 
+#if defined(__linux__)
+	/* in linux, lets rename parisc to hppa */
+	if (rstreq(un.machine, "parisc"))
+	    strcpy(un.machine, "hppa");
+#endif
+
 #	if defined(__hpux) && defined(_SC_CPU_VERSION)
 	{
 #	    if !defined(CPU_PA_RISC1_2)


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=52713 (private bug)

_Another one from SUSE_