### PR TITLE
fix couple of memory leaks in rpmbuild

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2542,6 +2542,7 @@ static rpmRC processPackageFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	if (generateBuildIDs (&fl, &idFiles) != 0) {
 	    rpmlog(RPMLOG_ERR, _("Generating build-id links failed\n"));
 	    fl.processingFailed = 1;
+	    argvFree(idFiles);
 	    goto exit;
 	}
 
@@ -2549,6 +2550,7 @@ static rpmRC processPackageFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	    resetPackageFilesDefaults (&fl, pkgFlags);
 	    addPackageFileList (&fl, pkg, &idFiles, NULL, NULL, 0);
 	}
+	argvFree(idFiles);
 
 	if (fl.processingFailed)
 	    goto exit;
@@ -2884,6 +2886,7 @@ static void filterDebuginfoPackage(rpmSpec spec, Package pkg,
 	}
 	path = _free(path);
     }
+    rpmfiFree(fi);
     /* Exclude debug files for files which were excluded in respective non-debug package */
     for (ARGV_const_t excl = pkg->fileExcludeList; excl && *excl; excl++) {
         const char *name = *excl;


### PR DESCRIPTION
```
==9077== 336 (40 direct, 296 indirect) bytes in 1 blocks are definitely lost in loss record 32 of 37
==9077==    at 0x4C31C15: realloc (vg_replace_malloc.c:785)
==9077==    by 0x57575B7: rrealloc (rpmmalloc.c:65)
==9077==    by 0x574FEE2: argvAdd (argv.c:138)
==9077==    by 0x4E45C8E: addNewIDSymlink (files.c:1705)
==9077==    by 0x4E4B946: generateBuildIDs (files.c:1969)
==9077==    by 0x4E4B946: processPackageFiles (files.c:2542)
==9077==    by 0x4E4B946: processBinaryFiles (files.c:3076)
==9077==    by 0x4E44180: buildSpec (build.c:262)
==9077==    by 0x402E6E: buildForTarget.constprop.1 (rpmbuild.c:517)
==9077==    by 0x4030CA: build.constprop.0 (rpmbuild.c:550)
==9077==    by 0x4020AA: main (rpmbuild.c:697)
==9077==
==9077== 487 (48 direct, 439 indirect) bytes in 1 blocks are definitely lost in loss record 33 of 37
==9077==    at 0x4C31C15: realloc (vg_replace_malloc.c:785)
==9077==    by 0x57575B7: rrealloc (rpmmalloc.c:65)
==9077==    by 0x574FEE2: argvAdd (argv.c:138)
==9077==    by 0x4E45C8E: addNewIDSymlink (files.c:1705)
==9077==    by 0x4E4BB74: generateBuildIDs (files.c:2015)
==9077==    by 0x4E4BB74: processPackageFiles (files.c:2542)
==9077==    by 0x4E4BB74: processBinaryFiles (files.c:3076)
==9077==    by 0x4E44180: buildSpec (build.c:262)
==9077==    by 0x402E6E: buildForTarget.constprop.1 (rpmbuild.c:517)
==9077==    by 0x4030CA: build.constprop.0 (rpmbuild.c:550)
==9077==    by 0x4020AA: main (rpmbuild.c:697)
==9077==
==9077== 149,066 (144 direct, 148,922 indirect) bytes in 2 blocks are definitely lost in loss record 37 of 37
==9077==    at 0x4C31A1E: calloc (vg_replace_malloc.c:711)
==9077==    by 0x575757E: rcalloc (rpmmalloc.c:55)
==9077==    by 0x509FCEE: initIter (rpmfi.c:1684)
==9077==    by 0x4E4A611: filterDebuginfoPackage (files.c:2831)
==9077==    by 0x4E4A611: processBinaryFiles (files.c:3080)
==9077==    by 0x4E44180: buildSpec (build.c:262)
==9077==    by 0x402E6E: buildForTarget.constprop.1 (rpmbuild.c:517)
==9077==    by 0x4030CA: build.constprop.0 (rpmbuild.c:550)
==9077==    by 0x4020AA: main (rpmbuild.c:697)
```

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>