### PR TITLE
[4.14.x] Forbid 'if' richops in 'or' context and 'unless' richops in 'and' con…

### DIFF
--- a/build/parseReqs.c
+++ b/build/parseReqs.c
@@ -224,7 +224,7 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 	    }
 	    data.spec = spec;
 	    data.sb = newStringBuf();
-	    if (rpmrichParse(&r, &emsg, parseRCPOTRichCB, &data) != RPMRC_OK) {
+	    if (rpmrichParseForTag(&r, &emsg, parseRCPOTRichCB, &data, nametag) != RPMRC_OK) {
 		freeStringBuf(data.sb);
 		goto exit;
 	    }

--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -486,6 +486,17 @@ typedef rpmRC (*rpmrichParseFunction) (void *cbdata, rpmrichParseType type,
  */
 rpmRC rpmrichParse(const char **dstrp, char **emsg, rpmrichParseFunction cb, void *cbdata);
 
+/**
+ * Parse a rich dependency string for a specific tag
+ * @param dstrp		pointer to sting, will be updated
+ * @param emsg		returns the error string, can be NULL
+ * @param cb		callback function
+ * @param cbdata	callback function data
+ * @param tagN		type of dependency
+ * @return		RPMRC_OK on success
+ */
+rpmRC rpmrichParseForTag(const char **dstrp, char **emsg, rpmrichParseFunction cb, void *cbdata, rpmTagVal tagN);
+
 
 /**
  * Return if current depenency is rich


### PR DESCRIPTION
…text

Guide users to the correct operator instead.

(cherry picked from commit 99e6de810904c2b9d32341832f541108c196cc97)