### PR TITLE
Add %optional tag

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -629,6 +629,7 @@ exit:
 static VFA_t const configAttrs[] = {
     { "missingok",	RPMFILE_MISSINGOK },
     { "noreplace",	RPMFILE_NOREPLACE },
+    { "optional",	RPMFILE_OPTIONAL },
     { NULL, 0 }
 };
 
@@ -1385,7 +1386,7 @@ static rpmRC addFile(FileList fl, const char * diskPath,
 	    int lvl = RPMLOG_ERR;
 	    const char *msg = fl->cur.isDir ? _("Directory not found: %s\n") :
 					      _("File not found: %s\n");
-	    if (fl->cur.attrFlags & RPMFILE_EXCLUDE) {
+	    if (fl->cur.attrFlags & RPMFILE_EXCLUDE || fl->cur.attrFlags & RPMFILE_OPTIONAL) {
 		lvl = RPMLOG_WARNING;
 		rc = RPMRC_OK;
 	    }
@@ -2341,6 +2342,8 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 		free(newfile);
 	    }
 	    argvFree(globFiles);
+	} else if (fl->cur.attrFlags & RPMFILE_OPTIONAL) {
+	    rpmlog(RPMLOG_WARNING, _("Optional file not found by glob: %s\n"), eorigfile);
 	} else {
 	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), eorigfile);
 	    fl->processingFailed = 1;

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -60,6 +60,7 @@ enum rpmfileAttrs_e {
     /* bits 9-10 unused */
     RPMFILE_PUBKEY	= (1 << 11),	/*!< from %%pubkey */
     RPMFILE_ARTIFACT	= (1 << 12),	/*!< from %%artifact */
+    RPMFILE_OPTIONAL	= (1 << 13),	/*!< from %%optional */
 };
 
 typedef rpmFlags rpmfileAttrs;

--- a/tests/data/SPECS/optional.spec
+++ b/tests/data/SPECS/optional.spec
@@ -1,0 +1,39 @@
+Summary: optional -- test for the %%optional tag
+Name: optional
+Version: 1.0
+Release: 1
+Group: Utilities
+License: GPL
+BuildArch: noarch
+URL: http://openmandriva.org/
+
+%description
+Test for files with the %%optional tag
+
+%prep
+
+%build
+
+%install
+mkdir -p %{buildroot}/dir-exists \
+	%{buildroot}/dirglob-exists-1 \
+	%{buildroot}/dirglob-exists-2
+touch %{buildroot}/file-exists \
+	%{buildroot}/glob-exists-1 \
+	%{buildroot}/glob-exists-2
+ln -s file-exists %{buildroot}/symlink-exists
+ln -s / %{buildroot}/symlink-to-dir-exists
+
+%files
+%defattr(-,root,root)
+%optional /file-exists
+%optional /file-does-not-exist
+%optional /glob-exists-*
+%optional /glob-does-not-exist-*
+%optional /dir-exists
+%optional /dir-does-not-exist
+%optional /dirglob-exists-*
+%optional /symlink-exists
+%optional /symlink-does-not-exist
+%optional /symlink-to-dir-exists
+%optional /symlink-to-dir-does-not-exist

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1358,3 +1358,31 @@ No hello.debug
 ],
 [ignore])
 AT_CLEANUP
+
+# ------------------------------
+# Check functionality of %optional tag
+AT_SETUP([rpmbuild optional tag])
+AT_KEYWORDS([build] [optional])
+AT_CHECK([[
+rm -rf ${TOPDIR}
+
+runroot rpmbuild \
+  -bb --quiet /data/SPECS/optional.spec
+
+runroot rpm -qp --qf \
+  "\n[%{filemodes:perms} %-8{fileusername} %-8{filegroupname} %{filenames}\n]"\
+  /build/RPMS/noarch/optional-1.0*.noarch.rpm
+]],
+[0],
+[
+drwxr-xr-x /dir-exists
+drwxr-xr-x /dirglob-exists-1
+drwxr-xr-x /dirglob-exists-2
+-rw-r--r-- /file-exists
+-rw-r--r-- /glob-exists-1
+-rw-r--r-- /glob-exists-2
+lrwxrwxrwx /symlink-exists
+lrwxrwxrwx /symlink-to-dir-exists
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
Add the %optional tag from rpm5 -- it allows to mark a file in the file
list as optional, meaning if it's there, it's packaged, but if it isn't
there, it will be ignored.

A typical use case is
%optional %{_includedir}/arch-specific-file.h
(easier and shorter than using %ifarch and having to list all
architectures that have the file -- will also automatically do the right
thing on a new architecture being added)

Another typical use case is in autogenerated file lists, e.g.
per-language subpackages in the likes of libreoffice where all languages
include translations, some languages additionally include dictionaries,
etc. -- with %optional, the same file list can be used for every
language subpackage.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>