### PR TITLE
Add support for special system-level %include path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -250,6 +250,7 @@ install-data-local:
 	@$(MKDIR_P) $(DESTDIR)$(localstatedir)/tmp
 	@$(MKDIR_P) $(DESTDIR)$(rpmconfigdir)/macros.d
 	@$(MKDIR_P) $(DESTDIR)$(rpmconfigdir)/lua
+	@$(MKDIR_P) $(DESTDIR)$(rpmconfigdir)/include
 
 # XXX to appease distcheck we need to remove "stuff" here...
 uninstall-local:
@@ -259,6 +260,7 @@ uninstall-local:
 	@rm -f $(DESTDIR)$(rpmconfigdir)/macros
 	@rm -rf $(DESTDIR)$(rpmconfigdir)/macros.d
 	@rm -rf $(DESTDIR)$(rpmconfigdir)/lua
+	@rm -rf $(DESTDIR)$(rpmconfigdir)/include
 
 MAINTAINERCLEANFILES = ChangeLog
 

--- a/macros.in
+++ b/macros.in
@@ -604,6 +604,7 @@ package or when debugging this package.\
 # %__myattr_exclude_path	exclude by path regex
 #
 %_fileattrsdir		%{_rpmconfigdir}/fileattrs
+%_rpmincludedir		%{_rpmconfigdir}/include
 
 # This macro defines how much space (in bytes) in package should be
 # reserved for gpg signatures during building of a package. If this space is

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ EXTRA_DIST += data/SPECS/filedep.spec
 EXTRA_DIST += data/SPECS/flangtest.spec
 EXTRA_DIST += data/SPECS/hlinktest.spec
 EXTRA_DIST += data/SPECS/iftest.spec
+EXTRA_DIST += data/SPECS/inctest.spec
 EXTRA_DIST += data/SPECS/symlinktest.spec
 EXTRA_DIST += data/SPECS/deptest.spec
 EXTRA_DIST += data/SPECS/verifyscript.spec

--- a/tests/data/SPECS/inctest.spec
+++ b/tests/data/SPECS/inctest.spec
@@ -1,0 +1,11 @@
+Name:           inctest
+Version:        1.0
+Release:        1
+Group:          Testing
+License:        GPL
+BuildArch:      noarch
+Summary:	Testing include directive
+
+%description
+%include %{incfile}
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -107,6 +107,7 @@ echo "Describe me" > "${RPMTEST}/${dsc}"
 runroot rpmspec -q "/data/SPECS/notthere.spec" 2>&1; echo $?
 runroot rpmspec -q --define "incfile /not/there" "/data/SPECS/inctest.spec" 2>&1; echo $?
 runroot rpmspec -q --define "incfile ${dsc}" --qf "%{description}\n" "/data/SPECS/inctest.spec" 2>&1; echo $?
+runroot rpmspec -q --define "%_rpmincludedir /usr/lib/rpm/include" --define "incfile <system.inc>" --buildrequires "/data/SPECS/inctest.spec" 2>&1; echo $?
 rm -f "${RPMTEST}/${dsc}"
 ],
 [0],
@@ -117,6 +118,9 @@ warning: Unable to open /not/there: No such file or directory
 inctest-1.0-1.noarch
 0
 Describe me
+0
+warning: Unable to open /usr/lib/rpm/include/system.inc: No such file or directory
+/usr/lib/rpm/include/system.inc
 0
 ],
 [])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -99,6 +99,29 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild include])
+AT_KEYWORDS([build])
+AT_CHECK([
+dsc="/tmp/description"
+echo "Describe me" > "${RPMTEST}/${dsc}"
+runroot rpmspec -q "/data/SPECS/notthere.spec" 2>&1; echo $?
+runroot rpmspec -q --define "incfile /not/there" "/data/SPECS/inctest.spec" 2>&1; echo $?
+runroot rpmspec -q --define "incfile ${dsc}" --qf "%{description}\n" "/data/SPECS/inctest.spec" 2>&1; echo $?
+rm -f "${RPMTEST}/${dsc}"
+],
+[0],
+[error: Unable to open /data/SPECS/notthere.spec: No such file or directory
+error: query of specfile /data/SPECS/notthere.spec failed, can't parse
+1
+warning: Unable to open /not/there: No such file or directory
+inctest-1.0-1.noarch
+0
+Describe me
+0
+],
+[])
+AT_CLEANUP
+
 # ------------------------------
 # %attr/%defattr tests
 AT_SETUP([rpmbuild %attr and %defattr])


### PR DESCRIPTION
When %include argument is enclosed in <> (ie similar to C includes), look for the file in system-level %_rpmincludedir path instead %_sourcedir, and treat these as build-dependencies that get recorded
in the src.rpm.

Depends on #684