### PR TITLE
Warn on absolute symlinks at build-time

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1200,6 +1200,10 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 		fl->processingFailed = 1;
 	    } else {
 		buf[llen] = '\0';
+		if (buf[0] == '/') {
+		    rpmlog(RPMLOG_WARNING, _("absolute symlink: %s -> %s\n"),
+			flp->cpioPath, buf);
+		}
 		if (buf[0] == '/' && !rstreq(fl->buildRoot, "/") &&
 			rstreqn(buf, fl->buildRoot, fl->buildRootLen)) {
 		    rpmlog(RPMLOG_ERR,

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -241,7 +241,9 @@ lrwxrwxrwx /opt/globtest/linkgood
 -rw-r--r-- /opt/globtest/zeb
 -rw-r--r-- /opt/globtest/zib
 ],
-[])
+[warning: absolute symlink: /opt/globtest/linkbad -> /opt/globtest/zub
+warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab
+])
 AT_CLEANUP
 
 AT_SETUP([rpmbuild prefixpostfix])
@@ -274,7 +276,9 @@ lrwxrwxrwx /opt/prefixtest/linkgood
 -rw-r--r-- /opt/prefixtest/zeb
 -rw-r--r-- /opt/prefixtest/zib
 ],
-[])
+[warning: absolute symlink: /opt/prefixtest/linkbad -> /opt/prefixtest/zub
+warning: absolute symlink: /opt/prefixtest/linkgood -> /opt/prefixtest/zab
+])
 AT_CLEANUP
 
 # ------------------------------


### PR DESCRIPTION
While supported of course, absolute symlinks are nasty in many ways
so issue a warning to packagers. Related to #668.