### PR TITLE
Drop %_lto_cflags macro afterall

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1025,7 +1025,7 @@ package or when debugging this package.\
 %build_fflags %{optflags} %{?_fmoddir:-I%{_fmoddir}}
 
 # Link editor flags.  This is usually called LDFLAGS in makefiles.
-#%build_ldflags -Wl,-z,relro %{?_lto_cflags}
+#%build_ldflags -Wl,-z,relro
 
 # Expands to shell code to seot the compiler/linker environment
 # variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have

--- a/platform.in
+++ b/platform.in
@@ -59,9 +59,6 @@
 
 %_smp_mflags -j%{_smp_build_ncpus}
 
-# Enable LTO optimization with a maximal parallelism
-%_lto_cflags -flto=%{_smp_build_ncpus}
-
 #==============================================================================
 # ---- Build policy macros.
 #


### PR DESCRIPTION
This was only added in commit 2bb7b0cf066c97a9d92eb0bf59618896000cb29d,
but turns out that this kind of usage is bad for build reproducability
because the system-specific CPU count gets recorded RPMTAG_OPTFLAGS
and the resulting binaries too (depending on gcc flags).
In addition, gcc upstream has decided to make -flto default to
autodetected parallelism. Since -flto can be overridden with
by simply appending -fno-lto for the packages that need to disable it,
there's no practical need for us to provide such a macro for disabling
either.