### PR TITLE
Rip the marker support for multiline %{expr:...} error messages

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -110,6 +110,11 @@ typedef struct _parseState {
 static void exprErr(const struct _parseState *state, const char *msg,
 		    const char *p)
 {
+    const char *newLine = strchr(state->str,'\n');
+
+    if (newLine && (*(newLine+1) != '\0'))
+	p = NULL;
+
     rpmlog(RPMLOG_ERR, "%s: %s\n", msg, state->str);
     if (p) {
 	int l = p - state->str + strlen(msg) + 2;


### PR DESCRIPTION
If the expression after '%{expr:' is mutiline like:
    %{expr: 0 || 0 ||
            0 || 0 |o| 0 ||
	    0 || 0 || 0 }
then it is better not to support marker pointing to the exact
place of the error.