### PR TITLE
Test a macro from a macro file that contains %ifxxx - %endif

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,6 +54,7 @@ EXTRA_DIST += data/SPECS/configtest.spec
 EXTRA_DIST += data/SPECS/filedep.spec
 EXTRA_DIST += data/SPECS/flangtest.spec
 EXTRA_DIST += data/SPECS/hlinktest.spec
+EXTRA_DIST += data/SPECS/iftest.spec
 EXTRA_DIST += data/SPECS/symlinktest.spec
 EXTRA_DIST += data/SPECS/deptest.spec
 EXTRA_DIST += data/SPECS/verifyscript.spec

--- a/tests/data/SPECS/iftest.spec
+++ b/tests/data/SPECS/iftest.spec
@@ -1,0 +1,27 @@
+%define mymacro0 \
+%if 0  \
+%global bbb0 ccc0\
+Summary: macro 0\
+%endif \
+%{nil}
+
+%define mymacro1 \
+%if 1  \
+%global bbb1 ccc1 \
+Summary: macro 1\
+%endif
+%{nil}
+
+Name:           iftest
+Version:        1.0
+Release:        1
+Group:          Testing
+License:        GPL
+BuildArch:      noarch
+
+%mymacro0
+%mymacro1
+
+%description
+%bbb0
+%bbb1

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -478,3 +478,15 @@ runroot rpm --macros "/data/macros.testfile" \
 macro_2
 ])
 AT_CLEANUP
+
+AT_SETUP([macro with %if-%endif])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpmspec -q --qf "%{summary}\n%{description}\n" /data/SPECS/iftest.spec
+],
+[0],
+[macro 1
+%bbb0
+ccc1
+])
+AT_CLEANUP


### PR DESCRIPTION
The underlying problem tested in the patch:

If a macro is in a macro file and at the same time it contains
%ifxxx - %endif (%ifxxx here denotes one of %if, %ifarch, %ifnarch,
%ifos, %ifnos) then during the rpm expansion of the macro the lines
inside %ifxxx - %endif are expanded in all cases (no matter whether
the condition after %ifxxx is satisfied or not).

Thus e.g. if the following definition is in a macro file:
   %mymacro \
   %if 0  \
   %global bbb ccc \
   %endif \
   %{nil}
and a spec file contains line:
   %mymacro
then during the expansion of %mymacro macro %bbb is globally
defined even if the condition after %if is not true.

It is not a problem in evaluation of the %if condition. It is caused
by the fact that the whole %mymacro is expanded in several recursive 
steps and in meantime there is no check whether some of its lines start 
by %ifxxx.