### PR TITLE
Continue patch/source autorenumbering from last specified number

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -313,10 +313,14 @@ static int addSource(rpmSpec spec, const char *field, rpmTagVal tag)
 	return RPMRC_FAIL;
     }
 
-    /* No number, use autonumbering */
     if (nonum > 0) {
+	/* No number specified, use autonumbering */
 	(*autonum)++;
 	num = *autonum;
+    } else {
+	/* Autonumbering continues from last specified number */
+	if ((int)num > *autonum)
+	    *autonum = num;
     }
 
     /* Check whether tags of the same number haven't already been defined */


### PR DESCRIPTION
Fixes a regression on mixed auto vs manual numbered patches/sources
introduced in commit 5fc4e1dd101b27eb8ed9526552c42bb809ac6790