### PR TITLE
Update Polish plural forms

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -20,9 +20,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
 #: cliutils.c:21 lib/poptI.c:29
 #, c-format


### PR DESCRIPTION
Transifex has wrong plural forms for Polish that they refuse to change.
Now that RPM ditched Transifex, we can fix it.