### PR TITLE
metainfo.prov: scan /usr/share/metainfo and /usr/share/appdata for bo…

### DIFF
--- a/scripts/metainfo.prov
+++ b/scripts/metainfo.prov
@@ -9,13 +9,9 @@
 OLD_IFS="$IFS"
 while read instfile ; do
 	case "$instfile" in
-	*.appdata.xml)
+	*.appdata.xml|*.metainfo.xml)
 		echo "metainfo()"
-		echo "metainfo(${instfile##*/appdata/})"
-		;;
-	*.metainfo.xml)
-		echo "metainfo()"
-		echo "metainfo(${instfile##*/metainfo/})"
+		echo "metainfo(${instfile##*/})"
 		;;
 	esac
 done


### PR DESCRIPTION
…th types

Directory name doesn't matter, content does. In specification, both
appdata.xml and metainfo.xml should be in /usr/share/metainfo, but
tools should support /usr/share/appdata as for legacy location.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1483644
Reported-by: Petr Pisar <ppisar@redhat.com>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>