### PR TITLE
Replace hardwired man page references to "redhat" in paths with "<ven…

### DIFF
--- a/doc/ja/rpm.8
+++ b/doc/ja/rpm.8
@@ -225,7 +225,7 @@ rpm \- RPM パッケージマネージャ
 によって順番に読み込まれる。
 .I FILELIST
 のデフォルトは
-.IR /usr/lib/rpm/rpmrc : /usr/lib/rpm/redhat/rpmrc : ~/.rpmrc
+.IR /usr/lib/rpm/rpmrc : /usr/lib/rpm/<vendor>/rpmrc : ~/.rpmrc
 である。
 .TP
 .BI "\-\-pipe " CMD
@@ -1143,14 +1143,14 @@ rpm     exec \-\-short\-circuit    rpmb \-\-short\-circuit
 .PP
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
 .SS マクロ設定
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi

--- a/doc/ja/rpmbuild.8
+++ b/doc/ja/rpmbuild.8
@@ -90,7 +90,7 @@ rpmbuils \- RPM パッケージのビルド
 に指定された順番で行われる。
 .I FILELIST
 のデフォルトは
-.IR /usr/lib/rpm/rpmrc : /usr/lib/rpm/redhat/rpmrc : ~/.rpmrc
+.IR /usr/lib/rpm/rpmrc : /usr/lib/rpm/<vendor>/rpmrc : ~/.rpmrc
 である。
 .TP
 .BI \-\-pipe  " CMD"
@@ -263,14 +263,14 @@ rpm を使ってビルドするには、他にも 2 つのやり方がある。
 .SS "rpmrc の設定"
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
 .SS マクロの設定
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi

--- a/doc/pl/rpm.8
+++ b/doc/pl/rpm.8
@@ -132,7 +132,7 @@ konfiguracji.
 Istnieć musi tylko pierwszy plik z listy, a tyldy są zamieniane na
 wartość \fB$HOME\fR.
 Domyślną \fILISTĄ_PLIKÓW\fR jest 
-\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/redhat/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
+\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/<vendor>/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
 .TP
 \fB--pipe \fIKOMENDA\fB\fR
 Przekazuje potokiem wyjście \fBrpm\fP-a do \fIKOMENDY\fR.
@@ -836,7 +836,7 @@ rpm     exec --short-circuit    rpmb --short-circuit
 .PP
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
@@ -844,7 +844,7 @@ rpm     exec --short-circuit    rpmb --short-circuit
 .PP
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi

--- a/doc/pl/rpmbuild.8
+++ b/doc/pl/rpmbuild.8
@@ -67,7 +67,7 @@ konfiguracji.
 Istnieć musi tylko pierwszy plik z listy, a tyldy są zamieniane na
 wartość \fB$HOME\fR.
 Domyślną \fILISTĄ_PLIKÓW\fR jest 
-\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/redhat/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
+\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/<vendor>/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
 .TP
 \fB--pipe \fIKOMENDA\fB\fR
 Przekazuje potokiem wyjście \fBrpm\fP-a do \fIKOMENDY\fR.
@@ -189,7 +189,7 @@ opcji, które są aktualnie ustawione w plikach konfiguracyjnych
 .PP
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
@@ -197,7 +197,7 @@ opcji, które są aktualnie ustawione w plikach konfiguracyjnych
 .PP
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi

--- a/doc/rpm.8
+++ b/doc/rpm.8
@@ -926,7 +926,7 @@ Install the package containing \fBrpmbuild\fR (usually \fBrpm-build\fR) and see
 .PP
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
@@ -934,7 +934,7 @@ Install the package containing \fBrpmbuild\fR (usually \fBrpm-build\fR) and see
 .PP
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi

--- a/doc/rpmbuild.8
+++ b/doc/rpmbuild.8
@@ -90,7 +90,7 @@ information.
 Only the first file in the list must exist, and tildes will be
 expanded to the value of \fB$HOME\fR.
 The default \fIFILELIST\fR is
-\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/redhat/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
+\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/<vendor>/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
 .TP
 \fB--pipe \fICMD\fB\fR
 Pipes the output of \fBrpm\fR to the command \fICMD\fR.
@@ -261,7 +261,7 @@ configuration file(s).
 .PP
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
@@ -269,7 +269,7 @@ configuration file(s).
 .PP
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi

--- a/doc/ru/rpm.8
+++ b/doc/ru/rpm.8
@@ -159,7 +159,7 @@ rpm \- Менеджер пакетов RPM
 В этом списке обязан существовать только первый файл; 
 все знаки тильда будут заменены значением \fB$HOME\fR.
 По умолчанию список файлов \fIFILELIST\fR выглядит как 
-\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/redhat/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
+\fI/usr/lib/rpm/rpmrc\fR:\fI/usr/lib/rpm/<vendor>/rpmrc\fR:\fI/etc/rpmrc\fR:\fI~/.rpmrc\fR.
 .TP
 \fB--pipe \fICMD\fB\fR
 Перенаправляет вывод \fBrpm\fR на вход команды \fICMD\fR.
@@ -884,7 +884,7 @@ rpm     exec --short-circuit    rpmb --short-circuit
 .PP
 .nf
 \fI/usr/lib/rpm/rpmrc\fR
-\fI/usr/lib/rpm/redhat/rpmrc\fR
+\fI/usr/lib/rpm/<vendor>/rpmrc\fR
 \fI/etc/rpmrc\fR
 \fI~/.rpmrc\fR
 .fi
@@ -892,7 +892,7 @@ rpm     exec --short-circuit    rpmb --short-circuit
 .PP
 .nf
 \fI/usr/lib/rpm/macros\fR
-\fI/usr/lib/rpm/redhat/macros\fR
+\fI/usr/lib/rpm/<vendor>/macros\fR
 \fI/etc/rpm/macros\fR
 \fI~/.rpmmacros\fR
 .fi


### PR DESCRIPTION
…dor>"

The politically correct version would be changing these all to .in files
with autoconf substituting the correct value during the build process
but that is such a PITA for what is at best a neglible benefit in this case,
it's just not worth it.

Fixes #779