### PR TITLE
Moving unnecessary notice about empty rpm packages to debug message.

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -121,7 +121,7 @@ int showQueryPackage(QVA_t qva, rpmts ts, Header h)
 
     fi = rpmfiNew(ts, h, RPMTAG_BASENAMES, fiflags);
     if (rpmfiFC(fi) <= 0) {
-	rpmlog(RPMLOG_NOTICE, _("(contains no files)\n"));
+	rpmlog(RPMLOG_DEBUG, _("(contains no files)\n"));
 	goto exit;
     }
 


### PR DESCRIPTION
This notice makes a problem when you want to process an output of rpm -ql of an empty rpm package in a shell script.

Example:
$ rpm -ql gpg-pubkey-f2ee9d55-560cfc0a 
(contains no files)
$ rpm -ql gpg-pubkey-f2ee9d55-560cfc0a | wc -l
1
---
But the package is empty!