### PR TITLE
legacy.c: Fix headerGetEntry count

### DIFF
--- a/lib/legacy.c
+++ b/lib/legacy.c
@@ -244,12 +244,12 @@ int headerConvert(Header h, int op)
 #define TDWRAP() \
     if (type) \
 	*type = td.type; \
+    if (c) \
+	*c = td.count; \
     if (p) \
 	*p = td.data; \
     else \
-	rpmtdFreeData(&td); \
-    if (c) \
-	*c = td.count
+	rpmtdFreeData(&td)
 
 int headerRemoveEntry(Header h, rpm_tag_t tag)
 {


### PR DESCRIPTION
rpmtdFreeData resets td.count to 0, so the whole thing never worked.
Better late than never, they say.