### PR TITLE
Sort list of hard linked files in find-debuginfo.sh (RhBug:1421272)

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -350,7 +350,7 @@ trap 'rm -rf "$temp"' EXIT
 touch "$temp/primary"
 find "$RPM_BUILD_ROOT" ! -path "${debugdir}/*.debug" -type f \
      		     \( -perm -0100 -or -perm -0010 -or -perm -0001 \) \
-		     -print |
+		     -print | LC_ALL=C sort |
 file -N -f - | sed -n -e 's/^\(.*\):[ 	]*.*ELF.*, not stripped.*/\1/p' |
 xargs --no-run-if-empty stat -c '%h %D_%i %n' |
 while read nlinks inum f; do


### PR DESCRIPTION
It helps to make build results reproducible. Based on Mark Wielaard's idea.