### PR TITLE
rpmio/digest_nss.c: fix build on musl

### DIFF
--- a/rpmio/digest_nss.c
+++ b/rpmio/digest_nss.c
@@ -3,6 +3,7 @@
 #include <pthread.h>
 #include <nss.h>
 #include <sechash.h>
+#include <signal.h>
 #include <keyhi.h>
 #include <cryptohi.h>
 #include <blapit.h>


### PR DESCRIPTION
signal.h must be included to be able to use sigaction

Fixes:
 - http://autobuild.buildroot.org/results/395fd44a930dfc2ad380bc735c26d9ce62344295

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>