### PR TITLE
rpmfc: Return failures in rpmfcExec

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -157,8 +157,8 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
     rpmlog(RPMLOG_NOTICE, _("Executing(%s): %s\n"), name, buildCmd);
     if (rpmfcExec((ARGV_const_t)argv, NULL, sb_stdoutp, 1,
 		  spec->buildSubdir, cmdOut)) {
-	rpmlog(RPMLOG_ERR, _("Exec of %s failed (%s): %s\n"),
-		scriptName, name, strerror(errno));
+	rpmlog(RPMLOG_ERR, _("Bad exit status from %s (%s)\n"),
+		scriptName, name);
 	goto exit;
     }
     rc = RPMRC_OK;

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -446,14 +446,13 @@ int rpmfcExec(ARGV_const_t av, StringBuf sb_stdin, StringBuf * sb_stdoutp,
 		       failnonzero, buildRoot, dup);
     if (ec) {
 	sb = freeStringBuf(sb);
+	goto exit;
     }
 
     if (sb_stdoutp != NULL) {
 	*sb_stdoutp = sb;
 	sb = NULL;	/* XXX don't free */
     }
-
-    ec = 0;
 
 exit:
     freeStringBuf(sb);

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -382,7 +382,7 @@ static int getOutputFrom(ARGV_t argv,
         (unsigned)child, (unsigned)reaped, status);
 
     if (failNonZero && (!WIFEXITED(status) || WEXITSTATUS(status))) {
-	rpmlog(RPMLOG_ERR, _("%s failed: %x\n"), argv[0], status);
+	rpmlog(RPMLOG_DEBUG, _("%s failed: %x\n"), argv[0], status);
 	goto exit;
     }
     if (writeBytesLeft || myerrno) {


### PR DESCRIPTION
Also, emptying stdout if it was requested does not make sense when
command fails. Usually, if command fails, you still might want to see
the output and use it somehow.
    
References: https://github.com/rpm-software-management/rpm/issues/728
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>