### PR TITLE
Fix memleak during transaction verify step in the NOKEY case.

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1226,8 +1226,10 @@ static int vfyCb(struct rpmsinfo_s *sinfo, void *cbdata)
 	 */
 	if (!(vd->vfylevel & RPMSIG_SIGNATURE_TYPE))
 	    sinfo->rc = RPMRC_OK;
+	/* fallthrough */
     default:
-	vd->msg = rpmsinfoMsg(sinfo);
+	if (sinfo->rc)
+	    vd->msg = rpmsinfoMsg(sinfo);
 	break;
     }
     return (sinfo->rc == 0);


### PR DESCRIPTION
Found during RhBug:1714657 QA testing.
In addition, add a comment to clarify the fallthrough as intentional.