### PR TITLE
Add runtime_library_dirs for custom prefix.

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -36,6 +36,7 @@ rpmmod = Extension('rpm._rpm',
                    include_dirs = pkgconfig('--cflags'),
                    library_dirs = pkgconfig('--libs-only-L'),
                    libraries = pkgconfig('--libs-only-l'),
+                   runtime_library_dirs = pkgconfig('--libs-only-L'),
                    extra_compile_args = cflags,
                    extra_link_args = additional_link_args
                   )
@@ -45,6 +46,7 @@ rpmbuild_mod = Extension('rpm._rpmb',
                    include_dirs = pkgconfig('--cflags'),
                    library_dirs = pkgconfig('--libs-only-L'),
                    libraries = pkgconfig('--libs-only-l') + ['rpmbuild'],
+                   runtime_library_dirs = pkgconfig('--libs-only-L'),
                    extra_compile_args = cflags,
                    extra_link_args = additional_link_args
                   )
@@ -54,6 +56,7 @@ rpmsign_mod = Extension('rpm._rpms',
                    include_dirs = pkgconfig('--cflags'),
                    library_dirs = pkgconfig('--libs-only-L'),
                    libraries = pkgconfig('--libs-only-l') + ['rpmsign'],
+                   runtime_library_dirs = pkgconfig('--libs-only-L'),
                    extra_compile_args = cflags,
                    extra_link_args = additional_link_args
                   )


### PR DESCRIPTION
Previously we needed to set `LD_LIBRARY_PATH` to run the Python bindings for custom prefix.

```
$ LD_LIBRARY_PATH=$HOME/git/rpm/dest/lib python3 -c 'import rpm; print(rpm.__version__)'
4.14.90
```

This PR to do "import rpm" without LD_LIBRARY_PATH.
Below is the way to reproduce and test it.

This PR is related to https://github.com/rpm-software-management/rpm/pull/327 and https://github.com/rpm-software-management/rpm/issues/130 .

```
$ pwd
/home/jaruga/git/rpm

$ ./autogen.sh --noconfigure
$ ./configure --prefix="$(pwd)/dest"
$ make 
$ make install

$ dest/bin/rpm --version
RPM version 4.14.90

$ cd python/

$ which python3
/usr/local/python-3.6.2/bin/python3

$ python3 -m pip list | grep rpm

$ python3 setup.py build

$ sudo /usr/local/python-3.6.2/bin/python3 setup.py install

$ python3 -m pip list | grep rpm
rpm               4.14.90

$ cd ..

$ python3 -c 'import rpm; print(rpm.__version__)'
4.14.90
```

Ref.
https://docs.python.org/3/distutils/apiref.html
https://docs.python.org/2/distutils/apiref.html
> runtime_library_dirs | list of directories to search for C/C++ libraries at run time (for shared extensions, this is when the extension is loaded)



