### PR TITLE
RFC: Limit build parallelism by available memory too, add tunables (#804)

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -1035,7 +1035,7 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 
 #ifdef ENABLE_OPENMP
     /* Set number of OMP threads centrally */
-    int ncpus = rpmExpandNumeric("%{?_smp_build_ncpus}");
+    int ncpus = rpmExpandNumeric("%{?_smp_build_nthreads}");
     if (ncpus <= 0)
 	ncpus = 1;
     omp_set_num_threads(ncpus);

--- a/doc/manual/macros
+++ b/doc/manual/macros
@@ -84,6 +84,13 @@ to perform useful operations. The current list is
 	%{url2path:...}	convert url to a local path
 	%{getenv:...}	getenv(3) macro analogue
 	%{getconfdir:...}	expand to rpm "home" directory (typically /usr/lib/rpm)
+	%{getmem:<type>} get available memory info in megabytes, where <type>
+			is one of:
+				phys	total physical memory
+				avail	available physical memory
+				virt	virtual address space
+				proc	for process use
+				thread	for thread use
 	%{uncompress:...} expand ... to <file> and test to see if <file> is
 			compressed.  The expansion is
 				cat <file>		# if not compressed

--- a/macros.in
+++ b/macros.in
@@ -1069,12 +1069,27 @@ package or when debugging this package.\
 #------------------------------------------------------------------------------
 # Maximum number of CPU's to use when building, 0 for unlimited.
 #%_smp_ncpus_max 0
+#%_smp_nthreads_max 0
+
+# Estimated size of process/thread
+%_smp_procsize 1024
+%_smp_threadsize 512
 
 %_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
 	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
         ncpus_max=%{?_smp_ncpus_max}; \\\
         if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
+        memtasks_max="%{expr:%{getmem:proc}/%{_smp_procsize}}"; \\\
+        if [ "$RPM_BUILD_NCPUS" -gt "$memtasks_max" ]; then RPM_BUILD_NCPUS="$memtasks_max"; fi; \\\
         echo "$RPM_BUILD_NCPUS";)
+
+%_smp_build_nthreads %([ -z "$RPM_BUILD_NTHREADS" ] \\\
+	&& RPM_BUILD_NTHREADS="%{_smp_build_ncpus}"; \\\
+        nthreads_max=%{?_smp_nthreads_max}; \\\
+        if [ -n "$nthreads_max" ] && [ "$nthreads_max" -gt 0 ] && [ "$RPM_BUILD_NTHREADS" -gt "$nthreads_max" ]; then RPM_BUILD_NTHREADS="$nthreads_max"; fi; \\\
+        memtasks_max="%{expr:%{getmem:thread}/%{_smp_threadsize}}"; \\\
+        if [ "$RPM_BUILD_NTHREADS" -gt "$memtasks_max" ]; then RPM_BUILD_NTHREADS="$memtasks_max"; fi; \\\
+        echo "$RPM_BUILD_NTHREADS";)
 
 %_smp_mflags -j%{_smp_build_ncpus}
 

--- a/macros.in
+++ b/macros.in
@@ -1067,6 +1067,18 @@ package or when debugging this package.\
 	--infodir=%{_infodir}
 
 #------------------------------------------------------------------------------
+# Maximum number of CPU's to use when building, 0 for unlimited.
+#%_smp_ncpus_max 0
+
+%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
+	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
+        ncpus_max=%{?_smp_ncpus_max}; \\\
+        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
+        echo "$RPM_BUILD_NCPUS";)
+
+%_smp_mflags -j%{_smp_build_ncpus}
+
+#------------------------------------------------------------------------------
 # Tested features of make
 # Output synchronization for parallel make:
 %_make_output_sync %(! %{__make} --version -O >/dev/null 2>&1 || echo -O)

--- a/platform.in
+++ b/platform.in
@@ -48,17 +48,6 @@
 
 %_defaultdocdir		%{_datadir}/doc
 
-# Maximum number of CPU's to use when building, 0 for unlimited.
-#%_smp_ncpus_max 0
-
-%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
-	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
-        ncpus_max=%{?_smp_ncpus_max}; \\\
-        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
-        echo "$RPM_BUILD_NCPUS";)
-
-%_smp_mflags -j%{_smp_build_ncpus}
-
 #==============================================================================
 # ---- Build policy macros.
 #


### PR DESCRIPTION
This PR is to address two different but related issues:
1) On 32bit systems, available virtual memory is in practise very limited and easy to exhaust on systems with many CPUs. (RhBug:1729382)
2) There are systems with lot of CPUs (virtual or otherwise) but relatively limited memory, where just looking at available CPUs causes severe trashing. (RhBug:1118734)
    
This effectively caps the number of threads on 32bit to just four, but tunable by changing the thread size estimate. Number of processes is capped to gigabytes of memory or number of CPU's, whichever is smaller, and tunable by changing the process size estimate.

The series adds a new macro primitive for getting system memory information and builds bunch of heuristics on top of those. There's a lot of subtleties involved and no doubt some of them I've gotten wrong here, so this PR is not intended for immediate merging, but more as a basis for discussion and other feedback.

What bothers me personally here is that it adds quite a bit of brittle heuristics that we never needed before, heuristics that will inevitably go wrong. The 32bit thread issue could be handled by just slapping a hard limit, with just a couple of lines of code. OTOH, the many cpus but little memory -case is legit and solving does require heuristics no matter what. And since heuristics will go wrong sooner or later, there needs to be tunables, which is why so much of this is done in macro level despite being somewhat painful.