### PR TITLE
Report filename and line number on all macro expand errors and warnings

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -142,6 +142,8 @@ static OFI_t * pushOFI(rpmSpec spec, const char *fn)
     ofi->readPtr = NULL;
     ofi->next = spec->fileStack;
 
+    rpmPushMacro(spec->macros, "__file_name", NULL, fn, RMIL_SPEC);
+
     spec->fileStack = ofi;
     return spec->fileStack;
 }
@@ -158,6 +160,7 @@ static OFI_t * popOFI(rpmSpec spec)
 	free(ofi->fileName);
 	free(ofi->readBuf);
 	free(ofi);
+	rpmPopMacro(spec->macros, "__file_name");
     }
     return spec->fileStack;
 }
@@ -220,12 +223,28 @@ static parsedSpecLine parseLineType(char *line)
     return NULL;
 }
 
+int specExpand(rpmSpec spec, int lineno, const char *sbuf,
+		char **obuf)
+{
+    char lnobuf[16];
+    int rc;
+
+    snprintf(lnobuf, sizeof(lnobuf), "%d", lineno);
+    rpmPushMacro(spec->macros, "__file_lineno", NULL, lnobuf, RMIL_SPEC);
+
+    rc = (rpmExpandMacros(spec->macros, sbuf, obuf, 0) < 0);
+
+    rpmPopMacro(spec->macros, "__file_lineno");
+
+    return rc;
+}
 
 static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
 {
     char *lbuf = NULL;
     int isComment = 0;
     parsedSpecLine condition;
+    OFI_t *ofi = spec->fileStack;
 
     lbuf = spec->lbuf;
     SKIPSPACE(lbuf);
@@ -246,11 +265,8 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
     if (!spec->readStack->reading)
 	return 0;
 
-    if (rpmExpandMacros(spec->macros, spec->lbuf, &lbuf, 0) < 0) {
-	rpmlog(RPMLOG_ERR, _("line %d: %s\n"),
-		spec->lineNum, spec->lbuf);
+    if (specExpand(spec, ofi->lineNum, spec->lbuf, &lbuf))
 	return 1;
-    }
 
     if (strip & STRIP_COMMENTS && isComment) {
 	char *bufA = spec->lbuf;

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -530,6 +530,10 @@ rpmRC checkForEncoding(Header h, int addtag);
 RPM_GNUC_INTERNAL
 void copyInheritedTags(Header h, Header fromh);
 
+RPM_GNUC_INTERNAL
+int specExpand(rpmSpec spec, int lineno, const char *sbuf,
+		char **obuf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1599,7 +1599,6 @@ static int loadMacroFile(rpmMacroContext mc, const char * fn)
     size_t blen = MACROBUFSIZ;
     char *buf = xmalloc(blen);
     int rc = -1;
-    int ndefs = 0;
     int nfailed = 0;
 
     if (fd == NULL)
@@ -1615,14 +1614,12 @@ static int loadMacroFile(rpmMacroContext mc, const char * fn)
 	if (c != '%')
 		continue;
 	n++;	/* skip % */
-	ndefs++;
 	if (defineMacro(mc, n, RMIL_MACROFILES))
 	    nfailed++;
     }
     fclose(fd);
 
-    /* if all definitions fail then return an error, otherwise just warn */
-    rc = (nfailed && ndefs == nfailed);
+    rc = (nfailed > 0);
 
     if (nfailed) {
 	rpmlog(rc ? RPMLOG_ERR : RPMLOG_WARNING,

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -213,15 +213,16 @@ findEntry(rpmMacroContext mc, const char *name, size_t namelen, size_t *pos)
  * @param buf		input buffer
  * @param size		inbut buffer size (bytes)
  * @param f		file handle
- * @return		buffer, or NULL on end-of-file
+ * @return		number of lines read, or 0 on end-of-file
  */
-static char *
+static int
 rdcl(char * buf, size_t size, FILE *f)
 {
     char *q = buf - 1;		/* initialize just before buffer. */
     size_t nb = 0;
     size_t nread = 0;
     int pc = 0, bc = 0;
+    int nlines = 0;
     char *p = buf;
 
     if (f != NULL)
@@ -229,6 +230,7 @@ rdcl(char * buf, size_t size, FILE *f)
 	*(++q) = '\0';			/* terminate and move forward. */
 	if (fgets(q, size, f) == NULL)	/* read next line. */
 	    break;
+	nlines++;
 	nb = strlen(q);
 	nread += nb;			/* trim trailing \r and \n */
 	for (q += nb - 1; nb > 0 && iseol(*q); q--)
@@ -263,7 +265,7 @@ rdcl(char * buf, size_t size, FILE *f)
 	if (*q == '\r')			/* XXX avoid \r madness */
 	    *q = '\n';
     } while (size > 0);
-    return (nread > 0 ? buf : NULL);
+    return nlines;
 }
 
 /**
@@ -1605,7 +1607,7 @@ static int loadMacroFile(rpmMacroContext mc, const char * fn)
 	goto exit;
 
     buf[0] = '\0';
-    while (rdcl(buf, blen, fd) != NULL) {
+    while (rdcl(buf, blen, fd) > 0) {
 	char c, *n;
 
 	n = buf;

--- a/rpmio/rpmstring.c
+++ b/rpmio/rpmstring.c
@@ -52,31 +52,39 @@ int rstrncasecmp(const char *s1, const char *s2, size_t n)
   return (int)(c1 - c2);
 }
 
-/* 
- * Simple and stupid asprintf() clone.
- * FIXME: write to work with non-C99 vsnprintf or check for one in configure.
- */
-int rasprintf(char **strp, const char *fmt, ...)
+int rvasprintf(char **strp, const char *fmt, va_list ap)
 {
     int n;
-    va_list ap;
     char * p = NULL;
+    va_list aq;
   
     if (strp == NULL) 
 	return -1;
 
-    va_start(ap, fmt);
-    n = vsnprintf(NULL, 0, fmt, ap);
-    va_end(ap);
+    va_copy(aq, ap);
+    n = vsnprintf(NULL, 0, fmt, aq);
+    va_end(aq);
 
     if (n >= -1) {
 	size_t nb = n + 1;
 	p = xmalloc(nb);
-    	va_start(ap, fmt);
-        n = vsnprintf(p, nb, fmt, ap);
-    	va_end(ap);
+	va_copy(aq, ap);
+        n = vsnprintf(p, nb, fmt, aq);
+	va_end(aq);
     } 
     *strp = p;
+    return n;
+}
+
+int rasprintf(char **strp, const char *fmt, ...)
+{
+    int n;
+    va_list ap;
+
+    va_start(ap, fmt);
+    n = rvasprintf(strp, fmt, ap);
+    va_end(ap);
+
     return n;
 }
 

--- a/rpmio/rpmstring.h
+++ b/rpmio/rpmstring.h
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 #include <string.h>
+#include <stdarg.h>
 
 #include <rpm/rpmutil.h>
 
@@ -143,6 +144,11 @@ int rstrncasecmp(const char *s1, const char * s2, size_t n)	;
  * asprintf() clone
  */
 int rasprintf(char **strp, const char *fmt, ...) RPM_GNUC_PRINTF(2, 3);
+
+/** \ingroup rpmstring
+ * vasprintf() clone
+ */
+int rvasprintf(char **strp, const char *fmt, va_list ap);
 
 /** \ingroup rpmstring
  * Concatenate two strings with dynamically (re)allocated memory.

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -490,3 +490,27 @@ ccc0
 ccc1
 ])
 AT_CLEANUP
+
+AT_SETUP([macro file errors])
+AT_KEYWORDS([macros])
+AT_CHECK([
+cat << EOF > macros.bad
+%_i foo
+
+%multi \\
+line\\
+thing
+
+%foo bar
+%bad-name 123
+EOF
+
+run rpm --macros "macros.bad" --eval "%foo"
+],
+[0],
+[bar
+],
+[error: macros.bad: line 1: Macro %_i has illegal name (%define)
+warning: macros.bad: line 8: Macro %bad needs whitespace before body
+])
+AT_CLEANUP


### PR DESCRIPTION
Report filename and line number on all macro expand errors and warnings from macro files and specs, includes and manifests.

This is an alternative proposal for PR #494 to address ticket #491, and doesn't involve API changes or additions and covers more than just the spec.