### PR TITLE
Platform Python Changes

### DIFF
--- a/scripts/brp-python-bytecompile
+++ b/scripts/brp-python-bytecompile
@@ -57,9 +57,15 @@ EOF
 # and below /usr/lib/python3.1/, we're targeting /usr/bin/python3.1
 
 shopt -s nullglob
-for python_libdir in `find "$RPM_BUILD_ROOT" -type d|grep -E "/usr/lib(64)?/python[0-9]\.[0-9]$"`;
+for python_libdir in `find "$RPM_BUILD_ROOT" -type d|grep -E "/usr/lib(64)?/(platform-)?python[0-9]\.[0-9]$"`;
 do
-	python_binary=/usr/bin/$(basename $python_libdir)
+	python_basename=$(basename $python_libdir)
+	if [[ $python_basename == platform* ]];
+	then
+		python_binary=/usr/libexec/$python_basename
+	else
+		python_binary=/usr/bin/$python_basename
+	fi
 	real_libdir=${python_libdir/$RPM_BUILD_ROOT/}
 	echo "Bytecompiling .py files below $python_libdir using $python_binary"
 
@@ -88,14 +94,14 @@ if [ ! -x "$default_python" ]; then
 fi
 
 # Generate normal (.pyc) byte-compiled files.
-python_bytecompile "" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
+python_bytecompile "" $default_python "/bin/|/sbin/|/usr/lib(64)?/(platform-)?python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
 if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
 	# One or more of the files had a syntax error
 	exit 1
 fi
 
 # Generate optimized (.pyo) byte-compiled files.
-python_bytecompile "-O" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
+python_bytecompile "-O" $default_python "/bin/|/sbin/|/usr/lib(64)?/(platform-)?python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
 if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
 	# One or more of the files had a syntax error
 	exit 1

--- a/scripts/pythondeps.sh
+++ b/scripts/pythondeps.sh
@@ -13,8 +13,8 @@ case $1 in
     # generating a line of the form
     #    python(abi) = MAJOR.MINOR
     # (Don't match against -config tools e.g. /usr/bin/python2.6-config)
-    grep "/usr/bin/python.\..$" \
-        | sed -e "s|.*/usr/bin/python\(.\..\)|python(abi) = \1|"
+    egrep '/usr/(bin/|libexec/platform-)python.\..$' \
+        | sed -r -e "s@.*/usr/(bin/|libexec/(platform-))python(.\..)@\2python(abi) = \3@"
     ;;
 -R|--requires)
     shift
@@ -23,8 +23,8 @@ case $1 in
     #    /PATH/OF/BUILDROOT/usr/lib64/pythonMAJOR.MINOR/
     # generating (uniqely) lines of the form:
     #    python(abi) = MAJOR.MINOR
-    grep "/usr/lib[^/]*/python.\../.*" \
-        | sed -e "s|.*/usr/lib[^/]*/python\(.\..\)/.*|python(abi) = \1|g" \
+    egrep '/usr/lib[^/]*/(platform-|)python.\../.*' \
+        | sed -r -e "s@.*/usr/lib[^/]*/(platform-|)python(.\..)/.*@\1python(abi) = \2@g" \
         | sort | uniq
     ;;
 esac


### PR DESCRIPTION
Related to https://fedoraproject.org/wiki/Changes/Platform_Python_Stack

The changes are "backwards compatible" - i.e. it does not break systems without Platform Python. (Except in a rare case when someone would install to /usr/lib(64)?/platform-pythonX.Y without having a Platform Python.)

Not sure if this should go here or remain a Fedora specific patch, however trying here first.