### PR TITLE
Take changelog timezone in account (RhBug 1715412)

### DIFF
--- a/build/parseChangelog.c
+++ b/build/parseChangelog.c
@@ -44,7 +44,8 @@ static int dateToTimet(const char * datestr, time_t * secs, int * date_words)
     struct tm time, ntime;
     const char * const * idx;
     char *p, *pe, *q, *date, *tz;
-    char tz_name[10];               /* name of timezone (if extended format is used) */
+    char *tz_name = NULL;               /* name of timezone (if extended format is used) */
+    int tz_len;
 
     static const char * const days[] =
 	{ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", NULL };
@@ -130,10 +131,10 @@ static int dateToTimet(const char * datestr, time_t * secs, int * date_words)
 	SKIPNONSPACE(pe);
 	if (*pe != '\0')
 	   *pe++ = '\0';
-	if (((int)(pe-p) + 1) > 9 )
-	   goto exit;
-	strncpy(tz_name, p, (int)(pe-p));
-	tz_name[(int)(pe-p)] = '\0';
+	tz_len = pe - p;
+	tz_name = xmalloc(tz_len + 1);
+	strncpy(tz_name, p, tz_len);
+	tz_name[tz_len] = '\0';
 
 	/* first part of year entry */
 	p = pe;
@@ -185,6 +186,7 @@ static int dateToTimet(const char * datestr, time_t * secs, int * date_words)
     rc = 0;
 
 exit:
+    free(tz_name);
     free(date);
     return rc;
 }

--- a/build/parseChangelog.c
+++ b/build/parseChangelog.c
@@ -314,6 +314,7 @@ int parseChangelog(rpmSpec spec)
 	goto exit;
 
     if (sb && addChangelog(spec->packages->header, sb)) {
+	res = PART_ERROR;
 	goto exit;
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -77,6 +77,7 @@ EXTRA_DIST += data/SPECS/test-subpackages.spec
 EXTRA_DIST += data/SPECS/test-subpackages-exclude.spec
 EXTRA_DIST += data/SPECS/test-subpackages-pathpostfixes.spec
 EXTRA_DIST += data/SPECS/vattrtest.spec
+EXTRA_DIST += data/SPECS/timezonetest.spec
 EXTRA_DIST += data/SOURCES/buildrequires-1.0.tar.gz
 EXTRA_DIST += data/SOURCES/hello-1.0-modernize.patch
 EXTRA_DIST += data/SOURCES/hello-1.0-install.patch

--- a/tests/data/SPECS/timezonetest.spec
+++ b/tests/data/SPECS/timezonetest.spec
@@ -1,0 +1,19 @@
+Name:           timezonetest
+Version:        1.0
+Release:        2
+Summary:        Testing time zone
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%files
+
+%changelog
+* Tue May 28 09:00:00 %timezone_new 2019 Pavlina Moravcova Varekova <pmoravco@gmail.com> 1.0-2
+- Add correction
+
+* Tue May 28 09:00:00 %timezone_old 2019 Pavlina Moravcova Varekova <pmoravco@redhat.com> 1.0-1
+- Initial version

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1520,3 +1520,65 @@ run rpmbuild \
 [error: Bad source: ${TOPDIR}/SOURCES/hello-1.0.tar.gz: No such file or directory
 ])
 AT_CLEANUP
+
+# ------------------------------
+AT_SETUP([changelog time zone test success])
+AT_KEYWORDS([build changelog])
+AT_CHECK([
+rm -rf ${TOPDIR}
+
+run rpmbuild \
+  -ba "${abs_srcdir}/data/SPECS/timezonetest.spec" \
+  --quiet \
+  --define "%timezone_old UTC-3" \
+  --define "%timezone_new UTC-1" \
+
+run rpmbuild \
+  -ba "${abs_srcdir}/data/SPECS/timezonetest.spec" \
+  --quiet \
+  --define "%timezone_old UTC-83:00" \
+  --define "%timezone_new UTC-81:00" \
+
+run rpmbuild \
+  -ba "${abs_srcdir}/data/SPECS/timezonetest.spec" \
+  --quiet \
+  --define "%timezone_old UTC-3:00" \
+  --define "%timezone_new UTC" \
+],
+[0],
+[],
+[])
+AT_CLEANUP
+
+# ------------------------------
+AT_SETUP([changelog time zone test failure])
+AT_KEYWORDS([build changelog])
+AT_CHECK([
+rm -rf ${TOPDIR}
+
+run rpmbuild \
+  -ba "${abs_srcdir}/data/SPECS/timezonetest.spec" \
+  --quiet \
+  --define "%timezone_old UTC-1" \
+  --define "%timezone_new UTC-99" \
+
+run rpmbuild \
+  -ba "${abs_srcdir}/data/SPECS/timezonetest.spec" \
+  --quiet \
+  --define "%timezone_old UTC-01:00" \
+  --define "%timezone_new UTC-83:00" \
+
+
+run rpmbuild \
+  -ba "${abs_srcdir}/data/SPECS/timezonetest.spec" \
+  --quiet \
+  --define "%timezone_old UTC" \
+  --define "%timezone_new UTC-3:00" \
+],
+[1],
+[],
+[error: %changelog not in descending chronological order
+error: %changelog not in descending chronological order
+error: %changelog not in descending chronological order
+])
+AT_CLEANUP


### PR DESCRIPTION
When building RPMs that have %changelog sections with changelog entries with full timestamps, RPM did not take the time zone into account. Now the timezone description is taken into account using function tzset(). It handles correctly timezone descriptions like: 
"Europe/London",
"GMT-5", or
"NZST-12:00:00NZDT-13:00:00,M10.1.0,M3.3.0"
but it is not able to work with time zone descriptions that do not contain all information regarding the DST like e.g. "NZST".