### PR TITLE
Add support for %patchlist and %sourcelist spec sections

### DIFF
--- a/build/Makefile.am
+++ b/build/Makefile.am
@@ -16,7 +16,7 @@ librpmbuild_la_SOURCES = \
 	build.c expression.c files.c misc.c pack.c \
 	parseSimpleScript.c parseChangelog.c parseDescription.c \
 	parseFiles.c parsePreamble.c parsePrep.c parseReqs.c parseScript.c \
-	parseSpec.c reqprov.c rpmfc.c spec.c \
+	parseSpec.c parseList.c reqprov.c rpmfc.c spec.c \
 	parsePolicies.c policies.c \
 	rpmbuild_internal.h rpmbuild_misc.h
 

--- a/build/parseList.c
+++ b/build/parseList.c
@@ -1,0 +1,32 @@
+/** \ingroup rpmbuild
+ * \file build/parseBuildInstallClean.c
+ *  Parse %build/%install/%clean section from spec file.
+ */
+#include "system.h"
+
+#include <rpm/rpmlog.h>
+#include "build/rpmbuild_internal.h"
+#include "debug.h"
+
+
+int parseList(rpmSpec spec, const char *name, rpmTagVal tag)
+{
+    int res = PART_ERROR;
+    ARGV_t lst = NULL;
+
+    /* There are no options to %patchlist and %sourcelist */
+    if ((res = parseLines(spec, (STRIP_TRAILINGSPACE | STRIP_COMMENTS),
+			  &lst, NULL)) == PART_ERROR) {
+	goto exit;
+    }
+
+    for (ARGV_const_t l = lst; l && *l; l++) {
+	if (rstreq(*l, ""))
+	    continue;
+	addSource(spec, 0, *l, tag);
+    }
+
+exit:
+    argvFree(lst);
+    return res;
+}

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -278,7 +278,7 @@ static int parseTagNumber(const char *line, uint32_t *snum)
     return rc;
 }
 
-static int addSource(rpmSpec spec, const char *field, rpmTagVal tag)
+int addSource(rpmSpec spec, int specline, const char *srcname, rpmTagVal tag)
 {
     struct Source *p;
     int flag = 0;
@@ -306,11 +306,13 @@ static int addSource(rpmSpec spec, const char *field, rpmTagVal tag)
 	break;
     }
 
