### PR TITLE
Fix excessive use of thread local storage (RhBug:1722181)

### DIFF
--- a/lib/headerfmt.c
+++ b/lib/headerfmt.c
@@ -221,18 +221,18 @@ static char * hsaReserve(headerSprintfArgs hsa, size_t need)
 RPM_GNUC_PRINTF(2, 3)
 static void hsaError(headerSprintfArgs hsa, const char *fmt, ...)
 {
-    /* Use thread local static buffer as headerFormat() errmsg arg is const */
-    static __thread char errbuf[BUFSIZ];
+    /* Use thread local buffer as headerFormat() errmsg arg is const */
+    static __thread char *errbuf = NULL;
 
     if (fmt == NULL) {
 	hsa->errmsg = NULL;
     } else {
 	va_list ap;
 
+	free(errbuf);
 	va_start(ap, fmt);
-	vsnprintf(errbuf, sizeof(errbuf), fmt, ap);
+	rvasprintf(&errbuf, fmt, ap);
 	va_end(ap);
-
 	hsa->errmsg = errbuf;
     }
 }

--- a/rpmio/rpmsq.c
+++ b/rpmio/rpmsq.c
@@ -16,9 +16,9 @@
 
 #include "debug.h"
 
-static __thread int disableInterruptSafety;
-static __thread sigset_t rpmsqCaught;
-static __thread sigset_t rpmsqActive;
+static int disableInterruptSafety;
+static sigset_t rpmsqCaught;
+static sigset_t rpmsqActive;
 
 typedef struct rpmsig_s * rpmsig;
 
@@ -171,8 +171,8 @@ int rpmsqPoll(void)
 
 int rpmsqBlock(int op)
 {
-    static __thread sigset_t oldMask;
-    static __thread int blocked = 0;
+    static sigset_t oldMask;
+    static int blocked = 0;
     sigset_t newMask;
     int ret = 0;
 


### PR DESCRIPTION
We've been treating thread local storage as if it were free parking, but it's actually a scarce resource and our use is causing python imports to fail in busy programs (RhBug:1722181)

The header format error return is unavoidable but we can just as well use a dynamically alloced TLS buffer, saving muchos TLS memory. The __thread uses in rpmsq don't make sense at all in reality, so better revert and rethink from scratch.