### PR TITLE
Use distcheck as the CI test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,21 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-DISTCHECK_CONFIGURE_FLAGS = --enable-python
+DISTCHECK_CONFIGURE_FLAGS = \
+	--enable-python \
+	--enable-lmdb \
+	--enable-bdb \
+	--enable-ndb \
+	--enable-zstd \
+	--with-cap \
+	--with-acl \
+	--with-archive \
+	--with-lua \
+	--with-audit \
+	--with-selinux \
+	--with-imaevm \
+	--with-crypto=openssl \
+	--disable-dependency-tracking
 
 include $(top_srcdir)/rpm.am
 AM_CFLAGS = @RPMCFLAGS@

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora
 MAINTAINER Igor Gnatenko <i.gnatenko.brain@gmail.com>
 
-WORKDIR /opt/rpm
+WORKDIR /srv/rpm
 COPY . .
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
@@ -12,8 +12,10 @@ RUN dnf -y install \
   automake \
   libtool \
   gettext-devel \
+  doxygen \
   make \
   gcc \
+  git-core \
   zlib-devel \
   bzip2-devel \
   xz-devel \
@@ -27,7 +29,7 @@ RUN dnf -y install \
   libdb-devel \
   lmdb-devel \
   libselinux-devel \
-  ima-evm-utils \
+  ima-evm-utils-devel \
   libcap-devel \
   libacl-devel \
   audit-libs-devel \
@@ -54,4 +56,4 @@ RUN ./configure \
   --enable-silent-rules
 RUN make
 
-CMD make check; rc=$?; cat tests/rpmtests.log; exit $rc
+CMD make distcheck; rc=$?; find . -name rpmtests.log|xargs cat; exit $rc

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -167,8 +167,7 @@ check-local:
 endif !HAVE_FAKECHROOT
 
 installcheck-local: $(check_DATA) populate_testing
-	$(SHELL) '$(TESTSUITE)' AUTOTEST_PATH='$(bindir)' \
-	$(TESTSUITEFLAGS) ||:
+	$(SHELL) '$(TESTSUITE)' AUTOTEST_PATH='$(bindir)' $(TESTSUITEFLAGS)
 
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -135,9 +135,11 @@ atlocal:	atlocal.in Makefile
 DISTCLEANFILES = atlocal
 EXTRA_DIST += atlocal.in
 
+KILLAGENT = gpgconf --kill gpg-agent
+
 # The chmod is needed when copying from read-only sources (eg in distcheck)
 populate_testing:
-	HOME=$(abs_builddir)/testing gpg-connect-agent --no-autostart killagent bye ||:
+	HOME=$(abs_builddir)/testing $(KILLAGENT) ||:
 	rm -rf testing
 	mkdir -p testing/$(bindir)
 	ln -s ./$(bindir) testing/bin
@@ -160,6 +162,7 @@ check_DATA = atconfig atlocal $(TESTSUITE)
 if HAVE_FAKECHROOT
 check-local: $(check_DATA) populate_testing
 	$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS)
+	HOME=$(abs_builddir)/testing $(KILLAGENT) ||:
 else
 check-local:
 	echo "you need to have fakechroot installed"
@@ -168,6 +171,7 @@ endif !HAVE_FAKECHROOT
 
 installcheck-local: $(check_DATA) populate_testing
 	$(SHELL) '$(TESTSUITE)' AUTOTEST_PATH='$(bindir)' $(TESTSUITEFLAGS)
+	HOME=$(abs_builddir)/testing $(KILLAGENT) ||:
 
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean


### PR DESCRIPTION
Using distcheck instead of plain check will catch many more source-level errors, such as regressions to out-of-tree builds and source files present in git tree but missing from automake. These issues sometimes go unnoticed for long times, only to be discovered when preparing for a release at which point you'd rather worry about something else than chasing pesky distcheck regressions.