### PR TITLE
Couple of python binding cleanups

### DIFF
--- a/python/header-py.c
+++ b/python/header-py.c
@@ -376,9 +376,6 @@ static PyObject *hdr_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
 
     if (obj == NULL) {
 	h = headerNew();
-    } else if (PyCapsule_CheckExact(obj)) {
-	h = PyCapsule_GetPointer(obj, "rpm._C_Header");
-	headerLink(h);
     } else if (hdrObject_Check(obj)) {
 	h = headerCopy(((hdrObject*) obj)->h);
     } else if (PyBytes_Check(obj)) {

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -419,6 +419,19 @@ static PyObject * hdr_iternext(hdrObject *s)
     return res;
 }
 
+PyObject * utf8FromString(const char *s)
+{
+/* In Python 3, we return all strings as surrogate-escaped utf-8 */
+#if PY_MAJOR_VERSION >= 3
+    if (s != NULL)
+	return PyUnicode_DecodeUTF8(s, strlen(s), "surrogateescape");
+#else
+    if (s != NULL)
+	return PyBytes_FromString(s);
+#endif
+    Py_RETURN_NONE;
+}
+
 int utf8FromPyObject(PyObject *item, PyObject **str)
 {
     PyObject *res = NULL;

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -300,9 +300,6 @@ static int prepareInitModule(void)
     if (PyType_Ready(&rpmProblem_Type) < 0) return 0;
     if (PyType_Ready(&rpmPubkey_Type) < 0) return 0;
     if (PyType_Ready(&rpmstrPool_Type) < 0) return 0;
-#if 0
-    if (PyType_Ready(&rpmtd_Type) < 0) return 0;
-#endif
     if (PyType_Ready(&rpmte_Type) < 0) return 0;
     if (PyType_Ready(&rpmts_Type) < 0) return 0;
     if (PyType_Ready(&spec_Type) < 0) return 0;
@@ -414,11 +411,6 @@ static int initModule(PyObject *m)
 
     Py_INCREF(&rpmstrPool_Type);
     PyModule_AddObject(m, "strpool", (PyObject *) &rpmstrPool_Type);
-
-#if 0
-    Py_INCREF(&rpmtd_Type);
-    PyModule_AddObject(m, "td", (PyObject *) &rpmtd_Type);
-#endif
 
     Py_INCREF(&rpmte_Type);
     PyModule_AddObject(m, "te", (PyObject *) &rpmte_Type);

--- a/python/rpmsystem-py.h
+++ b/python/rpmsystem-py.h
@@ -19,17 +19,6 @@
 #define PyInt_AsSsize_t PyLong_AsSsize_t
 #endif
 
-static inline PyObject * utf8FromString(const char *s)
-{
-/* In Python 3, we return all strings as surrogate-escaped utf-8 */
-#if PY_MAJOR_VERSION >= 3
-    if (s != NULL)
-	return PyUnicode_DecodeUTF8(s, strlen(s), "surrogateescape");
-#else
-    if (s != NULL)
-	return PyBytes_FromString(s);
-#endif
-    Py_RETURN_NONE;
-}
+PyObject * utf8FromString(const char *s);
 
 #endif	/* H_SYSTEM_PYTHON */

--- a/python/rpmtd-py.h
+++ b/python/rpmtd-py.h
@@ -1,12 +1,6 @@
 #ifndef H_RPMTD_PY
 #define H_RPMTD_PY
 
-typedef struct rpmtdObject_s rpmtdObject;
-
-extern PyTypeObject rpmtd_Type;
-
-#define rpmtdObject_Check(v)	((v)->ob_type == &rpmtd_Type)
-
 PyObject * rpmtd_ItemAsPyobj(rpmtd td, rpmTagClass tclass);
 PyObject * rpmtd_AsPyobj(rpmtd td);
 

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -28,17 +28,9 @@
  *
  */
 
-/* Header objects are in another module, some hoop jumping required... */
 static PyObject *makeHeader(Header h)
 {
-    PyObject *rpmmod = PyImport_ImportModuleNoBlock("rpm");
-    if (rpmmod == NULL) return NULL;
-
-    PyObject *ptr = PyCapsule_New(h, "rpm._C_Header", NULL);
-    PyObject *hdr = PyObject_CallMethod(rpmmod, "hdr", "(O)", ptr);
-    Py_XDECREF(ptr);
-    Py_XDECREF(rpmmod);
-    return hdr;
+    return hdr_Wrap(&hdr_Type, headerLink(h));
 }
 
 struct specPkgObject_s {


### PR DESCRIPTION
Remove remnants of long dead code, and eliminate unnecessary hoops for header object creation from spec.