### PR TITLE
Use a rpmtsPrunedIterator iterator in markReplacedInstance

### DIFF
--- a/lib/psm.c
+++ b/lib/psm.c
@@ -514,7 +514,7 @@ void rpmpsmNotify(rpmpsm psm, int what, rpm_loff_t amount)
  */
 static void markReplacedInstance(rpmts ts, rpmte te)
 {
-    rpmdbMatchIterator mi = rpmtsInitIterator(ts, RPMDBI_NAME, rpmteN(te), 0);
+    rpmdbMatchIterator mi = rpmtsPrunedIterator(ts, RPMDBI_NAME, rpmteN(te), 1);
     rpmdbSetIteratorRE(mi, RPMTAG_EPOCH, RPMMIRE_STRCMP, rpmteE(te));
     rpmdbSetIteratorRE(mi, RPMTAG_VERSION, RPMMIRE_STRCMP, rpmteV(te));
     rpmdbSetIteratorRE(mi, RPMTAG_RELEASE, RPMMIRE_STRCMP, rpmteR(te));


### PR DESCRIPTION
This brings the code in sync with checkProblems() fixing errors
that happens when an erase element exists for an install of a
package with an identical NEVRA.

Use "rpm --reinstall --replacepkgs" to reproduce on the command
line.