### PR TITLE
Define DistTag as optional tag with macro just like DistURL (from SUSE, used by OMV)

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -519,6 +519,7 @@ static struct optionalTag {
     { RPMTAG_PACKAGER,		"%{packager}" },
     { RPMTAG_DISTRIBUTION,	"%{distribution}" },
     { RPMTAG_DISTURL,		"%{disturl}" },
+    { RPMTAG_DISTTAG,		"%{disttag}" },
     { RPMTAG_BUGURL,		"%{bugurl}" },
     { -1, NULL }
 };

--- a/macros.in
+++ b/macros.in
@@ -309,6 +309,16 @@ package or when debugging this package.\
 #
 #%disturl
 
+#	Configurable distribution tag, same as DistTag: tag in a specfile.
+#	The tag will be used to supply reliable information to tools like
+#	rpmfind.
+#
+# Note: You should not configure with disttag (or build packages with
+# the DistTag: tag) unless you are willing to supply content in a
+# yet-to-be-determined format at the tag specified.
+#
+#%disttag
+
 #	Configurable bug URL, same as BugURL: tag in a specfile.
 #	The URL will be used to supply reliable information to where
 #	to file bugs.


### PR DESCRIPTION
This PR enables support for defining `DistTag` via a macro. [This is being used by OpenMandriva](https://github.com/OpenMandrivaAssociation/rpm/commit/b3b111601ed34dd56223dae7256f2c105b6c7c3f) for [slightly customizing the output filename format](https://github.com/OpenMandrivaSoftware/rpm-openmandriva-setup/blob/b6d0ccad51ee636c7c8e4b290f09cfca8364a6e0/user/openmandriva/macros#L25-L30) so that the origin of the package is identifiable in the filename.

In essence, we're using this so that we don't need to introduce `%mkrel` back into the distribution, or go with something like `%dist` from Fedora and have it used in the `Release` field. The output filename format can't be changed with regular macros, only things that can be configured in rpm headers, so this is what we're using for it.