### PR TITLE
Clarify the disk space problem messages

### DIFF
--- a/lib/rpmprob.c
+++ b/lib/rpmprob.c
@@ -142,7 +142,7 @@ char * rpmProblemString(rpmProblem prob)
 	break;
     case RPMPROB_DISKSPACE:
 	rasprintf(&buf,
-	    _("installing package %s needs %" PRIu64 "%cB on the %s filesystem"),
+	    _("installing package %s needs %" PRIu64 "%cB more space on the %s filesystem"),
 		pkgNEVR,
 		prob->num1 > (1024*1024)
 		    ? (prob->num1 + 1024 * 1024 - 1) / (1024 * 1024)
@@ -152,7 +152,7 @@ char * rpmProblemString(rpmProblem prob)
 	break;
     case RPMPROB_DISKNODES:
 	rasprintf(&buf,
-	    _("installing package %s needs %" PRIu64 " inodes on the %s filesystem"),
+	    _("installing package %s needs %" PRIu64 " more inodes on the %s filesystem"),
 		pkgNEVR, prob->num1, str1);
 	break;
     case RPMPROB_REQUIRES:


### PR DESCRIPTION
These messages have been an endless source of confusion and complaint
throughout their existence, to the point that various programs have added
their own "translation" for these messages. Changing the message is likely
to break those (regex-based) translations but then hopefully the
translations will not be needed after this.

Fixes #879 (and at least a dozen bugs in various distro bugzillas
whose numbers I'm too lazy to dig up)