### PR TITLE
RFC: Test for ctermid() existence.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -759,6 +759,7 @@ AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 
 dnl Checks for library functions.
+AC_CHECK_FUNCS(ctermid)
 AC_CHECK_FUNCS(putenv)
 AC_CHECK_FUNCS(mempcpy)
 AC_CHECK_FUNCS(fdatasync)

--- a/luaext/lposix.c
+++ b/luaext/lposix.c
@@ -549,7 +549,13 @@ static int Pttyname(lua_State *L)		/** ttyname(fd) */
 static int Pctermid(lua_State *L)		/** ctermid() */
 {
 	char b[L_ctermid];
+#ifdef HAVE_CTERMID
 	lua_pushstring(L, ctermid(b));
+#else
+	// Use a fixed path that can be open/read/written and should
+	// satisfy simple requests.
+	lua_pushstring(L, "/dev/tty");
+#endif
 	return 1;
 }
 


### PR DESCRIPTION
Test for ctermid() in configure script instead of using OS define.