### PR TITLE
Fix rpm2archive behavior with multiple arguments

### DIFF
--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -187,34 +187,34 @@ static int process_package(rpmts ts, char * filename)
 
 int main(int argc, char *argv[])
 {
-    int rc;
-    
+    int rc, i;
+
     xsetprogname(argv[0]);	/* Portability call -- see system.h */
     rpmReadConfigFiles(NULL, NULL);
-    char * filename;
-    if (argc == 1)
-	filename = "-";
-    else {
-	if (rstreq(argv[1], "-h") || rstreq(argv[1], "--help")) {
-	    fprintf(stderr, "Usage: rpm2archive file.rpm\n");
-	    exit(EXIT_FAILURE);
-	} else {
-	    filename = argv[1];
-	}
+
+    if (argc > 1 && (rstreq(argv[1], "-h") || rstreq(argv[1], "--help"))) {
+	fprintf(stderr, "Usage: %s [file.rpm ...]\n", argv[0]);
+	exit(EXIT_FAILURE);
     }
 
-    rpmts ts = rpmtsCreate();
-    rpmVSFlags vsflags = 0;
+    if (argc == 1)
+	argv[argc++] = "-";
 
-    /* XXX retain the ageless behavior of rpm2cpio */
-    vsflags |= RPMVSF_MASK_NODIGESTS;
-    vsflags |= RPMVSF_MASK_NOSIGNATURES;
-    vsflags |= RPMVSF_NOHDRCHK;
-    (void) rpmtsSetVSFlags(ts, vsflags);
+    for (i = 1; i < argc; i++) {
+	rpmts ts = rpmtsCreate();
+	rpmVSFlags vsflags = 0;
 
-    rc = process_package(ts, filename);
+	/* XXX retain the ageless behavior of rpm2cpio */
+	vsflags |= RPMVSF_MASK_NODIGESTS;
+	vsflags |= RPMVSF_MASK_NOSIGNATURES;
+	vsflags |= RPMVSF_NOHDRCHK;
+	(void) rpmtsSetVSFlags(ts, vsflags);
 
-    ts = rpmtsFree(ts);
+	rc = process_package(ts, argv[i]);
+	(void) rpmtsFree(ts);
+	if (rc != 0)
+	    return rc;
+    }
 
     return rc;
 }

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -299,8 +299,8 @@ AT_CLEANUP
 AT_SETUP([rpm2cpio])
 AT_KEYWORDS([basic])
 AT_CHECK([
-runroot rpm2cpio data/RPMS/hello-2.0-1.x86_64.rpm | cpio -t --quiet
-runroot rpm2cpio data/SRPMS/hello-1.0-1.src.rpm | cpio -t --quiet
+runroot_other rpm2cpio data/RPMS/hello-2.0-1.x86_64.rpm | cpio -t --quiet
+runroot_other rpm2cpio data/SRPMS/hello-1.0-1.src.rpm | cpio -t --quiet
 ],
 [0],
 [./usr/bin/hello
@@ -316,8 +316,8 @@ AT_CLEANUP
 AT_SETUP([rpm2archive])
 AT_KEYWORDS([basic])
 AT_CHECK([
-runroot rpm2archive - < "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm | tar tz
-runroot rpm2archive - < "${RPMTEST}"/data/SRPMS/hello-1.0-1.src.rpm | tar tz
+runroot_other rpm2archive - < "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm | tar tz
+runroot_other rpm2archive - < "${RPMTEST}"/data/SRPMS/hello-1.0-1.src.rpm | tar tz
 ],
 [0],
 [./usr/bin/hello


### PR DESCRIPTION
If multiple arguments are passed to rpm2archive, convert them all to
tgz.  (Previous behavior was to convert only the first one and
silently ignore the rest.)

Signed-off-by: Robbie Harwood <rharwood@redhat.com>