### PR TITLE
Fix error message for rpmlock (#355), by removing dead code 

### DIFF
--- a/lib/rpmlock.c
+++ b/lib/rpmlock.c
@@ -21,22 +21,21 @@ struct rpmlock_s {
 
 static rpmlock rpmlock_new(const char *lock_path, const char *descr)
 {
-    rpmlock lock = (rpmlock) malloc(sizeof(*lock));
+    rpmlock lock = (rpmlock) xmalloc(sizeof(*lock));
+    mode_t oldmask;
 
-    if (lock != NULL) {
-	mode_t oldmask = umask(022);
-	lock->fd = open(lock_path, O_RDWR|O_CREAT, 0644);
-	(void) umask(oldmask);
+    oldmask = umask(022);
+    lock->fd = open(lock_path, O_RDWR|O_CREAT, 0644);
+    (void) umask(oldmask);
 
-	if (lock->fd == -1) {
-	    free(lock);
-	    lock = NULL;
-	}
-	if (lock) {
-	    lock->path = xstrdup(lock_path);
-	    lock->descr = xstrdup(descr);
-	    lock->fdrefs = 1;
-	}
+    if (lock->fd == -1) {
+	free(lock);
+	lock = NULL;
+    }
+    if (lock) {
+	lock->path = xstrdup(lock_path);
+	lock->descr = xstrdup(descr);
+	lock->fdrefs = 1;
     }
     return lock;
 }

--- a/lib/rpmlock.h
+++ b/lib/rpmlock.h
@@ -5,12 +5,6 @@
 
 typedef struct rpmlock_s * rpmlock;
 
-enum {
-    RPMLOCK_READ   = 1 << 0,
-    RPMLOCK_WRITE  = 1 << 1,
-    RPMLOCK_WAIT   = 1 << 2,
-};
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
(plus one bonus commit, hope that's ok)

---

rpmlock_acquire() failed to set errno, when it failed to acquire a
write-lock on a lock which was opened as read-only.  errno was printed in
the error message, so the error message was arbitrary.  Typically the
previous errno happened to be the right one, but if STDIN was not a TTY,
then it was not.  (Due to an intervening call to isatty()).

A one-line fix to set errno appropriately would not fix #355.  Because the
appropriate errno for performing write operations on a read-only handle
is EBADF.  This is too generic to tell the user what the real problem is
(i.e. that rpm was run without the necessary privilege to write to the lock
file).

This obstacle would disappear if we could avoid the automatic fallback
from a read-write open() to a read-only open().  It turns out that
rpmlock.h never exported a read-only lock feature, so this was never used.

Remove the code for automatic fallback to read-only and read-only locks.
This makes #355 go away.