### PR TITLE
Adopt compiler flags related enhancements from Fedora

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1007,6 +1007,24 @@ package or when debugging this package.\
 %_target_os		%{_host_os}
 
 #==============================================================================
+# ---- compiler flags.
+
+# C compiler flags.  This is traditionally called CFLAGS in makefiles.
+# Historically also available as %%{optflags}, and %%build sets the
+# environment variable RPM_OPT_FLAGS to this value.
+%build_cflags %{optflags}
+
+# C++ compiler flags.  This is traditionally called CXXFLAGS in makefiles.
+%build_cxxflags %{optflags}
+
+# Fortran compiler flags.  Makefiles use both FFLAGS and FCFLAGS as
+# the corresponding variable names.
+%build_fflags %{optflags} %{?_fmoddir:-I%{_fmoddir}}
+
+# Link editor flags.  This is usually called LDFLAGS in makefiles.
+#%build_ldflags -Wl,-z,relro %{?_lto_cflags}
+
+#==============================================================================
 # ---- specfile macros.
 #	Macro(s) here can be used reliably for reproducible builds.
 #	(Note: Above is the goal, below are the macros under development)
@@ -1017,9 +1035,11 @@ package or when debugging this package.\
 #
 %_configure ./configure
 %configure \
-  CFLAGS="${CFLAGS:-%optflags}" ; export CFLAGS ; \
-  CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ; \
-  FFLAGS="${FFLAGS:-%optflags}" ; export FFLAGS ; \
+  CFLAGS="${CFLAGS:-%{build_cflags}}" ; export CFLAGS ; \
+  CXXFLAGS="${CXXFLAGS:-%{build_cxxflags}}" ; export CXXFLAGS ; \
+  FFLAGS="${FFLAGS:-%{build_fflags}}" ; export FFLAGS ; \
+  FCFLAGS="${FCFLAGS:-%{build_fflags}}" ; export FCFLAGS ; \
+  LDFLAGS="${LDFLAGS:-%{build_ldflags}}" ; export LDFLAGS ; \
   %{_configure} --host=%{_host} --build=%{_build} \\\
 	--program-prefix=%{?_program_prefix} \\\
 	--disable-dependency-tracking \\\

--- a/macros.in
+++ b/macros.in
@@ -1024,6 +1024,16 @@ package or when debugging this package.\
 # Link editor flags.  This is usually called LDFLAGS in makefiles.
 #%build_ldflags -Wl,-z,relro %{?_lto_cflags}
 
+# Expands to shell code to seot the compiler/linker environment
+# variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have
+# not been set already.
+%set_build_flags \
+  CFLAGS="${CFLAGS:-%{build_cflags}}" ; export CFLAGS ; \
+  CXXFLAGS="${CXXFLAGS:-%{build_cxxflags}}" ; export CXXFLAGS ; \
+  FFLAGS="${FFLAGS:-%{build_fflags}}" ; export FFLAGS ; \
+  FCFLAGS="${FCFLAGS:-%{build_fflags}}" ; export FCFLAGS ; \
+  LDFLAGS="${LDFLAGS:-%{build_ldflags}}" ; export LDFLAGS
+
 #==============================================================================
 # ---- specfile macros.
 #	Macro(s) here can be used reliably for reproducible builds.
@@ -1035,11 +1045,7 @@ package or when debugging this package.\
 #
 %_configure ./configure
 %configure \
-  CFLAGS="${CFLAGS:-%{build_cflags}}" ; export CFLAGS ; \
-  CXXFLAGS="${CXXFLAGS:-%{build_cxxflags}}" ; export CXXFLAGS ; \
-  FFLAGS="${FFLAGS:-%{build_fflags}}" ; export FFLAGS ; \
-  FCFLAGS="${FCFLAGS:-%{build_fflags}}" ; export FCFLAGS ; \
-  LDFLAGS="${LDFLAGS:-%{build_ldflags}}" ; export LDFLAGS ; \
+  %{set_build_flags}; \
   %{_configure} --host=%{_host} --build=%{_build} \\\
 	--program-prefix=%{?_program_prefix} \\\
 	--disable-dependency-tracking \\\


### PR DESCRIPTION
This is bascially a more elaborate version of #660 :
- Add language specific %build_fooflags macros to allow separate distro-wide defaults for c, c++ and fortran
- Add %build_ldflags for specifying distro-wide ldflags (how on earth we didn't have this?)
- Split FOOFLAGS= setting out of %configure to %set_build_flags macro to make them available outside autotools
