### PR TITLE
Fix double-free on ternary operator parsing error

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -402,6 +402,7 @@ static Value doPrimary(ParseState state)
     goto err;
 
   default:
+    exprErr(state, _("syntax error in expression"), state->p);
     goto err;
     break;
   }

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -705,9 +705,9 @@ static Value doTernary(ParseState state)
       default:
 	goto err;
     }
-    valueFree(v1);
     if (rdToken(state))
       goto err;
+    valueFree(v1);
     v1 = doTernary(state);
     if (v1 == NULL)
       goto err;

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -735,7 +735,7 @@ int rpmExprBool(const char *expr)
 {
   struct _parseState state;
   int result = -1;
-  Value v;
+  Value v = NULL;
 
   DEBUG(printf("parseExprBoolean(?, '%s')\n", expr));
 
@@ -743,7 +743,8 @@ int rpmExprBool(const char *expr)
   state.p = state.str = xstrdup(expr);
   state.nextToken = 0;
   state.tokenValue = NULL;
-  (void) rdToken(&state);
+  if (rdToken(&state))
+    goto exit;
 
   /* Parse the expression. */
   v = doTernary(&state);
@@ -779,7 +780,7 @@ char *rpmExprStr(const char *expr)
 {
   struct _parseState state;
   char *result = NULL;
-  Value v;
+  Value v = NULL;
 
   DEBUG(printf("parseExprString(?, '%s')\n", expr));
 
@@ -787,7 +788,8 @@ char *rpmExprStr(const char *expr)
   state.p = state.str = xstrdup(expr);
   state.nextToken = 0;
   state.tokenValue = NULL;
-  (void) rdToken(&state);
+  if (rdToken(&state))
+    goto exit;
 
   /* Parse the expression. */
   v = doTernary(&state);

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -276,6 +276,8 @@ runroot rpm --eval '%{expr:"a"=!"b"}'
 runroot rpm --eval '%{expr:4+}'
 runroot rpm --eval '%{expr:bare}'
 runroot rpm --eval '%{expr:1/0}'
+runroot rpm --eval '%{expr:0 < 1 ? "a" : 1*"a"}'
+runroot rpm --eval '%{expr:0 < 1 ? 1*"a" : "a"}'
 ],
 [1],
 [],
@@ -288,6 +290,8 @@ error: unexpected end of expression: 4+
 error: bare words are no longer supported, please use "...": bare
 error:                                                       ^
 error: division by zero: 1/0
+error: types must match: 0 < 1 ? "a" : 1*"a"
+error: types must match: 0 < 1 ? 1*"a" : "a"
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
v1 gets double-freed when there's an error parsing the result side
of the ternary operator. Add testcases to go, one that catches the
actual error and another which serves to demonstrate that the false
branch doesn't get parsed at all, errors or no.