### PR TITLE
Add %alias_provides() as a new "useful generic macro"

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1077,6 +1077,14 @@ package or when debugging this package.\
 %sources %{lua: for i, s in ipairs(sources) do print(s.." ") end}
 
 #------------------------------------------------------------------------------
+# Useful generic macros to bridge some slight inconveniences/unintuitiveness
+# Specify Provides: for both plain and, when not noarch, arch-qualified names,
+# so that the target makes a full-fledged alias for the originating package,
+# obviating, e.g., hefty 'Provides: libGL' + '~ libGL%{?_isa}' (libglvnd.spec);
+# first argument is required alias name, second optionally specified version:
+%alias_provides() Provides: %1 %{?2: = %2} %{?_isa:%1%{_isa} %{?2: = %2}}
+
+#------------------------------------------------------------------------------
 # Useful perl macros (from Artur Frysiak <wiget@t17.ds.pwr.wroc.pl>)
 #
 # For example, these can be used as (from ImageMagick.spec from PLD site)


### PR DESCRIPTION
This is spurred with a former naive assumption that arch-qualification
in Provides: will make any dependants (Requires:, Recommends: etc.) free
to choose whether to specify such qualifier or not, as that simply works
with direct package references (because both variants gets provided under
the hood unconditionally).  In fact, this arch-qualification is just
a conventional string serialization of this extra annotation, meaning
said assumption won't hold in the face of the applied string matching.

Upon closer examination, it turned out that it's actually quite
a wide-spread pattern with explicit/virtual/alias Provides: to specify
both these variants in row (250+ individual spec files in Fedora).

Hence, to allow this to be handled more conveniently (several years down
the road, admittedly), offer a brand new generic macro to simplify such
arrangements eventually.