### PR TITLE
Always execute file trigger scriptlet callbacks with owning header

### DIFF
--- a/lib/rpmtriggers.c
+++ b/lib/rpmtriggers.c
@@ -432,7 +432,7 @@ static int runHandleTriggersInPkg(rpmts ts, rpmte te, Header h,
 	    inputFunc = (char *(*)(void *)) matchFilesNext;
 	    rpmScriptSetNextFileFunc(script, inputFunc, mfi);
 
-	    nerrors += runScript(ts, te, h, installPrefixes.data,
+	    nerrors += runScript(ts, NULL, h, installPrefixes.data,
 				script, 0, -1);
 	    rpmtdFreeData(&installPrefixes);
 	    rpmScriptFree(script);


### PR DESCRIPTION
This is part II of commit 6d610e9b9a906548ce44265d7f36199441ea8bca which
missed one but common case where the element with matches gets passed
to the callback instead of the owning one, as pointed out in RhBug:1724779.