### PR TITLE
Make python examples run with python 3, the print commands.

### DIFF
--- a/python/header-py.c
+++ b/python/header-py.c
@@ -86,18 +86,18 @@
  * 	hdr = ts.hdrFromFdno(fdno)
  *	os.close(fdno)
  *	if hdr[rpm.RPMTAG_SOURCEPACKAGE]:
- *	   print "header is from a source package"
+ *	   print("header is from a source package")
  *	else:
- *	   print "header is from a binary package"
+ *	   print("header is from a binary package")
  * \endcode
  *
  * The Python interface to the header data is quite elegant.  It
  * presents the data in a dictionary form.  We'll take the header we
  * just loaded and access the data within it:
  * \code
- * 	print hdr[rpm.RPMTAG_NAME]
- * 	print hdr[rpm.RPMTAG_VERSION]
- * 	print hdr[rpm.RPMTAG_RELEASE]
+ * 	print(hdr[rpm.RPMTAG_NAME])
+ * 	print(hdr[rpm.RPMTAG_VERSION])
+ * 	print(hdr[rpm.RPMTAG_RELEASE])
  * \endcode
  * in the case of our "foo-1.0-1.i386.rpm" package, this code would
  * output:
@@ -109,9 +109,9 @@
  *
  * You make also access the header data by string name:
  * \code
- * 	print hdr['name']
- * 	print hdr['version']
- * 	print hdr['release']
+ * 	print(hdr['name'])
+ * 	print(hdr['version'])
+ * 	print(hdr['release'])
  * \endcode
  *
  * This method of access is a teensy bit slower because the name must be
@@ -687,17 +687,17 @@ static char hdr_doc[] =
   "	hdr = ts.hdrFromFdno(fdno)\n"
   "	os.close(fdno)\n"
   "	if hdr[rpm.RPMTAG_SOURCEPACKAGE]:\n"
-  "	   print 'header is from a source package'\n"
+  "	   print('header is from a source package')\n"
   "	else:\n"
-  "	   print 'header is from a binary package'\n"
+  "	   print('header is from a binary package')\n"
   "\n"
   "The Python interface to the header data is quite elegant.  It\n"
   "presents the data in a dictionary form.  We'll take the header we\n"
   "just loaded and access the data within it:\n"
   "\n"
-  "	print hdr[rpm.RPMTAG_NAME]\n"
-  "	print hdr[rpm.RPMTAG_VERSION]\n"
-  "	print hdr[rpm.RPMTAG_RELEASE]\n"
+  "	print(hdr[rpm.RPMTAG_NAME])\n"
+  "	print(hdr[rpm.RPMTAG_VERSION])\n"
+  "	print(hdr[rpm.RPMTAG_RELEASE])\n"
   "\n"
   "in the case of our 'foo-1.0-1.i386.rpm' package, this code would\n"
   "output:\n"
@@ -707,9 +707,9 @@ static char hdr_doc[] =
   "\n"
   "You make also access the header data by string name:\n"
   "\n"
-  "	print hdr['name']\n"
-  "	print hdr['version']\n"
-  "	print hdr['release']\n"
+  "	print(hdr['name'])\n"
+  "	print(hdr['version'])\n"
+  "	print(hdr['release'])\n"
   "\n"
   "This method of access is a teensy bit slower because the name must be\n"
   "translated into the tag number dynamically. You also must make sure\n"

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -23,7 +23,7 @@
  *	import rpm
  *	ts = rpm.TransactionSet()
  *	for name in ts.dbIndex("conflictname"):
- *	    print name
+ *	    print(name)
  * \endcode
  *
  * ts.dbIndex() can be used to get the packages containing the keys of interest

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -29,7 +29,7 @@
  *	import rpm
  *	ts = rpm.TransactionSet()
  *	for h in ts.dbMatch():
- *	    print h['name']
+ *	    print(h['name'])
  * \endcode
  *
  * Here's a more typical example that uses the Name index to retrieve
@@ -39,7 +39,7 @@
  *	ts = rpm.TransactionSet()
  *	mi = ts.dbMatch('name', 'kernel')
  *	for h in mi:
- *	    print '%s-%s-%s' % (h['name'], h['version'], h['release'])
+ *	    print('%s-%s-%s' % (h['name'], h['version'], h['release']))
  * \endcode
  *
  * Finally, here's an example that retrieves all packages whose name
@@ -50,7 +50,7 @@
  *	mi = ts.dbMatch()
  *	mi.pattern('name', rpm.RPMMIRE_GLOB, 'XFree*')
  *	for h in mi:
- *	    print '%s-%s-%s' % (h['name'], h['version'], h['release'])
+ *	    print('%s-%s-%s' % (h['name'], h['version'], h['release']))
  * \endcode
  *
  */
@@ -179,7 +179,7 @@ static char rpmmi_doc[] =
   "	import rpm\n"
   "	ts = rpm.TransactionSet()\n"
   "	for h in ts.dbMatch():\n"
-  "	    print h['name']\n"
+  "	    print(h['name'])\n"
   "\n"
   "Here's a more typical example that uses the Name index to retrieve\n"
   "all installed kernel(s):\n"
@@ -187,7 +187,7 @@ static char rpmmi_doc[] =
   "	ts = rpm.TransactionSet()\n"
   "	mi = ts.dbMatch('name', 'kernel')\n"
   "	for h in mi:\n"
-  "	    print '%s-%s-%s' % (h['name'], h['version'], h['release'])\n"
+  "	    print('%s-%s-%s' % (h['name'], h['version'], h['release']))\n"
   "\n"
   "Finally, here's an example that retrieves all packages whose name\n"
   "matches the glob expression 'XFree*':\n"
@@ -196,7 +196,7 @@ static char rpmmi_doc[] =
   "	mi = ts.dbMatch()\n"
   "	mi.pattern('name', rpm.RPMMIRE_GLOB, 'XFree*')\n"
   "	for h in mi:\n"
-  "	    print '%s-%s-%s' % (h['name'], h['version'], h['release'])\n"
+  "	    print('%s-%s-%s' % (h['name'], h['version'], h['release']))\n"
 ;
 
 PyTypeObject rpmmi_Type = {

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -21,7 +21,7 @@
  *  import rpm
  *  rpm.rpmPushMacro("_topdir","/path/to/topdir")
  *  s=rpm.spec("foo.spec")
- *  print s.prep()
+ *  print(s.prep())
  * \endcode
  *
  *  Macros set using add macro will be used allowing testing of conditional builds


### PR DESCRIPTION
Addressing things like
```
    print s.prep()
          ^
SyntaxError: invalid syntax
```