### PR TITLE
macros: add %_rpmmacrodir

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -146,6 +146,8 @@
 #
 #	The directory where rpm's configuration and scripts live
 %_rpmconfigdir		%{getconfdir}
+#       The directory where rpm's macro files live
+%_rpmmacrodir		%{_rpmconfigdir}/macros.d
 
 #	The directory where sources/patches will be unpacked and built.
 %_builddir		%{_topdir}/BUILD


### PR DESCRIPTION
It has been used in redhat-rpm-config for long time and some
packages depend on it (though without `_` prefix).

It's just more convenient than writing %{_rpmconfigdir}/macros.d/...

Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>