### PR TITLE
digest_openssl: return failure if setting key failed

### DIFF
--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -550,6 +550,7 @@ static int constructDSASigningKey(struct pgpDigKeyDSA_s *key)
 
     if (!DSA_set0_key(dsa, key->y, NULL)) {
         rc = 0;
+        goto done;
     }
 
     key->dsa_key = dsa;


### PR DESCRIPTION
```
digest_openssl.c:552:9: warning: Value stored to 'rc' is never read
        rc = 0;
        ^    ~
```

Acked-by: Stephen Gallagher <sgallagh@redhat.com>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>