### PR TITLE
Support build-id generation from compressed ELF files

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1828,7 +1828,11 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
 		   kernel modules (ET_REL files with .modinfo section)
 		   should have build-ids. */
 		GElf_Ehdr ehdr;
+#if HAVE_DWELF_ELF_BEGIN
+		Elf *elf = dwelf_elf_begin(fd);
+#else
 		Elf *elf = elf_begin (fd, ELF_C_READ, NULL);
+#endif
 		if (elf != NULL && elf_kind(elf) == ELF_K_ELF
 		    && gelf_getehdr(elf, &ehdr) != NULL
 		    && (ehdr.e_type == ET_EXEC || ehdr.e_type == ET_DYN

--- a/configure.ac
+++ b/configure.ac
@@ -487,6 +487,10 @@ AS_IF([test "$WITH_LIBELF" = yes],[
       # If possible we also want the strtab functions from elfutils 0.167.
       # But we can fall back on the (unsupported) ebl alternatives if not.
       AC_CHECK_LIB(dw, dwelf_strtab_init, [HAVE_LIBDW_STRTAB=yes])
+      # whether libdw supports compressed ELF objects
+      AC_CHECK_LIB(dw, dwelf_elf_begin, [
+                   AC_DEFINE(HAVE_DWELF_ELF_BEGIN, 1, [Have dwelf_elf_begin?])
+      ])
     ])
   ])
 ])


### PR DESCRIPTION
The prime use-case is build-id generation for compressed kernel modules, see  https://bugzilla.redhat.com/show_bug.cgi?id=1650072 for background.

The first commit is independent in that it simply improves the detection of kernel modules, the second part actually enables compressed ELF via use of dwelf_elf_begin().

Caveat: I haven't actually tested it with a kernel module due to not having a sane reproducer (rebuilding the entire kernel just for this is not an appetizing thought).