### PR TITLE
Push some add/del rpmdb logic deeper into backends

### DIFF
--- a/lib/backend/db3.c
+++ b/lib/backend/db3.c
@@ -1115,7 +1115,7 @@ static rpmRC updateIndex(dbiCursor dbc, const char *keyp, unsigned int keylen,
     return rc;
 }
 
-static rpmRC db3_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
+static rpmRC db3_idxdbPutOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
 	       dbiIndexItem rec)
 {
     dbiIndexSet set = NULL;
@@ -1141,7 +1141,12 @@ static rpmRC db3_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t 
     return rc;
 }
 
-static rpmRC db3_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
+static rpmRC db3_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, db3_idxdbPutOne);
+}
+
+static rpmRC db3_idxdbDelOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
 	       dbiIndexItem rec)
 {
     dbiIndexSet set = NULL;
@@ -1169,6 +1174,11 @@ static rpmRC db3_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t 
     dbiIndexSetFree(set);
 
     return rc;
+}
+
+static rpmRC db3_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, db3_idxdbDelOne);
 }
 
 static const void * db3_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)

--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -160,7 +160,7 @@ dbiCursor dbiCursorFree(dbiIndex dbi, dbiCursor dbc)
     return dbi->dbi_rpmdb->db_ops->cursorFree(dbi, dbc);
 }
 
-rpmRC pkgdbPut(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum, unsigned char *hdrBlob, unsigned int hdrLen)
+rpmRC pkgdbPut(dbiIndex dbi, dbiCursor dbc, unsigned int *hdrNum, unsigned char *hdrBlob, unsigned int hdrLen)
 {
     return dbi->dbi_rpmdb->db_ops->pkgdbPut(dbi, dbc, hdrNum, hdrBlob, hdrLen);
 }
@@ -173,11 +173,6 @@ rpmRC pkgdbDel(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum)
 rpmRC pkgdbGet(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum, unsigned char **hdrBlob, unsigned int *hdrLen)
 {
     return dbi->dbi_rpmdb->db_ops->pkgdbGet(dbi, dbc, hdrNum, hdrBlob, hdrLen);
-}
-
-rpmRC pkgdbNew(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum)
-{
-    return dbi->dbi_rpmdb->db_ops->pkgdbNew(dbi, dbc, hdrNum);
 }
 
 unsigned int pkgdbKey(dbiIndex dbi, dbiCursor dbc)

--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -185,14 +185,14 @@ rpmRC idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbi
     return dbi->dbi_rpmdb->db_ops->idxdbGet(dbi, dbc, keyp, keylen, set, curFlags);
 }
 
-rpmRC idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+rpmRC idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
 {
-    return dbi->dbi_rpmdb->db_ops->idxdbPut(dbi, dbc, keyp, keylen, rec);
+    return dbi->dbi_rpmdb->db_ops->idxdbPut(dbi, rpmtag, hdrNum, h);
 }
 
-rpmRC idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+rpmRC idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
 {
-    return dbi->dbi_rpmdb->db_ops->idxdbDel(dbi, dbc, keyp, keylen, rec);
+    return dbi->dbi_rpmdb->db_ops->idxdbDel(dbi, rpmtag, hdrNum, h);
 }
 
 const void * idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -216,15 +216,13 @@ dbiCursor dbiCursorFree(dbiIndex dbi, dbiCursor dbc);
 
 
 RPM_GNUC_INTERNAL
-rpmRC pkgdbPut(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum,
+rpmRC pkgdbPut(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum,
                unsigned char *hdrBlob, unsigned int hdrLen);
 RPM_GNUC_INTERNAL
 rpmRC pkgdbDel(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum);
 RPM_GNUC_INTERNAL
 rpmRC pkgdbGet(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum,
                unsigned char **hdrBlob, unsigned int *hdrLen);
-RPM_GNUC_INTERNAL
-rpmRC pkgdbNew(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum);
 RPM_GNUC_INTERNAL
 unsigned int pkgdbKey(dbiIndex dbi, dbiCursor dbc);
 
@@ -251,9 +249,8 @@ struct rpmdbOps_s {
     dbiCursor (*cursorFree)(dbiIndex dbi, dbiCursor dbc);
 
     rpmRC (*pkgdbGet)(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum, unsigned char **hdrBlob, unsigned int *hdrLen);
-    rpmRC (*pkgdbPut)(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum, unsigned char *hdrBlob, unsigned int hdrLen);
+    rpmRC (*pkgdbPut)(dbiIndex dbi, dbiCursor dbc, unsigned int *hdrNum, unsigned char *hdrBlob, unsigned int hdrLen);
     rpmRC (*pkgdbDel)(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum);
-    rpmRC (*pkgdbNew)(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum);
     unsigned int (*pkgdbKey)(dbiIndex dbi, dbiCursor dbc);
 
     rpmRC (*idxdbGet)(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexSet *set, int curFlags);

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -123,10 +123,16 @@ union _dbswap {
 \
   }
 
+typedef rpmRC (*idxfunc)(dbiIndex dbi, dbiCursor dbc,
+			const char *keyp, size_t keylen, dbiIndexItem rec);
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+RPM_GNUC_INTERNAL
+rpmRC tag2index(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h,
+		idxfunc idxupdate);
 
 RPM_GNUC_INTERNAL
 /* Globally enable/disable fsync in the backend */
@@ -230,11 +236,11 @@ RPM_GNUC_INTERNAL
 rpmRC idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
                dbiIndexSet *set, int curFlags);
 RPM_GNUC_INTERNAL
-rpmRC idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
-               dbiIndexItem rec);
+rpmRC idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h);
+
 RPM_GNUC_INTERNAL
