### PR TITLE
Fix packages getting erased on failed update with dnf (RhBug:1620275)

### DIFF
--- a/lib/depends.c
+++ b/lib/depends.c
@@ -121,7 +121,8 @@ static int removePackage(rpmts ts, Header h, rpmte depends)
 
     /* Filter out duplicate erasures. */
     if (packageHashGetEntry(tsmem->removedPackages, dboffset, &pp, NULL, NULL)) {
-	rpmteSetDependsOn(pp[0], depends);
+	if (depends)
+	    rpmteSetDependsOn(pp[0], depends);
 	return 0;
     }
 


### PR DESCRIPTION
When adding update elements, we set the erase element to depend on the
install element, but if an API user adds the same erasure manually
after adding the update, we know its a duplicate erasure and filter
it out, BUT we zero out the dependent element in the process. And
if installing the update now fails, we end up removing the whole package
due to that missing dependent element.

This never happens with rpm itself so we can't easily test it, but is
100% reproducable with dnf (at least dnf 3-4). Apparently it adds all
erasures by itself (which is kind of understandable I guess, perhaps
we should better allow this in the API)