### PR TITLE
Only fallback to read-only locking for errno==EACCES

### DIFF
--- a/lib/rpmlock.c
+++ b/lib/rpmlock.c
@@ -30,7 +30,7 @@ static rpmlock rpmlock_new(const char *lock_path, const char *descr)
 	(void) umask(oldmask);
 
 	if (lock->fd == -1) {
-	    if (errno != EROFS)
+	    if (errno == EACCES)
 		lock->fd = open(lock_path, O_RDONLY);
 	    if (lock->fd == -1) {
 		free(lock);


### PR DESCRIPTION
instead of for errno!=EROFS.
File creation could be also denied due to ENOSPC, for example.

Errors are generally easier to troubleshoot / debug if we abort early.
It's not so great to throw away e.g. ENOSPC and continue in read-only mode.