### PR TITLE
Remove TOK_IDENTIFIER support from expression parsing

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -128,22 +128,21 @@ static void exprErr(const struct _parseState *state, const char *msg,
 #define TOK_EOF          1
 #define TOK_INTEGER      2
 #define TOK_STRING       3
-#define TOK_IDENTIFIER   4
-#define TOK_ADD          5
-#define TOK_MINUS        6
-#define TOK_MULTIPLY     7
-#define TOK_DIVIDE       8
-#define TOK_OPEN_P       9
-#define TOK_CLOSE_P     10
-#define TOK_EQ          11
-#define TOK_NEQ         12
-#define TOK_LT          13
-#define TOK_LE          14
-#define TOK_GT          15
-#define TOK_GE          16
-#define TOK_NOT         17
-#define TOK_LOGICAL_AND 18
-#define TOK_LOGICAL_OR  19
+#define TOK_ADD          4
+#define TOK_MINUS        5
+#define TOK_MULTIPLY     6
+#define TOK_DIVIDE       7
+#define TOK_OPEN_P       8
+#define TOK_CLOSE_P      9
+#define TOK_EQ          10
+#define TOK_NEQ         11
+#define TOK_LT          12
+#define TOK_LE          13
+#define TOK_GT          14
+#define TOK_GE          15
+#define TOK_NOT         16
+#define TOK_LOGICAL_AND 17
+#define TOK_LOGICAL_OR  18
 
 #if defined(DEBUG_PARSER)
 typedef struct exprTokTableEntry {
@@ -155,7 +154,6 @@ ETTE_t exprTokTable[] = {
     { "EOF",	TOK_EOF },
     { "I",	TOK_INTEGER },
     { "S",	TOK_STRING },
-    { "ID",	TOK_IDENTIFIER },
     { "+",	TOK_ADD },
     { "-",	TOK_MINUS },
     { "*",	TOK_MULTIPLY },
@@ -286,17 +284,8 @@ static int rdToken(ParseState state)
       free(temp);
 
     } else if (risalpha(*p)) {
-      char *temp;
-      size_t ts;
-
-      for (ts=1; p[ts] && (risalnum(p[ts]) || p[ts] == '_'); ts++);
-      temp = xmalloc(ts+1);
-      memcpy(temp, p, ts);
-      p += ts-1;
-      temp[ts] = '\0';
-
-      token = TOK_IDENTIFIER;
-      v = valueMakeString(temp);
+      exprErr(state, _("bare words are no longer supported, please use \"...\""), p+1);
+      goto err;
 
     } else if (*p == '\"') {
       char *temp;
@@ -365,15 +354,6 @@ static Value doPrimary(ParseState state)
     if (rdToken(state))
       goto err;
     break;
-
-  case TOK_IDENTIFIER: {
-    const char *name = state->tokenValue->data.s;
-
-    v = valueMakeString( rpmExpand(name, NULL) );
-    if (rdToken(state))
-      goto err;
-    break;
-  }
 
   case TOK_MINUS:
     if (rdToken(state))

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1711,9 +1711,9 @@ runroot rpmbuild -ba --quiet      \
 ],
 [1],
 [],
-[error: parse error in expression:  rubbish:4-3
+[error: bare words are no longer supported, please use "...":  rubbish:4-3
 
-error:                                    ^
+error:                                                        ^
 error: /data/SPECS/eliftest.spec:40: bad %elif condition:  rubbish:4-3
 
 ])

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -270,19 +270,22 @@ AT_CLEANUP
 AT_SETUP([expr macro 2])
 AT_KEYWORDS([macros])
 AT_CHECK([
-runroot rpm --eval '%{expr:a*1}'
+runroot rpm --eval '%{expr:"a"*1}'
 runroot rpm --eval '%{expr:(5+1)*4)}'
-runroot rpm --eval '%{expr:a=!b}'
+runroot rpm --eval '%{expr:"a"=!"b"}'
 runroot rpm --eval '%{expr:4+}'
+runroot rpm --eval '%{expr:bare}'
 ],
 [1],
 [],
-[error: types must match: a*1
+[error: types must match: "a"*1
 error: syntax error in expression: (5+1)*4)
 error:                                    ^
-error: syntax error while parsing ==: a=!b
-error:                                  ^
+error: syntax error while parsing ==: "a"=!"b"
+error:                                    ^
 error: unexpected end of expression: 4+
+error: bare words are no longer supported, please use "...": bare
+error:                                                       ^
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
Identifier expansion got broken in 2000 when getMacroBody() was
removed from the API (commit 3ad99fcba52fcc5e8ab636d2f1760c945cdfbf19).

Nobody seemed to have noticied, so it's safe to say that there is
no one that used it the intented way.

With the bad commit there is an unintended use for it: it is
a way to specify a string without the otherwise needed quotes.

So this commit might break some existing spec files, but cleaning
those up is easy and makes the world a better place.