### PR TITLE
Alternative implementation of #663

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -807,7 +807,8 @@ package or when debugging this package.\
   RPM_OPT_FLAGS=\"%{optflags}\"\
   RPM_ARCH=\"%{_arch}\"\
   RPM_OS=\"%{_os}\"\
-  export RPM_SOURCE_DIR RPM_BUILD_DIR RPM_OPT_FLAGS RPM_ARCH RPM_OS\
+  RPM_BUILD_NCPUS=\"%{_smp_build_ncpus}\"\
+  export RPM_SOURCE_DIR RPM_BUILD_DIR RPM_OPT_FLAGS RPM_ARCH RPM_OS RPM_BUILD_NCPUS\
   RPM_DOC_DIR=\"%{_docdir}\"\
   export RPM_DOC_DIR\
   RPM_PACKAGE_NAME=\"%{NAME}\"\

--- a/scripts/brp-strip-static-archive
+++ b/scripts/brp-strip-static-archive
@@ -5,6 +5,7 @@ if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
 fi
 
 STRIP=${1:-strip}
+NCPUS=${RPM_BUILD_NCPUS:-1}
 
 case `uname -a` in
 Darwin*) exit 0 ;;
@@ -12,9 +13,10 @@ Darwin*) exit 0 ;;
 esac
 
 # Strip static libraries.
-for f in `find "$RPM_BUILD_ROOT" -type f -a -exec file {} \; | \
-        grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug"  | \
+for f in `find "$RPM_BUILD_ROOT" -type f | \
+	grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug" | \
+	xargs -r -P$NCPUS -n16 file | sed 's/:  */: /' | \
 	grep 'current ar archive' | \
-	sed -n -e 's/^\(.*\):[ 	]*current ar archive/\1/p'`; do
+	sed -n -e 's/^\(.*\):[  ]*current ar archive/\1/p'`; do
 	$STRIP -g "$f"
 done

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -144,7 +144,7 @@ populate_testing:
 	for d in dev etc magic tmp var; do if [ ! -d testing/$${d} ]; then mkdir testing/$${d}; fi; done
 	for node in urandom stdin stderr stdout null full; do ln -s /dev/$${node} testing/dev/$${node}; done
 	for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do [ -f /etc/$${cf} ] && ln -s /etc/$${cf} testing/etc/$${cf}; done
-	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
+	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 	HOME=$(abs_builddir)/testing gpg2 --import ${abs_srcdir}/data/keys/*.secret


### PR DESCRIPTION
This variant passes RPM_BUILD_NCPUS as environment variable to all build scripts and uses it to paralize brp-strip-static-archive.
Obsoletes #663 