-rpmRC idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
-               dbiIndexItem rec);
+rpmRC idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h);
+
 RPM_GNUC_INTERNAL
 const void * idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen);
 
@@ -254,8 +260,8 @@ struct rpmdbOps_s {
     unsigned int (*pkgdbKey)(dbiIndex dbi, dbiCursor dbc);
 
     rpmRC (*idxdbGet)(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexSet *set, int curFlags);
-    rpmRC (*idxdbPut)(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec);
-    rpmRC (*idxdbDel)(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec);
+    rpmRC (*idxdbPut)(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h);
+    rpmRC (*idxdbDel)(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h);
     const void * (*idxdbKey)(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen);
 };
 

--- a/lib/backend/dummydb.c
+++ b/lib/backend/dummydb.c
@@ -70,12 +70,12 @@ static rpmRC dummydb_idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, siz
     return RPMRC_FAIL;
 }
 
-static rpmRC dummydb_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC dummydb_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
 {
     return RPMRC_FAIL;
 }
 
-static rpmRC dummydb_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC dummydb_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
 {
     return RPMRC_FAIL;
 }

--- a/lib/backend/dummydb.c
+++ b/lib/backend/dummydb.c
@@ -45,12 +45,7 @@ static dbiCursor dummydb_CursorFree(dbiIndex dbi, dbiCursor dbc)
 }
 
 
-static rpmRC dummydb_pkgdbNew(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum)
-{
-    return RPMRC_FAIL;
-}
-
-static rpmRC dummydb_pkgdbPut(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum, unsigned char *hdrBlob, unsigned int hdrLen)
+static rpmRC dummydb_pkgdbPut(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum, unsigned char *hdrBlob, unsigned int hdrLen)
 {
     return RPMRC_FAIL;
 }
@@ -102,7 +97,6 @@ struct rpmdbOps_s dummydb_dbops = {
     .cursorInit	= dummydb_CursorInit,
     .cursorFree	= dummydb_CursorFree,
 
-    .pkgdbNew	= dummydb_pkgdbNew,
     .pkgdbPut	= dummydb_pkgdbPut,
     .pkgdbDel	= dummydb_pkgdbDel,
     .pkgdbGet	= dummydb_pkgdbGet,

--- a/lib/backend/lmdb.c
+++ b/lib/backend/lmdb.c
@@ -679,7 +679,7 @@ static rpmRC updateIndex(dbiCursor dbc, const char *keyp, unsigned int keylen,
     return rc;
 }
 
-static rpmRC lmdb_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
+static rpmRC lmdb_idxdbPutOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
 	       dbiIndexItem rec)
 {
     dbiIndexSet set = NULL;
@@ -707,7 +707,12 @@ exit:
     return rc;
 }
 
-static rpmRC lmdb_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
+static rpmRC lmdb_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, lmdb_idxdbPutOne);
+}
+
+static rpmRC lmdb_idxdbDelOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen,
 	       dbiIndexItem rec)
 {
     rpmRC rc = RPMRC_FAIL;
@@ -736,6 +741,11 @@ static rpmRC lmdb_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t
 
 exit:
     return rc;
+}
+
+static rpmRC lmdb_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, lmdb_idxdbDelOne);
 }
 
 static const void * lmdb_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -466,14 +466,24 @@ static rpmRC ndb_idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t 
     return rc;
 }
 
-static rpmRC ndb_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC ndb_idxdbPutOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
 {
     return rpmidxPut(dbc->dbi->dbi_db, (const unsigned char *)keyp, keylen, rec->hdrNum, rec->tagNum);
 }
 
