### PR TITLE
brp-python-bytecompile: Run a pre-flight find before invoking $default_python

### DIFF
--- a/scripts/brp-python-bytecompile
+++ b/scripts/brp-python-bytecompile
@@ -87,6 +87,10 @@ if [ ! -x "$default_python" ]; then
 	exit 0
 fi
 
+# Figure out if there are files to be bytecompiled with the default_python at all
+# this prevents unnecessary default_python invocation
+find "$RPM_BUILD_ROOT" -type f -name "*.py" | grep -Ev "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" || exit 0
+
 # Generate normal (.pyc) byte-compiled files.
 python_bytecompile "" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
 if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then


### PR DESCRIPTION
This added check figures out whether invoking `$default_python` is necessary and exits early if no files would be bytecompiled by the two blocks below.

This prevent's invoking `$default_python` (i.e. `%{__python}` (i.e. most likely `/usr/bin/python`)) when not needed. Currently (before this change) it has been invoked twice for each build (iff the executable was present in the buildroot), even tough in most cases it did nothing. While this might have been harmless, it prevents us to deprecate or even forbid `/usr/bin/python` invocation during RPM build as proposed in Fedora in [1].

While this change is driven by Fedora's needs, I believe it can be useful for others as well. It doesn't render the script utterly more complex, while it prevents it from doing 2 superfluous (possibly slow) operations.

[1]: https://fedoraproject.org/wiki/Changes/Avoid_usr_bin_python_in_RPM_Build