### PR TITLE
Remove unused variable id in find-debuginfo.sh

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -539,10 +539,6 @@ if $run_dwz \
     echo "original debug info size: ${size_before}kB, size after compression: ${size_after}kB"
     # Remove .dwz directory if empty
     rmdir "${RPM_BUILD_ROOT}/usr/lib/debug/.dwz" 2>/dev/null
-    if [ -f "${RPM_BUILD_ROOT}/usr/lib/debug/.dwz/${dwz_multifile_name}" ]; then
-      id="`readelf -Wn "${RPM_BUILD_ROOT}/usr/lib/debug/.dwz/${dwz_multifile_name}" \
-	     2>/dev/null | sed -n 's/^    Build ID: \([0-9a-f]\+\)/\1/p'`"
-    fi
 
     # dwz invalidates .gnu_debuglink CRC32 in the main files.
     cat "$ELFBINSFILE" |


### PR DESCRIPTION
There's code setting variable id in scripts/find-debuginfo.sh, but there's no
subsequent use.  The only use of $id in the script is in do_file, where it is
a local variable.

The variable setting was introduced in commit 6b3b435fa "Add dwz debuginfo
compression support" in combination with a subsequent make_id_link using the
variable, but the make_id_link was removed in commit bbfe1f86b
"Add build-id links to rpm for all ELF files".

Remove the unused variable.