### PR TITLE
Try to continue despite missing %include files on forced spec parse

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ EXTRA_DIST += data/SPECS/filedep.spec
 EXTRA_DIST += data/SPECS/flangtest.spec
 EXTRA_DIST += data/SPECS/hlinktest.spec
 EXTRA_DIST += data/SPECS/iftest.spec
+EXTRA_DIST += data/SPECS/inctest.spec
 EXTRA_DIST += data/SPECS/symlinktest.spec
 EXTRA_DIST += data/SPECS/deptest.spec
 EXTRA_DIST += data/SPECS/verifyscript.spec

--- a/tests/data/SPECS/inctest.spec
+++ b/tests/data/SPECS/inctest.spec
@@ -1,0 +1,11 @@
+Name:           inctest
+Version:        1.0
+Release:        1
+Group:          Testing
+License:        GPL
+BuildArch:      noarch
+Summary:	Testing include directive
+
+%description
+%include %{incfile}
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -99,6 +99,29 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild include])
+AT_KEYWORDS([build])
+AT_CHECK([
+dsc="/tmp/description"
+echo "Describe me" > "${RPMTEST}/${dsc}"
+runroot rpmspec -q "/data/SPECS/notthere.spec" 2>&1; echo $?
+runroot rpmspec -q --define "incfile /not/there" "/data/SPECS/inctest.spec" 2>&1; echo $?
+runroot rpmspec -q --define "incfile ${dsc}" --qf "%{description}\n" "/data/SPECS/inctest.spec" 2>&1; echo $?
+rm -f "${RPMTEST}/${dsc}"
+],
+[0],
+[error: Unable to open /data/SPECS/notthere.spec: No such file or directory
+error: query of specfile /data/SPECS/notthere.spec failed, can't parse
+1
+warning: Unable to open /not/there: No such file or directory
+inctest-1.0-1.noarch
+0
+Describe me
+0
+],
+[])
+AT_CLEANUP
+
 # ------------------------------
 # %attr/%defattr tests
 AT_SETUP([rpmbuild %attr and %defattr])


### PR DESCRIPTION
On forced spec parse (spec query or --force'd build) we already allow
sources and patches to be missing. %include differs from sources and
patches in that a missing include might make the spec unparseable,
but then we lose nothing by trying, as quite often the spec is parseable
enough to get at least some info out of it. Doesn't seem any worse
than allowing build without sources present...

Helps a bit in cases like RhBug:1658292 and RhBug:1547897.