### PR TITLE
Fix brp-strip-static-archive parallelism

### DIFF
--- a/scripts/brp-strip-static-archive
+++ b/scripts/brp-strip-static-archive
@@ -13,10 +13,6 @@ Darwin*) exit 0 ;;
 esac
 
 # Strip static libraries.
-for f in `find "$RPM_BUILD_ROOT" -type f | \
-	grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug" | \
-	xargs -r -P$NCPUS -n16 file | sed 's/:  */: /' | \
-	grep 'current ar archive' | \
-	sed -n -e 's/^\(.*\):[  ]*current ar archive/\1/p'`; do
-	$STRIP -g "$f"
-done
+find "$RPM_BUILD_ROOT" -type f | \
+    grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug" | \
+    xargs -r -P$NCPUS -n32 sh -c "file \"\$@\" | sed 's/:  */: /' | grep 'current ar archive' | sed -n -e 's/^\(.*\):[  ]*current ar archive/\1/p' | xargs -I\{\} $STRIP -g \{\}" ARG0


### PR DESCRIPTION
The change made in fc2c986 can break for large values of %_smp_build_ncpus as
this many processes are able to overflow the following pipe.

Thanks to Denys Vlasenko for testing this.

This change solves this problem by running a whole processing pileline for each
parallel (file) process. This has also the benefit of running at least some
stip commands in parallel.

The -n param fro xargs was increased to 32 to further reduce the over head of
spawing the helpers as they are now needed for each run of the file command.