### PR TITLE
Fix rpm-misc.8 man page

### DIFF
--- a/doc/rpm-misc.8
+++ b/doc/rpm-misc.8
@@ -1,5 +1,5 @@
-.TH RPM misc options 8
-.SH NAME rpm misc \- lesser need options for rpm(8)
+.TH "RPM misc options" 8
+.SH NAME rpm \- lesser need options for rpm(8)
 
 .SH OPTIONS
 .TP


### PR DESCRIPTION
Follow man page conventions:

- TH has two parameters, second one being section
- NAME should list program name before \-

Sorry, I've made typo in #353.