### PR TITLE
find-debuginfo.sh: Remove non-allocated NOBITS sections from minisymtab.

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -247,12 +247,16 @@ add_minidebug()
   local mini_debuginfo=`mktemp`
 
   # In the minisymtab we don't need the .debug_ sections (already removed
-  # by -S) but also not any other non-allocated PROGBITS or NOTE sections.
+  # by -S) but also not other non-allocated PROGBITS, NOTE or NOBITS sections.
   # List and remove them explicitly. We do want to keep the allocated,
   # symbol and NOBITS sections so cannot use --keep-only because that is
   # too aggressive. Field $2 is the section name, $3 is the section type
   # and $8 are the section flags.
-  local remove_sections=`readelf -W -S "$debuginfo" | awk '{ if (index($2,".debug_") != 1 && ($3 == "PROGBITS" || $3 == "NOTE") && index($8,"A") == 0) printf "--remove-section "$2" " }'`
+  local remove_sections=`readelf -W -S "$debuginfo" \
+	| awk '{ if (index($2,".debug_") != 1 \
+		     && ($3 == "PROGBITS" || $3 == "NOTE" || $3 == "NOBITS") \
+		     && index($8,"A") == 0) \
+		   printf "--remove-section "$2" " }'`
 
   # Extract the dynamic symbols from the main binary, there is no need to also have these
   # in the normal symbol table


### PR DESCRIPTION
In the minisymtab section (the .gnu_debugdata embedded ELF image) we
do not need unallocated sections (except for the SYMTAB and STRTAB
sections we are creating). We already remove PROGBITS and NOTES. Also
remove NOBITS sections. They should not really take up much (any) space
but they still add to the section tables. These sections might be created
with the new --keep-section support (which puts the actual section in
the main ELF binary, and a NOBITS variant in the .debug file).

Also binutils objcopy seems to sometimes add them anyway filled with
zeros instead of marking them NOBITS.

Signed-off-by: Mark Wielaard <mark@klomp.org>

(this is same patch as posted to mailing list, sending it here since now we have CI)