### PR TITLE
Implement %dnl (discard to next line) macro primitive for comment use

### DIFF
--- a/doc/manual/macros
+++ b/doc/manual/macros
@@ -68,6 +68,7 @@ to perform useful operations. The current list is
 	%dump		print the active (i.e. non-covered) macro table
 	%getncpus	return the number of CPUs
 	%verbose	is rpm in verbose mode?
+	%dnl		discard to next line (without expanding)
 
 	%{echo:...}	print ... to stdout
 	%{warn:...}	print warning: ... to stderr

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -456,6 +456,14 @@ static void mbAppendStr(MacroBuf mb, const char *str)
 }
 #endif
 
+static const char * doDnl(MacroBuf mb, const char * se, size_t slen)
+{
+    const char *s = se;
+    while (*s && !iseol(*s))
+	s++;
+    return (*s != '\0') ? s + 1 : s;
+}
+
 /**
  * Expand output of shell command into target buffer.
  * @param mb		macro expansion state
@@ -526,6 +534,7 @@ static struct builtins_s {
     { STR_AND_LEN("basename"),	doFoo,		NULL },
     { STR_AND_LEN("define"),	NULL,		doDef },
     { STR_AND_LEN("dirname"),	doFoo,		NULL },
+    { STR_AND_LEN("dnl"),	NULL,		doDnl },
     { STR_AND_LEN("dump"), 	NULL,		doDump },
     { STR_AND_LEN("echo"),	doOutput,	NULL },
     { STR_AND_LEN("error"),	doOutput,	NULL },

--- a/tests/data/macros.testfile
+++ b/tests/data/macros.testfile
@@ -4,3 +4,13 @@
 %first %{?def:macro_1\
 }
 %second %{?def:macro_2}
+
+%comment1 %{expand:
+read
+%dnl comment
+me
+}
+
+%comment2 see\
+%dnl comment\
+this

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -515,6 +515,24 @@ warning: macros.bad: line 8: Macro %bad needs whitespace before body
 ])
 AT_CLEANUP
 
+AT_SETUP([macro comments])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+	--macros /data/macros.testfile \
+	--eval "%{comment1}" \
+	--eval "%{comment2}"
+],
+[0],
+[
+read
+me
+
+see
+this
+],
+[])
+AT_CLEANUP
 
 AT_SETUP([%if, %else, %elif test basic])
 AT_KEYWORDS([if, else, elif])


### PR DESCRIPTION
There has been no way to add comments to multiline macros, and while
spec files technically support #-commenting at beginning of lines, it
does not apply to all sections and causes generation after generation
of packagers to stumble on the same items over and over: macros
are expanded within spec comment lines, which makes commenting multiline
macros such as %configure annoying, comments inteded for scriptlets
end up being in the previous scriptlets body, and numerous other quirks.

This implements the M4-inspired %dnl macro primitive which literally
discards everything until the next newline (or end of string), without
expanding the contents. This allows comments to be used inside multiline
macros and everywhere in spec.

Caveat: in some places such as %description the newline doesn't actually
get discarded but this is a a spec parser issue, not on the macro side.

Closes: #158