### PR TITLE
Revert "Sync disks at the end of transactions (RhBug:1461765)"

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1607,10 +1607,6 @@ exit:
 	rpmpluginsCallTsmPost(rpmtsPlugins(ts), ts, rc);
 
     /* Finish up... */
-    if (!(rpmtsFlags(ts) & RPMTRANS_FLAG_TEST) && rpmtsNElements(ts) > 0) {
-	rpmlog(RPMLOG_DEBUG, "syncing disks...\n");
-	sync();
-    }
     (void) umask(oldmask);
     (void) rpmtsFinish(ts);
     rpmpsFree(tsprobs);


### PR DESCRIPTION
This reverts commit b7a869f0f322cbe428e78150f2c175abea4c8c4b.

This would need to be at a minimum configurable, and default to off for
compatibility with software like rpm-ostree that is already taking care of all
of this.