### PR TITLE
find-debuginfo.sh: Handle position-independent executables

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -412,6 +412,7 @@ do_file()
     case "$(file -bi "$f")" in
       application/x-sharedlib*) skip_mini=false ;;
       application/x-executable*) skip_mini=false ;;
+      application/x-pie-executable*) skip_mini=false ;;
     esac
     $skip_mini || add_minidebug "${debugfn}" "$f"
   fi


### PR DESCRIPTION
Since file 5.33, PIEs are identified by a new MIME type, meaning that,
currently, for such executables, the .gnu_debugdata section is not
added, even if -m is passed.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>