### PR TITLE
Restore strict order of build scriptlet stdout/stderr output (#794)

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -60,7 +60,6 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
     int argc = 0;
     const char **argv = NULL;
     FILE * fp = NULL;
-    FILE * cmdOut = rpmIsVerbose() ? stdout : NULL;
 
     FD_t fd = NULL;
     rpmRC rc = RPMRC_FAIL; /* assume failure */
@@ -156,7 +155,7 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 
     rpmlog(RPMLOG_NOTICE, _("Executing(%s): %s\n"), name, buildCmd);
     if (rpmfcExec((ARGV_const_t)argv, NULL, sb_stdoutp, 1,
-		  spec->buildSubdir, cmdOut)) {
+		  spec->buildSubdir, NULL)) {
 	rpmlog(RPMLOG_ERR, _("Bad exit status from %s (%s)\n"),
 		scriptName, name);
 	goto exit;
@@ -242,6 +241,9 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
     int missing_buildreqs = 0;
     int test = (what & RPMBUILD_NOBUILD);
     char *cookie = buildArgs->cookie ? xstrdup(buildArgs->cookie) : NULL;
+    /* handle quiet mode by capturing the output into a sink buffer */
+    StringBuf sink = NULL;
+    StringBuf *sbp = rpmIsVerbose() ? NULL : &sink;
 
     if (rpmExpandNumeric("%{?source_date_epoch_from_changelog}") &&
 	getenv("SOURCE_DATE_EPOCH") == NULL) {
@@ -292,7 +294,7 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 
 	if ((what & RPMBUILD_PREP) &&
 	    (rc = doScript(spec, RPMBUILD_PREP, "%prep",
-			   getStringBuf(spec->prep), test, NULL)))
+			   getStringBuf(spec->prep), test, sbp)))
 		goto exit;
 
 	if (what & RPMBUILD_BUILDREQUIRES)
@@ -321,17 +323,17 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 
 	if ((what & RPMBUILD_BUILD) &&
 	    (rc = doScript(spec, RPMBUILD_BUILD, "%build",
-			   getStringBuf(spec->build), test, NULL)))
+			   getStringBuf(spec->build), test, sbp)))
 		goto exit;
 
 	if ((what & RPMBUILD_INSTALL) &&
 	    (rc = doScript(spec, RPMBUILD_INSTALL, "%install",
-			   getStringBuf(spec->install), test, NULL)))
+			   getStringBuf(spec->install), test, sbp)))
 		goto exit;
 
 	if ((what & RPMBUILD_CHECK) &&
 	    (rc = doScript(spec, RPMBUILD_CHECK, "%check",
-			   getStringBuf(spec->check), test, NULL)))
+			   getStringBuf(spec->check), test, sbp)))
 		goto exit;
 
 	if ((what & RPMBUILD_PACKAGESOURCE) &&
@@ -358,11 +360,11 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	
 	if ((what & RPMBUILD_CLEAN) &&
 	    (rc = doScript(spec, RPMBUILD_CLEAN, "%clean",
-			   getStringBuf(spec->clean), test, NULL)))
+			   getStringBuf(spec->clean), test, sbp)))
 		goto exit;
 
 	if ((what & RPMBUILD_RMBUILD) &&
-	    (rc = doScript(spec, RPMBUILD_RMBUILD, "--clean", NULL, test, NULL)))
+	    (rc = doScript(spec, RPMBUILD_RMBUILD, "--clean", NULL, test, sbp)))
 		goto exit;
     }
 
@@ -373,6 +375,7 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	(void) unlink(spec->specFile);
 
 exit:
