### PR TITLE
WIP/RFE: Hint to users to use ostree/rpm-ostree if we get EROFS

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1499,6 +1499,12 @@ static void rpmtsSync(rpmts ts)
 {
     if (rpmChrootDone())
 	return;
+    /* If the txn didn't get as far as calculating disk space,
+     * or disk space warnings are filtered out, assume we
+     * shouldn't sync.
+     */
+    if (!ts->dsi)
+	return;
 
 #if HAVE_SYNCFS
     for (rpmDiskSpaceInfo dsi = ts->dsi; dsi->bsize; dsi++) {


### PR DESCRIPTION
Down the line, it's likely that for rpm-ostree based systems we'll
install an interceptor for `/usr/bin/rpm` to redirect at least things
like local package installs.  There's a lot of work to do for
that, so in the meantime let's help admins out by giving them a
helpful error message.