-static rpmRC ndb_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC ndb_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, ndb_idxdbPutOne);
+}
+
+static rpmRC ndb_idxdbDelOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
 {
     return rpmidxDel(dbc->dbi->dbi_db, (const unsigned char *)keyp, keylen, rec->hdrNum, rec->tagNum);
+}
+
+static rpmRC ndb_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, ndb_idxdbDelOne);
 }
 
 static const void * ndb_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -544,7 +544,7 @@ static rpmRC sqlite_idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size
     return rc;
 }
 
-static rpmRC sqlite_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC sqlite_idxdbPutOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
 {
     int rc = dbiCursorPrep(dbc, "INSERT INTO '%q' VALUES(?, ?, ?)",
 			dbi->dbi_file);
@@ -558,7 +558,13 @@ static rpmRC sqlite_idxdbPut(dbiIndex dbi, dbiCursor dbc, const char *keyp, size
     return dbiCursorResult(dbc);
 }
 
-static rpmRC sqlite_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC sqlite_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, sqlite_idxdbPutOne);
+}
+
+
+static rpmRC sqlite_idxdbDelOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
 {
     int rc = dbiCursorPrep(dbc,
 			"DELETE FROM '%q' WHERE key=? AND hnum=? AND idx=?",
@@ -572,6 +578,11 @@ static rpmRC sqlite_idxdbDel(dbiIndex dbi, dbiCursor dbc, const char *keyp, size
 	while ((rc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {};
 
     return dbiCursorResult(dbc);
+}
+
+static rpmRC sqlite_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return tag2index(dbi, rpmtag, hdrNum, h, sqlite_idxdbDelOne);
 }
 
 static const void * sqlite_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -563,26 +563,20 @@ static rpmRC sqlite_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum
     return tag2index(dbi, rpmtag, hdrNum, h, sqlite_idxdbPutOne);
 }
 
-
-static rpmRC sqlite_idxdbDelOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
+static rpmRC sqlite_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
 {
-    int rc = dbiCursorPrep(dbc,
-			"DELETE FROM '%q' WHERE key=? AND hnum=? AND idx=?",
-			dbi->dbi_file);
-
+    dbiCursor dbc = dbiCursorInit(dbi, DBC_WRITE);
+    int rc = dbiCursorPrep(dbc, "DELETE FROM '%q' WHERE hnum=?", dbi->dbi_file);
 
     if (!rc)
-	rc = dbiCursorBindIdx(dbc, keyp, keylen, rec);
+	rc = dbiCursorBindPkg(dbc, hdrNum, NULL, 0);
 
     if (!rc)
 	while ((rc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {};
 
-    return dbiCursorResult(dbc);
-}
-
-static rpmRC sqlite_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
-{
-    return tag2index(dbi, rpmtag, hdrNum, h, sqlite_idxdbDelOne);
+    rc = dbiCursorResult(dbc);
+    dbiCursorFree(dbi, dbc);
+    return rc;
 }
 
 static const void * sqlite_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -979,7 +979,7 @@ static int miFreeHeader(rpmdbMatchIterator mi, dbiIndex dbi)
 	if (hdrBlob != NULL && rpmrc != RPMRC_FAIL) {
 	    rpmsqBlock(SIG_BLOCK);
 	    dbCtrl(mi->mi_db, DB_CTRL_LOCK_RW);
-	    rc = pkgdbPut(dbi, mi->mi_dbc, mi->mi_prevoffset,
+	    rc = pkgdbPut(dbi, mi->mi_dbc, &mi->mi_prevoffset,
 			  hdrBlob, hdrLen);
 	    dbCtrl(mi->mi_db, DB_CTRL_INDEXSYNC);
 	    dbCtrl(mi->mi_db, DB_CTRL_UNLOCK_RW);
@@ -2329,9 +2329,7 @@ int rpmdbAdd(rpmdb db, Header h)
 
     /* Add header to primary index */
     dbc = dbiCursorInit(dbi, DBC_WRITE);
-    ret = pkgdbNew(dbi, dbc, &hdrNum);
-    if (ret == 0)
-	ret = pkgdbPut(dbi, dbc, hdrNum, hdrBlob, hdrLen);
+    ret = pkgdbPut(dbi, dbc, &hdrNum, hdrBlob, hdrLen);
     dbiCursorFree(dbi, dbc);
 
     /* Add associated data to secondary indexes */


### PR DESCRIPTION
This is early steps towards uprooting the internal db API from its Berkeley DB origins - what makes sense with BDB/LMDB can be a huge hindrance with other types of backends.

The general plan is towards eliminating the generic, vague cursor object from the internal API and replace with iterator(s) on the backend level, and pushing operations further into the backend. 
This is only an RFC until the sqlite backend (#899) is merged (and will obviously need to be updated after that)