### PR TITLE
Optimize and unite setting CLOEXEC on fds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -959,7 +959,7 @@ AC_ARG_WITH([lua], [AS_HELP_STRING([--with-lua], [build with lua support])],
 
 AS_IF([test "$with_lua" != no],[
   PKG_CHECK_MODULES([LUA],
-    [lua >= 5.1],
+    [lua53 >= 5.1],
     [AC_DEFINE(WITH_LUA, 1, [Build with lua support?])],
     [AC_MSG_ERROR([lua not present (--without-lua to disable)])])
   AC_SUBST(LUA_CFLAGS)

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -1759,3 +1759,19 @@ DIGEST_CTX fdDupDigest(FD_t fd, int id)
 
     return ctx;
 }
+
+void rpmSetCloseOnExec(void)
+{
+	int flag, fdno, open_max;
+
+	open_max = sysconf(_SC_OPEN_MAX);
+	if (open_max == -1) {
+		open_max = 1024;
+	}
+	for (fdno = 3; fdno < open_max; fdno++) {
+		flag = fcntl(fdno, F_GETFD);
+		if (flag == -1 || (flag & FD_CLOEXEC))
+			continue;
+		fcntl(fdno, F_SETFD, FD_CLOEXEC);
+	}
+}

--- a/rpmio/rpmio_internal.h
+++ b/rpmio/rpmio_internal.h
@@ -41,6 +41,12 @@ DIGEST_CTX fdDupDigest(FD_t fd, int id);
 int rpmioSlurp(const char * fn,
                 uint8_t ** bp, ssize_t * blenp);
 
+/**
+ * Set close-on-exec flag for all opened file descriptors, except
+ * stdin/stdout/stderr.
+ */
+void rpmSetCloseOnExec(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In case maximum number of open files limit is set too high, both luaext/Pexec() and lib/doScriptExec() spend way too much time trying to set `FD_CLOEXEC` for all those file descriptors that might be open, resulting in severe increase of time it takes to execute rpm or dnf. For example, this happens while running under Docker because:

> $ docker run fedora ulimit -n
> 1048576

One obvious fix is to use procfs to get the actual list of opened file descriptors and iterate over those.

My quick-n-dirty benchmark shows the /proc approach is about 10x faster than iterating through a list of 1024 fds.

Note that the old method is still used in case /proc is not available.

While at it, unite the two implementations, and future(1) proof it by making sure we modify the existing flags.

(1) - currently the only known flag is `FD_CLOEXEC`.


This should fix:
- https://github.com/moby/moby/issues/23137
- https://bugzilla.redhat.com/show_bug.cgi?id=1537564