### PR TITLE
Make "%patchlist -f patches" work.

### DIFF
--- a/build/parseList.c
+++ b/build/parseList.c
@@ -8,13 +8,84 @@
 #include "build/rpmbuild_internal.h"
 #include "debug.h"
 
+static int addLinesFromFile(rpmSpec spec, const char * const file, rpmTagVal tag)
+{
+    char buf[PATH_MAX+1], *c;
+    FILE *f;
+    int res = 0;
+
+    f = fopen(file, "r");
+    if (f == NULL)
+	return -1;
+
+    buf[PATH_MAX] = '\0';
+
+    do {
+	c = fgets(buf, PATH_MAX+1, f);
+	if (c == NULL)
+	    continue;
+
+	c = strchrnul(buf, '\n');
+	*c = '\0';
+
+	addSource(spec, 0, buf, tag);
+    } while (c);
+
+    if (!c && ferror(f))
+	res = -1;
+
+    fclose(f);
+    return res;
+}
 
 int parseList(rpmSpec spec, const char *name, rpmTagVal tag)
 {
     int res = PART_ERROR;
     ARGV_t lst = NULL;
+    int rc, argc = 0;
+    int arg;
+    const char **argv = NULL;
+    poptContext optCon = NULL;
+    struct poptOption optionsTable[] = {
+	{ NULL, 'f', POPT_ARG_STRING, NULL, 'f', NULL, NULL},
+	{ 0, 0, 0, 0, 0, NULL, NULL}
+    };
 
-    /* There are no options to %patchlist and %sourcelist */
+    if ((rc = poptParseArgvString(spec->line, &argc, &argv))) {
+	rpmlog(RPMLOG_ERR, _("line %d: Error parsing %%%s: %s\n"),
+	       spec->lineNum, name, poptStrerror(rc));
+	goto exit;
+    }
+
+    optCon = poptGetContext(NULL, argc, argv, optionsTable, 0);
+    while ((arg = poptGetNextOpt(optCon)) > 0) {
+	;
+    }
+
+    if (arg < -1) {
+	rpmlog(RPMLOG_ERR, _("line %d: Bad option %s: %s\n"),
+	       spec->lineNum,
+	       poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
+	       spec->line);
+	goto exit;
+    }
+
+    lst = argvNew();
+
+    for (arg = 1; arg < argc; arg++) {
+	if (rstreq(argv[arg], "-f") && argv[arg+1]) {
+	    char * const file = rpmGetPath(argv[arg+1], NULL);
+	    addSource(spec, 0, file, RPMTAG_SOURCE);
+	    res = addLinesFromFile(spec, file, tag);
+	    free(file);
+	    if (res < 0) {
+		rpmlog(RPMLOG_ERR, _("line %d: Error parsing %%%s\n"),
+		       spec->lineNum, file);
+		goto exit;
+	    }
+	}
+    }
+
     if ((res = parseLines(spec, (STRIP_TRAILINGSPACE | STRIP_COMMENTS),
 			  &lst, NULL)) == PART_ERROR) {
 	goto exit;
@@ -28,5 +99,7 @@ int parseList(rpmSpec spec, const char *name, rpmTagVal tag)
 
 exit:
     argvFree(lst);
+    free(argv);
+    poptFreeContext(optCon);
     return res;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -98,6 +98,7 @@ EXTRA_DIST += data/RPMS/hello-2.0-1.x86_64-signed.rpm
 EXTRA_DIST += data/SRPMS/foo-1.0-1.src.rpm
 EXTRA_DIST += data/SRPMS/hello-1.0-1.src.rpm
 EXTRA_DIST += data/SOURCES/hello.c
+EXTRA_DIST += data/SOURCES/patchlist
 EXTRA_DIST += data/SPECS/hello-attr-buildid.spec
 EXTRA_DIST += data/SPECS/hello-config-buildid.spec
 EXTRA_DIST += data/SPECS/hello-cd.spec

--- a/tests/data/SOURCES/patchlist
+++ b/tests/data/SOURCES/patchlist
@@ -1,0 +1,2 @@
+hello-1.0-modernize.patch
+hello-1.0-install.patch

--- a/tests/data/SPECS/hello-patchlist-f.spec
+++ b/tests/data/SPECS/hello-patchlist-f.spec
@@ -1,0 +1,30 @@
+Name: hello
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Simple rpm demonstration.
+
+%sourcelist
+hello-1.0.tar.gz
+
+%patchlist -f patchlist
+
+%description
+Simple rpm demonstration.
+
+%prep
+%setup -q
+%patch0 -p1 -b .modernize
+%patch1 -p1 -b .install
+
+%build
+%make_build CFLAGS="$RPM_OPT_FLAGS"
+
+%install
+%make_install
+
+%files
+%doc	FAQ
+/usr/local/bin/hello
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -36,6 +36,8 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+# ------------------------------
+# Check if autosetup works
 AT_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
 AT_SKIP_IF([$LUA_DISABLED])
@@ -51,6 +53,24 @@ run rpmbuild \
 [ignore],
 [ignore])
 AT_CLEANUP
+
+# ------------------------------
+# Check if patchlist -f works
+AT_SETUP([rpmbuild -ba patchlist -f])
+AT_KEYWORDS([build])
+AT_CHECK([
+rm -rf ${TOPDIR}
+AS_MKDIR_P(${TOPDIR}/SOURCES)
+
+cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-*.patch "${abs_srcdir}"/data/SOURCES/patchlist ${TOPDIR}/SOURCES
+run rpmbuild \
+  -ba "${abs_srcdir}"/data/SPECS/hello-patchlist-f.spec
+],
+[0],
+[ignore],
+[ignore])
+AT_CLEANUP
+
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])


### PR DESCRIPTION
This adds a -f argument to %patchlist, similar to that for %files.
There is no limit to how many patchlist files you specify, and doing so
does not restrict the use of an inline patch list.  Patches get added
from the leftmost list to rightmost, and any patches listed below get
added after that.

I couldn't find other code that obviously just reads a list of lines
from a file without assuming it's a .spec, so I've open coded this.  If
there's a better way, I'm open to suggestions.

Signed-off-by: Peter Jones <pjones@redhat.com>