### PR TITLE
Fix Python bindings library path for custom prefix.

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -34,7 +34,8 @@ rpmmod = Extension('rpm._rpm',
                                 'rpmte-py.c', 'rpmts-py.c', 'rpmmodule.c',
                              ],
                    include_dirs = pkgconfig('--cflags'),
-                   libraries = pkgconfig('--libs'),
+                   library_dirs = pkgconfig('--libs-only-L'),
+                   libraries = pkgconfig('--libs-only-l'),
                    extra_compile_args = cflags,
                    extra_link_args = additional_link_args
                   )
@@ -42,7 +43,8 @@ rpmmod = Extension('rpm._rpm',
 rpmbuild_mod = Extension('rpm._rpmb',
                    sources = ['rpmbmodule.c', 'spec-py.c'],
                    include_dirs = pkgconfig('--cflags'),
-                   libraries = pkgconfig('--libs') + ['rpmbuild'],
+                   library_dirs = pkgconfig('--libs-only-L'),
+                   libraries = pkgconfig('--libs-only-l') + ['rpmbuild'],
                    extra_compile_args = cflags,
                    extra_link_args = additional_link_args
                   )
@@ -50,7 +52,8 @@ rpmbuild_mod = Extension('rpm._rpmb',
 rpmsign_mod = Extension('rpm._rpms',
                    sources = ['rpmsmodule.c'],
                    include_dirs = pkgconfig('--cflags'),
-                   libraries = pkgconfig('--libs') + ['rpmsign'],
+                   library_dirs = pkgconfig('--libs-only-L'),
+                   libraries = pkgconfig('--libs-only-l') + ['rpmsign'],
                    extra_compile_args = cflags,
                    extra_link_args = additional_link_args
                   )


### PR DESCRIPTION
This fixes the Python bindings ModuleNotFoundError for custom prefix.
http://lists.rpm.org/pipermail/rpm-maint/2017-September/006568.html

The reason is the Extension class libraries attribute does not accept library file or directory path.

According to
https://docs.python.org/3/distutils/apiref.html
https://docs.python.org/2/distutils/apiref.html
> libraries list of library names (not filenames or paths) to link against


We may close below ticket by this PR.
https://github.com/rpm-software-management/rpm/issues/130


Below is the work flow to check the bug is fixed.

```
$ pwd
/home/jaruga/git/rpm

$ ./autogen.sh --noconfigure

$ ./configure --prefix="$(pwd)/dest"

$ make

$ make install

$ dest/bin/rpm --version
RPM version 4.14.90

$ cd python/

$ which python3
/usr/local/python-3.6.2/bin/python3

$ python3 -m pip list
Package    Version
---------- -------
pip        9.0.1  
setuptools 28.8.0 
wheel      0.30.0 

$ python3 setup.py build

$ sudo /usr/local/python-3.6.2/bin/python3 setup.py install

$ python3 -m pip list
Package    Version
---------- -------
pip        9.0.1  
rpm        4.14.90
setuptools 28.8.0 
wheel      0.30.0 
```

The there was a trap I faced for below command.

`cd ..` is needed to change directory from `rpm/python`.

We should not run below `python3 -c 'import rpm'` in the `rpm/python` directory.

Because the command wrongly check `rpm/python/rpm/__init__.py` to do `import rpm`, it is not installed rpm python bindings' directory.

Thanks @pmatilai . I found it by `strace` command that you recommended me.

Then

```
$ cd ..

$ LD_LIBRARY_PATH=$HOME/git/rpm/dest/lib python3 -c 'import rpm; print(rpm.__version__)'
4.14.90
```

Correctly the library is loaded.

