### PR TITLE
lua: add rpm.execute()

### DIFF
--- a/lib/rpmliblua.c
+++ b/lib/rpmliblua.c
@@ -1,6 +1,9 @@
 #include "system.h"
 
 #ifdef WITH_LUA
+#include <errno.h>
+#include <spawn.h>
+#include <sys/wait.h>
 #include <lua.h>
 #include <lauxlib.h>
 #include <rpm/rpmlib.h>
@@ -8,6 +11,28 @@
 #define _RPMLUA_INTERNAL
 #include "rpmio/rpmlua.h"
 #include "lib/rpmliblua.h"
+#include "rpmio/rpmio_internal.h"
+
+static int pusherror(lua_State *L, int code, const char *info)
+{
+    lua_pushnil(L);
+    if (info == NULL)
+	lua_pushstring(L, strerror(code));
+    else
+	lua_pushfstring(L, "%s: %s", info, strerror(code));
+    lua_pushnumber(L, code);
+    return 3;
+}
+
+static int pushresult(lua_State *L, int result, const char *info)
+{
+    if (result == 0) {
+	lua_pushnumber(L, result);
+	return 1;
+    }
+
+    return pusherror(L, result, info);
+}
 
 static int rpm_vercmp(lua_State *L)
 {
@@ -23,8 +48,34 @@ static int rpm_vercmp(lua_State *L)
     return rc;
 }
 
+static int rpm_execute(lua_State *L)
+{
+    const char *file = luaL_checkstring(L, 1);
+    int i, n = lua_gettop(L);
+    int status;
+    pid_t pid;
+
+    char **argv = malloc((n + 1) * sizeof(char *));
+    if (argv == NULL)
+	return luaL_error(L, "not enough memory");
+    argv[0] = (char *)file;
+    for (i = 1; i < n; i++)
+	argv[i] = (char *)luaL_checkstring(L, i + 1);
+    argv[i] = NULL;
+    rpmSetCloseOnExec();
+    status = posix_spawnp(&pid, file, NULL, NULL, argv, environ);
+    free(argv);
+    if (status != 0)
+	return pusherror(L, status, "posix_spawnp");
+    if (waitpid(pid, &status, 0) == -1)
+	return pusherror(L, 0, "waitpid");
+    else
+	return pushresult(L, status, NULL);
+}
+
 static const luaL_Reg luarpmlib_f[] = {
     {"vercmp", rpm_vercmp},
+    {"execute", rpm_execute},
     {NULL, NULL}
 };
 

--- a/luaext/lposix.c
+++ b/luaext/lposix.c
@@ -348,6 +348,7 @@ static int Pexec(lua_State *L)			/** exec(path,[args]) */
 	for (i=1; i<n; i++) argv[i] = (char*)luaL_checkstring(L, i+1);
 	argv[i] = NULL;
 	execvp(path,argv);
+	free(argv);
 	return pusherror(L, path);
 }
 


### PR DESCRIPTION
At this point, if you want to avoid using shell you have only option
which is to use `posix.fork()` and `posix.exec()` which is too verbose and
not optimal (as Florian Weimer says, `posix_spawn()` can be implemented
more efficiently than usual `fork()` / `execve()` sequence).

Typical use-case is shown below.

```lua
-- Before
pid = posix.fork()
if pid == 0 then
  assert(posix.exec("/foo/bar"))
elseif pid > 0 then
  posix.wait(pid)
end
-- After
assert(rpm.execute("/foo/bar"))
```

Fixes: https://github.com/rpm-software-management/rpm/issues/389
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>

---

And also fix small memory leak.