### PR TITLE
Warn if a text is after %else or %endif

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -223,11 +223,22 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
 {
     char *lbuf = NULL;
     int isComment = 0;
+    parsedSpecLine condition;
 
     lbuf = spec->lbuf;
     SKIPSPACE(lbuf);
     if (lbuf[0] == '#')
 	isComment = 1;
+
+    condition = parseLineType(lbuf);
+    if ((condition) && (!condition->withArgs)) {
+	const char *s = lbuf + condition->textLen;
+	SKIPSPACE(s);
+	if (s[0])
+	    rpmlog(RPMLOG_WARNING,
+		_("extra tokens at the end of %s directive in line %d:  %s\n"),
+		condition->text, spec->lineNum, lbuf);
+    }
 
     /* Don't expand macros (eg. %define) in false branch of %if clause */
     if (!spec->readStack->reading)

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -426,7 +426,7 @@ int readLine(rpmSpec spec, int strip)
     parsedSpecLine lineType;
 
     if (!restoreFirstChar(spec)) {
-    retry:
+retry:
 	if ((rc = readLineFromOFI(spec, ofi)) != 0) {
 	    if (spec->readStack->next) {
 		rpmlog(RPMLOG_ERR, _("line %d: Unclosed %%if\n"),

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -224,15 +224,14 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
     char *lbuf = NULL;
     int isComment = 0;
 
-     /* Don't expand macros (eg. %define) in false branch of %if clause */
-    if (!spec->readStack->reading)
-	return 0;
-
     lbuf = spec->lbuf;
     SKIPSPACE(lbuf);
     if (lbuf[0] == '#')
 	isComment = 1;
 
+    /* Don't expand macros (eg. %define) in false branch of %if clause */
+    if (!spec->readStack->reading)
+	return 0;
 
     if (rpmExpandMacros(spec->macros, spec->lbuf, &lbuf, 0) < 0) {
 	rpmlog(RPMLOG_ERR, _("line %d: %s\n"),


### PR DESCRIPTION
Before this commit, rpm handles text after %else or %endif
nonconsistently and does not give any feedback:
- a text after %else was expanded according to evaluation
  of the previous %if.
- a text after %endif was expanded according to evaluation
  of the previous %else, resp. %if if there was no %else.

So in the current spec files there exist lines like:
    %else %if 0%{?centos}
    %else !use_embedded
    %endif # with_perf
(comments must have '#' at the start of the line to behave as defined)

So to be consistent and clear, this warning is added. It looks
for example:

warning: line 93, no text in allowed after %else