### PR TITLE
Fix build with --disable-openmp

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -1020,11 +1020,13 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 	}
     }
 
+#ifdef ENABLE_OPENMP
     /* Set number of OMP threads centrally */
     int ncpus = rpmExpandNumeric("%{?_smp_build_ncpus}");
     if (ncpus <= 0)
 	ncpus = 1;
     omp_set_num_threads(ncpus);
+#endif
 
     if (spec->clean == NULL) {
 	char *body = rpmExpand("%{?buildroot: %{__rm} -rf %{buildroot}}", NULL);

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,6 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 AC_CONFIG_TESTDIR(tests)
 
 AC_USE_SYSTEM_EXTENSIONS
-AC_OPENMP
 
 AC_DISABLE_STATIC
 
@@ -189,6 +188,16 @@ AC_CHECK_HEADERS([lzma.h],[
   AC_CHECK_LIB(lzma, lzma_easy_encoder, [WITH_LZMA_LIB=-llzma])
 ])
 AC_SUBST(WITH_LZMA_LIB)
+
+# AC_OPENMP supports --enable/disable-openmp out of the box, but it doesn't
+# actually give us a way to conditionalize the build based on that. Argh.
+OPENMP_CFLAGS=
+AC_OPENMP
+AS_IF([test "x$ac_cv_prog_c_openmp" != x &&
+       test "x$ac_cv_prog_c_openmp" != unsupported],[
+  AC_DEFINE(ENABLE_OPENMP, 1, [Enable multithreading support?])
+])
+AC_SUBST(OPENMP_CFLAGS)
 
 #=================
 # Check for zstd.


### PR DESCRIPTION
AC_OPENMP supports --enable/disable-openmp out of the box, but as it
only sets OPENMP_CFLAGS *if needed by the compiler to support openmp*,
it's utterly useless for conditional building. And because AC_OPENMP
doesn't set $ac_cv_prog_c_openmp to anything if --disable-openmp was
used, we need to test that it's neither empty nor unsupported to
determine if we actually have openmp, in order to set an autoconf
define that we can actually use to conditionalize aspects of the
build on. Argh.