### PR TITLE
Only destroy lua tables if there are no BASpecs left

### DIFF
--- a/build/spec.c
+++ b/build/spec.c
@@ -308,9 +308,12 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     spec->BANames = _free(spec->BANames);
 
 #ifdef WITH_LUA
+    // only destroy lua tables if there are no BASpecs left
+    if (spec->recursing || spec->BACount == 0) {
     rpmlua lua = NULL; /* global state */
     rpmluaDelVar(lua, "patches");
     rpmluaDelVar(lua, "sources");	
+    }
 #endif
 
     spec->sources = freeSources(spec->sources);


### PR DESCRIPTION
Lua tables *sources* and *patches* are created in `newSpec()` and destroyed in `rpmSpecFree()`.

But in case *BuildArch* processing takes place in `parseSpec()`, the function returns successfully but the tables are already destroyed by [`rpmSpecFree()`](https://github.com/rpm-software-management/rpm/blob/34c2ba3c6a80a778cdf2e42a9193b3264e08e1b3/build/parseSpec.c#L894) that has been called for the original `spec`.