### PR TITLE
Fix rpmVerifySignatures() passing garbage as verify flags in rpm >= 4.14

### DIFF
--- a/lib/rpmchecksig.c
+++ b/lib/rpmchecksig.c
@@ -267,8 +267,9 @@ int rpmVerifySignatures(QVA_t qva, rpmts ts, FD_t fd, const char * fn)
     int rc = 1; /* assume failure */
     if (ts && qva && fd && fn) {
 	rpmKeyring keyring = rpmtsGetKeyring(ts, 1);
+	rpmVSFlags vsflags = rpmtsVfyFlags(ts);
 	int vfylevel = rpmtsVfyLevel(ts);
-	rc = rpmpkgVerifySigs(keyring, vfylevel, qva->qva_flags, fd, fn);
+	rc = rpmpkgVerifySigs(keyring, vfylevel, vsflags, fd, fn);
     	rpmKeyringFree(keyring);
     }
     return rc;

--- a/lib/rpmcli.h
+++ b/lib/rpmcli.h
@@ -249,7 +249,7 @@ int showVerifyPackage(QVA_t qva, rpmts ts, Header h);
 
 /**
  * Check package and header signatures.
- * @param qva		parsed query/verify options
+ * @param qva		unused
  * @param ts		transaction set
  * @param fd		package file handle
  * @param fn		package file name


### PR DESCRIPTION
Commit a239ddefa90575ce80ed4436beb4005a97e32644 changed rpmpkgVerifySigs()
to accept fine-grained vsflags instead of query/verify style
nosignature/nodigest hammers, but rpmVerifySignatures() didn't get
updated accordingly. This will cause most unexpect behavior (in particular
in 4.14.x), for example QUERY_DIGEST which was used for disabling all
digest verification was defined as (1 << 19), which happens to be the same
as RPMVSF_NORSA which is how it would now be treated. Similarly confusion
with VERIFY_SCRIPT becoming RPMVSF_NODSA etc.

Just use the transaction verify flags instead, and mark the qva argument
as unused. It's an API change but that's okay in 4.15, and it's also an
explicit breakage at compile time (due to those DIGEST/SIGNATURE symbols
removal). In 4.14.x this is a regression but can be fixed within the API.