### PR TITLE
rpmopt: make query info command display disttag if it is non-null

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -102,6 +102,7 @@ Name        : %{NAME}\n\
 %|EPOCH?{Epoch       : %{EPOCH}\n}|\
 Version     : %{VERSION}\n\
 Release     : %{RELEASE}\n\
+%|DISTTAG?{DistTag     : %{DISTTAG}\n}|\
 Architecture: %{ARCH}\n\
 Install Date: %|INSTALLTIME?{%{INSTALLTIME:date}}:{(not installed)}|\n\
 Group       : %{GROUP}\n\


### PR DESCRIPTION
In ALT there can be different builds of the same NEVR which only
differ in disttag, so it is useful to print its value as part of
package information.

Signed-off-by: Vladimir D. Seleznev <vseleznv@altlinux.org>