### PR TITLE
rpmrc: Add architecture compatibility mapping between aarch64 and arm64

### DIFF
--- a/rpmrc.in
+++ b/rpmrc.in
@@ -99,6 +99,7 @@ optflags: sh4 -O2 -g -mieee
 optflags: sh4a -O2 -g -mieee
 
 optflags: aarch64 -O2 -g
+optflags: arm64 -O2 -g
 
 optflags: riscv64 -O2 -g
 
@@ -242,7 +243,9 @@ arch_canon:	sh3: sh3	17
 arch_canon:	sh4: sh4	17
 arch_canon:	sh4a: sh4a	17
 arch_canon:	xtensa: xtensa	18
-arch_canon:	aarch64: aarch64 19
+
+arch_canon:	aarch64: aarch64	19
+arch_canon:	arm64: arm64		19
 
 arch_canon:	mipsr6: mipsr6	20
 arch_canon:	mipsr6el: mipsr6el	20
@@ -377,6 +380,7 @@ buildarchtranslate: sh4: sh4
 buildarchtranslate: sh4a: sh4
 
 buildarchtranslate: aarch64: aarch64
+buildarchtranslate: arm64: aarch64
 
 buildarchtranslate: riscv: riscv64
 buildarchtranslate: riscv64: riscv64
@@ -485,7 +489,8 @@ arch_compat: sh3: noarch
 arch_compat: sh4: noarch
 arch_compat: sh4a: sh4
 
-arch_compat: aarch64: noarch
+arch_compat: aarch64: arm64 noarch
+arch_compat: arm64: aarch64 noarch
 
 arch_compat: riscv: noarch
 arch_compat: riscv64: noarch
@@ -522,6 +527,7 @@ os_compat: Darwin: MacOSX
 buildarch_compat: ia64: noarch
 
 buildarch_compat: aarch64: noarch
+buildarch_compat: arm64: aarch64
 
 buildarch_compat: riscv: noarch
 buildarch_compat: riscv64: noarch


### PR DESCRIPTION
AArch64 has another common name for the architecture: `arm64`. And while compilers, the kernel, and RPM use `aarch64`, a number of language ecosystems use `arm64`.

In addition, Debian packages use the `arm64` architecture name to refer to `aarch64`, and AArch64 packages that are translated from DEB to RPM format tend to not be installable because there's not a sufficient architecture mapping.

This change adds the `arm64` identifier as an alias for `aarch64` so that this works as expected, rather than breaking on unknown architectures.