### PR TITLE
Drop leftover autotools-related macros

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -80,13 +80,6 @@
 %__remsh		%{__rsh}
 %__strip		@__STRIP@
 
-# XXX avoid failures if tools are not installed when rpm is built.
-%__libtoolize		libtoolize
-%__aclocal		aclocal
-%__autoheader		autoheader
-%__automake		automake
-%__autoconf		autoconf
-
 #==============================================================================
 # Conditional build stuff.
 


### PR DESCRIPTION
The only real users were in the unused %GNUconfigure macro which was
already removed in commit bb2cd52cf1067b9d18106f127a5034e2ad50db64 and
these should've gone with them.

This is a counter-proposal to #688 