### PR TITLE
Prefer '[] && []' to '[ -a ]' and '[] || []' to '[ -o ]' in tests

### DIFF
--- a/scripts/brp-compress
+++ b/scripts/brp-compress
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # If using normal root, avoid changing anything.
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 

--- a/scripts/brp-java-gcjcompile
+++ b/scripts/brp-java-gcjcompile
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 # If using normal root, avoid changing anything.
-[ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ] && exit 0
+[ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ] && exit 0
 
 # If we are a noarch package, avoid changing anything.
 [ "$RPM_ARCH" = "noarch" ] && exit 0
 
 # If we don't have the required executables, avoid changing anything.
 gcj=${1:-/usr/bin/gcj}
-[ ! -x "$gcj" -o ! -x "$gcj-dbtool" ] && exit 0
+[ ! -x "$gcj" ] || [ ! -x "$gcj-dbtool" ] && exit 0
 
 # Now get to work...
 libdir="/usr/lib" # XXX need to sed this in or something

--- a/scripts/brp-python-bytecompile
+++ b/scripts/brp-python-bytecompile
@@ -3,7 +3,7 @@ errors_terminate=$2
 extra=$3
 
 # If using normal root, avoid changing anything.
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 
@@ -11,7 +11,7 @@ fi
 # number and hope it's enough, but somewhere, somebody's sure to run into it.
 depth=`(find "$RPM_BUILD_ROOT" -type f -name "*.py" -print0 ; echo /) | \
        xargs -0 -n 1 dirname | sed 's,[^/],,g' | sort -u | tail -n 1 | wc -c`
-if [ -z "$depth" -o "$depth" -le "1" ]; then
+if [ -z "$depth" ] || [ "$depth" -le "1" ]; then
 	exit 0
 fi
 
@@ -66,14 +66,14 @@ do
 
 	# Generate normal (.pyc) byte-compiled files.
 	python_bytecompile "" "$python_binary" "" "$python_libdir" "$depth" "$real_libdir"
-	if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+	if [ $? -ne 0 ] && [ 0$errors_terminate -ne 0 ]; then
 		# One or more of the files had a syntax error
 		exit 1
 	fi
 
 	# Generate optimized (.pyo) byte-compiled files.
 	python_bytecompile "-O" "$python_binary" "" "$python_libdir" "$depth" "$real_libdir"
-	if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+	if [ $? -ne 0 ] && [ 0$errors_terminate -ne 0 ]; then
 		# One or more of the files had a syntax error
 		exit 1
 	fi
@@ -98,14 +98,14 @@ find "$RPM_BUILD_ROOT" -type f -name "*.py" | grep -Ev "/bin/|/sbin/|/usr/lib(64
 
 # Generate normal (.pyc) byte-compiled files.
 python_bytecompile "" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
-if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+if [ $? -ne 0 ] && [ 0$errors_terminate -ne 0 ]; then
 	# One or more of the files had a syntax error
 	exit 1
 fi
 
 # Generate optimized (.pyo) byte-compiled files.
 python_bytecompile "-O" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
-if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+if [ $? -ne 0 ] && [ 0$errors_terminate -ne 0 ]; then
 	# One or more of the files had a syntax error
 	exit 1
 fi

--- a/scripts/brp-python-hardlink
+++ b/scripts/brp-python-hardlink
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # If using normal root, avoid changing anything.
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 

--- a/scripts/brp-strip
+++ b/scripts/brp-strip
@@ -1,6 +1,6 @@
 #!/bin/sh
 # If using normal root, avoid changing anything.
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 

--- a/scripts/brp-strip-comment-note
+++ b/scripts/brp-strip-comment-note
@@ -1,6 +1,6 @@
 #!/bin/sh
 # If using normal root, avoid changing anything.
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 

--- a/scripts/brp-strip-shared
+++ b/scripts/brp-strip-shared
@@ -3,7 +3,7 @@
 # Thu Apr 20 - Guilherme Manika <gwm@conectiva.com.br>
 #              Created file
 
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 

--- a/scripts/brp-strip-static-archive
+++ b/scripts/brp-strip-static-archive
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 

--- a/scripts/check-buildroot
+++ b/scripts/check-buildroot
@@ -18,7 +18,7 @@
 
 test -z "$QA_SKIP_BUILD_ROOT" || exit 0
 
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
         exit 0
 fi
 

--- a/scripts/check-rpaths
+++ b/scripts/check-rpaths
@@ -21,7 +21,7 @@ test -z "$QA_SKIP_RPATHS" || {
     exit 0
 }
 
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
         exit 0
 fi
 

--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -157,7 +157,7 @@ while [ $# -gt 0 ]; do
     include_gdb_index=true
     ;;
   -o)
-    if [ -z "${lists[$nout]}" -a -z "${ptns[$nout]}" ]; then
+    if [ -z "${lists[$nout]}" ] && [ -z "${ptns[$nout]}" ]; then
       out=$2
     else
       outs[$nout]=$2