-    nonum = parseTagNumber(spec->line + strlen(name), &num);
-    if (nonum < 0) {
-	rpmlog(RPMLOG_ERR, _("line %d: Bad %s number: %s\n"),
-		 spec->lineNum, name, spec->line);
-	return RPMRC_FAIL;
+    if (specline) {
+	nonum = parseTagNumber(spec->line + strlen(name), &num);
+	if (nonum < 0) {
+	    rpmlog(RPMLOG_ERR, _("line %d: Bad %s number: %s\n"),
+		     spec->lineNum, name, spec->line);
+	    return RPMRC_FAIL;
+	}
     }
 
     if (nonum > 0) {
@@ -330,7 +332,7 @@ static int addSource(rpmSpec spec, const char *field, rpmTagVal tag)
     }
 
     /* Create the entry and link it in */
-    p = newSource(num, field, flag);
+    p = newSource(num, srcname, flag);
     p->next = spec->sources;
     spec->sources = p;
     spec->numSources++;
@@ -884,7 +886,7 @@ static rpmRC handlePreambleTag(rpmSpec spec, Package pkg, rpmTagVal tag,
 	break;
     case RPMTAG_SOURCE:
     case RPMTAG_PATCH:
-	if (addSource(spec, field, tag))
+	if (addSource(spec, 1, field, tag))
 	    goto exit;
 	break;
     case RPMTAG_ICON:

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -74,6 +74,8 @@ static const struct PartRec {
     { PART_TRANSFILETRIGGERUN,	    LEN_AND_STR("%transfiletriggerun")},
     { PART_TRANSFILETRIGGERPOSTUN,  LEN_AND_STR("%transfiletriggerpostun")},
     { PART_EMPTY,		    LEN_AND_STR("%end")},
+    { PART_PATCHLIST,               LEN_AND_STR("%patchlist")},
+    { PART_SOURCELIST,              LEN_AND_STR("%sourcelist")},
     {0, 0, 0}
 };
 
@@ -890,6 +892,12 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 	case PART_PREAMBLE:
 	    parsePart = parsePreamble(spec, initialPackage);
 	    initialPackage = 0;
+	    break;
+	case PART_PATCHLIST:
+	    parsePart = parseList(spec, "%patchlist", RPMTAG_PATCH);
+	    break;
+	case PART_SOURCELIST:
+	    parsePart = parseList(spec, "%sourcelist", RPMTAG_SOURCE);
 	    break;
 	case PART_PREP:
 	    parsePart = parsePrep(spec);

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -500,6 +500,9 @@ rpmRC addReqProvPkg(void *cbdata, rpmTagVal tagN,
 RPM_GNUC_INTERNAL
 void addPackageProvides(Package pkg);
 
+RPM_GNUC_INTERNAL
+int addSource(rpmSpec spec, int specline, const char *srcname, rpmTagVal tag);
+
 /** \ingroup rpmbuild
  * Add rpmlib feature dependency.
  * @param pkg		package

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -187,7 +187,9 @@ typedef enum rpmParseState_e {
     PART_TRANSFILETRIGGERUN	= 37+PART_BASE, /*!< */
     PART_TRANSFILETRIGGERPOSTUN	= 38+PART_BASE, /*!< */
     PART_EMPTY			= 39+PART_BASE, /*!< */
-    PART_LAST			= 40+PART_BASE  /*!< */
+    PART_PATCHLIST		= 40+PART_BASE, /*!< */
+    PART_SOURCELIST		= 41+PART_BASE, /*!< */
+    PART_LAST			= 42+PART_BASE  /*!< */
 } rpmParseState; 
 
 
@@ -307,6 +309,9 @@ int parsePrep(rpmSpec spec);
  */
 RPM_GNUC_INTERNAL
 int parseScript(rpmSpec spec, int parsePart);
+
+RPM_GNUC_INTERNAL
+int parseList(rpmSpec spec, const char *name, int stype);
 
 /** \ingroup rpmbuild
  * Check for inappropriate characters. All alphanums are considered sane.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ EXTRA_DIST += $(TESTSUITE_AT)
 ## testsuite data
 EXTRA_DIST += data/SPECS/attrtest.spec
 EXTRA_DIST += data/SPECS/hello.spec
+EXTRA_DIST += data/SPECS/hello-auto.spec
 EXTRA_DIST += data/SPECS/hello-r2.spec
 EXTRA_DIST += data/SPECS/hello-script.spec
 EXTRA_DIST += data/SPECS/hello2.spec
@@ -75,6 +76,7 @@ EXTRA_DIST += data/SPECS/test-subpackages-exclude.spec
 EXTRA_DIST += data/SPECS/test-subpackages-pathpostfixes.spec
 EXTRA_DIST += data/SPECS/vattrtest.spec
 EXTRA_DIST += data/SOURCES/hello-1.0-modernize.patch
+EXTRA_DIST += data/SOURCES/hello-1.0-install.patch
 EXTRA_DIST += data/SOURCES/hello-1.0.tar.gz
 EXTRA_DIST += data/SOURCES/hello-2.0.tar.gz
 EXTRA_DIST += data/RPMS/foo-1.0-1.noarch.rpm

--- a/tests/data/SOURCES/hello-1.0-install.patch
+++ b/tests/data/SOURCES/hello-1.0-install.patch
@@ -1,0 +1,11 @@
+diff -up hello-1.0/Makefile.flags hello-1.0/Makefile
+--- hello-1.0/Makefile.flags	2019-04-25 12:26:37.684540172 +0300
++++ hello-1.0/Makefile	2019-04-25 12:27:22.438450581 +0300
+@@ -1,6 +1,7 @@
+ all: hello
+ 
+ install:
++	mkdir -p $(DESTDIR)/usr/local/bin/
+ 	install -m 0755 hello $(DESTDIR)/usr/local/bin
+ 
+ clean:

--- a/tests/data/SPECS/hello-auto.spec
+++ b/tests/data/SPECS/hello-auto.spec
@@ -1,0 +1,30 @@
+Name: hello
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Simple rpm demonstration.
+
+%sourcelist
+hello-1.0.tar.gz
+
+%patchlist
+hello-1.0-modernize.patch
+hello-1.0-install.patch
+
+%description
+Simple rpm demonstration.
+
+%prep
+%autosetup
+
+%build
+%make_build CFLAGS="$RPM_OPT_FLAGS"
+
+%install
+%make_install
+
+%files
+%doc	FAQ
+/usr/local/bin/hello
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -36,6 +36,20 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild -ba autosetup])
+AT_KEYWORDS([build])
+AT_CHECK([
+rm -rf ${TOPDIR}
+AS_MKDIR_P(${TOPDIR}/SOURCES)
+
+cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-*.patch ${TOPDIR}/SOURCES
+run rpmbuild \
+  -ba "${abs_srcdir}"/data/SPECS/hello-auto.spec
+],
+[0],
+[ignore],
+[ignore])
+AT_CLEANUP
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])


### PR DESCRIPTION
This introduces two new spec sections, %patchlist and %sourcelist,
which can be used for adding patches and sources by just listing their
names instead of all the tedious Patch[n]: etc boilerplate, you can
just copy-paste file names into the list, the entries are always
autonumbered, eg:
    
        Patch0: popt-1.16-pkgconfig.patch
        Patch1: popt-1.16-execfail.patch
        Patch2: popt-1.16-man-page.patch
        ...
    
can now we replaced with
    
        %patchlist
        popt-1.16-pkgconfig.patch
        popt-1.16-execfail.patch
        popt-1.16-man-page.patch
    
Typical packages have far fewer sources than patches, so %sourcelist
is not as immediately useful but added anyway for symmetry and because
its so easy.

Depends on PR #678 