### PR TITLE
lib/header.c: fix hdrblobVerifyRegion() to handle old packages that use HEADERIMAGE

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1841,7 +1841,9 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     ei2h(&trailer, &einfo);
     /* Trailer offset is negative and has a special meaning */
     einfo.offset = -einfo.offset;
-    if (!(einfo.tag == regionTag &&
+    /* old packages use HEADERIMAGE */
+    if (!(((regionTag == RPMTAG_HEADERSIGNATURES && einfo.tag == RPMTAG_HEADERIMAGE) ||
+	  einfo.tag == regionTag) &&
 	  einfo.type == REGION_TAG_TYPE && einfo.count == REGION_TAG_COUNT))
     {
 	rasprintf(buf,


### PR DESCRIPTION
This fix is based on commit 21818c6c8f3d4fe7836326d27f38421c29c22db7,
which fix was lost in commit 85a5b004306fe8486424142cdc98575c25142776.

Related bugreport ALT#33710:

https://bugzilla.altlinux.org/show_bug.cgi?id=33710