### PR TITLE
find-debuginfo.sh: sort output of find

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -487,7 +487,7 @@ fi
 # Invoke the DWARF Compressor utility.
 if $run_dwz \
    && [ -d "${RPM_BUILD_ROOT}/usr/lib/debug" ]; then
-  readarray dwz_files < <(cd "${RPM_BUILD_ROOT}/usr/lib/debug"; find -type f -name \*.debug)
+  readarray dwz_files < <(cd "${RPM_BUILD_ROOT}/usr/lib/debug"; find -type f -name \*.debug | LC_ALL=C sort)
   if [ ${#dwz_files[@]} -gt 0 ]; then
     dwz_multifile_name="${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}-${RPM_PACKAGE_RELEASE}.${RPM_ARCH}"
     dwz_multifile_suffix=


### PR DESCRIPTION
sort output of find in find-debuginfo.sh
to make build results more reproducible
in spite of indeterministic filesystem readdir order.

Even where these lists do not become part of an rpm,
it makes it easier to debug unrelated issues
by having less overall diff from diffing build filesystem trees (one of the standard reproducibility-debugging techniques I use).

For openSUSE, this helped to make squid, openssh, postfix and shadow
packages build reproducibly.

See https://reproducible-builds.org/ for why this is good.

Note: elfbins.list has remaining indeterminism from the `run_job` function running in parallel unless using `-j1`

Note: only tested in a slightly different variant on openSUSE's rpm-4.14.1