### PR TITLE
Enable -Werror in CI builds

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -56,7 +56,8 @@ RUN ./configure \
   --with-lua \
   --with-audit \
   --enable-python \
-  --enable-silent-rules
+  --enable-silent-rules \
+  --enable-werror
 RUN make
 
 CMD make distcheck; rc=$?; find . -name rpmtests.log|xargs cat; exit $rc

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,8 @@ if test "$GCC" = yes; then
     done
     RPMCFLAGS="-D_REENTRANT -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes $RPMCFLAGS"
 fi
+AC_ARG_ENABLE(werror, [AS_HELP_STRING([--enable-werror], [build with -Werror])],
+		[RPMCFLAGS="$RPMCFLAGS -Werror"], [])
 AC_SUBST(RPMCFLAGS)
 
 AC_SYS_LARGEFILE


### PR DESCRIPTION
This adds a configure option to cleanly enable -Werror in builds, and enables it for CI, hopefully for obvious reasons.