### PR TITLE
Change the default crypto implementation to libgcrypt (from NSS)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,9 +10,12 @@ The source for the file utility + library is available from
     ftp://ftp.astron.com/pub/file/
 
 You will need a cryptographic library to support digests and signatures.
-This library may be Mozilla NSS, OpenSSL or beecrypt. Which library to use
-must be specified with the --with-crypto=[beecrypt|nss|openssl] argument
-to configure.
+This library may be libgcrypt, Mozilla NSS, OpenSSL or beecrypt.
+Which library to use can be specified with the
+--with-crypto=[libgcrypt|beecrypt|nss|openssl] argument to configure,
+libgcrypt is the default.
+
+libgcrypt library is available from https://www.gnupg.org/software/libgcrypt/
 
 If using the Mozilla NSS library for encyption (and NSPR library which
 NSS uses) it must be version 3.12 or later. Both NSPR and NSS libraries and

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,6 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--with-audit \
 	--with-selinux \
 	--with-imaevm \
-	--with-crypto=openssl \
 	--disable-dependency-tracking
 
 include $(top_srcdir)/rpm.am

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf -y install \
   elfutils-libelf-devel \
   elfutils-devel \
   openssl-devel \
+  libgcrypt-devel \
   file-devel \
   popt-devel \
   libarchive-devel \
@@ -48,7 +49,7 @@ RUN dnf -y install \
   && dnf clean all
 RUN autoreconf -vfi
 RUN ./configure \
-  --with-crypto=openssl \
+  --with-crypto=libgcrypt \
   --with-selinux \
   --with-cap \
   --with-acl \

--- a/configure.ac
+++ b/configure.ac
@@ -270,9 +270,9 @@ AM_CONDITIONAL(LIBDWARF,[test "$WITH_LIBDWARF" = yes])
 # Select crypto library
 AC_ARG_WITH(crypto,
             [AC_HELP_STRING([--with-crypto=CRYPTO_LIB],
-                            [The cryptographic library to use (nss|beecrypt|openssl|libgcrypt). The default is nss.])
+                            [The cryptographic library to use (nss|beecrypt|openssl|libgcrypt). The default is libgcrypt.])
                             ],[],
-                            [with_crypto=nss])
+                            [with_crypto=libgcrypt])
 
 # Refuse to proceed if someone specified --with-beecrypt (removed)
 AC_ARG_WITH(beecrypt,


### PR DESCRIPTION
libgcrypt is a much more straightforward and lightweight as a library,
doesn't come with a massive runtime library of its own, runtime which
messes with SIGPIPE and all, has a nice clearly compatible license (LGPL)
and is somewhat faster than NSS. What's not to like?

Change the default and add relevant documentation to INSTALL. Drop
the hopefully now unnecessary override from distcheck flags, and
switch CI over too.