### PR TITLE
Fix regression causing patch/source tags leaking to other macros

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1111,8 +1111,7 @@ static int findPreambleTag(rpmSpec spec,rpmTagVal * tag,
     }
 
     *tag = p->tag;
-    if (p->ismacro && macro)
-	*macro = p->token;
+    *macro = p->ismacro ? p->token : NULL;
     return 0;
 }
 

--- a/tests/data/SPECS/foo.spec
+++ b/tests/data/SPECS/foo.spec
@@ -2,22 +2,22 @@ Summary: foo
 Name: foo
 Version: 1.0
 Release: 1
-Group: Utilities
+Source: hello-2.0.tar.gz
+Patch1: hello-1.0-modernize.patch
+Group: Testing
 License: GPLv2+
-Distribution: RPM test suite.
 BuildArch: noarch
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description
 Simple rpm demonstration.
 
-%prep
+%package sub
+Summary: %{summary}
+Requires: %{name} = %{version}-%{release}
 
-%build
-
-%install
-
-%clean
-rm -rf $RPM_BUILD_ROOT
+%description sub
+%{summary}
 
 %files
+
+%files sub

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -228,3 +228,34 @@ runroot rpmspec --query \
 error: query of specfile /data/SPECS/test-parsebits.spec failed, can't parse
 ])
 AT_CLEANUP
+
+AT_SETUP([rpmspec --parse])
+AT_KEYWORDS([rpmspec])
+AT_CHECK([runroot rpmspec --parse /data/SPECS/foo.spec],
+[0],
+[Summary: foo
+Name: foo
+Version: 1.0
+Release: 1
+Source: hello-2.0.tar.gz
+Patch1: hello-1.0-modernize.patch
+Group: Testing
+License: GPLv2+
+BuildArch: noarch
+
+%description
+Simple rpm demonstration.
+
+%package sub
+Summary: foo
+Requires: foo = 1.0-1
+
+%description sub
+foo
+
+%files
+
+%files sub
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
Commit 6dafb24684baa71fe3b89be6404e6ab0362cf316 introduced a regression
where patch/source (and likely buildroot and docdir too) values
end up leaking to macros of other tags, due to missing reinitialization
to NULL in the code.

This only shows up in specs ordered in a specific way which is why
our test-suite failed to trip it, but it caused eg Fedora attr.spec and
kernel.spec to fail parse. Hijack the otherwise unused foo.spec to
create a test-case for this.