### PR TITLE
Cleanup + fix --build-in-place handling in %setup

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -242,7 +242,6 @@ static int doSetupMacro(rpmSpec spec, const char *line)
     uint32_t num;
     int leaveDirs = 0, skipDefaultAction = 0;
     int createDir = 0, quietly = 0;
-    int buildInPlace = 0;
     const char * dirName = NULL;
     struct poptOption optionsTable[] = {
 	    { NULL, 'a', POPT_ARG_STRING, NULL, 'a',	NULL, NULL},
@@ -259,6 +258,11 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 
     if ((xx = poptParseArgvString(line, &argc, &argv))) {
 	rpmlog(RPMLOG_ERR, _("Error parsing %%setup: %s\n"), poptStrerror(xx));
+	goto exit;
+    }
+
+    if (rpmExpandNumeric("%{_build_in_place}")) {
+	rc = RPMRC_OK;
 	goto exit;
     }
 
@@ -298,16 +302,7 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 		  headerGetString(spec->packages->header, RPMTAG_NAME),
 		  headerGetString(spec->packages->header, RPMTAG_VERSION));
     }
-    /* Mer addition - support --build-in-place */
-    if (rpmExpandNumeric("%{_build_in_place}")) {
-	buildInPlace = 1;
-	spec->buildSubdir = NULL;
-    }
     rpmPushMacro(spec->macros, "buildsubdir", NULL, spec->buildSubdir, RMIL_SPEC);
-    if (buildInPlace) {
-	rc = RPMRC_OK;
-	goto exit;
-    }
     
     /* cd to the build dir */
     {	char * buildDir = rpmGenPath(spec->rootDir, "%{_builddir}", "");


### PR DESCRIPTION
If we don't want spec->buildSubdir to be set, then we should just bail
out before the logic that sets it, not undo it afterwards and set macro
body to NULL, amazing that this isn't blowing up someplace.
Lastly, %setup -a/-b would try to access tarballs that build-in-place
is supposed to skip entirely, just skip the whole argument checking
instead as they're not going to be used anyway.