### PR TITLE
Add a testcase for filenames with special characters in them

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -80,6 +80,7 @@ EXTRA_DIST += data/SPECS/test-subpackages.spec
 EXTRA_DIST += data/SPECS/test-subpackages-exclude.spec
 EXTRA_DIST += data/SPECS/test-subpackages-pathpostfixes.spec
 EXTRA_DIST += data/SPECS/vattrtest.spec
+EXTRA_DIST += data/SPECS/weirdnames.spec
 EXTRA_DIST += data/SOURCES/buildrequires-1.0.tar.gz
 EXTRA_DIST += data/SOURCES/hello-1.0-modernize.patch
 EXTRA_DIST += data/SOURCES/hello-1.0-install.patch

--- a/tests/data/SPECS/weirdnames.spec
+++ b/tests/data/SPECS/weirdnames.spec
@@ -1,0 +1,37 @@
+%bcond_with illegal
+
+Name:		weirdnames
+Version:	1.0
+Release:	1
+Summary:	Testing weird filename behavior
+License:	GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p %{buildroot}/opt
+cd %{buildroot}/opt
+touch "foo'ed" 'bar"ed' "just space" "\$talks" \
+	"to?be" "the * are falling" '#nocomment' "(maybe)" \
+	"perhaps;not" "true:false" "!absolutely" "&ground" \
+	"after{all}" "index[this]" "equals=not" "tee|two" "~right" \
+	"<namehere>"
+%if %{with illegal}
+touch "only	time"
+# the dependency generator cannot handle newlines in filenames
+touch "new
+line"
+
+%endif
+for f in *; do
+    echo -e "#!/bin/ary\ndada\n" > ${f}
+done
+chmod a+x *
+
+# script.req fails on the backslash
+touch "\.back"
+
+%files
+/opt/*

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -98,6 +98,50 @@ run rpmbuild \
 ])
 AT_CLEANUP
 
+# weird filename survival test
+AT_SETUP([rpmbuild package with weird filenames])
+AT_KEYWORDS([build])
+AT_CHECK([
+rm -rf ${TOPDIR}
+
+runroot rpmbuild -bb --quiet /data/SPECS/weirdnames.spec
+runroot rpm -qpl /build/RPMS/noarch/weirdnames-1.0-1.noarch.rpm
+],
+[0],
+[/opt/!absolutely
+/opt/#nocomment
+/opt/$talks
+/opt/&ground
+/opt/(maybe)
+/opt/<namehere>
+/opt/\.back
+/opt/after{all}
+/opt/bar"ed
+/opt/equals=not
+/opt/foo'ed
+/opt/index[[this]]
+/opt/just space
+/opt/perhaps;not
+/opt/tee|two
+/opt/the * are falling
+/opt/to?be
+/opt/true:false
+/opt/~right
+],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpmbuild package with illegal filenames])
+AT_KEYWORDS([build])
+AT_CHECK([
+# XXX current output is not well suited for grab + compare, just ignore
+runroot rpmbuild -bb --quiet --with illegal /data/SPECS/weirdnames.spec
+],
+[1],
+[],
+[ignore])
+AT_CLEANUP
+
 # ------------------------------
 # Check if tar build works
 # TODO: test that the rpms are actually created...


### PR DESCRIPTION
Being C, rpm itself can typically handle pretty much anything you throw at it, but the surrounding scripts are much more fragile. The notable exception is the dependency generator which whose "API" specifically uses newlines to separate filenames.

This fails on brp-strip-static-archive  since commit fc2c986d8f5e4174885ae377750185339636f062 