### PR TITLE
fileattrs: Don't scan libraries in $libdir/haswell for Provides

### DIFF
--- a/fileattrs/Makefile.am
+++ b/fileattrs/Makefile.am
@@ -6,8 +6,8 @@ AM_CFLAGS = @RPMCFLAGS@
 fattrsdir = $(rpmconfigdir)/fileattrs
 
 fattrs_DATA = \
-	debuginfo.attr desktop.attr elf.attr font.attr libtool.attr metainfo.attr \
-	perl.attr perllib.attr pkgconfig.attr python.attr pythondist.attr ocaml.attr \
-	script.attr mono.attr
+	debuginfo.attr desktop.attr elf.attr elfoptimized.attr font.attr \
+	libtool.attr metainfo.attr perl.attr perllib.attr pkgconfig.attr \
+	python.attr pythondist.attr ocaml.attr script.attr mono.attr
 
 EXTRA_DIST = $(fattrs_DATA)

--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -2,3 +2,4 @@
 %__elf_requires		%{_rpmconfigdir}/elfdeps --requires %{?__filter_GLIBC_PRIVATE:--filter-private}
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
 %__elf_flags		exeonly
+%__elf_exclude_path     ^(/usr/lib/debug|(/usr)?/lib(64)?/(i686|x86_64|sse2|haswell|tls))/

--- a/fileattrs/elfoptimized.attr
+++ b/fileattrs/elfoptimized.attr
@@ -1,0 +1,4 @@
+%__elfoptimized_requires		%{_rpmconfigdir}/elfdeps --requires %{?__filter_GLIBC_PRIVATE:--filter-private}
+%__elfoptimized_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
+%__elfoptimized_flags		exeonly
+%__elfoptimized_path		^(/usr)?/lib(64)?/(i686|x86_64|sse2|haswell|tls)/


### PR DESCRIPTION
Those libraries are meant to be runtime replacements of the ones in the
regular $libdir. If a packager decides to split them into a separate
sub-package, the dependency resolver shouldn't be deciding to install
that instead of the base package.