### PR TITLE
Increase lmdb DB size from 256M to 1G

### DIFF
--- a/lib/backend/lmdb.c
+++ b/lib/backend/lmdb.c
@@ -145,7 +145,7 @@ static int db_init(rpmdb rdb, const char * dbhome)
 
     MDB_dbi maxdbs = 32;
     unsigned int maxreaders = 16;
-    size_t mapsize = 256 * 1024 * 1024;
+    size_t mapsize = 1024 * 1024 * 1024;
 
     if ((rc = mdb_env_create(&env))
      || (rc = mdb_env_set_maxreaders(env, maxreaders))


### PR DESCRIPTION
The mapsize in LMDB is a limit of the DB size. It's set to 256M now, and if the DB reaches this size, rpm operations fails with:
---
error: lmdb:    rc(-30792) = mdb_cursor_put(): MDB_MAP_FULL: Environment mapsize limit reached
error: rc(-30792) adding header #31959 record: MDB_MAP_FULL: Environment mapsize limit reached
---

In my case, it was next to it, and it was failing on updating an RPM with 34.5K of files (as during update it should store data for the old and new files both).

Increase the size of the DB to 1GB, it should cover most of use cases now, but we should probably come up with a better solution in the future, if we decide to use this DB.