### PR TITLE
if there is no caps, remove them

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -57,8 +57,13 @@ rpm	alias --setugids -q --qf \
 	--POPTdesc=$"set user/group ownership of files in a package"
 
 rpm	alias --setcaps -q --qf \
-	"[\[ -f %{FILENAMES:shescape} -a ! -L %{FILENAMES:shescape} \] \
-	    && setcap %|FILECAPS?{%{FILECAPS:shescape}}:{''}| %{FILENAMES:shescape}\n]" \
+        "[if \[ -f %{FILENAMES:shescape} -a ! -L %{FILENAMES:shescape} \]; then\n\
+%|FILECAPS?{  if \[ -n %{FILECAPS:shescape} \]; then\n\
+    setcap %{FILECAPS:shescape} %{FILENAMES:shescape}\n\
+  el}:{  }|if \[ -n \"\$(getcap %{FILENAMES:shescape})\" \]; then\n\
+    setcap -r %{FILENAMES:shescape}\n\
+  fi\n\
+fi\n]" \
 	--pipe "sh" \
 	--POPTdesc=$"set capabilities of files in a package"
 


### PR DESCRIPTION
This should fix #585 but it is tested only in Fedora 29 x86_64 and rpm-4.14.2.1-1.fc29.x86_64.

Updated as I noticed you can not remove capabilities (setcap -r) if there is none without spurious error message and also because there is different situations. When ever package does not have any capabilities set %|FILECAPS? is false. If some files have capabilities, %|FILECAPS? is true but %{FILECAPS} is '' when the file does not have capabilities and '= <capstring>' when there is some.

It would be simpler if %FILECAPS would be false if it is empty or missing.