### PR TITLE
Consolidate most spec line reading into a single helper function

### DIFF
--- a/build/parseChangelog.c
+++ b/build/parseChangelog.c
@@ -300,7 +300,7 @@ exit:
 
 int parseChangelog(rpmSpec spec)
 {
-    int nextPart, rc, res = PART_ERROR;
+    int res = PART_ERROR;
     ARGV_t sb = NULL;
 
     if (headerIsEntry(spec->packages->header, RPMTAG_CHANGELOGTIME)) {
@@ -308,28 +308,12 @@ int parseChangelog(rpmSpec spec)
 	goto exit;
     }
     
-    /* There are no options to %changelog */
-    if ((rc = readLine(spec, STRIP_COMMENTS)) > 0) {
-	res = PART_NONE;
+    if ((res = parseLines(spec, STRIP_COMMENTS, &sb, NULL)) == PART_ERROR)
 	goto exit;
-    } else if (rc < 0) {
-	goto exit;
-    }
-    
-    while (! (nextPart = isPart(spec->line))) {
-	argvAdd(&sb, spec->line);
-	if ((rc = readLine(spec, STRIP_COMMENTS)) > 0) {
-	    nextPart = PART_NONE;
-	    break;
-	} else if (rc < 0) {
-	    goto exit;
-	}
-    }
 
     if (sb && addChangelog(spec->packages->header, sb)) {
 	goto exit;
     }
-    res = nextPart;
 
 exit:
     argvFree(sb);

--- a/build/parseDescription.c
+++ b/build/parseDescription.c
@@ -63,27 +63,11 @@ int parseDescription(rpmSpec spec)
     if (lookupPackage(spec, name, flag, &pkg))
 	goto exit;
 
-    sb = newStringBuf();
-
-    if ((rc = readLine(spec, STRIP_TRAILINGSPACE | STRIP_COMMENTS)) > 0) {
-	nextPart = PART_NONE;
-    } else if (rc < 0) {
-	    nextPart = PART_ERROR;
-	    goto exit;
-    } else {
-	while (! (nextPart = isPart(spec->line))) {
-	    appendLineStringBuf(sb, spec->line);
-	    if ((rc =
-		readLine(spec, STRIP_TRAILINGSPACE | STRIP_COMMENTS)) > 0) {
-		nextPart = PART_NONE;
-		break;
-	    } else if (rc < 0) {
-		nextPart = PART_ERROR;
-		goto exit;
-	    }
-	}
+    if ((nextPart = parseLines(spec, (STRIP_TRAILINGSPACE |STRIP_COMMENTS),
+				NULL, &sb)) == PART_ERROR) {
+	goto exit;
     }
-    
+
     stripTrailingBlanksStringBuf(sb);
     if (addLangTag(spec, pkg->header,
 		   RPMTAG_DESCRIPTION, getStringBuf(sb), lang)) {

--- a/build/parseFiles.c
+++ b/build/parseFiles.c
@@ -12,7 +12,7 @@
 
 int parseFiles(rpmSpec spec)
 {
-    int nextPart, res = PART_ERROR;
+    int res = PART_ERROR;
     Package pkg;
     int rc, argc;
     int arg;
@@ -84,23 +84,7 @@ int parseFiles(rpmSpec spec)
     }
 
     pkg->fileList = argvNew();
-
-    if ((rc = readLine(spec, STRIP_COMMENTS)) > 0) {
-	nextPart = PART_NONE;
-    } else if (rc < 0) {
-	goto exit;
-    } else {
-	while (! (nextPart = isPart(spec->line))) {
-	    argvAdd(&(pkg->fileList), spec->line);
-	    if ((rc = readLine(spec, STRIP_COMMENTS)) > 0) {
-		nextPart = PART_NONE;
-		break;
-	    } else if (rc < 0) {
-		goto exit;
-	    }
-	}
-    }
-    res = nextPart;
+    res = parseLines(spec, STRIP_COMMENTS, &(pkg->fileList), NULL);
 
 exit:
     rpmPopMacro(NULL, "license");

--- a/build/parsePolicies.c
+++ b/build/parsePolicies.c
@@ -14,7 +14,7 @@
 
 int parsePolicies(rpmSpec spec)
 {
-    int nextPart, res = PART_ERROR;
+    int res = PART_ERROR;
     Package pkg;
     int rc, argc;
     int arg;
@@ -61,22 +61,8 @@ int parsePolicies(rpmSpec spec)
     if (lookupPackage(spec, name, flag, &pkg))
 	goto exit;
 
-    if ((rc = readLine(spec, STRIP_TRAILINGSPACE | STRIP_COMMENTS)) > 0) {
-	nextPart = PART_NONE;
-    } else if (rc < 0) {
-	goto exit;
-    } else {
-	while (!(nextPart = isPart(spec->line))) {
-	    argvAdd(&(pkg->policyList), spec->line);
-	    if ((rc = readLine(spec, STRIP_TRAILINGSPACE | STRIP_COMMENTS)) > 0) {
-		nextPart = PART_NONE;
-		break;
-	    } else if (rc < 0) {
-		goto exit;
-	    }
-	}
-    }
-    res = nextPart;
+    res = parseLines(spec, (STRIP_TRAILINGSPACE | STRIP_COMMENTS),
+		     &(pkg->policyList), NULL);
 
   exit:
     free(argv);

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -92,7 +92,6 @@ int parseScript(rpmSpec spec, int parsePart)
     int flag = PART_SUBNAME;
     Package pkg;
     StringBuf sb = NULL;
-    int nextPart;
     int index;
     char * reqargs = NULL;
 
@@ -355,22 +354,8 @@ int parseScript(rpmSpec spec, int parsePart)
 	goto exit;
     }
 
-    sb = newStringBuf();
-    if ((rc = readLine(spec, STRIP_NOTHING)) > 0) {
-	nextPart = PART_NONE;
-    } else if (rc < 0) {
+    if ((res = parseLines(spec, STRIP_NOTHING, NULL, &sb)) == PART_ERROR)
 	goto exit;
-    } else {
-	while (! (nextPart = isPart(spec->line))) {
-	    appendStringBuf(sb, spec->line);
-	    if ((rc = readLine(spec, STRIP_NOTHING)) > 0) {
-		nextPart = PART_NONE;
-		break;
-	    } else if (rc < 0) {
-		goto exit;
-	    }
-	}
-    }
     stripTrailingBlanksStringBuf(sb);
     p = getStringBuf(sb);
 
@@ -474,8 +459,7 @@ int parseScript(rpmSpec spec, int parsePart)
 	    }
 	}
     }
