### PR TITLE
Suppress inhibition lock warning message in single-user mode

### DIFF
--- a/plugins/systemd_inhibit.c
+++ b/plugins/systemd_inhibit.c
@@ -52,7 +52,9 @@ static int inhibit(void)
 	dbus_message_unref(reply);
     }
     
-    if (dbus_error_is_set(&err)) {
+    if (dbus_error_is_set(&err)
+	&& !dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER)
+	&& !dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND)) {
 	rpmlog(RPMLOG_WARNING,
 	       "Unable to get systemd shutdown inhibition lock: %s\n",
 		err.message);


### PR DESCRIPTION
The inhibition lock warning message is output in single-user mode
due to absent of dbus service. I suppress the warning message because
the "inhibit" operation may not be needed in this mode and the message
just confuses users.