### PR TITLE
Fix segfault regression on empty script or description at end of spec

### DIFF
--- a/build/parseDescription.c
+++ b/build/parseDescription.c
@@ -21,6 +21,7 @@ int parseDescription(rpmSpec spec)
     const char **argv = NULL;
     const char *name = NULL;
     const char *lang = RPMBUILD_DEFAULT_LANG;
+    const char *descr = "";
     poptContext optCon = NULL;
     struct poptOption optionsTable[] = {
 	{ NULL, 'n', POPT_ARG_STRING, &name, 'n', NULL, NULL},
@@ -68,9 +69,13 @@ int parseDescription(rpmSpec spec)
 	goto exit;
     }
 
-    stripTrailingBlanksStringBuf(sb);
+    if (sb) {
+	stripTrailingBlanksStringBuf(sb);
+	descr = getStringBuf(sb);
+    }
+
     if (addLangTag(spec, pkg->header,
-		   RPMTAG_DESCRIPTION, getStringBuf(sb), lang)) {
+		   RPMTAG_DESCRIPTION, descr, lang)) {
 	nextPart = PART_ERROR;
     }
      

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -79,7 +79,7 @@ int parseScript(rpmSpec spec, int parsePart)
     /*  -p "<sh> <args>..."                */
     /*  -f <file>                          */
 
-    const char *p;
+    const char *p = "";
     const char **progArgv = NULL;
     int progArgc;
     const char *partname = NULL;
@@ -354,8 +354,11 @@ int parseScript(rpmSpec spec, int parsePart)
 
     if ((res = parseLines(spec, STRIP_NOTHING, NULL, &sb)) == PART_ERROR)
 	goto exit;
-    stripTrailingBlanksStringBuf(sb);
-    p = getStringBuf(sb);
+
+    if (sb) {
+	stripTrailingBlanksStringBuf(sb);
+	p = getStringBuf(sb);
+    }
 
 #ifdef WITH_LUA
     if (rstreq(progArgv[0], "<lua>")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,7 @@ EXTRA_DIST += data/SPECS/symlinktest.spec
 EXTRA_DIST += data/SPECS/deptest.spec
 EXTRA_DIST += data/SPECS/verifyscript.spec
 EXTRA_DIST += data/SPECS/fakeshell.spec
+EXTRA_DIST += data/SPECS/mini.spec
 EXTRA_DIST += data/SPECS/scripts.spec
 EXTRA_DIST += data/SPECS/scriptfail.spec
 EXTRA_DIST += data/SPECS/selfconflict.spec

--- a/tests/data/SPECS/mini.spec
+++ b/tests/data/SPECS/mini.spec
@@ -1,0 +1,7 @@
+Name: mini
+Version: 1
+Release: 1
+License: k
+Summary: Minimal spec
+
+%description

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1598,3 +1598,16 @@ run rpmbuild \
 [error: Bad source: ${TOPDIR}/SOURCES/hello-1.0.tar.gz: No such file or directory
 ])
 AT_CLEANUP
+
+AT_SETUP([rpmbuild minimal spec])
+AT_KEYWORDS([build])
+AT_CHECK_UNQUOTED([
+rm -rf ${TOPDIR}
+
+run rpmbuild \
+  -bb --quiet "${abs_srcdir}"/data/SPECS/mini.spec
+],
+[0],
+[],
+[])
+AT_CLEANUP


### PR DESCRIPTION
More ripples from the parseLines() unification, the callers used to
explicitly allocate an empty string buffer, but with lazy allocation
from parseLines() they're getting NULL in the special circumstance of
being last in the spec, and no "body". Specifically this happens with
empty %description or scriptlet without a body, eg
"%post -p /sbin/ldconfig".

The script regression report + reproducer and a preliminary patch
originally from RhBug:1732276 by nvwarr.