### PR TITLE
Change dbpath from /var/lib/rpm to /usr/lib/rpmdb

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -160,7 +160,7 @@
 %_bzip2bin		%{__bzip2}
 
 #	The location of the rpm database file(s).
-%_dbpath		%{_var}/lib/rpm
+%_dbpath		%{_usr}/lib/rpmdb
 
 #	The location of the rpm database file(s) after "rpm --rebuilddb".
 %_dbpath_rebuild	%{_dbpath}


### PR DESCRIPTION
As discussed in http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html

As there has been no objections yet to the suggestion this might be a suitable new default, here's the change making it the default.
