### PR TITLE
Fix use-after-free introduced in 0f21bdd0d7b2c45564ddb5a24bbebd530867…

### DIFF
--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -34,7 +34,6 @@ int rpmDoDigest(int algo, const char * fn,int asAscii, unsigned char * digest)
 	fdInitDigest(fd, algo, 0);
 	while ((rc = Fread(buf, sizeof(*buf), buflen, fd)) > 0) {};
 	fdFiniDigest(fd, algo, (void **)&dig, &diglen, asAscii);
-	Fclose(fd);
     }
 
     if (dig == NULL || Ferror(fd)) {
@@ -45,6 +44,7 @@ int rpmDoDigest(int algo, const char * fn,int asAscii, unsigned char * digest)
 
     dig = _free(dig);
     free(buf);
+    Fclose(fd);
 
     return rc;
 }


### PR DESCRIPTION
…bd54

Unlike typical fooFree() functions in rpm, Fclose() doesn't set the
pointer to NULL so there's a use-after-free in checking for Ferror()
that segfaults and stuff. Delay Fclose() until the end so we actually
catch io errors too, that was another thing that went missing in
commit 0f21bdd0d7b2c45564ddb5a24bbebd530867bd54 (although it would've
probably caused an error via null digest instead)