### PR TITLE
lib/transaction: Don't SEGV in sync if a txn was failed

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1499,6 +1499,12 @@ static void rpmtsSync(rpmts ts)
 {
     if (rpmChrootDone())
 	return;
+    /* If the txn didn't get as far as calculating disk space,
+     * or disk space warnings are filtered out, assume we
+     * shouldn't sync.
+     */
+    if (!ts->dsi)
+	return;
 
 #if HAVE_SYNCFS
     for (rpmDiskSpaceInfo dsi = ts->dsi; dsi->bsize; dsi++) {


### PR DESCRIPTION
I was actually testing a change to better handle `rpm -e atomic` on Fedora
Atomic Host, wondering why my patch was crashing, but in fact it was the
recently added sync code in master.