### PR TITLE
Do not set RPMTAG_BUILDTIME to SOURCE_DATE_EPOCH when defined by default

### DIFF
--- a/build/spec.c
+++ b/build/spec.c
@@ -207,7 +207,7 @@ static rpm_time_t getBuildTime(void)
     char *endptr;
 
     srcdate = getenv("SOURCE_DATE_EPOCH");
-    if (srcdate) {
+    if (srcdate && rpmExpandNumeric("%{?use_source_date_epoch_as_buildtime}")) {
         errno = 0;
         epoch = strtol(srcdate, &endptr, 10);
         if (srcdate == endptr || *endptr || errno != 0)

--- a/macros.in
+++ b/macros.in
@@ -238,6 +238,11 @@ package or when debugging this package.\
 #	to the timestamp of the topmost changelog entry
 %source_date_epoch_from_changelog 0
 
+#	If true, make sure that buildtime in built rpms
+#	is set to the value of SOURCE_DATE_EPOCH.
+#	Is ignored when SOURCE_DATE_EPOCH is not set.
+%use_source_date_epoch_as_buildtime 0
+
 #	If true, make sure that timestamps in built rpms
 #	are not later than the value of SOURCE_DATE_EPOCH.
 #	Is ignored when SOURCE_DATE_EPOCH is not set.


### PR DESCRIPTION
Since b8a54d6a1e9bb6140b6b47e23dc707e4b967537e, when `SOURCE_DATE_EPOCH` is set, `RPMTAG_BUILDTIME` winds up being set with that value. This is not always desirable, particularly if you are using the build time for filters and evaluation in certain types of package release pipelines.

This is an adaptation of the downstream patch in SUSE's rpm package written by @mlschroe intended to address [SuseBug:1087065](https://bugzilla.suse.com/show_bug.cgi?id=1087065) (private bug 😢).