### PR TITLE
configure: Fix typo for libcrypto usability check for OpenSSL check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -347,7 +347,7 @@ AC_CHECK_LIB(crypto, EVP_MD_CTX_new, [
     AC_DEFINE(HAVE_EVP_MD_CTX_NEW, 1, [Define to 1 if OpenSSL has EVP_MD_CTX_new])
     AC_SUBST(HAVE_EVP_MD_CTX_NEW, [1])
   ], [
-  AC_CHECK_LIB(crypt, EVP_MD_CTX_create, [], [
+  AC_CHECK_LIB(crypto, EVP_MD_CTX_create, [], [
       AC_MSG_ERROR([required OpenSSL library 'libcrypto' missing or too old])
   ])
 ])


### PR DESCRIPTION
The typo in this check prevents rpm for correctly detecting compatibility with OpenSSL 1.0.2.