### PR TITLE
Use an erase element to delete packages with same NEVRA

### DIFF
--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -70,6 +70,7 @@ struct rpmte_s {
     uint8_t *badrelocs;		/*!< (TR_ADDED) Bad relocations (or NULL) */
     FD_t fd;			/*!< (TR_ADDED) Payload file descriptor. */
     int verified;		/*!< (TR_ADDED) Verification status */
+    int addop;			/*!< (TR_ADDED) RPMTE_INSTALL/UPDATE/REINSTALL */
 
 #define RPMTE_HAVE_PRETRANS	(1 << 0)
 #define RPMTE_HAVE_POSTTRANS	(1 << 1)
@@ -246,11 +247,12 @@ rpmte rpmteFree(rpmte te)
 }
 
 rpmte rpmteNew(rpmts ts, Header h, rpmElementType type, fnpyKey key,
-	       rpmRelocation * relocs)
+	       rpmRelocation * relocs, int addop)
 {
     rpmte p = xcalloc(1, sizeof(*p));
     p->ts = ts;
     p->type = type;
+    p->addop = addop;
     p->verified = RPMSIG_UNVERIFIED_TYPE;
 
     if (addTE(p, h, key, relocs)) {
@@ -772,6 +774,11 @@ void rpmteSetVerified(rpmte te, int verified)
 int rpmteVerified(rpmte te)
 {
     return (te != NULL) ? te->verified : 0;
+}
+
+int rpmteAddOp(rpmte te)
+{
+    return te->addop;
 }
 
 int rpmteProcess(rpmte te, pkgGoal goal, int num)

--- a/lib/rpmte_internal.h
+++ b/lib/rpmte_internal.h
@@ -23,6 +23,12 @@ typedef enum pkgGoal_e {
  */
 typedef struct tsortInfo_s *		tsortInfo;
 
+enum addOp_e {
+  RPMTE_INSTALL       = 0,
+  RPMTE_UPGRADE       = 1,
+  RPMTE_REINSTALL     = 2,
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -34,11 +40,12 @@ extern "C" {
  * @param type		TR_ADDED/TR_REMOVED/TR_RPMDB
  * @param key		(TR_ADDED) package retrieval key (e.g. file name)
  * @param relocs	(TR_ADDED) package file relocations
+ * @param addop         (TR_ADDED) RPMTE_INSTALL/UPGRADE/REINSTALL
  * @return		new transaction element
  */
 RPM_GNUC_INTERNAL
 rpmte rpmteNew(rpmts ts, Header h, rpmElementType type, fnpyKey key,
-	       rpmRelocation * relocs);
+	       rpmRelocation * relocs, int addop);
 
 /** \ingroup rpmte
  * Destroy a transaction element.
@@ -106,6 +113,9 @@ unsigned int rpmteHeaderSize(rpmte te);
  */
 RPM_GNUC_INTERNAL
 rpmRC rpmpsmRun(rpmts ts, rpmte te, pkgGoal goal);
+
+RPM_GNUC_INTERNAL
+int rpmteAddOp(rpmte te);
 
 #ifdef __cplusplus
 }

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1328,10 +1328,10 @@ static rpmps checkProblems(rpmts ts)
 	    rpmdbFreeIterator(mi);
 	}
 
-	if (!(probFilter & RPMPROB_FILTER_REPLACEPKG)) {
+	if (!(probFilter & RPMPROB_FILTER_REPLACEPKG) && rpmteAddOp(p) != RPMTE_REINSTALL) {
 	    Header h;
 	    rpmdbMatchIterator mi;
-	    mi = rpmtsPrunedIterator(ts, RPMDBI_NAME, rpmteN(p), 1);
+	    mi = rpmtsInitIterator(ts, RPMDBI_NAME, rpmteN(p), 0);
 	    rpmdbSetIteratorRE(mi, RPMTAG_EPOCH, RPMMIRE_STRCMP, rpmteE(p));
 	    rpmdbSetIteratorRE(mi, RPMTAG_VERSION, RPMMIRE_STRCMP, rpmteV(p));
 	    rpmdbSetIteratorRE(mi, RPMTAG_RELEASE, RPMMIRE_STRCMP, rpmteR(p));
@@ -1602,7 +1602,7 @@ rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
 
     /* Create a temporary transaction element for triggers from rpmdb */
     if (te == NULL) {
-	te = rpmteNew(ts, h, TR_RPMDB, NULL, NULL);
+	te = rpmteNew(ts, h, TR_RPMDB, NULL, NULL, 0);
 	rpmteSetHeader(te, h);
     }
 

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -246,7 +246,7 @@ static int rpmVerifyScript(rpmts ts, Header h)
 
     if (headerIsEntry(h, RPMTAG_VERIFYSCRIPT)) {
 	/* fake up a transaction element */
-	rpmte p = rpmteNew(ts, h, TR_RPMDB, NULL, NULL);
+	rpmte p = rpmteNew(ts, h, TR_RPMDB, NULL, NULL, 0);
 
 	if (p != NULL) {
 	    rpmteSetHeader(p, h);

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -129,7 +129,6 @@ AT_SETUP([rpm -U --replacepkgs 2])
 AT_KEYWORDS([rpmdb install])
 
 AT_CHECK([
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_CLEAR
 RPMDB_INIT
 


### PR DESCRIPTION
Rpm used to rely on the "replacepkgs hack" to get rid of the old
header entry when reinstalling a package. This has a number of
problems when the headers are not identical or different
install flags were used.

To mitigate this, a '--reinstall' option was added that made rpm
use an erase element in this case.

This commit takes this one step further by changing the code to also
use an erase element in the --upgrade case. The code is mostly simpler,
but we need a different implementation for commit fd40d58efa, as we now
have erase elements both for --reinstall and --upgrade. Thus we
need to store the addop in the transaction element.

The commit does not change the behaviour of 'rpm --install'.