### PR TITLE
Fix dynamic buildrequire error handling

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -200,8 +200,9 @@ static int doBuildRequires(rpmSpec spec, int test)
     outc = argvCount(output);
 
     for (int i = 0; i < outc; i++) {
-	parseRCPOT(spec, spec->sourcePackage, output[i], RPMTAG_REQUIRENAME,
-		   0, RPMSENSE_FIND_REQUIRES, addReqProvPkg, NULL);
+	if (parseRCPOT(spec, spec->sourcePackage, output[i], RPMTAG_REQUIRENAME,
+		       0, RPMSENSE_FIND_REQUIRES, addReqProvPkg, NULL))
+	    goto exit;
     }
 
     rpmdsPutToHeader(

--- a/build/build.c
+++ b/build/build.c
@@ -201,7 +201,7 @@ static int doBuildRequires(rpmSpec spec, int test)
 
     for (int i = 0; i < outc; i++) {
 	parseRCPOT(spec, spec->sourcePackage, output[i], RPMTAG_REQUIRENAME,
-		   0, 0, addReqProvPkg, NULL);
+		   0, RPMSENSE_FIND_REQUIRES, addReqProvPkg, NULL);
     }
 
     rpmdsPutToHeader(

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1603,16 +1603,16 @@ cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
 
 run rpmbuild \
   -br  --quiet --nodeps "${abs_srcdir}"/data/SPECS/buildrequires.spec
-runroot rpm -qpR /build/SRPMS/buildrequires-1.0-1.buildreqs.nosrc.rpm
+runroot rpm -qpvR /build/SRPMS/buildrequires-1.0-1.buildreqs.nosrc.rpm
 ],
 [0],
-[(bar = 3.4 or bar = 3.5)
-foo > 1.3
-foo-bar = 2.0
-rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib(DynamicBuildRequires) <= 4.15.0-1
-rpmlib(FileDigests) <= 4.6.0-1
-rpmlib(RichDependencies) <= 4.12.0-1
+[auto: (bar = 3.4 or bar = 3.5)
+auto: foo > 1.3
+auto: foo-bar = 2.0
+rpmlib: rpmlib(CompressedFileNames) <= 3.0.4-1
+rpmlib: rpmlib(DynamicBuildRequires) <= 4.15.0-1
+rpmlib: rpmlib(FileDigests) <= 4.6.0-1
+rpmlib: rpmlib(RichDependencies) <= 4.12.0-1
 ],
 [ignore])
 AT_CLEANUP


### PR DESCRIPTION
Mark dynamically generated buildrequires autogenerated to make them in line with other autogenerated dependencies, this also makes the parseRCPOT() error reporting work.
Also stop on invalid generated dependencies.

Fixes #801