### PR TITLE
Don't fail build trying to kill a non-existent process (RhBug:1720143)

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -816,7 +816,7 @@ package or when debugging this package.\
 #%___build_body		%{nil}
 %___build_post	\
   RPM_EC=$?\
-  for pid in $(jobs -p); do kill -9 ${pid}; done\
+  for pid in $(jobs -p); do kill -9 ${pid} || continue; done\
   exit ${RPM_EC}\
 %{nil}
 


### PR DESCRIPTION
The job killer introduced at 06953879d3e0b1e9a434979056d1225ab4646142
failed to take into account the fact that the processes *can* die between
us grabbing the pids and actually killing them, and that trying to kill
a non-existent process will cause a script running with -e to actually
terminate an error. So we end up failing a successful build by trying
to kill process that exited on its own, ugh :)