### PR TITLE
Remove redundant 'cd %{_builddir}'.

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -338,15 +338,6 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 	goto exit;
     }
     
-    /* cd to the build dir */
-    {	char * buildDir = rpmGenPath(spec->rootDir, "%{_builddir}", "");
-
-	rasprintf(&buf, "cd '%s'", buildDir);
-	appendLineStringBuf(spec->prep, buf);
-	free(buf);
-	free(buildDir);
-    }
-    
     /* delete any old sources */
     if (!leaveDirs) {
 	rasprintf(&buf, "rm -rf '%s'", spec->buildSubdir);

--- a/macros.in
+++ b/macros.in
@@ -821,7 +821,7 @@ package or when debugging this package.\
   \
   %{verbose:set -x}%{!verbose:exec > /dev/null}\
   umask 022\
-  cd \"%{u2p:%{_builddir}}\"\
+  cd $RPM_BUILD_DIR\
 
 
 #%___build_body		%{nil}


### PR DESCRIPTION
And reuse the already exported environment.