### PR TITLE
Refactor aux file reading (%files -f manifest etc) to a common helper

### DIFF
--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -247,6 +247,8 @@ typedef enum rpmParseState_e {
 #define STRIP_TRAILINGSPACE (1 << 0)
 #define STRIP_COMMENTS      (1 << 1)
 
+#define ALLOW_EMPTY         (1 << 16)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -584,6 +586,14 @@ RPM_GNUC_INTERNAL
 int specExpand(rpmSpec spec, int lineno, const char *sbuf,
 		char **obuf);
 
+/*
+ * Read expanded lines from a file into avp and/or sbp, controlled by
+ * flags (STRIP_*, ALLOW_EMPTY)
+ * Returns number or read lines, or -1 on error.
+ */
+RPM_GNUC_INTERNAL
+int readManifest(rpmSpec spec, const char *path, const char *descr, int flags,
+		ARGV_t *avp, StringBuf *sbp);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,6 +69,7 @@ EXTRA_DIST += data/SPECS/fakeshell.spec
 EXTRA_DIST += data/SPECS/mini.spec
 EXTRA_DIST += data/SPECS/scripts.spec
 EXTRA_DIST += data/SPECS/scriptfail.spec
+EXTRA_DIST += data/SPECS/scriptfile.spec
 EXTRA_DIST += data/SPECS/selfconflict.spec
 EXTRA_DIST += data/SPECS/replacetest.spec
 EXTRA_DIST += data/SPECS/triggers.spec

--- a/tests/data/SPECS/scriptfile.spec
+++ b/tests/data/SPECS/scriptfile.spec
@@ -1,0 +1,38 @@
+Name: scriptfile
+Version: 1
+Release: 1
+License: GPL
+Group: Testing
+Summary: Testing scriptlet file behavior
+BuildArch: noarch
+
+%description
+
+%build
+cat << EOF > one.sh
+#!/bin/sh
+echo one
+EOF
+
+cat << EOF > two.sh
+#!/bin/sh
+echo two
+EOF
+
+%pre -f one.sh
+
+%postun -f two.sh
+
+%triggerin -f one.sh -- %{name}
+
+%triggerun -f two.sh -- %{name}
+
+%transfiletriggerin -f one.sh -- /path
+
+%transfiletriggerun -f two.sh -- /path
+
+%filetriggerin -f one.sh -- /path
+
+%filetriggerin -f two.sh -- /path
+
+%files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -158,6 +158,52 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild scriptlet -f])
+AT_KEYWORDS([build])
+AT_CHECK([
+
+runroot rpmbuild \
+	-bb --quiet /data/SPECS/scriptfile.spec
+runroot rpm -qp --scripts --triggers --filetriggers \
+	/build/RPMS/noarch/scriptfile-1-1.noarch.rpm
+],
+[0],
+[preinstall scriptlet (using /bin/sh):
+#!/bin/sh
+echo one
+
+postuninstall scriptlet (using /bin/sh):
+#!/bin/sh
+echo two
+
+triggerin scriptlet (using /bin/sh) -- scriptfile
+#!/bin/sh
+echo one
+
+triggerun scriptlet (using /bin/sh) -- scriptfile
+#!/bin/sh
+echo two
+
+filetriggerin scriptlet (using /bin/sh) -- /path
+#!/bin/sh
+echo one
+
+filetriggerin scriptlet (using /bin/sh) -- /path
+#!/bin/sh
+echo two
+
+transfiletriggerin scriptlet (using /bin/sh) -- /path
+#!/bin/sh
+echo one
+
+transfiletriggerun scriptlet (using /bin/sh) -- /path
+#!/bin/sh
+echo two
+
+],
+[])
+AT_CLEANUP
+
 # ------------------------------
 # %attr/%defattr tests
 AT_SETUP([rpmbuild %attr and %defattr])


### PR DESCRIPTION
 Support for -f is not limited to %files, so it makes sense to have a common helper to do it. Inspired by the third such case to be added in #874 .