### PR TITLE
Use --dpbath only with full path (RhBug:1696408)

### DIFF
--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -147,6 +147,10 @@ static void rpmcliAllArgCallback( poptContext con,
 	break;
     case POPT_DBPATH:
 	rpmcliConfigured();
+	if (arg && arg[0] != '/') {
+	    fprintf(stderr, _("arguments to --dbpath must begin with '/'\n"));
+	    exit(EXIT_FAILURE);
+	}
 	rpmPushMacro(NULL, "_dbpath", NULL, arg, RMIL_CMDLINE);
 	break;
     case POPT_SHOWVERSION:


### PR DESCRIPTION
Before the patch rpm treats the relative path as a full path.
The new behavior is similar to the "--root" option.