### PR TITLE
Use -flto=auto as a default for _lto_cflags.

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -59,8 +59,10 @@
 
 %_smp_mflags -j%{_smp_build_ncpus}
 
-# Enable LTO optimization with a maximal parallelism
-%_lto_cflags -flto=%{_smp_build_ncpus}
+# Enable LTO optimization with automatic detection
+# for GNU make's jobserver or maximum parallelism based
+# on number of cores.
+%_lto_cflags -flto=auto
 
 #==============================================================================
 # ---- Build policy macros.


### PR DESCRIPTION
After a long discussion, we as GCC community newly introduced
-flto=auto option. Doing that, LTO can automatically detect
make's jobserver or fall back to # of cores.