### PR TITLE
find-debuginfo.sh: decompress DWARF compressed ELF sections

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -357,6 +357,9 @@ do_file()
   get_debugfn "$f"
   [ -f "${debugfn}" ] && return
 
+  echo "explicitly decompress any DWARF compressed ELF sections in $f"
+  eu-elfcompress -q -p -t none "$f"
+
   echo "extracting debug info from $f"
   # See also cpio SOURCEFILE copy. Directories must match up.
   debug_base_name="$RPM_BUILD_DIR"


### PR DESCRIPTION
debugedit and dwz do not support DWARF compressed ELF sections, let's
just decompress those before extracting debuginfo.

Tested-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>