### PR TITLE
fileattrs: Add attr for pythondistdeps and fix python attr

### DIFF
--- a/fileattrs/Makefile.am
+++ b/fileattrs/Makefile.am
@@ -7,7 +7,7 @@ fattrsdir = $(rpmconfigdir)/fileattrs
 
 fattrs_DATA = \
 	debuginfo.attr desktop.attr elf.attr font.attr libtool.attr metainfo.attr \
-	perl.attr perllib.attr pkgconfig.attr python.attr ocaml.attr script.attr \
-	mono.attr
+	perl.attr perllib.attr pkgconfig.attr python.attr pythondist.attr ocaml.attr \
+	script.attr mono.attr
 
 EXTRA_DIST = $(fattrs_DATA)

--- a/fileattrs/pythondist.attr
+++ b/fileattrs/pythondist.attr
@@ -1,0 +1,3 @@
+%__pythondist_provides	%{_rpmconfigdir}/pythondistdeps.py --provides --majorver-provides
+%__pythondist_requires	%{_rpmconfigdir}/pythondistdeps.py --requires
+%__pythondist_path		/lib(64)?/python[[:digit:]]\\.[[:digit:]]/.*\\.(dist.*|egg.*)$


### PR DESCRIPTION
Rather than having the pythondistdeps dependency generator run on all Python code, this separate attr will activate it only if the package includes Python dist metadata (such as egg-info or dist-info for Python Eggs and Python Wheels, respectively).

This is much more efficient, too, since the generator is only run in circumstances where it will provide useful information.

This is based on the dependency generator attr used in Mageia, OpenMandriva, and other systems that use the generator.