### PR TITLE
Fix sigheader generation for big archives

### DIFF
--- a/lib/signature.c
+++ b/lib/signature.c
@@ -118,6 +118,8 @@ rpmRC rpmGenerateSignature(char *SHA256, char *SHA1, uint8_t *MD5,
     char *reservedSpace;
     int spaceSize = 32; /* always reserve a bit of space */
     int gpgSize = rpmExpandNumeric("%{__gpg_reserved_space}");
+    rpm_off_t size32 = size;
+    rpm_off_t payloadSize32 = payloadSize;
 
     /* Prepare signature */
     if (SHA256) {
@@ -149,21 +151,34 @@ rpmRC rpmGenerateSignature(char *SHA256, char *SHA1, uint8_t *MD5,
 
     rpmtdReset(&td);
     td.count = 1;
-    if (payloadSize < UINT32_MAX) {
-	rpm_off_t p = payloadSize;
-	rpm_off_t s = size;
-	td.type = RPM_INT32_TYPE;
+    td.type = RPM_INT32_TYPE;
 
-	td.tag = RPMSIGTAG_PAYLOADSIZE;
-	td.data = &p;
-	headerPut(sig, &td, HEADERPUT_DEFAULT);
+    td.tag = RPMSIGTAG_PAYLOADSIZE;
+    td.data = &payloadSize32;
+    headerPut(sig, &td, HEADERPUT_DEFAULT);
 
-	td.tag = RPMSIGTAG_SIZE;
-	td.data = &s;
-	headerPut(sig, &td, HEADERPUT_DEFAULT);
-    } else {
+    td.tag = RPMSIGTAG_SIZE;
+    td.data = &size32;
+    headerPut(sig, &td, HEADERPUT_DEFAULT);
+
+    if (size >= UINT32_MAX || payloadSize >= UINT32_MAX) {
+	/*
+	 * Put the 64bit size variants into the header, but
+	 * modify spaceSize so that the resulting header has
+	 * the same size. Note that this only works if all tags
+	 * with a lower number than RPMSIGTAG_RESERVEDSPACE are
+	 * already added and no tag with a higher number is
+	 * added yet.
+	 */
 	rpm_loff_t p = payloadSize;
 	rpm_loff_t s = size;
+	int newsigSize, oldsigSize;
+
+	oldsigSize = headerSizeof(sig, HEADER_MAGIC_YES);
+
+	headerDel(sig, RPMSIGTAG_PAYLOADSIZE);
+	headerDel(sig, RPMSIGTAG_SIZE);
+
 	td.type = RPM_INT64_TYPE;
 
 	td.tag = RPMSIGTAG_LONGARCHIVESIZE;
@@ -174,8 +189,8 @@ rpmRC rpmGenerateSignature(char *SHA256, char *SHA1, uint8_t *MD5,
 	td.data = &s;
 	headerPut(sig, &td, HEADERPUT_DEFAULT);
 
-	/* adjust for the size difference between 64- and 32bit tags */
-	spaceSize -= 8;
+	newsigSize = headerSizeof(sig, HEADER_MAGIC_YES);
+	spaceSize -= newsigSize - oldsigSize;
     }
 
     if (gpgSize > 0)


### PR DESCRIPTION
The old code just subtracted 8 bytes from the reserved space, but
that does not take tag alignment into account and led to the
signature header overwriting the package header.

We now use headerSizeof to calculate the real size difference.

Note that this only works reliable if the reserved space tag comes
last in the signature header!