### PR TITLE
Also apply signatures to config files

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -744,6 +744,11 @@ package or when debugging this package.\
 # performance for rotational disks)
 #%_flush_io	0
 
+# Set to 1 to have IMA signatures written also on %config files.
+# Note that %config files may be changed and therefore end up with
+# a wrong or missing signature.
+#%_ima_sign_config_files	0
+
 #
 # Default output format string for rpm -qa
 #


### PR DESCRIPTION
Even though config files may be close to what could be described as
'mutuable files', we now want to install the signatures on these files
as well.  However, we should be aware that the signatures of these
files may become incorrect or missing once RPM post installation scripts
or other programs have modified these configuration files.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com