### PR TITLE
debugedit: don't reorder sections

### DIFF
--- a/tools/debugedit.c
+++ b/tools/debugedit.c
@@ -2347,10 +2347,9 @@ fdopen_dso (int fd, const char *name)
       goto error_out;
     }
 
-  /* If there are phdrs we want to maintain the layout of the
-     allocated sections in the file.  */
-  if (phnum != 0)
-    elf_flagelf (elf, ELF_C_SET, ELF_F_LAYOUT);
+  /* We maintain the layout of the allocated sections in the file:
+     https://github.com/rpm-software-management/rpm/issues/423  */
+  elf_flagelf (elf, ELF_C_SET, ELF_F_LAYOUT);
 
   memset (dso, 0, sizeof(DSO));
   dso->elf = elf;


### PR DESCRIPTION
In https://bugs.gentoo.org/666954 debugedit processed
crtbeginS.o from gcc-8.2.0 and turned into invalid ELF:

```
$ cp crtbeginS-ok-7.3.0.o.back crtbeginS-ok-7.3.0.o
$ debugedit -i -b $(pwd) -d /usr/src/debug -l ./foo crtbeginS-ok-7.3.0.o
$ export LANG=C
$ readelf -a crtbeginS-ok-7.3.0.o.back >/dev/null && echo ok
readelf: Warning: [ 9]: Info field (8) should index a relocatable section.
ok

$ readelf -a crtbeginS-ok-7.3.0.o >/dev/null && echo ok
readelf: Warning: [ 9]: Info field (8) should index a relocatable section.
readelf: Error:  bad symbol index: 54495f00 in reloc
readelf: Error:  bad symbol index: 656c6261 in reloc
readelf: Error:  bad symbol index: 62615465 in reloc
readelf: Error:  bad symbol index: 69665f61 in reloc
readelf: Warning: local symbol 11 found at index >= symtab's sh_info value of 11
readelf: Warning: local symbol 14 found at index >= symtab's sh_info value of 11
readelf: Warning: local symbol 15 found at index >= symtab's sh_info value of 11
```

Ths fix is not to reorder sections as debugedit does not
account for offset change.

debugedit already does it for final executables and shared libraries.

Bug: https://bugs.gentoo.org/666954
Closes: https://github.com/rpm-software-management/rpm/issues/423
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>