### PR TITLE
Document uncompressed payload

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -381,6 +381,7 @@ package or when debugging this package.\
 #		"w6.xzdio"	xz level 6, xz's default.
 #		"w7T16.xzdio"	xz level 7 using 16 thread (xz only)
 #		"w6.lzdio"	lzma-alone level 6, lzma's default
+#		"w.ufdio"	uncompressed
 #
 #%_source_payload	w9.gzdio
 #%_binary_payload	w9.gzdio


### PR DESCRIPTION
e.g. can be useful for src.rpms where .tar.xz files are already compressed