### PR TITLE
Ignore object files as they do not have a build id

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -334,7 +334,7 @@ touch "$temp/primary"
 find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*.debug" -type f \
      		     \( -perm -0100 -or -perm -0010 -or -perm -0001 \) \
 		     -print |
-file -N -f - | sed -n -e 's/^\(.*\):[ 	]*.*ELF.*, not stripped.*/\1/p' |
+file -N -f - | sed -rn -e 's/^(.*):[ 	]*.*ELF.*(executable|shared object).*, not stripped.*/\1/p' |
 xargs --no-run-if-empty stat -c '%h %D_%i %n' |
 while read nlinks inum f; do
   if [ $nlinks -gt 1 ]; then


### PR DESCRIPTION
The v4l-utils package contains some compiled BPF IR decoders. These
are stored in ELF relocation file. The build fails on this, see:

https://kojipkgs.fedoraproject.org//work/tasks/5458/31055458/build.log

For now, we have this workaround:

https://src.fedoraproject.org/rpms/v4l-utils/c/f86cf18b6bb6dc0d84b62256bd0460394702515c?branch=master

build ids generated by the linker, so out of the four ELF types,
just select executables and shared objects. We should not be
packaging core files or extracting debug information from them.