### PR TITLE
rpmio.c: In Fread(buf,size,nmemb,FD), require size be 1

### DIFF
--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -1310,13 +1310,16 @@ ssize_t Fread(void *buf, size_t size, size_t nmemb, FD_t fd)
 {
     ssize_t rc = -1;
 
+    /* Returns the number of bytes vs the number of items */
+    assert(size == 1);
+
     if (fd != NULL) {
 	FDSTACK_t fps = fdGetFps(fd);
 	fdio_read_function_t _read = FDIOVEC(fps, read);
 
 	fdstat_enter(fd, FDSTAT_READ);
 	do {
-	    rc = (_read ? (*_read) (fps, buf, size * nmemb) : -2);
+	    rc = (_read ? (*_read) (fps, buf, nmemb) : -2);
 	} while (rc == -1 && errno == EINTR);
 	fdstat_exit(fd, FDSTAT_READ, rc);
 
@@ -1324,8 +1327,8 @@ ssize_t Fread(void *buf, size_t size, size_t nmemb, FD_t fd)
 	    fdUpdateDigests(fd, buf, rc);
     }
 
-    DBGIO(fd, (stderr, "==>\tFread(%p,%p,%ld) rc %ld %s\n",
-	  fd, buf, (long)size * nmemb, (long)rc, fdbg(fd)));
+    DBGIO(fd, (stderr, "==>\tFread(%p,%p,%zu) rc %zd %s\n",
+	  fd, buf, nmemb, rc, fdbg(fd)));
 
     return rc;
 }


### PR DESCRIPTION
It seems that Fread returns the number of bytes read, as opposed
to the number of items, each size bytes long.  The relevant comment
in rpmio.h says that Fread is "fread(3) clone" (which implies that
the number of items should be returned).

This breaks the following idiomatic code which used to work with rpm-4.0:
```c
    char buf[110];
    if (Fread(buf, 110, 1, cpio->fd) != 1)
	die("%s: cannot read cpio header", cpio->rpmbname);
```
The program dies with "cannot read cpio header", while in fact Fread
returns 110.  It seems that the only way to reconcile the number of
bytes and the number of items is to require that size be 1.  Indeed,
I would much prefer an assertion failure.

This change breaks the existing code which calls Fread with nmemb=1
and expects the number of bytes to be returned.