### PR TITLE
Fix off-by-one in hdrblobGet() making last entry unreachable (RhBug:1…

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -2015,7 +2015,7 @@ rpmRC hdrblobGet(hdrblob blob, uint32_t tag, rpmtd td)
     memset(&einfo, 0, sizeof(einfo));
     rpmtdReset(td);
 
-    for (int i = 1; i < blob->il; i++, pe++) {
+    for (int i = 0; i < blob->il; i++, pe++) {
 	if (pe->tag != ntag)
 	    continue;
 	ei2h(pe, &einfo);


### PR DESCRIPTION
…722921)

hdrblobGet() introduced in commits acfde0d0e812e9f8e153ab6be8c9f2682bdd4763
and 9821de18811db97238c34a564221e315f5f35b44 has an off-by-one thinko
(perhaps the idea was to skip the first, region tag) which causes
the last entry to be unreachable. In typical packages, that is
RPMSIG_PAYLOADSIZE which is not used at all in this context so it doesn't
matter, but in large packages use RPMSIG_LONGARCHIVESIZE which has a lower
tag number and leaves either RPMSIGTAG_MD5 or RPMSIGTAG_GPG last,
unreachable and thus unverifiable. Oops.

This fixes the regression introduced in rpm 4.14, affecting verification
of large packages (ie having RPMSIG_LONGARCHIVESIZE)