### PR TITLE
Add NEVR provides for all packages that would be built into source rpms

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -690,6 +690,17 @@ static void initSourceHeader(rpmSpec spec)
 	    }
 	}
     }
+
+    /* Provide all package NEVRs that would be built */
+    for (Package p = spec->packages; p != NULL; p = p->next) {
+	if (p->fileList) {
+	    Header h = sourcePkg->header;
+	    uint32_t dsflags = rpmdsFlags(p->ds);
+	    headerPutString(h, RPMTAG_PROVIDENAME, rpmdsN(p->ds));
+	    headerPutUint32(h, RPMTAG_PROVIDEFLAGS, &dsflags, 1);
+	    headerPutString(h, RPMTAG_PROVIDEVERSION, rpmdsEVR(p->ds));
+	}
+    }
 }
 
 /* Add extra provides to package.  */

--- a/tests/data/SPECS/foo.spec
+++ b/tests/data/SPECS/foo.spec
@@ -1,3 +1,5 @@
+%bcond_with bus
+
 Summary: foo
 Name: foo
 Version: 1.0
@@ -18,6 +20,17 @@ Requires: %{name} = %{version}-%{release}
 %description sub
 %{summary}
 
+%package bus
+Summary: %{summary}
+Requires: %{name} = %{version}-%{release}
+
+%description bus
+%{summary}
+
 %files
 
 %files sub
+
+%if %{with bus}
+%files bus
+%endif

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -233,7 +233,9 @@ AT_SETUP([rpmspec --parse])
 AT_KEYWORDS([rpmspec])
 AT_CHECK([runroot rpmspec --parse /data/SPECS/foo.spec],
 [0],
-[Summary: foo
+[
+
+Summary: foo
 Name: foo
 Version: 1.0
 Release: 1
@@ -253,9 +255,33 @@ Requires: foo = 1.0-1
 %description sub
 foo
 
+%package bus
+Summary: foo
+Requires: foo = 1.0-1
+
+%description bus
+foo
+
 %files
 
 %files sub
+
+],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpmspec --srpm provides])
+AT_KEYWORDS([rpmspec])
+AT_CHECK([
+runroot rpmspec -q --srpm --provides /data/SPECS/foo.spec
+runroot rpmspec -q --srpm --provides --with bus /data/SPECS/foo.spec
+],
+[0],
+[foo = 1.0-1
+foo-sub = 1.0-1
+foo = 1.0-1
+foo-sub = 1.0-1
+foo-bus = 1.0-1
 ],
 [])
 AT_CLEANUP


### PR DESCRIPTION
Since requires in source rpms are buildrequires, with the same logic
provides in source rpms are buildprovides, and what does a build
provide if its not the names of the packages to be generated.

This seems like a natural fit, should be useful for various purposes, and
eliminates the need for a special rpmspecQuery() with RPMQV_SPECBUILTRPMS
to get that information.