### PR TITLE
Fix %arm macro to include newer processor types

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1106,7 +1106,7 @@ package or when debugging this package.\
 
 #------------------------------------------------------------------------------
 # arch macro for all supported ARM processors
-%arm	armv3l armv4b armv4l armv4tl armv5tl armv5tel armv5tejl armv6l armv6hl armv7l armv7hl armv7hnl
+%arm	armv3l armv4b armv4l armv4tl armv5tl armv5tel armv5tejl armv6l armv6hl armv7l armv7hl armv7hnl armv8l armv8hl armv8hnl armv8hcnl
 
 #------------------------------------------------------------------------------
 # arch macro for 32-bit MIPS processors


### PR DESCRIPTION
Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>