### PR TITLE
rpm.spec's .prep seems to be an attribute.

### DIFF
--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -21,7 +21,7 @@
  *  import rpm
  *  rpm.rpmPushMacro("_topdir","/path/to/topdir")
  *  s=rpm.spec("foo.spec")
- *  print(s.prep())
+ *  print(s.prep)
  * \endcode
  *
  *  Macros set using add macro will be used allowing testing of conditional builds


### PR DESCRIPTION
Addressing
```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    print(s.prep())
TypeError: 'str' object is not callable
```