### PR TITLE
Remove full paths from expected results of --addsign <corrupted> test

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -484,11 +484,17 @@ pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
 dd if=/dev/zero of="${RPMTEST}"/tmp/${pkg} \
    conv=notrunc bs=1 seek=333 count=4 2> /dev/null
-run rpmsign --key-id 1964C5FC --addsign "${RPMTEST}/tmp/${pkg}"
+run rpmsign --key-id 1964C5FC --addsign "${RPMTEST}/tmp/${pkg}" >/dev/null 2>"${RPMTEST}"/stderr
+echo $?
+more "${RPMTEST}"/stderr | wc -l
+grep -c "error: not signing corrupt package " "${RPMTEST}"/stderr
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 ],
-[1],
-[/home/pmatilai/repos/rpm/tests/testing/tmp/hello-2.0-1.x86_64.rpm:
+[0],
+[1
+1
+1
+/tmp/hello-2.0-1.x86_64.rpm:
 ],
-[error: not signing corrupt package /home/pmatilai/repos/rpm/tests/testing/tmp/hello-2.0-1.x86_64.rpm: MD5 digest: BAD (Expected 007ca1d8b35cca02a1854ba301c5432e != 137ca1d8b35cca02a1854ba301c5432e)
-])
+[])
 AT_CLEANUP


### PR DESCRIPTION
The full paths should be removed from the expected results of the test. If the way that is used in the patch is not the one you prefer, feel free to correct it differently.