### PR TITLE
Percolate errors up from rpmfcHelper()

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,6 +70,7 @@ EXTRA_DIST += data/SPECS/mini.spec
 EXTRA_DIST += data/SPECS/scripts.spec
 EXTRA_DIST += data/SPECS/scriptfail.spec
 EXTRA_DIST += data/SPECS/selfconflict.spec
+EXTRA_DIST += data/SPECS/shebang.spec
 EXTRA_DIST += data/SPECS/replacetest.spec
 EXTRA_DIST += data/SPECS/triggers.spec
 EXTRA_DIST += data/SPECS/filetriggers.spec

--- a/tests/data/SPECS/shebang.spec
+++ b/tests/data/SPECS/shebang.spec
@@ -1,0 +1,23 @@
+Name:           shebang
+Version:        0.1
+Release:        1
+Summary:        Testing shebang dependency generation
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p %{buildroot}/bin
+cat << EOF > %{buildroot}/bin/shebang
+#!/bin/blabla
+echo shebang
+EOF
+
+chmod a+x %{buildroot}/bin/shebang
+
+%files
+%defattr(-,root,root,-)
+/bin/shebang

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -386,7 +386,7 @@ runroot rpmbuild -bb --quiet \
 ])
 AT_CLEANUP
 
-AT_SETUP([Dependency generation])
+AT_SETUP([Dependency generation 1])
 AT_KEYWORDS([build])
 AT_CHECK([
 
@@ -427,6 +427,40 @@ Fileprovides:
 [])
 AT_CLEANUP
 
+AT_SETUP([Dependency generation 2])
+AT_KEYWORDS([build])
+AT_CHECK([
+
+runroot rpmbuild -bb --quiet \
+		/data/SPECS/shebang.spec
+runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^rpmlib
+],
+[0],
+[/bin/blabla
+],
+[])
+AT_CLEANUP
+
+AT_SETUP([Dependency generation 3])
+AT_KEYWORDS([build])
+AT_CHECK([
+
+cat << EOF > "${RPMTEST}"/tmp/bad.req
+#!/bin/sh
+echo 'bad = *'
+EOF
+chmod a+x "${RPMTEST}"/tmp/bad.req
+
+runroot rpmbuild -bb --quiet \
+		--define "__script_requires /tmp/bad.req" \
+		/data/SPECS/shebang.spec
+],
+[1],
+[],
+[error: Illegal char '*' (0x2a) in: *
+    Illegal char '*' (0x2a) in: *
+])
+AT_CLEANUP
 
 # ------------------------------
 # Test spec query functionality


### PR DESCRIPTION
Ignoring the error code from rpmfcHelper() means that invalid dependencies
get silently ignores. Intentionally not stopping at the first error though,
as it's often useful to get all errors at once.

Add testcases for legal and illegal output from dependency generator.

Fixes #881