### PR TITLE
Stop immediately if there is a problem with Source

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -212,11 +212,11 @@ static char *doUntar(rpmSpec spec, uint32_t c, int quietly)
 
 exit:
     free(tar);
-    return rstrcat(&buf,
-		"\nSTATUS=$?\n"
-		"if [ $STATUS -ne 0 ]; then\n"
-		"  exit $STATUS\n"
-		"fi");
+    return buf ? rstrcat(&buf,
+		    "\nSTATUS=$?\n"
+		    "if [ $STATUS -ne 0 ]; then\n"
+		    "  exit $STATUS\n"
+		    "fi") : NULL;
 }
 
 /**
@@ -493,7 +493,7 @@ int parsePrep(rpmSpec spec)
 
     if (spec->prep != NULL) {
 	rpmlog(RPMLOG_ERR, _("line %d: second %%prep\n"), spec->lineNum);
-	return PART_ERROR;
+	goto exit;
     }
 
     spec->prep = newStringBuf();
@@ -512,6 +512,7 @@ int parsePrep(rpmSpec spec)
 	    appendStringBuf(spec->prep, *lines);
 	}
 	if (rc != RPMRC_OK && !(spec->flags & RPMSPEC_FORCE)) {
+	    res = PART_ERROR;
 	    goto exit;
 	}
     }

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1503,3 +1503,20 @@ rpmlib(RichDependencies) <= 4.12.0-1
 ],
 [ignore])
 AT_CLEANUP
+
+# ------------------------------
+# Check that rpmbuild aborts with missing Source
+AT_SETUP([rpmbuild -ba missing source])
+AT_KEYWORDS([build])
+AT_CHECK_UNQUOTED([
+rm -rf ${TOPDIR}
+AS_MKDIR_P(${TOPDIR}/SOURCES)
+
+run rpmbuild \
+  -bb "${abs_srcdir}"/data/SPECS/hello.spec
+],
+[1],
+[],
+[error: Bad source: ${TOPDIR}/SOURCES/hello-1.0.tar.gz: No such file or directory
+])
+AT_CLEANUP


### PR DESCRIPTION
First issue is that doUntar() when encounters an issue related to the
spec file, returns non-NULL which indicates that no error has happened.
Second is that even if it would return that, parsePrep() is simply
ignores return code.

Also be more consistent with "goto exit;".

Fixes: 76c429c3178c965c6517629957a633768132904c
Fixes: c7a8c1e079d2a166b9848ae6afa1b0cfab1b250a
Fixes: https://github.com/rpm-software-management/rpm/issues/728
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>