### PR TITLE
scripts/pkgconfigdeps.sh fixes

### DIFF
--- a/scripts/pkgconfigdeps.sh
+++ b/scripts/pkgconfigdeps.sh
@@ -47,7 +47,7 @@ case $1 in
 	[ $i -eq 1 ] && echo "$pkgconfig"
 	DIR="`dirname ${filename}`"
 	export PKG_CONFIG_PATH="$DIR:$DIR/../../share/pkgconfig"
-	$pkgconfig --print-requires --print-requires-private "$filename" 2> /dev/null | while read n r v ; do
+	$pkgconfig --print-requires "$filename" 2> /dev/null | while read n r v ; do
 	    [ -n "$n" ] || continue
 	    echo -n "pkgconfig($n) "
 	    [ -n "$r" ] && [ -n "$v" ] && echo -n "$r" "$v"

--- a/scripts/pkgconfigdeps.sh
+++ b/scripts/pkgconfigdeps.sh
@@ -43,8 +43,6 @@ case $1 in
     while read filename ; do
     case "${filename}" in
     *.pc)
-	i="`expr $i + 1`"
-	[ $i -eq 1 ] && echo "$pkgconfig"
 	DIR="`dirname ${filename}`"
 	export PKG_CONFIG_PATH="$DIR:$DIR/../../share/pkgconfig"
 	$pkgconfig --print-requires "$filename" 2> /dev/null | while read n r v ; do


### PR DESCRIPTION
1) remove --print-requires-private from $pkconfig parameters
It generates list of Requires when static linking is used:

$ pkg-config --help | grep -A1 -- --print-requires-private
  --print-requires-private          print required dependency frameworks for static
                                    linking to stdout
By using this option generated list Requires is flooded static linking requirements
when all distributions now are trying to avoid even build and provide any possible
static libraries.

2) Remove add pkgconfig to list of generated Requires is at least one .p…  …
…c file was found.

Provide .pc file by any package does not mean that it will be used.
Usually .pc files are used on building other packages.
By this redundant Requires in Fedora almost 750 packages packages requires pkgconfig.

$ dnf -qC repoquery --whatrequires pkgconfig --qf="%{name}"| wc -l
748

pkgconfig should be only in Requires if for example in autoconf .m4 macros is used
pkg-config (to provide the list of libs or cflags). In any other case pkgconfig or pkg-config
should be used only in BuildRequires.