### PR TITLE
build: Make sure SOURCE_DATE_EPOCH is in the past

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -209,8 +209,11 @@ static rpmRC buildSpec(BTA_t buildArgs, rpmSpec spec, int what)
 	struct rpmtd_s td;
 	if (headerGet(h, RPMTAG_CHANGELOGTIME, &td, (HEADERGET_MINMEM|HEADERGET_RAW))) {
 	    char sdestr[22];
-	    snprintf(sdestr, sizeof(sdestr), "%lli",
-		     (long long) rpmtdGetNumber(&td));
+	    long long sdeint = rpmtdGetNumber(&td);
+	    if (sdeint % 86400 == 43200) /* date was rounded to 12:00 */
+		/* make sure it is in the past, so that clamping times works */
+		sdeint -= 43200;
+	    snprintf(sdestr, sizeof(sdestr), "%lli", sdeint);
 	    rpmlog(RPMLOG_NOTICE, _("setting %s=%s\n"), "SOURCE_DATE_EPOCH", sdestr);
 	    setenv("SOURCE_DATE_EPOCH", sdestr, 0);
 	    rpmtdFreeData(&td);


### PR DESCRIPTION
Make sure SOURCE_DATE_EPOCH is in the past,
otherwise, builds before noon will not have normalized mtimes
from %clamp_mtime_to_source_date_epoch

This also helps other programs like tar --clamp-mtime

Tested successfully on openSUSE.
To reproduce, create a changelog entry with only a date
```
* Fri Aug 31 2018 user@host
- dummy
```
and build it before 12:00 UTC
using macros
```
%source_date_epoch_from_changelog Y
%clamp_mtime_to_source_date_epoch Y
%use_source_date_epoch_as_buildtime Y
%_buildhost reproducible
```

`rpm -qpvl` showed file mtime values to not be normalized
and therefore build results were not bit-identical.

Edit: would be nice to avoid the modulo heuristic and find out if there was a time in the changelog or just a date. How?