### PR TITLE
Make %setup use %{__tar_opts} to set tar options.

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -129,7 +129,9 @@ static char *doUntar(rpmSpec spec, uint32_t c, int quietly)
 {
     char *buf = NULL;
     char *tar = NULL;
-    const char *taropts = ((rpmIsVerbose() && !quietly) ? "-xvvof" : "-xof");
+    const char *taropts = rpmExpand((rpmIsVerbose() && !quietly) ?
+				    "%{__tar_opts_verbose} %{__tar_opts}" :
+				    "%{__tar_opts}", NULL);
     struct Source *sp;
     rpmCompressedMagic compressed = COMPRESSED_NOT;
 

--- a/macros.in
+++ b/macros.in
@@ -56,6 +56,8 @@
 %__semodule		@__SEMODULE@
 %__ssh			@__SSH@
 %__tar			@__TAR@
+%__tar_opts_verbose	-vv
+%__tar_opts		-xof
 %__unzip		@__UNZIP@
 %__zstd			@__ZSTD@
 %__gem			@__GEM@


### PR DESCRIPTION
This patch adds __tar_opts and __tar_opts_verbose macros, which can be
overriden to change the default tar behavior when called from %setup
while building packages.

Signed-off-by: Peter Jones <pjones@redhat.com>