### PR TITLE
Fix type error introduced in commit 1d055ae1df90fe54cf5c056de085cd987…

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -408,7 +408,7 @@ static Value doPrimary(ParseState state)
     break;
 
   case TOK_EOF:
-    exprErr(&state, _("unexpected end of expression"), NULL);
+    exprErr(state, _("unexpected end of expression"), NULL);
     goto err;
 
   default:

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -273,6 +273,7 @@ AT_CHECK([
 runroot rpm --eval '%{expr:a*1}'
 runroot rpm --eval '%{expr:(5+1)*4)}'
 runroot rpm --eval '%{expr:a=!b}'
+runroot rpm --eval '%{expr:4+}'
 ],
 [1],
 [],
@@ -281,6 +282,7 @@ error: syntax error in expression: (5+1)*4)
 error:                                    ^
 error: syntax error while parsing ==: a=!b
 error:                                  ^
+error: unexpected end of expression: 4+
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
…f0f6bbf

"state" is a pointer in this function, we don't want a pointer to it.
Fixes garbage getting printed in the error message. Add a testcase too.