### PR TITLE
Remove unused target variable from rpmspec.c

### DIFF
--- a/rpmspec.c
+++ b/rpmspec.c
@@ -17,7 +17,6 @@ enum modes {
 
 static int mode = MODE_UNKNOWN;
 static int source = RPMQV_SPECRPMS;
-const char *target = NULL;
 char *queryformat = NULL;
 
 static struct poptOption specOptsTable[] = {
@@ -65,12 +64,6 @@ int main(int argc, char *argv[])
 
     if (rpmcliPipeOutput && initPipe())
 	exit(EXIT_FAILURE);
-
-    if (target) {
-	rpmFreeMacros(NULL);
-	rpmFreeRpmrc();
-	rpmReadConfigFiles(rpmcliRcfile, target);
-    }
 	
     ts = rpmtsCreate();
     switch (mode) {


### PR DESCRIPTION
Commit d2f48e93d32e222d4727b9684d2032f9bb9fc498 moved the --target
argument to be global, but didn't completely remove the local target
variable from rpmspec.c, or the code that used it to trigger re-loading
the rpm configuration files (which is now handled by the global argument
callback in poptALL.c).