### PR TITLE
Print an error for expressions with missing operands

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -406,6 +406,11 @@ static Value doPrimary(ParseState state)
 
     v = valueMakeInteger(! v->data.i);
     break;
+
+  case TOK_EOF:
+    exprErr(&state, _("unexpected end of expression"), NULL);
+    goto err;
+
   default:
     goto err;
     break;


### PR DESCRIPTION
Expressions like '5 +' did not print an error message before.