### PR TITLE
Stop expanding strings in the expression parser

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -311,8 +311,7 @@ static int rdToken(ParseState state)
       p++;
 
       token = TOK_STRING;
-      v = valueMakeString( rpmExpand(temp, NULL) );
-      free(temp);
+      v = valueMakeString( temp );
 
     } else {
       exprErr(state, _("parse error in expression"), p+1);


### PR DESCRIPTION
The %if lines in the specfile are expanded before the expressions
get evaluated, so the re-expansion of strings is surprising.
It's also not done for integers, which makes it inconsistent.

The original expression parser seems to have been written
without taking the upfront expansion into account, thus the
string expansion and the TOK_IDENTIFIER code.

As I can't imagine anybody using this feature lets just drop it.