### PR TITLE
Make list of dependencies in test/README consistent

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,5 +1,5 @@
 To run these tests you need at least these dependencies:
-fakechroot gdb gpg2 python-rpm
+fakechroot gdb gnupg>=2.0
 
 Then run
 


### PR DESCRIPTION
The other entries in the list of dependencies are names of provides. But gpg2 is name of executable and the command is not in package gpg2 or in a package with gpg2 in provides.