### PR TITLE
Make dependency generation test payload-compression agnostic

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -384,6 +384,7 @@ package or when debugging this package.\
 #		"w6.xzdio"	xz level 6, xz's default.
 #		"w7T16.xzdio"	xz level 7 using 16 thread (xz only)
 #		"w6.lzdio"	lzma-alone level 6, lzma's default
+#		"w3.zstdio"	zstd level 3, zstd's default
 #		"w.ufdio"	uncompressed
 #
 #%_source_payload	w9.gzdio

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -391,6 +391,7 @@ AT_KEYWORDS([build])
 AT_CHECK([
 
 runroot rpmbuild -bb --quiet \
+		--define "_binary_payload w9.gzdio" \
 		/data/SPECS/filedep.spec
 echo Requires:
 runroot rpm  -qp --requires /build/RPMS/noarch/filedep-1.0-1.noarch.rpm


### PR DESCRIPTION
Non-gzip compression introduces extra dependencies to packages, force gzip compression on the dependency generation test to avoid basically false failures. This lets us run the test-suite with other compression methods as needed (but not changing any defaults here)

Also document zstd compression in macros file.