### PR TITLE
Provide a way to opt out from automagic Python bytecompilation

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -64,12 +64,13 @@
 #
 
 %__arch_install_post   @ARCH_INSTALL_POST@
+%_python_bytecompile_extra   1
 
 # Standard brp-macro naming:
 # convert all '-' in basename to '_', add two leading underscores.
 %__brp_compress %{_rpmconfigdir}/brp-compress
 %__brp_java_gcjcompile %{_rpmconfigdir}/brp-java-bytecompile
-%__brp_python_bytecompile %{_rpmconfigdir}/brp-python-bytecompile
+%__brp_python_bytecompile %{_rpmconfigdir}/brp-python-bytecompile "" "%{?_python_bytecompile_errors_terminate_build}" "%{?_python_bytecompile_extra}"
 %__brp_strip %{_rpmconfigdir}/brp-strip %{__strip}
 %__brp_strip_comment_note %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump}
 %__brp_strip_shared %{_rpmconfigdir}/brp-strip-shared

--- a/scripts/brp-python-bytecompile
+++ b/scripts/brp-python-bytecompile
@@ -1,5 +1,6 @@
 #!/bin/bash
 errors_terminate=$2
+extra=$3
 
 # If using normal root, avoid changing anything.
 if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
@@ -79,9 +80,13 @@ do
 done
 
 
-# Handle other locations in the filesystem using the default python
-# implementation - if we  have a default python interpreter
+# Handle other locations in the filesystem using the default python implementation
+# if extra is set to 0, don't do this
+if [ 0$extra -eq 0 ]; then
+	exit 0
+fi
 
+# If we don't have a default python interpreter, we cannot proceed
 default_python=${1:-/usr/bin/python}
 if [ ! -x "$default_python" ]; then
 	exit 0


### PR DESCRIPTION
One can now use `%?disable_automagic_pybytecompile` to opt out from automagic Python bytecompilation outside of `/usr/lib(64)?/pythonX.Y`.

One can also use `%?enable_automagic_pybytecompile` to explicitly opt in, even tough this is currently still the default.

Automagic Python bytecompilation of files outside of Python's own directories (`/usr/lib(64)?/pythonX.Y`) with `/usr/bin/python` is error prone. For context, see [this Fedora change][1], it describes all the problems and provides a longer explanation about why we are doing this.

[1]: https://fedoraproject.org/wiki/Changes/No_more_automagic_Python_bytecompilation