### PR TITLE
Write the content of a file with hard links into the first file

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -269,7 +269,7 @@ exit:
  * Create file from payload stream.
  * @return		0 on success
  */
-static int expandRegular(rpmfi fi, const char *dest, rpmpsm psm, int exclusive, int nodigest, int nocontent)
+static int expandRegular(rpmfi fi, const char *dest, rpmpsm psm, int exclusive, int nodigest)
 {
     FD_t wfd = NULL;
     int rc;
@@ -278,8 +278,7 @@ static int expandRegular(rpmfi fi, const char *dest, rpmpsm psm, int exclusive, 
     if (rc != 0)
         goto exit;
 
-    if (!nocontent)
-	rc = rpmfiArchiveReadToFilePsm(fi, wfd, nodigest, psm);
+    rc = rpmfiArchiveReadToFilePsm(fi, wfd, nodigest, psm);
     wfd_close(&wfd);
 exit:
     return rc;
@@ -311,7 +310,7 @@ static int fsmMkfile(rpmfi fi, const char *dest, rpmfiles files,
        existing) file with content */
     if (numHardlinks<=1) {
 	if (!rc)
-	    rc = expandRegular(fi, dest, psm, 1, nodigest, 0);
+	    rc = expandRegular(fi, dest, psm, 1, nodigest);
     } else if (rpmfiArchiveHasContent(fi)) {
 	if (!rc)
 	    rc = rpmfiArchiveReadToFilePsm(fi, *firstlinkfile, nodigest, psm);

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -238,6 +238,33 @@ static void wfd_close(FD_t *wfdp)
     }
 }
 
+static int wfd_open(FD_t *wfdp, const char *dest, int exclusive)
+{
+    int rc = 0;
+    /* Create the file with 0200 permissions (write by owner). */
+    {
+	mode_t old_umask = umask(0577);
+	*wfdp = Fopen(dest, exclusive ? "wx.ufdio" : "a.ufdio");
+	umask(old_umask);
+
+	/* If reopening, make sure the file is what we expect */
+	if (!exclusive && *wfdp != NULL && !linkSane(*wfdp, dest)) {
+	    rc = RPMERR_OPEN_FAILED;
+	    goto exit;
+	}
+    }
+    if (Ferror(*wfdp)) {
+	rc = RPMERR_OPEN_FAILED;
+	goto exit;
+    }
+
+    return 0;
+
+exit:
+    wfd_close(wfdp);
+    return rc;
+}
+
 /** \ingroup payload
  * Create file from payload stream.
  * @return		0 on success
@@ -245,29 +272,16 @@ static void wfd_close(FD_t *wfdp)
 static int expandRegular(rpmfi fi, const char *dest, rpmpsm psm, int exclusive, int nodigest, int nocontent)
 {
     FD_t wfd = NULL;
-    int rc = 0;
+    int rc;
 
-    /* Create the file with 0200 permissions (write by owner). */
-    {
-	mode_t old_umask = umask(0577);
-	wfd = Fopen(dest, exclusive ? "wx.ufdio" : "a.ufdio");
-	umask(old_umask);
-
-	/* If reopening, make sure the file is what we expect */
-	if (!exclusive && wfd != NULL && !linkSane(wfd, dest)) {
-	    rc = RPMERR_OPEN_FAILED;
-	    goto exit;
-	}
-    }
-    if (Ferror(wfd)) {
-	rc = RPMERR_OPEN_FAILED;
-	goto exit;
-    }
+    rc = wfd_open(&wfd, dest, exclusive);
+    if (rc != 0)
+        goto exit;
 
     if (!nocontent)
 	rc = rpmfiArchiveReadToFilePsm(fi, wfd, nodigest, psm);
-exit:
     wfd_close(&wfd);
+exit:
     return rc;
 }
 

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -287,7 +287,7 @@ exit:
 
 static int fsmMkfile(rpmfi fi, const char *dest, rpmfiles files,
 		     rpmpsm psm, int nodigest, int *setmeta,
-		     int * firsthardlink)
+		     int * firsthardlink, FD_t *firstlinkfile)
 {
     int rc = 0;
     int numHardlinks = rpmfiFNlink(fi);
@@ -296,7 +296,7 @@ static int fsmMkfile(rpmfi fi, const char *dest, rpmfiles files,
 	/* Create first hardlinked file empty */
 	if (*firsthardlink < 0) {
 	    *firsthardlink = rpmfiFX(fi);
-	    rc = expandRegular(fi, dest, psm, 1, nodigest, 1);
+	    rc = wfd_open(firstlinkfile, dest, 1);
 	} else {
 	    /* Create hard links for others */
 	    char *fn = rpmfilesFN(files, *firsthardlink);
@@ -314,7 +314,8 @@ static int fsmMkfile(rpmfi fi, const char *dest, rpmfiles files,
 	    rc = expandRegular(fi, dest, psm, 1, nodigest, 0);
     } else if (rpmfiArchiveHasContent(fi)) {
 	if (!rc)
-	    rc = expandRegular(fi, dest, psm, 0, nodigest, 0);
+	    rc = rpmfiArchiveReadToFilePsm(fi, *firstlinkfile, nodigest, psm);
+	wfd_close(firstlinkfile);
 	*firsthardlink = -1;
     } else {
 	*setmeta = 0;
@@ -881,6 +882,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
     int nodigest = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOFILEDIGEST) ? 1 : 0;
     int nofcaps = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOCAPS) ? 1 : 0;
     int firsthardlink = -1;
+    FD_t firstlinkfile = NULL;
     int skip;
     rpmFileAction action;
     char *tid = NULL;
@@ -952,7 +954,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
             if (S_ISREG(sb.st_mode)) {
 		if (rc == RPMERR_ENOENT) {
 		    rc = fsmMkfile(fi, fpath, files, psm, nodigest,
-				   &setmeta, &firsthardlink);
+				   &setmeta, &firsthardlink, &firstlinkfile);
 		}
             } else if (S_ISDIR(sb.st_mode)) {
                 if (rc == RPMERR_ENOENT) {
@@ -990,7 +992,8 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 	    /* we skip the hard linked file containing the content */
 	    /* write the content to the first used instead */
 	    char *fn = rpmfilesFN(files, firsthardlink);
-	    rc = expandRegular(fi, fn, psm, 0, nodigest, 0);
+	    rc = rpmfiArchiveReadToFilePsm(fi, firstlinkfile, nodigest, psm);
+	    wfd_close(&firstlinkfile);
 	    firsthardlink = -1;
 	    free(fn);
 	}


### PR DESCRIPTION
This series of patches attempts to address the errors we are seeing when installing RPMs that contain hard links and an IMA policy that measures on reading and writing of files. The problem has been explained in issue #333.

The solution is to open the first file that is created empty but now keep the file descriptor to that file open and complete the writing of the file at the last file (hard link) that actually has the file content.