### PR TITLE
fileattrs: Tighten pythondist path regex for metadata (RhBug:1618949)

### DIFF
--- a/fileattrs/python.attr
+++ b/fileattrs/python.attr
@@ -1,4 +1,4 @@
 %__python_provides	%{_rpmconfigdir}/pythondeps.sh --provides
 %__python_requires	%{_rpmconfigdir}/pythondeps.sh --requires
-%__python_path	((/lib(64)?/python[[:digit:]]\\.[[:digit:]]/.*\\.(py[oc]?|so))|(^%{_bindir}/python[[:digit:]]\\.[[:digit:]]))$
+%__python_path	((/lib(64)?/python[[:digit:]]\\.[[:digit:]]+/.*\\.(py[oc]?|so))|(^%{_bindir}/python[[:digit:]]\\.[[:digit:]]+))$
 %__python_magic		[Pp]ython.*(executable|byte-compiled)

--- a/fileattrs/pythondist.attr
+++ b/fileattrs/pythondist.attr
@@ -1,3 +1,3 @@
 %__pythondist_provides	%{_rpmconfigdir}/pythondistdeps.py --provides --majorver-provides
 %__pythondist_requires	%{_rpmconfigdir}/pythondistdeps.py --requires
-%__pythondist_path		/lib(64)?/python[[:digit:]]\\.[[:digit:]]/.*\\.(dist.*|egg.*)$
+%__pythondist_path		/lib(64)?/python[[:digit:]]\\.[[:digit:]]+/site-packages/[^/]+\\.(dist-info|egg-info|egg-link)$


### PR DESCRIPTION
The current regular expression for matching on Python metadata files was
too greedy, leading to generating dependency information for Python modules
that were actually bundled in another module rather than actually being
installed in a way that is usable and accessible from any Python code
using the system interpreter.

This change tightens the regular expression so that we only match on
modules that are installed in a way that they'll register with
distutils/setuptools based tools (such as pip) and usable as
dependencies for other Python module packages.

Resolves [RhBug:1618949](https://bugzilla.redhat.com/show_bug.cgi?id=1618949)