+    freeStringBuf(sink);
     free(cookie);
     spec->rootDir = NULL;
     if (rc != RPMRC_OK && rc != RPMRC_MISSINGBUILDREQUIRES &&

--- a/build/build.c
+++ b/build/build.c
@@ -155,7 +155,7 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 
     rpmlog(RPMLOG_NOTICE, _("Executing(%s): %s\n"), name, buildCmd);
     if (rpmfcExec((ARGV_const_t)argv, NULL, sb_stdoutp, 1,
-		  spec->buildSubdir, NULL)) {
+		  spec->buildSubdir)) {
 	rpmlog(RPMLOG_ERR, _("Bad exit status from %s (%s)\n"),
 		scriptName, name);
 	goto exit;

--- a/build/files.c
+++ b/build/files.c
@@ -2781,7 +2781,7 @@ static int checkFiles(const char *buildRoot, StringBuf fileList)
 
     rpmlog(RPMLOG_NOTICE, _("Checking for unpackaged file(s): %s\n"), s);
 
-    rc = rpmfcExec(av_ckfile, fileList, &sb_stdout, 0, buildRoot, NULL);
+    rc = rpmfcExec(av_ckfile, fileList, &sb_stdout, 0, buildRoot);
     if (rc < 0)
 	goto exit;
     

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -490,11 +490,10 @@ rpmRC rpmfcGenerateDepends(const rpmSpec spec, Package pkg);
  * @retval *sb_stdoutp	helper output
  * @param failnonzero	IS non-zero helper exit status a failure?
  * @param buildRoot	buildRoot directory (or NULL)
- * @param dup		duplicate output (or NULL)
  */
 RPM_GNUC_INTERNAL
 int rpmfcExec(ARGV_const_t av, StringBuf sb_stdin, StringBuf * sb_stdoutp,
-		int failnonzero, const char *buildRoot, FILE *dup);
+		int failnonzero, const char *buildRoot);
 
 /** \ingroup rpmbuild
  * Post-build processing for policies in binary package(s).

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -260,7 +260,7 @@ static rpmds rpmdsSingleNS(rpmstrPool pool,
 static int getOutputFrom(ARGV_t argv,
 			 const char * writePtr, size_t writeBytesLeft,
 			 StringBuf sb_stdout,
-			 int failNonZero, const char *buildRoot, FILE *dup)
+			 int failNonZero, const char *buildRoot)
 {
     pid_t child, reaped;
     int toProg[2] = { -1, -1 };
@@ -268,7 +268,7 @@ static int getOutputFrom(ARGV_t argv,
     int status;
     int myerrno = 0;
     int ret = 1; /* assume failure */
-    int doio = (writePtr || sb_stdout || dup);
+    int doio = (writePtr || sb_stdout);
 
     if (doio && (pipe(toProg) < 0 || pipe(fromProg) < 0)) {
 	rpmlog(RPMLOG_ERR, _("Couldn't create pipe for %s: %m\n"), argv[0]);
@@ -369,8 +369,6 @@ static int getOutputFrom(ARGV_t argv,
 	    buf[iorc] = '\0';
 	    if (sb_stdout)
 		appendStringBuf(sb_stdout, buf);
-	    if (dup)
-		fprintf(dup, "%s", buf);
 	}
     }
 
@@ -402,7 +400,7 @@ exit:
 }
 
 int rpmfcExec(ARGV_const_t av, StringBuf sb_stdin, StringBuf * sb_stdoutp,
-		int failnonzero, const char *buildRoot, FILE *dup)
+		int failnonzero, const char *buildRoot)
 {
     char * s = NULL;
     ARGV_t xav = NULL;
@@ -448,7 +446,7 @@ int rpmfcExec(ARGV_const_t av, StringBuf sb_stdin, StringBuf * sb_stdoutp,
 	sb = newStringBuf();
     }
     ec = getOutputFrom(xav, buf_stdin, buf_stdin_len, sb,
-		       failnonzero, buildRoot, dup);
+		       failnonzero, buildRoot);
     if (ec) {
 	sb = freeStringBuf(sb);
 	goto exit;
@@ -498,7 +496,7 @@ static ARGV_t runCmd(const char *cmd,
     argvAdd(&av, cmd);
 
     appendLineStringBuf(sb_stdin, fn);
-    if (rpmfcExec(av, sb_stdin, &sb_stdout, 0, buildRoot, NULL) == 0) {
+    if (rpmfcExec(av, sb_stdin, &sb_stdout, 0, buildRoot) == 0) {
 	argvSplit(&output, getStringBuf(sb_stdout), "\n\r");
     }
 
@@ -1359,7 +1357,7 @@ static rpmRC rpmfcApplyExternal(rpmfc fc)
 	free(s);
 
 	if (rpmfcExec(dm->argv, sb_stdin, &sb_stdout,
-			failnonzero, fc->buildRoot, NULL) == -1)
+			failnonzero, fc->buildRoot) == -1)
 	    continue;
 
 	if (sb_stdout == NULL) {


### PR DESCRIPTION
Commit 18e8f4e9b2dd170d090843adf5b5084658d68cf7 and related changes caused us to capture and re-emit stdout of all build scriptlets, whether we actually use the output for anything or not. Besides doing a whole bunch of work for nothing, this can disrupt the output of build scriptlets by making the output jerky and out of order, at least inside mock and other tools which in turn grab rpm output. This makes troubleshooting failed builds unnecessarily hard for no good reason.
    
Handle the whole thing in a different way: on regular builds, don't capture anything where we don't actually need to. This restores the natural flow of output. We still need to somehow handle quiet builds though, and we can't use redirect to /dev/null from %___build_pre like we used to, because dynamic buildrequires need to provide output even on quiet builds. So somewhat counter-intuitively, we need to capture the output in order to discard it.