### PR TITLE
Resurrect %_missing_doc_files_terminate_build functionality

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,6 +41,7 @@ EXTRA_DIST += $(TESTSUITE_AT)
 ## testsuite data
 EXTRA_DIST += data/SPECS/attrtest.spec
 EXTRA_DIST += data/SPECS/buildrequires.spec
+EXTRA_DIST += data/SPECS/docmiss.spec
 EXTRA_DIST += data/SPECS/hello.spec
 EXTRA_DIST += data/SPECS/hello-auto.spec
 EXTRA_DIST += data/SPECS/hello-r2.spec

--- a/tests/data/SPECS/docmiss.spec
+++ b/tests/data/SPECS/docmiss.spec
@@ -1,0 +1,24 @@
+Name:           docmiss
+Version:        1.0
+Release:        1
+Summary:        Testing missing doc behavior
+Group:          Testing
+License:        GPL
+
+%description
+%{summary}
+
+
+%prep
+%setup  -c -n %{name}-%{version} -T
+
+cat << EOF > COPYING
+This is not a license
+EOF
+
+cat << EOF > README
+This is a dog project
+EOF
+
+%files
+%doc CREDITS COPYING README

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1613,6 +1613,26 @@ run rpmbuild \
 [])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild missing doc])
+AT_KEYWORDS([build])
+AT_CHECK_UNQUOTED([
+rm -rf ${TOPDIR}
+
+for val in 1 0; do
+    run rpmbuild \
+        -bb --quiet \
+        --define "_missing_doc_files_terminate_build ${val}" \
+        "${abs_srcdir}"/data/SPECS/docmiss.spec
+    echo $?
+done
+],
+[],
+[1
+0
+],
+[ignore])
+AT_CLEANUP
+
 AT_SETUP([%if, %else, %elif test basic])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([


### PR DESCRIPTION
Fixes regression from commit 1ba05a7456aafb52e89df5dd42d494d09f9ea6a4
where doc files always terminate build regardless of the macro value.
Add a testcase to go.

Fixes #807