### PR TITLE
build: Limit copying changelog one at a time

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -713,6 +713,7 @@ static rpmRC packageBinary(rpmSpec spec, Package pkg, const char *cookie, int ch
     }
 
     /* Copy changelog from src rpm */
+    #pragma omp critical
     headerCopyTags(spec->sourcePackage->header, pkg->header, copyTags);
 
     headerPutString(pkg->header, RPMTAG_RPMVERSION, VERSION);


### PR DESCRIPTION
Getting header content in multiple threads is causing problems since it
can (and apparently does) change internal state.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>