### PR TITLE
New rpmExpandMacrosAt API with location information.

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -175,6 +175,7 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
 {
     char *lbuf = NULL;
     int isComment = 0;
+    struct rpmSpecLocation_s loc;
 
      /* Don't expand macros (eg. %define) in false branch of %if clause */
     if (!spec->readStack->reading)
@@ -185,8 +186,9 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
     if (lbuf[0] == '#')
 	isComment = 1;
 
-
-    if (rpmExpandMacros(spec->macros, spec->lbuf, &lbuf, 0) < 0) {
+    loc.lineNum = spec->lineNum;
+    loc.source = spec->specFile;
+    if (rpmExpandMacrosAt(&loc, spec->macros, spec->lbuf, &lbuf, 0) < 0) {
 	rpmlog(RPMLOG_ERR, _("line %d: %s\n"),
 		spec->lineNum, spec->lbuf);
 	return 1;

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -129,6 +129,15 @@ struct rpmRelocation_s {
     char * newPath;	/*!< NULL means to omit the file completely! */
 };
 
+/**
+ * We pass these around to identify source locations.
+ */
+struct rpmSpecLocation_s {
+    char * source;	/*!< NULL here evals to no source file, */
+    int lineNum;	/*!< -1 here means no line number. */
+    int reserved[16];	/*!< Reserved for future location use. */
+};
+
 enum rpmfiFlags_e {
     RPMFI_NOHEADER		= 0,
     RPMFI_KEEPHEADER		= (1 << 0),

--- a/lib/rpmtypes.h
+++ b/lib/rpmtypes.h
@@ -91,6 +91,7 @@ typedef struct rpmSpec_s * rpmSpec;
 
 typedef struct rpmRelocation_s rpmRelocation;
 
+typedef struct rpmSpecLocation_s * rpmSpecLoc;
 
 /** \ingroup rpmtypes 
  * RPM IO file descriptor type

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -69,6 +69,18 @@ int	rpmExpandMacros	(rpmMacroContext mc, const char * sbuf,
 				char ** obuf, int flags);
 
 /** \ingroup rpmmacro
+ * Expand macro into buffer with location information for errors.
+ * @param loc		location information (NULL none available).
+ * @param mc		macro context (NULL uses global context).
+ * @param sbuf		input macro to expand
+ * @param obuf		macro expansion (malloc'ed)
+ * @param flags		flags (currently unused)
+ * @return		negative on failure
+ */
+int	rpmExpandMacrosAt (rpmSpecLoc loc, rpmMacroContext mc,
+			   const char * sbuf, char ** obuf, int flags);
+
+/** \ingroup rpmmacro
  * Push macro to context.
  * @param mc		macro context (NULL uses global context).
  * @param n		macro name


### PR DESCRIPTION
The macro expansion API lacks location information for warnings.
The simplest way to add this information is to pass location
information to a new macro expansion API and for that location
to be used in subsequence diagonistics.

A new 'struct rpmSpecLocation_s' structure is created to hold the
location information. A new API rpmExpandMacrosAt() is created
which operates exactly like rpmExpandMacros() but takes an
additional first argument of type 'rpmSpecLoc' and uses this
information when printing warnings and errors.

Example warning without the patch:
[carlos@localhost SPECS]$ rpmbuild -bs glibc.spec
warning: Macro %pie needs whitespace before body
Wrote: /home/carlos/rpmbuild/SRPMS/glibc-2.28-3.fc29.src.rpm

Example warning with the patch:
[carlos@localhost SPECS]$ rpmbuild -bs glibc.spec
warning: line 66: Macro %pie needs whitespace before body
Wrote: /home/carlos/rpmbuild/SRPMS/glibc-2.28-3.fc29.src.rpm

Notice with the patch 'line 66' is immediately called out at
the location of the macro being expanded, this allows developers
to immediately find the problem.

A solution of a new API with a new location structure was chosen
to minimize the impact on existing structures, APIs, and information
leakage across library boundaries. For example it might have been
convenient to pass the whole rpmSpec to the macro expansion, but
this would have required making the opaque type visible to the
macro expansion code, and may have resulted in maintenance
difficulties. Lastly, even if we extended rpmMacroEntry to contain
location information, we would still need to pass it from the spec
file parsing down, and so could not avoid some other kind of
interface. In the case of rpmMacroContext, adding the current
location to the structure seemed fragile since the context contains
many macros all which can come from different places. Perhaps the
best solution is to eventually expand rpmMacroEntry to record the
location passed by rpmExpandMacrosAt() in order to use it in the
display and dumping of the macro context.

No regressions on x86_64, tested in Fedora Rawhide by using make
dist, integrating the new tarball into the fedora build and then
testing that out to build glibc.spec.