### PR TITLE
Support new %[ ] expression expansion syntax

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -501,7 +501,7 @@ retry:
 	else
 	    checkCondition = spec->readStack->readable;
 	if (checkCondition) {
-	    match = rpmExprBool(s);
+	    match = rpmExprBool(s, 0);
 	    if (match < 0) {
 		rpmlog(RPMLOG_ERR,
 			    _("%s:%d: bad %s condition: %s\n"),

--- a/doc/manual/macros
+++ b/doc/manual/macros
@@ -50,12 +50,7 @@ if the flag was present. The negative form, "%{!-f:Y}", expanding to (the
 expansion of) Y if -f was *not* present, is also supported.
 
 In addition to the "%{...}" form, shell expansion can be performed
-using "%(shell command)". The expansion of "%(...)" is the output of
-(the expansion of) ... fed to /bin/sh. For example, "%(date
-+%%y%%m%%d)" expands to the string "YYMMDD" (final newline is
-deleted). Note the 2nd % needed to escape the arguments to /bin/date.
-There is currently an 8K limit on the size that this macro can expand
-to.
+using "%(shell command)".
 
 \section macros_builtin Builtin Macros
 
@@ -231,6 +226,45 @@ This will cause all occurrences of %1 in the macro definition to be
 replaced by the first argument to the macro, but only if the macro
 is invoked as "%mymacro 5".  Invoking as "%{mymacro} 5" will not work
 as desired in this case.
+
+\section macros_shell_expansion Shell Expansion
+
+Shell expansion can be performed using "%(shell command)". The expansion
+of "%(...)" is the output of (the expansion of) ... fed to /bin/sh.
+For example, "%(date +%%y%%m%%d)" expands to the string "YYMMDD" (final
+newline is deleted). Note the 2nd % needed to escape the arguments to
+/bin/date.
+
+\section macros_expression_expansion Expression Expansion
+
+Expression expansion can be performed using "%[expression]".  An
+expression consists of terms that can be combined using
+operators.  Rpm supports two kinds of terms, numbers made up
+from digits and strings enclosed in double quotes.  Rpm will
+expand macros when evaluating terms.
+
+You can use the standard operators to combine terms: logical
+operators &&, ||, !, relational operators !=, ==, <, > , <=, >=,
+arithmetic operators +, -, /, *, the ternary operator ? :, and
+parentheses.  For example, "%[ 3 + 4 * (1 + %two) ]" will expand
+to "15" if "%two" expands to "2".
+
+Note that the "%[expression]" expansion is different to the
+"%{expr:expression}" macro.  With the latter, the macros in the
+expression are expanded first and then the expression is
+evaluated (without re-expanding the terms).  Thus
+\verbatim
+	rpm --define 'foo 1 + 2' --eval '%{expr:%foo}'
+\endverbatim
+will print "3".  Using '%[%foo]' instead will result in the
+error that "1 + 2" is not a number.
+
+Doing the macro expansion when evaluating the terms has two
+advantages.  First, it allows rpm to do correct short-circuit 
+processing when evaluation logical operators.  Second, the
+expansion result does not influence the expression parsing,
+e.g. '%["%file"] will even work if the "%file" macro expands
+to a string that contains a double quote.
 
 \section macros_commandline Command Line Options
 

--- a/rpmio/Makefile.am
+++ b/rpmio/Makefile.am
@@ -22,7 +22,7 @@ librpmio_la_SOURCES = \
 	rpmpgp.c rpmsq.c rpmsw.c url.c \
 	rpmio_internal.h rpmhook.h \
 	rpmstring.c rpmfileutil.c rpmglob.c \
-	rpmkeyring.c rpmstrpool.c
+	rpmkeyring.c rpmstrpool.c rpmmacro_internal.h
 
 if WITH_BEECRYPT
 librpmio_la_SOURCES += digest_beecrypt.c

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -49,6 +49,9 @@ extern const char * macrofiles;
 #define addMacro(_mc, _n, _o, _b, _l) rpmPushMacro(_mc, _n, _o, _b, _l)
 #define delMacro(_mc, _n) rpmPopMacro(_mc, _n)
 
+/* rpm expression parser flags */
+#define RPMEXPR_EXPAND		(1 << 0)	/*!< expand primary terms */
+
 /** \ingroup rpmmacro
  * Print macros to file stream.
  * @param mc		macro context (NULL uses global context).
@@ -156,16 +159,18 @@ const char *rpmConfigDir(void);
 /** \ingroup rpmmacro
  * Evaluate boolean expression.
  * @param expr		expression to parse
+ * @param flags		parser flags
  * @return
  */
-int rpmExprBool(const char * expr);
+int rpmExprBool(const char * expr, int flags);
 
 /** \ingroup rpmmacro
  * Evaluate string expression.
  * @param expr		expression to parse
+ * @param flags		parser flags
  * @return
  */
-char * rpmExprStr(const char * expr);
+char * rpmExprStr(const char * expr, int flags);
 
 
 #ifdef __cplusplus

--- a/rpmio/rpmmacro_internal.h
+++ b/rpmio/rpmmacro_internal.h
@@ -1,0 +1,27 @@
+#ifndef _H_MACRO_INTERNAL
+#define	_H_MACRO_INTERNAL
+
+/** \ingroup rpmio
+ * \file rpmio/rpmmacro_internal.h
+ *
+ * Internal Macro API
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \ingroup rpmmacro
+ * Find the end of a macro call
+ * @param str           pointer to the character after the initial '%'
+ * @return              pointer to the next character after the macro
+ */
+RPM_GNUC_INTERNAL
+const char *findMacroEnd(const char *str);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* _H_ MACRO_INTERNAL */

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -325,6 +325,22 @@ runroot rpm \
 [])
 AT_CLEANUP
 
+AT_SETUP([short circuiting])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --eval '%{expr: 0 && 1 / 0}' \
+    --eval '%{expr: 1 || 1 / 0}' \
+    --eval '%{expr: 1 ? 2 : 1 / 0}' \
+],
+[0],
+[0
+1
+2
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([shell expansion])
 AT_KEYWORDS([macros])
 AT_CHECK([

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -336,6 +336,45 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([expression expansion 1])
+AT_KEYWORDS([macros])
+AT_CHECK([[
+runroot rpm \
+    --define "aaa 5" \
+    --define "bbb 0" \
+    --eval '%[4*1024]' \
+    --eval '%[5 < 1]' \
+    --eval '%[%aaa]' \
+    --eval '%[%{aaa}]' \
+    --eval '%["%{aaa}"]' \
+    --eval '%[%{?ccc}]' \
+]],
+[0],
+[4096
+0
+5
+5
+5
+0
+],
+[])
+AT_CLEANUP
+
+AT_SETUP([expression expansion 2])
+AT_KEYWORDS([macros])
+AT_CHECK([[
+runroot rpm --define "aaa hello" --eval '%[%aaa]'
+runroot rpm --eval '%[%{foo]'
+]],
+[1],
+[],
+[error: macro expansion returned a bare word, please use "...": %aaa
+error:                                                         ^
+error: expanded string: hello
+error: Unterminated {: {foo 
+])
+AT_CLEANUP
+
 AT_SETUP([simple lua --eval])
 AT_KEYWORDS([macros lua])
 AT_CHECK([


### PR DESCRIPTION
This adds %[ expr ] as a new means to do expression expansion in rpm. Unlike %{expr:} the expression is expanded in the parser, so we are safe against expansion results messing up the syntax and also can to short-circuiting.