### PR TITLE
Make configure cope with multiple users/groups with ID 0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -996,8 +996,8 @@ if test "$with_dmalloc" = yes ; then
   LIBS="$LIBS -ldmalloc"
 fi
 
-user_with_uid0=$(awk -F: '$3==0 {print $1}' /etc/passwd)
-group_with_gid0=$(awk -F: '$3==0 {print $1}' /etc/group)
+user_with_uid0=$(awk -F: '$3==0 {print $1;exit}' /etc/passwd)
+group_with_gid0=$(awk -F: '$3==0 {print $1;exit}' /etc/group)
 AC_DEFINE_UNQUOTED([UID_0_USER],["$user_with_uid0"],[Get the user name having userid 0])
 AC_DEFINE_UNQUOTED([GID_0_GROUP],["$group_with_gid0"],[Get the group name having groupid 0])
 


### PR DESCRIPTION
If /etc/passwd contains multiple users with UID 0 then user_with_uid0 will
contain a line feed which results in config.h containing:

 #define UID_0_USER "root

(i.e. without a closing quote.)

The same problem occurs with /etc/group.

Let's only emit the first match in each case so that there is only ever a
single result.