### PR TITLE
Use setuptools to prevent deprecation message when uninstalling.

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 import subprocess
 import os
 


### PR DESCRIPTION
Right now there is a deprecation message when uninstalling Python bindings.

```
(venv) $ pip list
Package    Version
---------- -------
pip        9.0.1
rpm        4.14.90
setuptools 28.8.0

(venv) $ pip uninstall rpm
DEPRECATION: Uninstalling a distutils installed project (rpm) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.
Uninstalling rpm-4.14.90:
  /home/jaruga/git/rpm/python/venv/lib/python3.6/site-packages/rpm-4.14.90-py3.6.egg-info
Proceed (y/n)? y
  Successfully uninstalled rpm-4.14.90
```

After this modification, there is no deprecation message.

```
(venv) $ pip uninstall rpm
Uninstalling rpm-4.14.90:
  /home/jaruga/git/rpm/python/venv/lib/python3.6/site-packages/rpm-4.14.90-py3.6-linux-x86_64.egg
Proceed (y/n)? y
  Successfully uninstalled rpm-4.14.90
```
