### PR TITLE
Skip showing empty Relocations line in rpm -qi

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -111,7 +111,7 @@ Signature   : %|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig
 Source RPM  : %{SOURCERPM}\n\
 Build Date  : %{BUILDTIME:date}\n\
 Build Host  : %{BUILDHOST}\n\
-Relocations : %|PREFIXES?{[%{PREFIXES} ]}:{(not relocatable)}|\n\
+%|PREFIXES?{Relocations : [%{PREFIXES} ]\n}|\
 %|PACKAGER?{Packager    : %{PACKAGER}\n}|\
 %|VENDOR?{Vendor      : %{VENDOR}\n}|\
 %|URL?{URL         : %{URL}\n}|\


### PR DESCRIPTION
Almost nobody uses them, so the
"Relocations : (not relocatable)" line is a waste of screen estate.
Just output the line if there's something interesting to show.