### PR TITLE
Include file capability test material in dist tarballs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -82,6 +82,7 @@ EXTRA_DIST += data/SOURCES/hello-1.0-modernize.patch
 EXTRA_DIST += data/SOURCES/hello-1.0-install.patch
 EXTRA_DIST += data/SOURCES/hello-1.0.tar.gz
 EXTRA_DIST += data/SOURCES/hello-2.0.tar.gz
+EXTRA_DIST += data/RPMS/capstest-1.0-1.noarch.rpm
 EXTRA_DIST += data/RPMS/foo-1.0-1.noarch.rpm
 EXTRA_DIST += data/RPMS/hello-1.0-1.i386.rpm
 EXTRA_DIST += data/RPMS/hello-1.0-1.ppc64.rpm


### PR DESCRIPTION
Another distcheck regression fix, should've been in commit
ad8c12c5d962c136232d6309d3324a4e57b32877

Originally part of #719 but there's still problems with that.