### PR TITLE
Pass %patch options to patch command as is.

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -80,7 +80,7 @@ static char *doPatch(rpmSpec spec, uint32_t c, int strip, const char *db,
     if ((spec->flags & RPMSPEC_FORCE) || checkOwners(fn) || rpmFileIsCompressed(fn, &compressed)) goto exit;
 
     if (db) {
-	rasprintf(&arg_backup, "-b --suffix %s", db);
+	rasprintf(&arg_backup, "-b -z %s", db);
     } else arg_backup = xstrdup("");
 
     if (dir) {
@@ -92,7 +92,7 @@ static char *doPatch(rpmSpec spec, uint32_t c, int strip, const char *db,
     } else arg_outfile = xstrdup("");
 
     if (fuzz >= 0) {
-	rasprintf(&arg_fuzz, " --fuzz=%d", fuzz);
+	rasprintf(&arg_fuzz, " -F %d", fuzz);
     } else arg_fuzz = xstrdup("");
 
     rasprintf(&args, "%s -p%d %s%s%s%s%s%s", arg_patch_flags, strip, arg_backup, arg_fuzz, arg_dir, arg_outfile,

--- a/macros.in
+++ b/macros.in
@@ -1193,12 +1193,12 @@ package or when debugging this package.\
 # Plain patch (-m is unused)
 %__scm_setup_patch(q) %{nil}
 %__scm_apply_patch(qp:m:)\
-%{__patch} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags}
+%{__patch} %{-p:-p%{-p*}} %{-q:-s} -F %{_default_patch_fuzz} %{_default_patch_flags}
 
 # Plain patch with backups for gendiff
 %__scm_setup_gendiff(q) %{nil}
 %__scm_apply_gendiff(qp:m:)\
-%{__patch} %{-p:-p%{-p*}} %{-q:-s} --fuzz=%{_default_patch_fuzz} %{_default_patch_flags} -b --suffix ".%{2}"
+%{__patch} %{-p:-p%{-p*}} %{-q:-s} -F %{_default_patch_fuzz} %{_default_patch_flags} -b -z ".%{2}"
 
 # Mercurial (aka hg)
 %__scm_setup_hg(q)\


### PR DESCRIPTION
The `%patch` macro uses only single-character options; for consistency, these are passed to the `patch` command as well.