-    res = nextPart;
-    
+
 exit:
     free(reqargs);
     freeStringBuf(sb);

--- a/build/parseSimpleScript.c
+++ b/build/parseSimpleScript.c
@@ -11,7 +11,7 @@
 
 int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp)
 {
-    int nextPart, rc, res = PART_ERROR;
+    int res = PART_ERROR;
     
     if (*sbp != NULL) {
 	rpmlog(RPMLOG_ERR, _("line %d: second %s\n"),
@@ -19,26 +19,8 @@ int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp)
 	goto exit;
     }
     
-    *sbp = newStringBuf();
-
     /* There are no options to %build, %install, %check, or %clean */
-    if ((rc = readLine(spec, STRIP_NOTHING)) > 0) {
-	res = PART_NONE;
-	goto exit;
-    } else if (rc < 0) {
-	goto exit;
-    }
-    
-    while (! (nextPart = isPart(spec->line))) {
-	appendStringBuf(*sbp, spec->line);
-	if ((rc = readLine(spec, STRIP_NOTHING)) > 0) {
-	    nextPart = PART_NONE;
-	    break;
-	} else if (rc < 0) {
-	    goto exit;
-	}
-    }
-    res = nextPart;
+    res = parseLines(spec, STRIP_NOTHING, NULL, sbp);
     
 exit:
 

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -552,6 +552,39 @@ after_classification:
     return 0;
 }
 
+int parseLines(rpmSpec spec, int strip, ARGV_t *avp, StringBuf *sbp)
+{
+    int rc, nextPart = PART_ERROR;
+    int nl = (strip & STRIP_TRAILINGSPACE);
+
+    if ((rc = readLine(spec, strip)) > 0) {
+	nextPart = PART_NONE;
+	goto exit;
+    } else if (rc < 0) {
+	goto exit;
+    }
+
+    if (sbp && *sbp == NULL)
+	*sbp = newStringBuf();
+
+    while (! (nextPart = isPart(spec->line))) {
+	if (avp)
+	    argvAdd(avp, spec->line);
+	if (sbp)
+	    appendStringBufAux(*sbp, spec->line, nl);
+	if ((rc = readLine(spec, strip)) > 0) {
+	    nextPart = PART_NONE;
+	    break;
+	} else if (rc < 0) {
+	    nextPart = PART_ERROR;
+	    break;
+	}
+    }
+
+exit:
+    return nextPart;
+}
+
 void closeSpec(rpmSpec spec)
 {
     while (popOFI(spec)) {};

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -222,6 +222,17 @@ RPM_GNUC_INTERNAL
 int readLine(rpmSpec spec, int strip);
 
 /** \ingroup rpmbuild
+ * Read next line from spec file.
+ * @param spec		spec file control structure
+ * @param strip		truncate comments?
+ * @retval avp		pointer to argv (optional, alloced)
+ * @retval sbp		pointer to string buf (optional, alloced)
+ * @return		next spec part or PART_ERROR on error
+ */
+RPM_GNUC_INTERNAL
+int parseLines(rpmSpec spec, int strip, ARGV_t *avp, StringBuf *sbp);
+
+/** \ingroup rpmbuild
  * Check line for section separator, return next parser state.
  * @param		line from spec file
  * @return		next parser state


### PR DESCRIPTION
Consolidate umptheen copy-slop variants of the same readLine() construct into a unified helper, port all simple cases to use it. parsePreamble.c has a couple of readLine() uses that do more work than just add lines, that's left as an exercise for another rainy day. Supposedly no functional changes, other than truly unified behavior for all these cases (there were some subtle error checks missing in some of the copies)