### PR TITLE
Parse multiline conditional and %include parameters correctly (#775)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,6 +59,7 @@ EXTRA_DIST += data/SPECS/filedep.spec
 EXTRA_DIST += data/SPECS/flangtest.spec
 EXTRA_DIST += data/SPECS/hlinktest.spec
 EXTRA_DIST += data/SPECS/iftest.spec
+EXTRA_DIST += data/SPECS/ifmultiline.spec
 EXTRA_DIST += data/SPECS/eliftest.spec
 EXTRA_DIST += data/SPECS/symlinktest.spec
 EXTRA_DIST += data/SPECS/deptest.spec

--- a/tests/data/SPECS/ifmultiline.spec
+++ b/tests/data/SPECS/ifmultiline.spec
@@ -1,0 +1,28 @@
+Name:           ifmultiline
+Version:         1.0
+Release:        1
+Group:          Testing
+License:        GPL
+BuildArch:      noarch
+Summary: Test multiline if conditions
+
+%description
+%{summary}
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+mkdir -p $RPM_BUILD_ROOT/a
+echo "x" > $RPM_BUILD_ROOT/a/empty\
+Caps1
+
+%if 1 && ( 9|| \
+1)
+
+%endif
+
+%files -n %{name}
+/a/emptyCaps1
+
+
+%changelog

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -637,3 +637,15 @@ error: /data/SPECS/eliftest.spec:40: bad %elif condition:  rubbish:4-3
 
 ])
 AT_CLEANUP
+
+
+AT_SETUP([multiline %if test])
+AT_KEYWORDS([if, macros])
+AT_CHECK([
+runroot rpmbuild -ba --quiet      \
+ data/SPECS/ifmultiline.spec
+],
+[0],
+[],
+[])
+AT_CLEANUP


### PR DESCRIPTION
Trailing '\' after multiline conditionals or %include will be trimmed.
After the patch lines like:

    %if 1 && ( 2 || \
    3 )
    %endif

will be parsed correctly. The other lines stay unchanged.
A test is added.