### PR TITLE
Only permit one thread at a time in addFileToTag()

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -113,6 +113,8 @@ static rpmRC addFileToTag(rpmSpec spec, const char * file,
     if (file == NULL)
 	return RPMRC_OK;
 
+    #pragma omp critical
+    {
     fn = rpmGetPath("%{_builddir}/%{?buildsubdir:%{buildsubdir}/}", file, NULL);
 
     f = fopen(fn, "r");
@@ -151,6 +153,7 @@ exit:
     }
     free(fn);
     freeStringBuf(sb);
+    } /* omp critical */
 
     return rc;
 }


### PR DESCRIPTION
When creating packages in parallel, more than one thread can call
this at once. As it's modifying global macro state to update file
name and line number, things will get garbled if we permit more than
one thread.

While this is necessary for the above reason, and should fix #742,
it shouldn't crash even without this so there's probably something
else wrong too.

Closes: #742