### PR TITLE
rpmio: Handle EOF without EOL better at END PGP in rpmpgp.c

### DIFF
--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -1289,9 +1289,10 @@ static pgpArmor decodePkts(uint8_t *b, uint8_t **pkt, size_t *pktlen)
 		goto exit;
 	    }
 	    t += (sizeof("-----")-1);
-	    if (t >= te) continue;
+	    /* Handle EOF without EOL here, *t == '\0' at EOF */
+	    if (*t && (t >= te)) continue;
 	    /* XXX permitting \r here is not RFC-2440 compliant <shrug> */
-	    if (!(*t == '\n' || *t == '\r')) continue;
+	    if (!(*t == '\n' || *t == '\r' || *t == '\0')) continue;
 
 	    crcdec = NULL;
 	    crclen = 0;


### PR DESCRIPTION
Currently a PGP public key file which does not have any end-of-line character(s) at end of file, but is valid otherwise, is not considered valid by rpmio.

This change adds a special-case for the string terminating null byte right after the terminating `-----` of the `END PGP` header.
