### PR TITLE
Add %setup option -pN.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1270,8 +1270,9 @@ end}
 #           	usage of git repository and per-patch commits.
 # -N		Disable automatic patch application
 # -p<num>	Use -p<num> for patch application	
-%autosetup(a:b:cDn:TvNS:p:)\
-%setup %{-a} %{-b} %{-c} %{-D} %{-n} %{-T} %{!-v:-q}\
+# -t<num>	Use --strip-component=<num> for tar application	
+%autosetup(a:b:cDn:TvNS:p:t:)\
+%setup %{-a} %{-b} %{-c} %{-D} %{-n} %{-T} %{!-v:-q} %{-t:-p%{-t*}}\
 %{-S:%global __scm %{-S*}}\
 %{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
 %{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}


### PR DESCRIPTION
`%patch` provides option `-pN` that gets promoted to `patch` with the same name.

I propose a similar option `-pN` for `%setup` that gets promoted to `tar` as its option `--strip-component=N` (available both in Linux and BSD tar).