### PR TITLE
Cap number of threads on 32bit platforms, add a tunable (RhBug:1729382)

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -1036,9 +1036,8 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 #ifdef ENABLE_OPENMP
     /* Set number of OMP threads centrally */
     int ncpus = rpmExpandNumeric("%{?_smp_build_ncpus}");
-    if (ncpus <= 0)
-	ncpus = 1;
-    omp_set_num_threads(ncpus);
+    if (ncpus > 0)
+	omp_set_num_threads(ncpus);
 #endif
 
     if (spec->clean == NULL) {

--- a/platform.in
+++ b/platform.in
@@ -59,6 +59,11 @@
 
 %_smp_mflags -j%{_smp_build_ncpus}
 
+# Maximum number of threads to use when building, 0 for unlimited
+#%_smp_nthreads_max 0
+
+%_smp_build_nthreads %{_smp_build_ncpus}
+
 #==============================================================================
 # ---- Build policy macros.
 #


### PR DESCRIPTION
On 32bit plaforms, address space is easily exhausted with multiple threads, causing arbitrary builds failure regressions (RhBug:1729382). Simply cap the number of threads to maximum of four on any 32bit platform to play it safe. It's still three more than we were able to use on older releases...
    
In addition, introduce a separate tunable for tweaking the maximum number of threads just in case, defaulting to max CPUs available.

This is a stopgap solution to the 32bit arch build regressions in 4.15.x (RhBug:1729382) that is simple and straightforward enough for 4.15.0. The more elaborate heuristics suggested in PR #821 need more time for discussing, tweaking and testing than we have right now.