### PR TITLE
Do not hardcode "lib/rpm" as the installation path for default configuration and macros.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1005,7 +1005,7 @@ else
     usrprefix=$prefix
 fi
 
-RPMCONFIGDIR="`echo ${usrprefix}/lib/rpm`"
+RPMCONFIGDIR="`echo ${libdir}/rpm`"
 AC_SUBST(RPMCONFIGDIR)
 
 AC_SUBST(OBJDUMP)

--- a/rpm.am
+++ b/rpm.am
@@ -1,10 +1,8 @@
 # Internal binaries
-## HACK: It probably should be $(libexecdir)/rpm or $(libdir)/rpm
-rpmlibexecdir = $(prefix)/lib/rpm
+rpmlibexecdir = $(libdir)/rpm
 
 # Host independent config files
-## HACK: it probably should be $(datadir)/rpm
-rpmconfigdir = $(prefix)/lib/rpm
+rpmconfigdir = $(libdir)/rpm
 
 # Libtool version (current-revision-age) for all our libraries
 rpm_version_info = 7:0:0


### PR DESCRIPTION
This can be named in various different ways, especially in cross-compilation
environments, so let's take it from the build setup.

This is a much simpler and less invasive version of an earlier patch: it simply changes references to $(prefix)/lib/rpm, so that they become $(libdir)/rpm. Hopefully this is less controversial or problematic.