### PR TITLE
Initialize verifyFlags for specialdir

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2354,6 +2354,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     FileEntryFree(&fl->cur);
     FileEntryFree(&fl->def);
     copyFileEntry(&sd->entries[0].defEntry, &fl->def);
+    copyFileEntry(&sd->entries[0].curEntry, &fl->cur);
     fl->cur.isDir = 1;
     (void) processBinaryFile(pkg, fl, sd->dirname);
 


### PR DESCRIPTION
Initialize verifyFlags for specialdir, because
FileEntryFree(&fl->cur) zeroed all fields, including verifyFlags, so we have to fill them again.

Closes issue #655

Note: only slightly tested