### PR TITLE
Add macros for default flags of file extractors.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -413,6 +413,12 @@ package or when debugging this package.\
 #%_default_patch_flags	-s
 %_default_patch_flags --no-backup-if-mismatch
 
+#	Default flags for source file extraction
+%_default_tar_flags -k
+%_default_gem_flags --ruby
+%_default_unzip_flags %{nil}
+%_default_7zip_flags %{nil}
+
 #==============================================================================
 # ---- Build configuration macros.
 #


### PR DESCRIPTION
`%patch` is supplied with `%_default_patch_flags` from `macros.in`.

A similar macro `%_default_tar_flags` may be useful when `%__tar` is invoked by `%setup` "behind the scenes". A possible setting in `macros.in` is `--keep-old-files` (`-k`).