### PR TITLE
[Proposal] Adding style and pytest environment on tox for rpm python bindings module.

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,7 +37,13 @@ RUN dnf -y install \
   pkgconfig \
   /usr/bin/gdb-add-index \
   dwz \
+  python-devel \
+  python3-devel \
+  redhat-rpm-config \
   && dnf clean all
+RUN python3 -m ensurepip \
+    && python3 -m pip install --upgrade pip setuptools \
+    && python3 -m pip install tox
 RUN autoreconf -vfi
 RUN ./configure \
   --with-crypto=openssl \
@@ -47,5 +53,11 @@ RUN ./configure \
   --with-lua \
   --enable-silent-rules
 RUN make
+RUN cd python \
+  && python setup.py build \
+  && python3 setup.py build
+# Install RPM to use /usr/local/lib/rpm/rpmrc in tox test.
+RUN make install
 
-CMD make check; rc=$?; cat tests/rpmtests.log; exit $rc
+CMD make check && pushd python && tox && popd; rc=$?; \
+  cat tests/rpmtests.log; exit $rc

--- a/python/.flake8
+++ b/python/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore =
+    F403, # import * used
+    F405, # variable may be undefined, or defined from star imports
+    F821  # undefined name

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,1 +1,2 @@
 /setup.py
+!.flake8

--- a/python/rpm/__init__.py
+++ b/python/rpm/__init__.py
@@ -7,8 +7,8 @@ accessing RPM from Python. For most usage, call
 the TransactionSet method to get a transaction set (rpmts).
 
 For example:
-	import rpm
-	ts = rpm.TransactionSet()
+    import rpm
+    ts = rpm.TransactionSet()
 
 The transaction set will open the RPM database as needed, so
 in most cases, you do not need to explicitly open the

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -4,6 +4,7 @@ from distutils.core import setup, Extension
 import subprocess
 import os
 
+
 def pkgconfig(what):
     out = []
     cmd = 'pkg-config %s %s' % (what, '@PACKAGE_NAME@')
@@ -12,54 +13,59 @@ def pkgconfig(what):
         out.append(token[2:])
     return out
 
+
 cflags = ['-std=c99', '-Wno-strict-aliasing']
 additional_link_args = []
 
-# See if we're building in-tree
-if os.access('Makefile.am', os.F_OK):
-    cflags.append('-I../include')
-    additional_link_args.extend(['-Wl,-L../rpmio/.libs',
-                                 '-Wl,-L../lib/.libs',
-                                 '-Wl,-L../build/.libs',
-                                 '-Wl,-L../sign/.libs'])
-    os.environ['PKG_CONFIG_PATH'] = '..'
+# See if we're building
+if not os.environ.get('RPM_NO_SEARCH_BUILD_DIR'):
+    top_builddir = '@abs_top_builddir@'
+    cflags.append('-I' + top_builddir + '/include')
 
+    def make_link_arg(dir_name):
+        return '-Wl,-L%s/%s/.libs' % (top_builddir, dir_name)
+
+    link_args = list(map(make_link_arg, [
+        'rpmio',
+        'lib',
+        'build',
+        'sign'
+    ]))
+    additional_link_args.extend(link_args)
+    os.environ['PKG_CONFIG_PATH'] = top_builddir
 
 rpmmod = Extension('rpm._rpm',
-                   sources = [  'header-py.c', 'rpmds-py.c', 'rpmfd-py.c',
-				'rpmfi-py.c', 'rpmii-py.c', 'rpmkeyring-py.c',
-                                'rpmmacro-py.c', 'rpmmi-py.c', 'rpmps-py.c',
-                                'rpmstrpool-py.c', 'rpmfiles-py.c', 
-				'rpmarchive-py.c', 'rpmtd-py.c',
-                                'rpmte-py.c', 'rpmts-py.c', 'rpmmodule.c',
-                             ],
-                   include_dirs = pkgconfig('--cflags'),
-                   libraries = pkgconfig('--libs'),
-                   extra_compile_args = cflags,
-                   extra_link_args = additional_link_args
-                  )
+                   sources=[
+                       'header-py.c', 'rpmds-py.c', 'rpmfd-py.c',
+                       'rpmfi-py.c', 'rpmii-py.c', 'rpmkeyring-py.c',
+                       'rpmmacro-py.c', 'rpmmi-py.c', 'rpmps-py.c',
+                       'rpmstrpool-py.c', 'rpmfiles-py.c',
+                       'rpmarchive-py.c', 'rpmtd-py.c',
+                       'rpmte-py.c', 'rpmts-py.c', 'rpmmodule.c',
+                   ],
+                   include_dirs=pkgconfig('--cflags'),
+                   libraries=pkgconfig('--libs'),
+                   extra_compile_args=cflags,
+                   extra_link_args=additional_link_args)
 
 rpmbuild_mod = Extension('rpm._rpmb',
-                   sources = ['rpmbmodule.c', 'spec-py.c'],
-                   include_dirs = pkgconfig('--cflags'),
-                   libraries = pkgconfig('--libs') + ['rpmbuild'],
-                   extra_compile_args = cflags,
-                   extra_link_args = additional_link_args
-                  )
+                         sources=['rpmbmodule.c', 'spec-py.c'],
+                         include_dirs=pkgconfig('--cflags'),
+                         libraries=pkgconfig('--libs') + ['rpmbuild'],
+                         extra_compile_args=cflags,
+                         extra_link_args=additional_link_args)
 
 rpmsign_mod = Extension('rpm._rpms',
-                   sources = ['rpmsmodule.c'],
-                   include_dirs = pkgconfig('--cflags'),
-                   libraries = pkgconfig('--libs') + ['rpmsign'],
-                   extra_compile_args = cflags,
-                   extra_link_args = additional_link_args
-                  )
+                        sources=['rpmsmodule.c'],
+                        include_dirs=pkgconfig('--cflags'),
+                        libraries=pkgconfig('--libs') + ['rpmsign'],
+                        extra_compile_args=cflags,
+                        extra_link_args=additional_link_args)
 
 setup(name='@PACKAGE_NAME@',
       version='@VERSION@',
       description='Python bindings for @PACKAGE_NAME@',
       maintainer_email='@PACKAGE_BUGREPORT@',
       url='http://www.rpm.org/',
-      packages = ['@PACKAGE_NAME@'],
-      ext_modules= [rpmmod, rpmbuild_mod, rpmsign_mod]
-     )
+      packages=['@PACKAGE_NAME@'],
+      ext_modules=[rpmmod, rpmbuild_mod, rpmsign_mod])

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flake8

