### PR TITLE
Localize our chroot in/out operations to minimize time spent inside

### DIFF
--- a/lib/rpmtriggers.c
+++ b/lib/rpmtriggers.c
@@ -166,9 +166,6 @@ int runPostUnTransFileTrigs(rpmts ts)
     rpmtriggers trigs = ts->trigs2run;
     int nerrors = 0;
 
-    if (rpmChrootIn() != 0)
-	return -1;
-
     rpmtriggersSortAndUniq(trigs);
     /* Iterate over stored triggers */
     for (i = 0; i < trigs->count; i++) {
@@ -193,8 +190,6 @@ int runPostUnTransFileTrigs(rpmts ts)
 	rpmScriptFree(script);
 	headerFree(trigH);
     }
-
-    rpmChrootOut();
 
     return nerrors;
 }
@@ -554,11 +549,6 @@ rpmRC runFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
     /* Sort triggers by priority, offset, trigger index */
     rpmtriggersSortAndUniq(triggers);
 
-    if (rpmChrootIn() != 0) {
-	rpmtriggersFree(triggers);
-	return RPMRC_FAIL;
-    }
-
     /* Handle stored triggers */
     for (i = 0; i < triggers->count; i++) {
 	if (priorityClass == 1) {
@@ -579,8 +569,6 @@ rpmRC runFileTriggers(rpmts ts, rpmte te, rpmsenseFlags sense,
 	headerFree(trigH);
     }
     rpmtriggersFree(triggers);
-    /* XXX an error here would require a full abort */
-    (void) rpmChrootOut();
 
     return (nerrors == 0) ? RPMRC_OK : RPMRC_FAIL;
 }

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1602,6 +1602,9 @@ rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
     FD_t sfd = NULL;
     int warn_only = !(rpmScriptFlags(script) & RPMSCRIPT_FLAG_CRITICAL);
 
+    if (rpmChrootIn())
+	return RPMRC_FAIL;
+
     /* Create a temporary transaction element for triggers from rpmdb */
     if (te == NULL) {
 	te = rpmteNew(ts, h, TR_RPMDB, NULL, NULL, 0);
@@ -1632,6 +1635,8 @@ rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
 	}
 	rpmtsNotify(ts, te, RPMCALLBACK_SCRIPT_ERROR, stag, rc);
     }
+
+    rpmChrootOut();
 
     if (te != xte)
 	rpmteFree(te);


### PR DESCRIPTION
The primary motivation here is to consolidate all database accesses
on one side of the chroot, currently it happens on both sides of the
border causing all sorts of issues and limitations (such as preventing
us from using more advanced modes of databases).
As a positive side-effect, the sections where we potentially run
inside chroot are more easily identifiable.

Consolidating on the outside may seem counter-productive, to improve
security it seems you'd want to spend as much time *in* as possible,
including database accesses. Unfortunately due to rpm's access patterns
and API promises, that's not really achievable (tried several approaches,
run into as many dead-ends).

Technically we could localize the chroot placement much further, but
doing so would change the side for transaction callbacks, which could
cause nasty breakage for our API users as various clients use those
callback slots to update their own databases and logs. So the chroot
spots here are selected to cover minimum possible code while preserving
the chroot side of callbacks and plugin slots: RPMCALLBACK_INST_OPEN/CLOSE,
ELEM_PROGRESS and VERIFY_* occur outside the chroot, everything else inside.
Of plugin slots, init/cleanup and tsm_pre/post occur outside, everything
else inside.