### PR TITLE
Unify build-script running to always use rpmfcExec()

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2727,7 +2727,7 @@ static int checkFiles(const char *buildRoot, StringBuf fileList)
 
     rpmlog(RPMLOG_NOTICE, _("Checking for unpackaged file(s): %s\n"), s);
 
-    rc = rpmfcExec(av_ckfile, fileList, &sb_stdout, 0, buildRoot);
+    rc = rpmfcExec(av_ckfile, fileList, &sb_stdout, 0, buildRoot, NULL);
     if (rc < 0)
 	goto exit;
     

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -408,10 +408,11 @@ rpmRC rpmfcGenerateDepends(const rpmSpec spec, Package pkg);
  * @retval *sb_stdoutp	helper output
  * @param failnonzero	IS non-zero helper exit status a failure?
  * @param buildRoot	buildRoot directory (or NULL)
+ * @param dup		duplicate output (or NULL)
  */
 RPM_GNUC_INTERNAL
 int rpmfcExec(ARGV_const_t av, StringBuf sb_stdin, StringBuf * sb_stdoutp,
-		int failnonzero, const char *buildRoot);
+		int failnonzero, const char *buildRoot, FILE *dup);
 
 /** \ingroup rpmbuild
  * Post-build processing for policies in binary package(s).


### PR DESCRIPTION
Simplifies the code and could be of use to PR #593 

The downside is that it eats more memory due to buffering the entire build output but whether that matters... and could be conditionalized of course.