### PR TITLE
Add support for 'unless' rich dependencies

### DIFF
--- a/lib/order.c
+++ b/lib/order.c
@@ -189,7 +189,7 @@ static inline int addRelation(rpmts ts,
 	if (rpmdsParseRichDep(requires, &ds1, &ds2, &op, NULL) == RPMRC_OK) {
 	    if (op != RPMRICHOP_ELSE)
 		addRelation(ts, al, p, ds1, reversed);
-	    if (op == RPMRICHOP_IF) {
+	    if (op == RPMRICHOP_IF || op == RPMRICHOP_UNLESS) {
 	      rpmds ds21, ds22;
 	      rpmrichOp op2;
 	      if (rpmdsParseRichDep(requires, &ds21, &ds22, &op2, NULL) == RPMRC_OK && op2 == RPMRICHOP_ELSE) {

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2129,7 +2129,7 @@ static rpmRC updateRichDepCB(void *cbdata, rpmrichParseType type,
 	data->nargv++;
 	_free(name);
     }
-    if (type == RPMRICH_PARSE_OP && op == RPMRICHOP_IF) {
+    if (type == RPMRICH_PARSE_OP && (op == RPMRICHOP_IF || op == RPMRICHOP_UNLESS)) {
 	/* save nargv in case of ELSE */
 	data->nargv_level[data->level - 1] = data->nargv;
 	data->neg ^= 1;
@@ -2146,7 +2146,7 @@ static rpmRC updateRichDepCB(void *cbdata, rpmrichParseType type,
 	}
 	data->neg ^= 1;
     }
-    if (type == RPMRICH_PARSE_LEAVE && op == RPMRICHOP_IF) {
+    if (type == RPMRICH_PARSE_LEAVE && (op == RPMRICHOP_IF || op == RPMRICHOP_UNLESS)) {
 	data->neg ^= 1;
     }
     return RPMRC_OK;

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1380,6 +1380,7 @@ static struct RichOpComp {
     { "and",	 RPMRICHOP_AND},
     { "or",	 RPMRICHOP_OR},
     { "if",	 RPMRICHOP_IF},
+    { "unless",	 RPMRICHOP_UNLESS},
     { "else",	 RPMRICHOP_ELSE},
     { "with",	 RPMRICHOP_WITH},
     { "without", RPMRICHOP_WITHOUT},
@@ -1420,6 +1421,8 @@ const char *rpmrichOpStr(rpmrichOp op)
 	return "or";
     if (op == RPMRICHOP_IF)
 	return "if";
+    if (op == RPMRICHOP_UNLESS)
+	return "unless";
     if (op == RPMRICHOP_ELSE)
 	return "else";
     if (op == RPMRICHOP_WITH)
@@ -1515,7 +1518,7 @@ static rpmRC rpmrichParseInternal(const char **dstrp, char **emsg, rpmrichParseF
         pe = p;
         if (parseRichDepOp(&pe, &op, emsg) != RPMRC_OK)
             return RPMRC_FAIL;
-	if (op == RPMRICHOP_ELSE && chainop == RPMRICHOP_IF)
+	if (op == RPMRICHOP_ELSE && (chainop == RPMRICHOP_IF || chainop == RPMRICHOP_UNLESS))
 	    chainop = 0;
         if (chainop && op != chainop) {
             if (emsg)

--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -461,7 +461,8 @@ typedef enum rpmrichOp_e {
     RPMRICHOP_IF      = 4,
     RPMRICHOP_ELSE    = 5,
     RPMRICHOP_WITH    = 6,
-    RPMRICHOP_WITHOUT = 7
+    RPMRICHOP_WITHOUT = 7,
+    RPMRICHOP_UNLESS  = 8
 } rpmrichOp;
 
 typedef enum rpmrichParseType_e {


### PR DESCRIPTION
An (A unless B) dependency implements (A and not(B)). This kind is useful
for "or" type dependencies, e.g. "Conflicts" or "Supplements".

As "Conflicts: (A unless B)" is equivalent to "Requires: (B if A)", I
thought this type is not needed. But there is no such equivalence
for Supplements, thus the change in mind.

Like with "if" we also have a syntactic sugar "else" flavor:
(A unless B else C) is the same as ((A unless B) or (B and C))

This commit also makes the "else" handling code in depends.c much
easier to understand.