### PR TITLE
Compress annobin notes

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -296,8 +296,6 @@ add_minidebug()
   xz "$mini_debuginfo"
   mini_debuginfo="${mini_debuginfo}.xz"
   objcopy --add-section .gnu_debugdata="$mini_debuginfo" "$binary"
-  # Compress any annobin notes in the original binary.
-  objcopy --merge-notes "$binary"
   rm -f "$dynsyms" "$funcsyms" "$keep_symbols" "$mini_debuginfo"
 }
 
@@ -406,6 +404,10 @@ do_file()
       exit 2
     fi
   fi
+
+  # Compress any annobin notes in the original binary.
+  # Ignore any errors, since older objcopy don't support --merge-notes.
+  objcopy --merge-notes "$f" 2>/dev/null || true
 
   # A binary already copied into /usr/lib/debug doesn't get stripped,
   # just has its file names collected and adjusted.

--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -296,6 +296,8 @@ add_minidebug()
   xz "$mini_debuginfo"
   mini_debuginfo="${mini_debuginfo}.xz"
   objcopy --add-section .gnu_debugdata="$mini_debuginfo" "$binary"
+  # Compress any annobin notes in the original binary.
+  objcopy --merge-notes "$binary"
   rm -f "$dynsyms" "$funcsyms" "$keep_symbols" "$mini_debuginfo"
 }
 


### PR DESCRIPTION
This is a request to add support for compressing annobin notes found in executable binaries built on Fedora and RHEL systems.

The annobin project adds a note section to binary files describing the security hardening features of how they were built.  Unfortunately these notes can get quite large, especially for projects that use lots of object files.  The objcopy program from the binutils package has an option to reduce the size of these notes by eliminating empties and merging duplicates.  If the binary does not contain any annobin notes then the objcopy will take no noticeable amount of time.  In fact even if the file does contain annobin notes the merging process is relatively fast and it is unlikely to add any significant amount of time to the overall build process.