### PR TITLE
 Correct rpm -ql exit value when optional -p is omitted (RhBug:1680610)

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -574,7 +574,8 @@ int rpmcliArgIter(rpmts ts, QVA_t qva, ARGV_const_t argv)
 	    if (mi == NULL && qva->qva_source == RPMQV_PACKAGE) {
 		size_t l = strlen(*arg);
 		if (l > 4 && !strcmp(*arg + l - 4, ".rpm")) {
-		    rpmgi gi = rpmgiNew(ts, giFlags, argv);
+		    char * const argFirst[2] = { arg[0], NULL };
+		    rpmgi gi = rpmgiNew(ts, giFlags, argFirst);
 		    ecLocal = rpmgiShowMatches(qva, ts, gi);
 		    rpmgiFree(gi);
 		}

--- a/lib/query.c
+++ b/lib/query.c
@@ -492,8 +492,7 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 	}
 	mi = rpmdbFreeIterator(mi);
 	if (! matches) {
-	    size_t l = strlen(arg);
-	    if (!(l > 4 && !strcmp(arg + l - 4, ".rpm")))
+	    if (!rpmFileHasSuffix(arg, ".rpm"))
 		rpmlog(RPMLOG_NOTICE, _("package %s is not installed\n"), arg);
 	} else {
 	    mi = rpmtsInitIterator(ts, RPMDBI_LABEL, arg, 0);
@@ -572,8 +571,7 @@ int rpmcliArgIter(rpmts ts, QVA_t qva, ARGV_const_t argv)
 	    rpmdbMatchIterator mi = initQueryIterator(qva, ts, *arg);
 	    ecLocal = rpmcliShowMatches(qva, ts, mi);
 	    if (mi == NULL && qva->qva_source == RPMQV_PACKAGE) {
-		size_t l = strlen(*arg);
-		if (l > 4 && !strcmp(*arg + l - 4, ".rpm")) {
+		if (rpmFileHasSuffix(*arg, ".rpm")) {
 		    char * const argFirst[2] = { arg[0], NULL };
 		    rpmgi gi = rpmgiNew(ts, giFlags, argFirst);
 		    ecLocal = rpmgiShowMatches(qva, ts, gi);

--- a/lib/query.c
+++ b/lib/query.c
@@ -568,16 +568,18 @@ int rpmcliArgIter(rpmts ts, QVA_t qva, ARGV_const_t argv)
 	break;
     default:
 	for (ARGV_const_t arg = argv; arg && *arg; arg++) {
+	    int ecLocal;
 	    rpmdbMatchIterator mi = initQueryIterator(qva, ts, *arg);
-	    ec += rpmcliShowMatches(qva, ts, mi);
+	    ecLocal = rpmcliShowMatches(qva, ts, mi);
 	    if (mi == NULL && qva->qva_source == RPMQV_PACKAGE) {
 		size_t l = strlen(*arg);
 		if (l > 4 && !strcmp(*arg + l - 4, ".rpm")) {
 		    rpmgi gi = rpmgiNew(ts, giFlags, argv);
-		    ec += rpmgiShowMatches(qva, ts, gi);
+		    ecLocal = rpmgiShowMatches(qva, ts, gi);
 		    rpmgiFree(gi);
 		}
 	    }
+	    ec += ecLocal;
 	    rpmdbFreeIterator(mi);
 	}
 	break;

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -62,6 +62,24 @@ hello.spec
 AT_CLEANUP
 
 # ------------------------------
+AT_SETUP([rpm -ql multiple *.rpm])
+AT_KEYWORDS([query])
+AT_CHECK([
+runroot rpm \
+  -ql \
+  /data/SRPMS/hello-1.0-1.src.rpm /data/RPMS/hello-1.0-1.i386.rpm
+],
+[0],
+[hello-1.0.tar.gz
+hello.spec
+/usr/local/bin/hello
+/usr/share/doc/hello-1.0
+/usr/share/doc/hello-1.0/FAQ
+],
+[ignore])
+AT_CLEANUP
+
+# ------------------------------
 AT_SETUP([rpmspec -q])
 AT_KEYWORDS([query])
 AT_CHECK([


### PR DESCRIPTION
Additionally if a package query with the argument was successful, there 
is no need to rpm query of the argument.