### PR TITLE
find-debuginfo.sh: make sure that debugsourcefiles.list is generated …

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -566,6 +566,7 @@ if [ -d "${RPM_BUILD_ROOT}/usr/lib" -o -d "${RPM_BUILD_ROOT}/usr/src" ]; then
 fi
 
 if [ -n "$srcout" ]; then
+  srcout="$BUILDDIR/$srcout"
   > "$srcout"
   if [ -d "${RPM_BUILD_ROOT}/usr/src/debug" ]; then
     (cd "${RPM_BUILD_ROOT}/usr"


### PR DESCRIPTION
…under the builddir

The %_debugsource_template expects the debugsourcefiles.list file
to be in the (current) build dir. Make sure that is always the case
even if find-debuginfo.sh was invoked in a different (sub) directory
by prepending $BUILDDIR to the output file as written in description
"All file names in switches are relative to builddir (. if not given).".

Closes: https://github.com/rpm-software-management/rpm/issues/279
Based-on-patch-by: Mark Wielaard <mark@klomp.org>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>