### PR TITLE
Python generators: Use nonstandardlib for purelib definition

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -82,8 +82,8 @@ for f in files:
     if py_abi and (lower.endswith('.py') or lower.endswith('.pyc') or lower.endswith('.pyo')):
         if name not in py_deps:
             py_deps[name] = []
-        purelib = get_python_lib(standard_lib=1, plat_specific=0).split(version[:3])[0]
-        platlib = get_python_lib(standard_lib=1, plat_specific=1).split(version[:3])[0]
+        purelib = get_python_lib(standard_lib=0, plat_specific=0).split(version[:3])[0]
+        platlib = get_python_lib(standard_lib=0, plat_specific=1).split(version[:3])[0]
         for lib in (purelib, platlib):
             if lib in f:
                 spec = ('==', f.split(lib)[1].split(sep)[0])


### PR DESCRIPTION
The purelib and platlib were both defined to /usr/lib64/python on 64bits systems. This is because:

    >>> get_python_lib(standard_lib=1, plat_specific=0)
    '/usr/lib64/python3.7'

    >>> get_python_lib(standard_lib=1, plat_specific=1)
    '/usr/lib64/python3.7'

    >>> get_python_lib(standard_lib=0, plat_specific=0)
    '/usr/lib/python3.7/site-packages'

    >>> get_python_lib(standard_lib=0, plat_specific=1)
    '/usr/lib64/python3.7/site-packages'

So now we use standard_lib=0 to get the site-packages base path from /usr/lib and not /usr/lib64.

See https://bugzilla.redhat.com/show_bug.cgi?id=1609492

And https://src.fedoraproject.org/rpms/python-rpm-generators/pull-request/2
