### PR TITLE
Don't report unimplemented db ctrl and verify ops as errors

### DIFF
--- a/lib/backend/dummydb.c
+++ b/lib/backend/dummydb.c
@@ -22,7 +22,7 @@ static int dummydb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int fla
 
 static int dummydb_Verify(dbiIndex dbi, unsigned int flags)
 {
-    return 1;
+    return 0;
 }
 
 static void dummydb_SetFSync(rpmdb rdb, int enable)
@@ -31,7 +31,7 @@ static void dummydb_SetFSync(rpmdb rdb, int enable)
 
 static int dummydb_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
 {
-    return 1;
+    return 0;
 }
 
 static dbiCursor dummydb_CursorInit(dbiIndex dbi, unsigned int flags)

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -179,7 +179,7 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 
 static int ndb_Verify(dbiIndex dbi, unsigned int flags)
 {
-    return 1;
+    return 0;
 }
 
 static void ndb_SetFSync(rpmdb rdb, int enable)


### PR DESCRIPTION
ndb doesn't implement a specific verify option, but that doesn't mean
the data within should be considered invalid. This causes ndb to fail
the test-suite on "rpmdb --rebuilddb and verify empty database" for no
good reason. Similar arguments could be made for dummydb although it
matters much less there.