### PR TITLE
Do not hardcode "lib/rpm" as the installation path for default config…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1005,7 +1005,7 @@ else
     usrprefix=$prefix
 fi
 
-RPMCONFIGDIR="`echo ${usrprefix}/lib/rpm`"
+RPMCONFIGDIR="`echo ${datadir}/rpm`"
 AC_SUBST(RPMCONFIGDIR)
 
 AC_SUBST(OBJDUMP)

--- a/macros.in
+++ b/macros.in
@@ -942,7 +942,7 @@ package or when debugging this package.\
 %_sharedstatedir	%{_prefix}/com
 %_localstatedir		%{_prefix}/var
 %_lib			lib
-%_libdir		%{_exec_prefix}/%{_lib}
+%_libdir		@libdir@
 %_includedir		%{_prefix}/include
 %_infodir		%{_datadir}/info
 %_mandir		%{_datadir}/man

--- a/rpm.am
+++ b/rpm.am
@@ -1,10 +1,8 @@
 # Internal binaries
-## HACK: It probably should be $(libexecdir)/rpm or $(libdir)/rpm
-rpmlibexecdir = $(prefix)/lib/rpm
+rpmlibexecdir = $(libexecdir)/rpm
 
 # Host independent config files
-## HACK: it probably should be $(datadir)/rpm
-rpmconfigdir = $(prefix)/lib/rpm
+rpmconfigdir = $(datadir)/rpm
 
 # Libtool version (current-revision-age) for all our libraries
 rpm_version_info = 7:0:0


### PR DESCRIPTION
…uration and macros.

This can be named in various different ways, especially in cross-compilation
environments, so let's take it from the build setup.