### PR TITLE
Fix memleak in rpmfcApplyInternal() in standalone operation (eg rpmdeps)

### DIFF
--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -382,6 +382,12 @@ rpmRC lookupPackage(rpmSpec spec, const char * name, int flag,
 RPM_GNUC_INTERNAL
 Package newPackage(const char *name, rpmstrPool pool, Package * pkglist);
 
+/** \ingroup rpmbuild
+ * Free a package control structure.
+ * @param pkg          package control structure
+ */
+RPM_GNUC_INTERNAL
+Package freePackage(Package pkg);
 
 /** \ingroup rpmbuild
  * Return rpmds containing the dependencies of a given type

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -777,7 +777,7 @@ rpmfc rpmfcFree(rpmfc fc)
 	free(fc->fattrs);
 	free(fc->fcolor);
 	free(fc->fcdictx);
-	free(fc->pkg);
+	freePackage(fc->pkg);
 	argiFree(fc->fddictx);
 	argiFree(fc->fddictn);
 	argiFree(fc->ddictx);
@@ -1407,7 +1407,7 @@ rpmRC rpmfcGenerateDepends(const rpmSpec spec, Package pkg)
     }
 
     fc = rpmfcCreate(spec->buildRoot, 0);
-    free(fc->pkg);
+    freePackage(fc->pkg);
     fc->pkg = pkg;
     fc->skipProv = !pkg->autoProv;
     fc->skipReq = !pkg->autoReq;

--- a/build/spec.c
+++ b/build/spec.c
@@ -142,7 +142,7 @@ Package newPackage(const char *name, rpmstrPool pool, Package *pkglist)
     return p;
 }
 
-static Package freePackage(Package pkg)
+Package freePackage(Package pkg)
 {
     if (pkg == NULL) return NULL;
     


### PR DESCRIPTION
When called in spec context, the package structs are properly freed
but in rpmdeps context, commit 49f2bb7d8fd91f2d8b22bf7128fd3defe4ed5434
only added a "dirty kludgery" to make it not blow up. This causes
the rpmds structures created in rpmfcApplyInternal() to leak memory.
Make freePackage() internally available and use it for freeing the
dummy struct too to fix.