### PR TITLE
Drop leftoever popt.h include from rpmlib.h

### DIFF
--- a/lib/rpmlib.h
+++ b/lib/rpmlib.h
@@ -8,8 +8,6 @@
  *
  */
 
-#include <popt.h>
-
 #include <rpm/rpmio.h>
 #include <rpm/header.h>
 #include <rpm/rpmtag.h>


### PR DESCRIPTION
Pointed out in #724, including popt.h is in no way necessary for rpmlib.h
or using librpm in general, only the rpmcli API needs it.