### PR TITLE
elfdeps: Add full multiarch deps support

### DIFF
--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,4 +1,4 @@
-%__elf_provides		%{_rpmconfigdir}/elfdeps --provides %{?__filter_GLIBC_PRIVATE:--filter-private}
-%__elf_requires		%{_rpmconfigdir}/elfdeps --requires %{?__filter_GLIBC_PRIVATE:--filter-private}
+%__elf_provides		%{_rpmconfigdir}/elfdeps --provides %{?__filter_GLIBC_PRIVATE:--filter-private} %{?__multiarch_deps:--multiarch-deps}
+%__elf_requires		%{_rpmconfigdir}/elfdeps --requires %{?__filter_GLIBC_PRIVATE:--filter-private} %{?__multiarch_deps:--multiarch-deps}
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
 %__elf_flags		exeonly

--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -18,6 +18,7 @@ int soname_only = 0;
 int fake_soname = 1;
 int filter_soname = 1;
 int require_interp = 0;
+int multiarch_deps = 0;
 
 typedef struct elfInfo_s {
     Elf *elf;
@@ -30,6 +31,7 @@ typedef struct elfInfo_s {
     char *soname;
     char *interp;
     const char *marker;		/* elf class marker or NULL */
+    const char *archmarker;		/* elf arch marker or NULL */
 
     ARGV_t requires;
     ARGV_t provides;
@@ -97,6 +99,102 @@ static const char *mkmarker(GElf_Ehdr *ehdr)
     return marker;
 }
 
+static const char *mkarchmarker(GElf_Ehdr *ehdr)
+{
+    /* Hopefully this is enough for the arch marker */
+    char archmarker[25];
+    const char* elf_machine = NULL;
+    const char* elf_endian = NULL;
+    const char* elf_bitsize = NULL;
+
+    /* First the machine type... */
+    switch (ehdr->e_machine) {
+    case EM_SPARC:
+	elf_machine = "sparc";
+	break;
+    case EM_386:
+    case EM_X86_64:
+	elf_machine = "x86";
+	break;
+    case EM_MIPS:
+	elf_machine = "mips";
+	break;
+    case EM_PPC:
+    case EM_PPC64:
+	elf_machine = "ppc";
+	break;
+    case EM_S390:
+	elf_machine = "s390";
+	break;
+    case EM_ARM:
+	if ((ehdr->e_flags | EF_ARM_ABI_FLOAT_HARD) == EF_ARM_ABI_FLOAT_HARD)
+		elf_machine = "armhfp";
+	if ((ehdr->e_flags | EF_ARM_ABI_FLOAT_SOFT) == EF_ARM_ABI_FLOAT_SOFT)
+		elf_machine = "armsfp";
+	break;
+    case EM_SPARCV9:
+	elf_machine = "sparcv9";
+	break;
+    case EM_ALPHA:
+	elf_machine = "alpha";
+	break;
+    case EM_AARCH64:
+	elf_machine = "aarch";
+	break;
+    case EM_RISCV:
+	elf_machine = "riscv";
+	break;
+    default:
+	break;
+    }
+
+    /* Then the endianness of the CPU... */
+    switch (ehdr->e_ident[EI_DATA]) {
+    case ELFDATA2LSB:
+	elf_endian = "le";
+	break;
+    case ELFDATA2MSB:
+	elf_endian = "be";
+	break;
+    default:
+	break;
+    }
+
+    /* Then the bit size of the CPU... */
+    switch (ehdr->e_ident[EI_CLASS]) {
+    case ELFCLASS64:
+	elf_bitsize = "64";
+	break;
+    case ELFCLASS32:
+	elf_bitsize = "32";
+	break;
+    default:
+	break;
+    }
+
+    /* Finally the arch marker! */
+    switch (ehdr->e_machine) {
+    case EM_MIPS:
+    case EM_ARM:
+    case EM_PPC64:
+	snprintf(archmarker, sizeof(archmarker), "(%s%s-%s)", elf_machine, elf_endian, elf_bitsize);
+	break;
+    case EM_X86_64:
+	/* This handling for x32 makes me weep inside... */
+	if (ehdr->e_ident[EI_CLASS] == ELFCLASS32) {
+	    snprintf(archmarker, sizeof(archmarker), "(%s-%s-%s)", elf_machine, "64", "x32");
+	} else {
+	    snprintf(archmarker, sizeof(archmarker), "(%s-%s)", elf_machine, elf_bitsize);
+	}
+	break;
+    default:
+	snprintf(archmarker, sizeof(archmarker), "(%s-%s)", elf_machine, elf_bitsize);
+	break;
+    }
+
+    return strndup(archmarker, strlen(archmarker));
+}
+
 static void addDep(ARGV_t *deps,
 		   const char *soname, const char *ver, const char *marker)
 {
@@ -146,6 +244,8 @@ static void processVerDef(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 		    continue;
 		} else if (soname && !soname_only && !skipPrivate(s)) {
 		    addDep(&ei->provides, soname, s, ei->marker);
+		    if (multiarch_deps)
+			addDep(&ei->provides, soname, s, ei->archmarker);
 		}
 	    }
 		    
@@ -184,7 +284,10 @@ static void processVerNeed(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 		    break;
 
 		if (ei->isExec && soname && !soname_only && !skipPrivate(s)) {
-		    addDep(&ei->requires, soname, s, ei->marker);
+	    	    if (multiarch_deps)
+		        addDep(&ei->requires, soname, s, ei->archmarker);
+		    else
+		    	addDep(&ei->requires, soname, s, ei->marker);
 		}
 		auxoffset += aux->vna_next;
 	    }
@@ -225,7 +328,10 @@ static void processDynamic(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 		if (ei->isExec) {
 		    s = elf_strptr(ei->elf, shdr->sh_link, dyn->d_un.d_val);
 		    if (s)
-			addDep(&ei->requires, s, NULL, ei->marker);
+	    	        if (multiarch_deps)
+		            addDep(&ei->requires, s, NULL, ei->archmarker);
+		        else
+			    addDep(&ei->requires, s, NULL, ei->marker);
 		}
 		break;
 	    }
@@ -299,6 +405,7 @@ static int processFile(const char *fn, int dtype)
 
     if (ehdr->e_type == ET_DYN || ehdr->e_type == ET_EXEC) {
 	ei->marker = mkmarker(ehdr);
+	ei->archmarker = mkarchmarker(ehdr);
     	ei->isDSO = (ehdr->e_type == ET_DYN);
 	ei->isExec = (st.st_mode & (S_IXUSR|S_IXGRP|S_IXOTH));
 
@@ -324,8 +431,11 @@ static int processFile(const char *fn, int dtype)
 	    const char *bn = strrchr(fn, '/');
 	    ei->soname = rstrdup(bn ? bn + 1 : fn);
 	}
-	if (ei->soname)
+	if (ei->soname) {
 	    addDep(&ei->provides, ei->soname, NULL, ei->marker);
+	    if (multiarch_deps)
+		addDep(&ei->provides, ei->soname, NULL, ei->archmarker);
+	}
     }
 
     /* If requested and present, add dep for interpreter (ie dynamic linker) */
