### PR TITLE
Raise an error if reading a file during rpmbuild fails (#776)

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1575,6 +1575,8 @@ static rpmRC recurseDir(FileList fl, const char * diskPath)
 	case FTS_INIT:		/* initialized only */
 	case FTS_W:		/* whiteout object */
 	default:
+	    rpmlog(RPMLOG_ERR, _("Can't read content of file: %s\n"),
+		fts->fts_path);
 	    rc = RPMRC_FAIL;
 	    break;
 	}


### PR DESCRIPTION
In case of #776 the added rpmbuild error looks:
error: Can't read content of file: /home/tester/reps/776/zdroj/776/tests/testing/build/BUILDROOT/h-1.0-1.x86_64/etc/foo/bar