### PR TITLE
Short option for SCM setting.

### DIFF
--- a/doc/rpmbuild.8
+++ b/doc/rpmbuild.8
@@ -111,6 +111,15 @@ will be run after a chroot(2) to
 .TP
 \fB-D, --define='\fIMACRO EXPR\fB'\fR
 Defines \fIMACRO\fR with value \fIEXPR\fR.
+.TP
+\fB--scm=\fISCM\fR
+Defines macro \fB__scm\fR with value \fISCM\fR. If your spec file uses
+%autosetup \fIwithout\fR option '\fB-S\fR', macro \fB__scm\fR will be used
+to initialize versioning in the BUILD arena and each patch will be added to
+the setup history.
+Note that not all values for \fISCM\fR, e.g., \fBpatch\fR (the default) and
+\fBgendiff\fR, \fBgit\fR, or \fBquilt\fR work interchangeably with all
+other options stated in the %autosetup line, especially option \fB-p\fIN\fR.
 .SS "BUILD OPTIONS"
 .PP
 The general form of an rpm build command is 

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -204,7 +204,9 @@ rpmbuild alias --with		--define "_with_!#:+     --with-!#:+" \
 rpmbuild alias --without	--define "_without_!#:+  --without-!#:+" \
 	--POPTdesc=$"disable configure <option> for build" \
 	--POPTargs=$"<option>"
-rpmbuild alias -S		--define '__scm !#:+'
+rpmbuild alias --scm		--define '__scm !#:+' \
+	--POPTdesc=$"shortcut for '--define=\"__scm <scm>\"'" \
+	--POPTargs=$"<scm>"
 # Build policies enabled from command line. Last policy applies.
 rpmbuild alias --buildpolicy --define '__os_install_post %{_rpmconfigdir}/brp-!#:+' \
 	--POPTdesc=$"set buildroot <policy> (e.g. compress man pages)" \

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -204,6 +204,7 @@ rpmbuild alias --with		--define "_with_!#:+     --with-!#:+" \
 rpmbuild alias --without	--define "_without_!#:+  --without-!#:+" \
 	--POPTdesc=$"disable configure <option> for build" \
 	--POPTargs=$"<option>"
+rpmbuild alias -S		--define '__scm !#:+'
 # Build policies enabled from command line. Last policy applies.
 rpmbuild alias --buildpolicy --define '__os_install_post %{_rpmconfigdir}/brp-!#:+' \
 	--POPTdesc=$"set buildroot <policy> (e.g. compress man pages)" \


### PR DESCRIPTION
In addition to `--define="__scm <SCM>"` and `-D "__scm <SCM>"`, rpmbuild now acknowledges the short form `--scm=<SCM>` for selecting the versioning system from the command line.