### PR TITLE
[RFE] Use file path in %patch macro

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1187,6 +1187,14 @@ package or when debugging this package.\
 
 #------------------------------------------------------------------------------
 # Macros for further automated spec %setup and patch application
+#
+# Macros used when expanding %%patchX or %patch -P X
+%__apply_patchx_common(b:d:o:F:REp:m:)\
+%{__patch} %{_default_patch_flags} %{-p:-p%{-p*}} %{-b:-b --suffix %{-b*}} %{-o:-o%{-o*}} %{-F:--fuzz=%{-F*}}%{!-F:--fuzz=%{_default_patch_fuzz}} %{-R} %{-E}
+%__apply_patchx_plain(b:d:o:F:REp:m:)\
+%{__apply_patchx_common %{-p} %{-b} %{-o} %{-F} %{-R} %{-E} %{1} %{2}} < %{1}
+%__apply_patchx_uncompress(b:d:o:F:REp:m:)\
+{ %{uncompress:%{1}} || echo patch_fail ; } | %{__apply_patchx_common %{-p} %{-b} %{-o} %{-F} %{-R} %{-E} %{1} %{2}}
 
 # default to plain patch
 %__scm patch


### PR DESCRIPTION
Moves single %patchX from RPM code to macros. This can be then
redefined.

Similar to apply_patch, but allows all custom flags that can be passed
to %__patch utility. Forwards also name and number of a patch.

Rename to __apply_patchx_{common,plain,uncompress}

Use single macro in two variants, cleanup some parts.
Remove default patch flags, they are in common part already.