### PR TITLE
macros: make unversioned python macros not expand to empty

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1102,9 +1102,9 @@ package or when debugging this package.\
 #------------------------------------------------------------------------------
 # Useful python macros for determining python version and paths
 #
-%python_sitelib %(%{__python} -Es %{_rpmconfigdir}/python-macro-helper sitelib)
-%python_sitearch %(%{__python} -Es %{_rpmconfigdir}/python-macro-helper sitearch)
-%python_version %(%{__python} -Es %{_rpmconfigdir}/python-macro-helper version)
+%python_sitelib %(%{__python} -Es %{_rpmconfigdir}/python-macro-helper sitelib || echo %%{python_sitelib})
+%python_sitearch %(%{__python} -Es %{_rpmconfigdir}/python-macro-helper sitearch || echo %%{python_sitearch})
+%python_version %(%{__python} -Es %{_rpmconfigdir}/python-macro-helper version || echo %%{python_version})
 
 #------------------------------------------------------------------------------
 # arch macro for all Intel i?86 compatible processors


### PR DESCRIPTION
In Fedora the removal of /usr/bin/python in favour of explicit
/usr/bin/python2 and /usr/bin/python3 is happening now. Unless
python-unversioned-command.rpm is installed, /usr/bin/python does not
exists. This means that packages use
%python_{sitelib,sitearch,version}, they get a warning in the build
log, and the macro evaluates to an empty string.
It seems better to keep the unexpanded macro instead, as if it wasn't
defined at all.

See https://bugzilla.redhat.com/show_bug.cgi?id=1585626#c4.