### PR TITLE
replaceSigDigests is only used with IMAEVM.

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -469,6 +469,7 @@ static void unloadImmutableRegion(Header *hdrp, rpmTagVal tag)
     }
 }
 
+#ifdef WITH_IMAEVM
 static rpmRC replaceSigDigests(FD_t fd, const char *rpm, Header *sigp,
 			       off_t sigStart, off_t sigTargetSize,
 			       char *SHA256, char *SHA1, uint8_t *MD5)
@@ -516,6 +517,7 @@ static rpmRC replaceSigDigests(FD_t fd, const char *rpm, Header *sigp,
 exit:
     return rc;
 }
+#endif
 
 static rpmRC includeFileSignatures(FD_t fd, const char *rpm,
 				   Header *sigp, Header *hdrp,


### PR DESCRIPTION
The replaceSigDigests function is only used in includeFileSignatures
when WITH_IMAEVM is defined. If not warning is generated.

Signed-off-by: Mark Wielaard <mark@klomp.org>

(this is same patch as posted to mailing list, sending it here since now we have CI)