### PR TITLE
Support triple operator for conditional shortcut (#115)

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -619,3 +619,33 @@ error: /data/SPECS/eliftest.spec:40: bad %elif condition:  rubbish:4-3
 
 ])
 AT_CLEANUP
+
+AT_SETUP([triple coindition operatot test])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm --eval '%{?!{cosi001}:%{echo:OK1}:%{echo:WRONG}}x'
+runroot rpm --eval '%{?{cosi001}:%{echo:WRONG}:%{echo:OK2}}x'
+runroot rpm --define 'this that' --eval '%{?{this}:%{echo:OK3}%{echo:OK4}:%{echo:WRONG}}x'
+runroot rpm --define 'this that' --eval '%{?!{this}:%{echo:WRONG}:%{echo:OK5}}x'
+runroot rpm --eval '%{?!{cosi001}:OK6}x'
+runroot rpm --eval '%{?{cosi001}:WRONG}x'
+runroot rpm --define "this that" --eval '%{?{this}:OK7}x'
+runroot rpm --define "this that" --eval '%{?!{this}:WRONG}x'
+],
+[0],
+[OK1
+x
+OK2
+x
+OK3
+OK4
+x
+OK5
+x
+OK6x
+x
+OK7x
+x
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
    %{?  { macro_name } : true  : false }
    %{?  { macro_name } : true             }
    %{?! { macro_name } : false : true  }
    %{?! { macro_name } : false           }
    
More detailed description of the notation:
* Between the first chars "%{?" resp. "%{!?" or "%{?!  there can not be a space.
* On the other hand around {condition} and :, there can but not need to be a space.
* In {condition}, there can be a space before or after macro_name.
    
So e.g. the following conditions are similar (from rpm point of view):
%{?{macro}:true:false}
%{? { macro } : true : false }