### PR TITLE
Only switch to userns-root if we actually need it for chroot()

### DIFF
--- a/lib/rpmchroot.c
+++ b/lib/rpmchroot.c
@@ -100,8 +100,6 @@ int rpmChrootSet(const char *rootDir)
 	    rpmlog(RPMLOG_ERR, _("Unable to open current directory: %m\n"));
 	    rc = -1;
 	}
-	if (!_rpm_nouserns && rc == 0 && getuid())
-	    try_become_root();
     }
 
     return rc;
@@ -123,6 +121,9 @@ int rpmChrootIn(void)
     if (rootState.chrootDone > 0) {
 	rootState.chrootDone++;
     } else if (rootState.chrootDone == 0) {
+	if (!_rpm_nouserns && getuid())
+	    try_become_root();
+
 	if (chdir("/") == 0 && chroot(rootState.rootDir) == 0) {
 	    rootState.chrootDone = 1;
 	} else {


### PR DESCRIPTION
Since we don't have proper user/group info inside userns-root, avoid
going there unless we have to. Fixes a regression introduced in
commit b4c832caed0da0c4b0710cfe2510203a3940c2db where non-root,
non-chroot verification shows user and group differing on all files.