### PR TITLE
Logical op improvements

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -817,6 +817,11 @@ static Value doTernary(ParseState state)
       goto err;
     state->flags = oldflags;
 
+    if (! valueSameType(v1, v2)) {
+      exprErr(state, _("types must match"), NULL);
+      goto err;
+    }
+
     valueFree(cond ? v2 : v1);
     return cond ? v1 : v2;
   }

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -481,12 +481,7 @@ static Value doPrimary(ParseState state)
     if (v == NULL)
       goto err;
 
-    if (! valueIsInteger(v)) {
-      exprErr(state, _("! only on numbers"), NULL);
-      goto err;
-    }
-
-    valueSetInteger(v, ! v->data.i);
+    valueSetInteger(v, ! boolifyValue(v));
     break;
 
   case TOK_EOF:

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -276,8 +276,10 @@ runroot rpm --eval '%{expr:"a"=!"b"}'
 runroot rpm --eval '%{expr:4+}'
 runroot rpm --eval '%{expr:bare}'
 runroot rpm --eval '%{expr:1/0}'
-runroot rpm --eval '%{expr:0 < 1 ? "a" : 1*"a"}'
-runroot rpm --eval '%{expr:0 < 1 ? 1*"a" : "a"}'
+runroot rpm --eval '%{expr:0 < 1 ? 2 : 1*"a"}'
+runroot rpm --eval '%{expr:0 < 1 ? 1*"a" : 2}'
+runroot rpm --eval '%{expr:0 < 1 ? 2 : "a"}'
+runroot rpm --eval '%{expr:0 < 1 ? "a" : 2}'
 ],
 [1],
 [],
@@ -290,8 +292,10 @@ error: unexpected end of expression: 4+
 error: bare words are no longer supported, please use "...": bare
 error:                                                       ^
 error: division by zero: 1/0
-error: types must match: 0 < 1 ? "a" : 1*"a"
-error: types must match: 0 < 1 ? 1*"a" : "a"
+error: types must match: 0 < 1 ? 2 : 1*"a"
+error: types must match: 0 < 1 ? 1*"a" : 2
+error: types must match: 0 < 1 ? 2 : "a"
+error: types must match: 0 < 1 ? "a" : 2
 ])
 AT_CLEANUP
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -257,16 +257,32 @@ runroot rpm \
     --eval '%{expr:%{aaa} || %{bbb}}' \
     --eval '%{expr:%{aaa} && %{bbb}}' \
     --eval '%{expr:! ""}' \
-    --eval '%{expr:! "foo"}' 
+    --eval '%{expr:! "foo"}' \
+    --eval '%{expr: 0 || 3}' \
+    --eval '%{expr: 2 || 3}' \
+    --eval '%{expr: "" || "foo"}' \
+    --eval '%{expr: "bar" || "foo"}' \
+    --eval '%{expr: 0 && 3}' \
+    --eval '%{expr: 2 && 3}' \
+    --eval '%{expr: "" && "foo"}' \
+    --eval '%{expr: "bar" && "foo"}'
 ],
 [0],
 [4096
 0
 1
-1
+5
 0
 1
 0
+3
+2
+foo
+bar
+0
+3
+
+foo
 ],
 [])
 AT_CLEANUP

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -255,12 +255,16 @@ runroot rpm \
     --eval '%{expr:5 < 1}' \
     --eval '%{expr:(4 + 5) * 2 == 18}' \
     --eval '%{expr:%{aaa} || %{bbb}}' \
-    --eval '%{expr:%{aaa} && %{bbb}}'
+    --eval '%{expr:%{aaa} && %{bbb}}' \
+    --eval '%{expr:! ""}' \
+    --eval '%{expr:! "foo"}' 
 ],
 [0],
 [4096
 0
 1
+1
+0
 1
 0
 ],


### PR DESCRIPTION
This commits change the handling of the logical operators. It allows to use strings as condition and also changes || and && to return the last evaluated term like in perl/python/ruby.

Fixes #852 