### PR TITLE
Fix recently introduced uninitialized variable warning in rpm2archive

### DIFF
--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -187,7 +187,7 @@ static int process_package(rpmts ts, char * filename)
 
 int main(int argc, char *argv[])
 {
-    int rc, i;
+    int rc = 0, i;
 
     xsetprogname(argv[0]);	/* Portability call -- see system.h */
     rpmReadConfigFiles(NULL, NULL);


### PR DESCRIPTION
Fixes "warning: ‘rc’ may be used uninitialized in this function"
introduced in commit c73b0f34e32c299c87b7163352808d1071a05d2b.