### PR TITLE
rpmbuild: %patch: fix a memory leak

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -441,14 +441,13 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
     optCon = poptGetContext(NULL, argc, argv, patchOpts, 0);
     while ((c = poptGetNextOpt(optCon)) > 0) {
 	switch (c) {
-	case 'P': {
-	    char *arg = poptGetOptArg(optCon);
-	    if (arg) {
-	    	argvAdd(&patchnums, arg);
-	    	free(arg);
+	case 'P':
+	    if (opt_P) {
+		argvAdd(&patchnums, opt_P);
+		free(opt_P);
 	    }
 	    break;
-	}
+
 	default:
 	    break;
 	}
@@ -483,6 +482,9 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
     rc = RPMRC_OK;
 
 exit:
+    free(opt_b);
+    free(opt_d);
+    free(opt_o);
     argvFree(patchnums);
     free(argv);
     poptFreeContext(optCon);


### PR DESCRIPTION
While debugging something else, I noticed that when I run rpmbuild,
valgrind says:

==189844==
==189844== HEAP SUMMARY:
==189844==     in use at exit: 12,088 bytes in 45 blocks
==189844==   total heap usage: 61,336 allocs, 61,291 frees, 28,975,297 bytes allocated
==189844==
==189844== 24 bytes in 4 blocks are definitely lost in loss record 4 of 21
==189844==    at 0x483880B: malloc (vg_replace_malloc.c:309)
==189844==    by 0x4FB5168: poptSaveArg (popt.c:1206)
==189844==    by 0x4FB5168: poptGetNextOpt (popt.c:1510)
==189844==    by 0x485EDF0: doPatchMacro (parsePrep.c:442)
==189844==    by 0x485F44A: parsePrep (parsePrep.c:513)
==189844==    by 0x4862C9F: parseSpec (parseSpec.c:924)
==189844==    by 0x40322C: buildForTarget.constprop.0 (rpmbuild.c:506)
==189844==    by 0x40340A: build.constprop.0 (rpmbuild.c:539)
==189844==    by 0x40267F: main (rpmbuild.c:701)
==189844==

This looks pretty suspicious to me, so I went and looked at the code.
poptSaveArg() says:

    case POPT_ARG_STRING:
        /* XXX memory leak, application is responsible for free. */
        arg.argv[0] = (con->os->nextArg) ? xstrdup(con->os->nextArg) : NULL;

This is the case where we've got a string argument pointer in
poptOption->arg.  In the case of %patch -P, we also keep a second copy
of it, obtained from poptGetNextArg(), which we *are* freeing.

This patch makes doPatchMacro() not need an extra allocated copy of
opt_P, and frees all the poptOption->arg strings that are allocated.

Signed-off-by: Peter Jones <pjones@redhat.com>