### PR TITLE
Revert "Fully shutdown DBUS on systemd_inhibit cleanup (RhBug:1714657)"

### DIFF
--- a/plugins/systemd_inhibit.c
+++ b/plugins/systemd_inhibit.c
@@ -82,11 +82,6 @@ static rpmRC systemd_inhibit_init(rpmPlugin plugin, rpmts ts)
     return RPMRC_NOTFOUND;
 }
 
-static void systemd_inhibit_cleanup(rpmPlugin plugin)
-{
-    dbus_shutdown();
-}
-
 static rpmRC systemd_inhibit_tsm_pre(rpmPlugin plugin, rpmts ts)
 {
     if (rpmtsFlags(ts) & (RPMTRANS_FLAG_TEST|RPMTRANS_FLAG_BUILD_PROBS))
@@ -113,7 +108,6 @@ static rpmRC systemd_inhibit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 
 struct rpmPluginHooks_s systemd_inhibit_hooks = {
     .init = systemd_inhibit_init,
-    .cleanup = systemd_inhibit_cleanup,
     .tsm_pre = systemd_inhibit_tsm_pre,
     .tsm_post = systemd_inhibit_tsm_post,
 };


### PR DESCRIPTION
Turns out this isn't a safe thing to do, as an API user could have
their own dbus connections in the same process and shutting those
down is a rather impolite thing to do (and causes crash, burn and
other injuries, eg RhBug:1750575)

This reverts commit d5f201345f6d27b6280750e5c6502f4418614fbc.