### PR TITLE
Use [ ] and && to avoid sub processes in find-debuginfo.sh (RhBug:172…

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -213,7 +213,7 @@ if test -n "$build_id_seed" -a "$no_recompute_build_id" = "true"; then
   exit 2
 fi
 
-if [ "$strip_g" = "true" -a "$strip_glibs" = "true" ]; then
+if [ "$strip_g" = "true" ] && [ "$strip_glibs" = "true" ]; then
   echo >&2 "*** ERROR: -g  and --g-libs cannot be used together"
   exit 2
 fi


### PR DESCRIPTION
…0590)

Thanks to Florian Festi for spotting this and proposing the solution.