### PR TITLE
Watch out for char signedness when checking for printable

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1323,7 +1323,8 @@ static struct stat * fakeStat(FileEntry cur, struct stat * statp)
 static int validFilename(const char *fn)
 {
     int rc = 1;
-    for (const char *s = fn; *s; s++) {
+    /* char is signed but we're dealing with unsigned values here! */
+    for (const unsigned char *s = (const unsigned char *)fn; *s; s++) {
 	/* Ban DEL and anything below space, UTF-8 is validated elsewhere */
 	if (*s == 0x7f || *s < 0x20) {
 	    rpmlog(RPMLOG_ERR,


### PR DESCRIPTION
Commit ee3126dd3d4ca609f254ac5d647c9ff3e413e9dd added an innocent
looking check to ban characters below < 0x20, but char is signed
so it ends up banning the whole upper range too. Cast to unsigned
and add a comment as a reminder. Thanks to Michael Schroeder for
pointing this out!

Fixes ee3126dd3d4ca609f254ac5d647c9ff3e413e9dd