### PR TITLE
rpmbuild: Generate buildreqs.nosrc.rpm even if no output

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -200,10 +200,6 @@ static int doBuildRequires(rpmSpec spec, int test)
     argvSplit(&output, getStringBuf(sb_stdout), "\n\r");
     outc = argvCount(output);
 
-    if (!outc) {
-	goto exit;
-    }
-
     for (int i = 0; i < outc; i++) {
 	parseRCPOT(spec, spec->sourcePackage, output[i], RPMTAG_REQUIRENAME,
 		   0, 0, addReqProvPkg, NULL);


### PR DESCRIPTION
Fixes: https://github.com/rpm-software-management/rpm/issues/781
Reported-by: Michael Schroeder <mls@suse.de>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>