@@ -428,7 +428,7 @@ do_file()
   # strip -g implies we have full symtab, don't add mini symtab in that case.
   # It only makes sense to add a minisymtab for executables and shared
   # libraries. Other executable ELF files (like kernel modules) don't need it.
-  if [ "$include_minidebug" = "true" -a "$strip_g" = "false" ]; then
+  if [ "$include_minidebug" = "true" ] && [ "$strip_g" = "false" ]; then
     skip_mini=true
     if [ "$strip_glibs" = "false" ]; then
       case "$(file -bi "$f")" in
@@ -587,7 +587,7 @@ if [ -s "$SOURCEFILE" ]; then
   xargs --no-run-if-empty -0 chmod 0755
 fi
 
-if [ -d "${RPM_BUILD_ROOT}/usr/lib" -o -d "${RPM_BUILD_ROOT}/usr/src" ]; then
+if [ -d "${RPM_BUILD_ROOT}/usr/lib" ] || [ -d "${RPM_BUILD_ROOT}/usr/src" ]; then
   ((nout > 0)) ||
   test ! -d "${RPM_BUILD_ROOT}/usr/lib" ||
   (cd "${RPM_BUILD_ROOT}/usr/lib"; find debug -type d) |

--- a/scripts/find-lang.sh
+++ b/scripts/find-lang.sh
@@ -184,7 +184,7 @@ s:%lang(C) ::
 /^$/d' >> $MO_NAME
 
 KDE3_HTML=`kde-config --expandvars --install html 2>/dev/null`
-if [ x"$KDE3_HTML" != x -a -d "$TOP_DIR$KDE3_HTML" ]; then
+if [ x"$KDE3_HTML" != x ] && [ -d "$TOP_DIR$KDE3_HTML" ]; then
 find "$TOP_DIR$KDE3_HTML" -type d|sed '
 s:'"$TOP_DIR"'::
 '"$NO_ALL_NAME$KDE"'s:\(.*/HTML/\)\([^/_]\+\)\(.*/'"$NAME"'/\)::
@@ -197,7 +197,7 @@ s:%lang(C) ::
 fi
 
 KDE4_HTML=`kde4-config --expandvars --install html 2>/dev/null`
-if [ x"$KDE4_HTML" != x -a -d "$TOP_DIR$KDE4_HTML" ]; then
+if [ x"$KDE4_HTML" != x ] && [ -d "$TOP_DIR$KDE4_HTML" ]; then
 find "$TOP_DIR$KDE4_HTML" -type d|sed '
 s:'"$TOP_DIR"'::
 '"$NO_ALL_NAME$KDE"'s:\(.*/HTML/\)\([^/_]\+\)\(.*/'"$NAME"'/\)::
@@ -210,7 +210,7 @@ s:%lang(C) ::
 fi
 
 KF5_HTML=`kf5-config --expandvars --install html 2>/dev/null`
-if [ x"$KF5_HTML" != x -a -d "$TOP_DIR$KF5_HTML" ]; then
+if [ x"$KF5_HTML" != x ] && [ -d "$TOP_DIR$KF5_HTML" ]; then
 find "$TOP_DIR$KF5_HTML" -type d|sed '
 s:'"$TOP_DIR"'::
 '"$NO_ALL_NAME$KDE"'s:\(.*/HTML/\)\([^/_]\+\)\(.*/'"$NAME"'/\)::

--- a/scripts/gendiff
+++ b/scripts/gendiff
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$1" -o -z "$2" ] && {
+[ -z "$1" ] || [ -z "$2" ] && {
 # usage
   echo "usage: $0 <directory> <diff-extension>" 1>&2
   exit 1

--- a/scripts/rpm2cpio.sh
+++ b/scripts/rpm2cpio.sh
@@ -6,7 +6,7 @@ fatal() {
 }
 
 pkg="$1"
-[ -n "$pkg" -a -e "$pkg" ] ||
+[ -n "$pkg" ] && [ -e "$pkg" ] ||
 	fatal "No package supplied"
 
 _dd() {

--- a/scripts/rpmdb_loadcvt
+++ b/scripts/rpmdb_loadcvt
@@ -28,7 +28,7 @@ loadfmt="${5%%:}"
     exit 0
 }
 
-[ "$ac" != "0" -o "`/usr/bin/id -u`" != "0" ] && {
+[ "$ac" != "0" ] || [ "`/usr/bin/id -u`" != "0" ] && {
     echo "$cmd: Convert $rpmdb files to db-$loadfmt format."
     echo "$cmd: Must be run as root, takes no arguments."
     exit 1

--- a/scripts/tgpg
+++ b/scripts/tgpg
@@ -3,7 +3,7 @@
 
 for pkg in $*
 do
-    if [ "$pkg" = "" -o ! -e "$pkg" ]; then
+    if [ "$pkg" = "" ] || [ ! -e "$pkg" ]; then
 	echo "no package supplied" 1>&2
 	exit 1
     fi


### PR DESCRIPTION
It corrects warnings  [SC2166] spotted by covscan:
warning: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
warning: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined. [SC2166]

Motivated by last the comment in #802. This should fix all [sc2166] warnings spotted by covscan on RPM version 4.14.2.