### PR TITLE
build/files: don't produce warning if file marked as %doc is already …

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1067,9 +1067,9 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	    /* Note that an %exclude is a duplication of a file reference */
 
 	    /* file flags */
-	    flp[1].flags |= flp->flags;	
+	    flp[1].flags |= flp->flags;
 
-	    if (!(flp[1].flags & RPMFILE_EXCLUDE))
+	    if (!(flp[1].flags & (RPMFILE_EXCLUDE | RPMFILE_DOC | RPMFILE_LICENSE)))
 		rpmlog(RPMLOG_WARNING, _("File listed twice: %s\n"),
 			flp->cpioPath);
    


### PR DESCRIPTION
…included

In Rust packaging there is need to have some files (license, doc)
in special location (where the rest of package is) and there is no point
in duplicating files.

Fixes: https://github.com/rpm-software-management/rpm/issues/336
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>