### PR TITLE
Fix a problem where scripts would fail to run with exit code 127

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -219,9 +219,7 @@ static void doScriptExec(ARGV_const_t argv, ARGV_const_t prefixes,
 	/* XXX Don't mtrace into children. */
 	unsetenv("MALLOC_CHECK_");
 
-	if (xx == 0) {
-	    xx = execv(argv[0], argv);
-	}
+	xx = execv(argv[0], argv);
     }
     _exit(127); /* exit 127 for compatibility with bash(1) */
 }


### PR DESCRIPTION
Commit 9c3e5de3240554c8ea1b29d52eeadee4840fefac,  "Factor out
and unify setting CLOEXEC" moved code which set the xx variable.

There are now ways this function can fail to set xx at all leaving
it at the mercy of the compiler. gcc 4.8.5 for example will leave
this with a non-zero value causing scripts to fail.

The original code here checked for return codes of functions
which no longer set xx. As far as I can tell the best thing is
to simple remove the seemingly erroneous test and make things
deterministic!

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>