@@ -365,6 +475,7 @@ int main(int argc, char *argv[])
 	{ "no-fake-soname", 0, POPT_ARG_VAL, &fake_soname, 0, NULL, NULL },
 	{ "no-filter-soname", 0, POPT_ARG_VAL, &filter_soname, 0, NULL, NULL },
 	{ "require-interp", 0, POPT_ARG_VAL, &require_interp, -1, NULL, NULL },
+	{ "multiarch-deps", 0, POPT_ARG_VAL, &multiarch_deps, -1, NULL, NULL },
 	POPT_AUTOHELP 
 	POPT_TABLEEND
     };


### PR DESCRIPTION
This changes elfdeps to emit dependency strings that contain full architecture names instead of just declaring whether something is "64bit". This means that systems that allow more than two architectures to be installed on the same computer will actually be able to resolve library dependencies correctly.

This means that RPM dependencies would be compatible with system library install schemes like Debian's, where libraries are installed into subdirectories under `/usr/lib` that are named after the platform triple. It also allows for multiarch installations where foreign architecture packages are automatically relocated to be installed under a system root target location (e.g. `/usr/<triple>/lib(64)`) as is done in distributions like Exherbo.

This behavior can be enabled by passing `--multiarch-deps` or by setting `%__multiarch_deps` to `1` in the spec or vendor configuration.