### PR TITLE
Add a dummy line to CI setup to allow controlling dnf gpgcheck per build

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,6 +6,8 @@ COPY . .
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
 RUN rm -f /etc/yum.repos.d/*modular.repo
+# dummy for controlling per-repo gpgcheck via Semaphore setup
+RUN sed -i -e "s:^gpgcheck=.$:gpgcheck=1:g" /etc/yum.repos.d/*.repo
 RUN dnf -y update
 RUN dnf -y install \
   autoconf \


### PR DESCRIPTION
This doesn't do anything at all in itself because all the repositories
have gpgcheck=1 by default. However adding this line allows disabling
the gpgcheck for individual builds via Semaphore build settings, which
allows us to deal with signatures on rawhide breaking twice a year
causing our builds to appear failed for no good reason.