### PR TITLE
build: Add missing ifdef to conditionalize omp.h include statement

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -6,7 +6,9 @@
 #include "system.h"
 
 #include <errno.h>
+#ifdef ENABLE_OPENMP
 #include <omp.h>
+#endif
 #ifdef HAVE_ICONV
 #include <iconv.h>
 #endif


### PR DESCRIPTION
In 464d21dc8c176222c6586e2ee503fec6207f0d29, support for building RPM
without OpenMP was conditionalized on the `ENABLE_OPENMP` define being
set by the compiler. However, the include statement for omp.h in
parseSpec.c was not conditionalized as everything else was.

Because the conditional was previously missing, RPM fails to build
in environments where OpenMP is completely unavailable. This is the
case in environments such as macOS, as Clang does not provide an
OpenMP implementation there.