### PR TITLE
Avoid using types from Lua includes in rpmlua.h again

### DIFF
--- a/lib/rpmliblua.c
+++ b/lib/rpmliblua.c
@@ -1,6 +1,7 @@
 #include "system.h"
 
 #include <lua.h>
+#include <lauxlib.h>
 
 #include <rpm/rpmlib.h>
 

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -179,8 +179,9 @@ rpmlua rpmluaFree(rpmlua lua)
     return NULL;
 }
 
-void rpmluaRegister(rpmlua lua, const luaL_Reg *funcs, const char *lib)
+void rpmluaRegister(rpmlua lua, const void *regfuncs, const char *lib)
 {
+    const luaL_Reg *funcs = regfuncs;
     lua_getfield(lua->L, LUA_REGISTRYINDEX, LUA_LOADED_TABLE);
     lua_getfield(lua->L, -1, lib);
     luaL_setfuncs(lua->L, funcs, 0);

--- a/rpmio/rpmlua.h
+++ b/rpmio/rpmlua.h
@@ -1,10 +1,6 @@
 #ifndef RPMLUA_H
 #define RPMLUA_H
 
-#ifdef WITH_LUA
-#include <lauxlib.h>
-#endif
-
 typedef enum rpmluavType_e {
     RPMLUAV_NIL		= 0,
     RPMLUAV_STRING	= 1,
@@ -23,9 +19,7 @@ rpmlua rpmluaNew(void);
 rpmlua rpmluaFree(rpmlua lua);
 rpmlua rpmluaGetGlobalState(void);
 
-#ifdef WITH_LUA
-void rpmluaRegister(rpmlua lua, const luaL_Reg *funcs, const char *lib);
-#endif
+void rpmluaRegister(rpmlua lua, const void *regfuncs, const char *lib);
 
 int rpmluaCheckScript(rpmlua lua, const char *script,
 		      const char *name);


### PR DESCRIPTION
rpmlua.h was originally written in a way that allows it to be included
regardless of whether Lua is actually enabled in rpm or not, or where
Lua headers are, specifically to isolate the rest of rpm from these
details. That was changed in commit 62bd62286aa888c60145daf315a938dd87eadc89
when <lauxlib.h> started getting included in rpmlua.h, which leaks to
places like librpmbuild which do not directly use Lua.

The way Lua typedef's the luaL_Reg struct to itself defies my C fu for
for handling this in some nicer typesafe way, fix this all by just using
a void pointer instead, this is just an internal API where buyer can be
expected to beware.

Fixes #888