### PR TITLE
Don't insert rpmlib() dependencies for dynamic buildrequires

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -209,10 +209,6 @@ static int doBuildRequires(rpmSpec spec, int test)
 	*packageDependencies(spec->sourcePackage, RPMTAG_REQUIRENAME),
 	spec->sourcePackage->header);
 
-    parseRCPOT(spec, spec->sourcePackage,
-	       "rpmlib(DynamicBuildRequires) = 4.15.0-1",
-	       RPMTAG_PROVIDENAME, 0, RPMSENSE_FIND_PROVIDES | RPMSENSE_RPMLIB,
-	       addReqProvPkg, NULL);
     rc = RPMRC_MISSINGBUILDREQUIRES;
 
  exit:

--- a/build/pack.c
+++ b/build/pack.c
@@ -786,10 +786,6 @@ rpmRC packageSources(rpmSpec spec, char **cookie)
     headerPutUint32(sourcePkg->header, RPMTAG_BUILDTIME, &(spec->buildTime), 1);
     headerPutUint32(sourcePkg->header, RPMTAG_SOURCEPACKAGE, &one, 1);
 
-    if (spec->buildrequires) {
-	(void) rpmlibNeedsFeature(sourcePkg, "DynamicBuildRequires", "4.15.0-1");
-    }
-
     /* XXX this should be %_srpmdir */
     {	sourcePkg->filename = rpmGetPath("%{_srcrpmdir}/", spec->sourceRpmName,NULL);
 	char *pkgcheck = rpmExpand("%{?_build_pkgcheck_srpm} ", sourcePkg->filename, NULL);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1538,7 +1538,6 @@ runroot rpm -qpR /build/SRPMS/buildrequires-1.0-1.src.rpm
 ],
 [0],
 [rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib(DynamicBuildRequires) <= 4.15.0-1
 rpmlib(FileDigests) <= 4.6.0-1
 ],
 [ignore])
@@ -1610,7 +1609,6 @@ runroot rpm -qpvR /build/SRPMS/buildrequires-1.0-1.buildreqs.nosrc.rpm
 auto: foo > 1.3
 auto: foo-bar = 2.0
 rpmlib: rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib: rpmlib(DynamicBuildRequires) <= 4.15.0-1
 rpmlib: rpmlib(FileDigests) <= 4.6.0-1
 rpmlib: rpmlib(RichDependencies) <= 4.12.0-1
 ],


### PR DESCRIPTION
rpmlib() dependencies are an installability barrier, and dynamic
buildrequires do not qualify: the package cannot be correctly *built*
with older rpm versions, but they will simply fail to parse the spec
due to unknown tag. However rpmlib(DynamicBuildRequires) as it is
injected by rpm 4.15.0 prevents rpm -i (ie unpack) of such an src.rpm,
which is simply wrong as rpm has no problem unpacking it for inspection,
and it's also possible to conditionalize the use of dynamic buildrequires
in a way that makes said src.rpm buildable on the system afterall.

This makes the rpmlib(DynamicBuildRequires) capability redundant and unused, but we now kinda have to carry it forever to support unpacking packages created with 4.15.0.

Originally reported in https://pagure.io/copr/copr/issue/1038