### PR TITLE
Drop bogus condition from header index allocation

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -251,10 +251,7 @@ static Header headerCreate(void *blob, int32_t indexLen)
     }
     h->instance = 0;
     h->sorted = HEADERSORT_NONE;
-
-    h->index = (h->indexAlloced
-	? xcalloc(h->indexAlloced, sizeof(*h->index))
-	: NULL);
+    h->index = xcalloc(h->indexAlloced, sizeof(*h->index));
 
     h->nrefs = 0;
     return headerLink(h);


### PR DESCRIPTION
We always allocate the index here as should be obvious from the code,
the condition is a leftover that might've been relevant in the turn
of the millenium but not anymore.

This construct confused clang into thinking there's a NULL pointer
dereference at the end of a long callchain (maybe because the indexlen
argument is signed so if you passed in -1 as indexLen... but fixing
those int32_t's is another story)