--- a/python/tests/test_rpm.py
+++ b/python/tests/test_rpm.py
@@ -1,0 +1,6 @@
+import rpm
+
+
+def test_transaction_set():
+    ts = rpm.TransactionSet()
+    assert ts

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = style,py3,py2
+
+[testenv]
+setenv = LD_LIBRARY_PATH=../rpmio/.libs:../lib/.libs:../build/.libs:../sign/.libs
+deps =
+    -rtest-requirements.txt
+commands =
+    pytest -s -v {posargs} tests
+
+[testenv:style]
+skip_install = true
+deps =
+    -rtest-requirements.txt
+whitelist_externals =
+    bash
+commands =
+    flake8 --version
+    flake8 --show-source --statistics rpm/ tests/ setup.py.in


### PR DESCRIPTION
## Motivation

I want to add style (static code analysis) test and pytest for the python code.
When I did debug the python code for the issue related to library path: https://github.com/rpm-software-management/rpm/issues/130 , I thought adding those was useful.

## Detail

We have tests/rpmpython.at for the rpm python binding.
However I think that using pytest is also good to maintain and customize the detail of the test easily.

The style check for python code is one of the merit to keep the python code clean.

- Style check by `flake8`.
  - I used `flake8` because `flake8` is better than pylint simple style check.
    and it is also used in `rpmlint` project.
  - I used `python/.flake8` as a compromise to warnings from "import *".
    In the future, we can do below style removing the `.flake8` file.
    > http://docs.python-guide.org/en/latest/writing/structure/#modules
    > import modu
    > [...]
    > x = modu.sqrt(4)  # sqrt is visibly part of modu's namespace

- Test for python binding by pytest.
  The test is here `python/tests/test_rpm.py`.
  Right now only 1 test case as a proposal.

- python/setup.py.in
  In the tox test, `pytyhon setup.py build` is run under `/tmp/pip-l2s21mdp-build`.
  So, previous logic to check parent directory's `Makefile.am` file
  does not work in this case.
    
  In the case of that there is no parent directory for build directory,
  users can build with specifying include and library direcotory.
    
``` 
RPM_NO_SEARCH_BUILD_DIR=1 python3 setup.py build \
  --include-dirs=/path/to/include/ --library-dirs=/path/to/libs/
```

- ci/Dockerfile
  Added the logic to run the pytest and the style test.


## Workflow example

### Build

```
$ ./autogen.sh --noconfigure

$ ./configure --prefix="$(pwd)/dest"

$ make
```

### Build for the python module.

```
$ cd python

$ python setup.py build

$ python3 setup.py build

$ cd ..
```

### Test

```
$ make check
```

### Install

```
$ make install
```

### test for the python bindings.

```
$ tox
```

### Check linked libraries.

```
$ LD_LIBRARY_PATH="$(pwd)/dest/lib" \
ldd python/build/lib.*/rpm/*.so
python/build/lib.linux-x86_64-2.7/rpm/_rpmb.so:
	linux-vdso.so.1 (0x00007ffdd5e68000)
	librpm.so.8 => /home/jaruga/git/rpm/dest/lib/librpm.so.8 (0x00007f6681393000)
	librpmio.so.8 => /home/jaruga/git/rpm/dest/lib/librpmio.so.8 (0x00007f6681164000)
librpmbuild.so.8 => /home/jaruga/git/rpm/dest/lib/librpmbuild.so.8 (0x00007f6680f3a000)
...
```

See https://gist.github.com/junaruga/789866509a21afb32e3c1ab40b48120a to check full result of the `ldd` command.
