### PR TITLE
Purge %_buildshell default.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -153,9 +153,6 @@
 #	The directory where sources/patches will be unpacked and built.
 %_builddir		%{_topdir}/BUILD
 
-#	The interpreter used for build scriptlets.
-%_buildshell		/bin/sh
-
 #	The path to the bzip2 executable (legacy, use %{__bzip2} instead).
 %_bzip2bin		%{__bzip2}
 


### PR DESCRIPTION
`%___build_shell` is perfectly set up to work without it.

Note: You can use `rpmbuild --define="_buildshell /bin/bash"` to use a different shell interpreter.