### PR TITLE
Stop papering over the security disaster known as prelink

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1188,7 +1188,7 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	buf[0] = '\0';
 	if (S_ISREG(flp->fl_mode) && !(flp->flags & RPMFILE_GHOST))
 	    (void) rpmDoDigest(digestalgo, flp->diskPath, 1, 
-			       (unsigned char *)buf, NULL);
+			       (unsigned char *)buf);
 	headerPutString(h, RPMTAG_FILEDIGESTS, buf);
 	
 	buf[0] = '\0';

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -993,7 +993,7 @@ int rpmfileContentsEqual(rpmfiles ofi, int oix, rpmfiles nfi, int nix)
 	    goto exit;
 	}
 
-	if (rpmDoDigest(nalgo, fn, 0, (unsigned char *)buffer, NULL) != 0) {
+	if (rpmDoDigest(nalgo, fn, 0, (unsigned char *)buffer) != 0) {
 	     goto exit;		/* assume file has been removed */
 	}
 
@@ -1077,7 +1077,7 @@ rpmFileAction rpmfilesDecideFate(rpmfiles ofi, int oix,
 	/* See if the file on disk is identical to the one in new pkg */
 	ndigest = rpmfilesFDigest(nfi, nix, &nalgo, &ndiglen);
 	if (diskWhat == REG && newWhat == REG) {
-	    if (rpmDoDigest(nalgo, fn, 0, (unsigned char *)buffer, NULL))
+	    if (rpmDoDigest(nalgo, fn, 0, (unsigned char *)buffer))
 		goto exit;		/* assume file has been removed */
 	    if (ndigest && memcmp(ndigest, buffer, ndiglen) == 0) {
 		action = FA_TOUCH;
@@ -1090,7 +1090,7 @@ rpmFileAction rpmfilesDecideFate(rpmfiles ofi, int oix,
 	if (diskWhat == REG) {
 	    /* hash algo changed or digest was not computed, recalculate it */
 	    if ((oalgo != nalgo) || (newWhat != REG)) {
-		if (rpmDoDigest(oalgo, fn, 0, (unsigned char *)buffer, NULL))
+		if (rpmDoDigest(oalgo, fn, 0, (unsigned char *)buffer))
 		    goto exit;	/* assume file has been removed */
 		}
 	    if (odigest && memcmp(odigest, buffer, odiglen) == 0)
@@ -1216,7 +1216,7 @@ int rpmfilesConfigConflict(rpmfiles fi, int ix)
 	int algo;
 	size_t diglen;
 	const unsigned char *ndigest = rpmfilesFDigest(fi,ix, &algo, &diglen);
-	if (rpmDoDigest(algo, fn, 0, (unsigned char *)buffer, NULL))
+	if (rpmDoDigest(algo, fn, 0, (unsigned char *)buffer))
 	    goto exit;	/* assume file has been removed */
 	if (ndigest && memcmp(ndigest, buffer, diglen) == 0)
 	    goto exit;	/* unmodified config file */

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -128,15 +128,12 @@ rpmVerifyAttrs rpmfilesVerify(rpmfiles fi, int ix, rpmVerifyAttrs omitMask)
 	int algo;
 	size_t diglen;
 
-	/* XXX If --nomd5, then prelinked library sizes are not corrected. */
 	if ((digest = rpmfilesFDigest(fi, ix, &algo, &diglen))) {
 	    unsigned char fdigest[diglen];
-	    rpm_loff_t fsize;
 
-	    if (rpmDoDigest(algo, fn, 0, fdigest, &fsize)) {
+	    if (rpmDoDigest(algo, fn, 0, fdigest)) {
 		vfy |= (RPMVERIFY_READFAIL|RPMVERIFY_FILEDIGEST);
 	    } else {
-		sb.st_size = fsize;
 		if (memcmp(fdigest, digest, diglen))
 		    vfy |= RPMVERIFY_FILEDIGEST;
 	    }

--- a/macros.in
+++ b/macros.in
@@ -677,16 +677,6 @@ package or when debugging this package.\
 #	gpg --batch --no-verbose --verify --no-secmem-warning \
 #	%{__signature_filename} %{__plaintext_filename}
 #
-# XXX rpm-4.1 verifies prelinked libraries using a prelink undo helper.
-#	Normally this macro is defined in /etc/rpm/macros.prelink, installed
-#	with the prelink package. If the macro is undefined, then prelinked
-#	shared libraries contents are MD5 digest verified (as usual), rather
-#	than MD5 verifying the output of the prelink undo helper.
-#
-#	Note: The 2nd token is used as argv[0] and "library" is a
-#	placeholder that will be deleted and replaced with the appropriate
-#	library file path.
-#%__prelink_undo_cmd     /usr/sbin/prelink prelink -y library
 
 # Horowitz Key Protocol server configuration
 #

--- a/rpmio/Makefile.am
+++ b/rpmio/Makefile.am
@@ -42,7 +42,6 @@ librpmio_la_LIBADD = \
 	@WITH_OPENSSL_LIB@ \
 	@WITH_BZ2_LIB@ \
 	@WITH_ZLIB_LIB@ \
-	@WITH_LIBELF_LIB@ \
 	@WITH_POPT_LIB@ \
 	@WITH_LZMA_LIB@ \
 	$(ZSTD_LIBS) \

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -21,21 +21,18 @@
 static const char *rpm_config_dir = NULL;
 static pthread_once_t configDirSet = PTHREAD_ONCE_INIT;
 
-int rpmDoDigest(int algo, const char * fn,int asAscii,
-                unsigned char * digest, rpm_loff_t * fsizep)
+int rpmDoDigest(int algo, const char * fn,int asAscii, unsigned char * digest)
 {
     unsigned char * dig = NULL;
     size_t diglen, buflen = 32 * BUFSIZ;
     unsigned char *buf = xmalloc(buflen);
-    rpm_loff_t fsize = 0;
     int rc = 0;
 
     FD_t fd = Fopen(fn, "r.ufdio");
 
     if (fd) {
 	fdInitDigest(fd, algo, 0);
-	while ((rc = Fread(buf, sizeof(*buf), buflen, fd)) > 0)
-	    fsize += rc;
+	while ((rc = Fread(buf, sizeof(*buf), buflen, fd)) > 0) {};
 	fdFiniDigest(fd, algo, (void **)&dig, &diglen, asAscii);
 	Fclose(fd);
     }
@@ -44,8 +41,6 @@ int rpmDoDigest(int algo, const char * fn,int asAscii,
 	rc = 1;
     } else {
 	memcpy(digest, dig, diglen);
-	if (fsizep)
-	    *fsizep = fsize;
     }
 
     dig = _free(dig);

--- a/rpmio/rpmfileutil.h
+++ b/rpmio/rpmfileutil.h
@@ -37,11 +37,9 @@ typedef enum rpmCompressedMagic_e {
  * @param fn		file name
  * @param asAscii	return digest as ascii string?
  * @retval digest	address of calculated digest
- * @retval *fsizep	file size pointer (or NULL)
  * @return		0 on success, 1 on error
  */
-int rpmDoDigest(int algo, const char * fn,int asAscii,
-		  unsigned char * digest, rpm_loff_t * fsizep);
+int rpmDoDigest(int algo, const char * fn,int asAscii, unsigned char * digest);
 
 /** \ingroup rpmfileutil
  * Thin wrapper for mkstemp(3). 


### PR DESCRIPTION
Back in the turn of the century somebody thought it was a neat idea
to completely compromise system security to improve program start-up
start-up times a wee bit. Since then, people have thankfully started
coming to their senses and removed prelink from distros entirely.

Lets stop papering over the security disaster: we obviously cannot
stop people from using prelink, but instead of trying to undo the
damage for verification purposes, we'll now report such a system as
compromised. Which is how it should be, IMNSHO.

This eliminates a whole lot of extra junk from each and every file
digest calculation that we do, so it might even show up on somebodys
performance charts. It also gets rid of libelf dependency outside
librpmbuild, which is a nice little bonus.

Inspired by a patch to eliminate a rendundant double open of regular
files in rpmDoDigest() from Denys Vlasenko, taken a little further...