### PR TITLE
Backport NDB fixes to RPM 4.15

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -561,10 +561,8 @@ yes|no) ;;
 esac],
 [enable_ndb=no])
 AS_IF([test "$enable_ndb" = yes],[
-  AC_CHECK_FUNCS([mremap],
-    [AC_DEFINE(ENABLE_NDB, 1, [Enable new rpm database format?])],
-    [AC_MSG_ERROR([mremap function required by ndb])],
-    [#include <sys/mman.h>])
+  AC_DEFINE(ENABLE_NDB, 1, [Enable new rpm database format?])
+  AC_CHECK_FUNCS(mremap, [], [], [#include <sys/mman.h>])
 ])
 AM_CONDITIONAL([NDB], [test "$enable_ndb" = yes])
 

--- a/lib/backend/dummydb.c
+++ b/lib/backend/dummydb.c
@@ -22,7 +22,7 @@ static int dummydb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int fla
 
 static int dummydb_Verify(dbiIndex dbi, unsigned int flags)
 {
-    return 1;
+    return 0;
 }
 
 static void dummydb_SetFSync(rpmdb rdb, int enable)
@@ -31,7 +31,7 @@ static void dummydb_SetFSync(rpmdb rdb, int enable)
 
 static int dummydb_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
 {
-    return 1;
+    return 0;
 }
 
 static dbiCursor dummydb_CursorInit(dbiIndex dbi, unsigned int flags)

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -179,7 +179,7 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 
 static int ndb_Verify(dbiIndex dbi, unsigned int flags)
 {
-    return 1;
+    return 0;
 }
 
 static void ndb_SetFSync(rpmdb rdb, int enable)

--- a/lib/backend/ndb/rpmidx.c
+++ b/lib/backend/ndb/rpmidx.c
@@ -483,7 +483,7 @@ static int rpmidxRebuildInternal(rpmidxdb idxdb)
 
     nidxdb = &nidxdb_s;
     memset(nidxdb, 0, sizeof(*nidxdb));
-    nidxdb->pagesize = sysconf(_SC_PAGE_SIZE);
+    nidxdb->pagesize = rpmxdbPagesize(idxdb->xdb);
 
     /* calculate nslots the hard way, don't trust usedslots */
     nslots = 0;
@@ -906,9 +906,8 @@ int rpmidxOpenXdb(rpmidxdb *idxdbp, rpmpkgdb pkgdb, rpmxdb xdb, unsigned int xdb
     idxdb->xdbtag = xdbtag;
     idxdb->xdbid = id;
     idxdb->pkgdb = pkgdb;
-    idxdb->pagesize = sysconf(_SC_PAGE_SIZE);
-    if (rpmxdbIsRdonly(xdb))
-	idxdb->rdonly = 1;
+    idxdb->pagesize = rpmxdbPagesize(xdb);
+    idxdb->rdonly = rpmxdbIsRdonly(xdb) ? 1 : 0;
     if (!id) {
 	if (rpmidxInit(idxdb)) {
 	    free(idxdb);

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -1151,6 +1151,11 @@ int rpmxdbIsRdonly(rpmxdb xdb)
     return xdb->rdonly;
 }
 
+unsigned int rpmxdbPagesize(rpmxdb xdb)
+{
+    return xdb->pagesize;
+}
+
 static int rpmxdbFsync(rpmxdb xdb)
 {
 #ifdef HAVE_FDATASYNC

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -1127,12 +1127,21 @@ int rpmxdbIsRdonly(rpmxdb xdb)
     return xdb->rdonly;
 }
 
+static int rpmxdbFsync(rpmxdb xdb)
+{
+#ifdef HAVE_FDATASYNC
+    return fdatasync(xdb->fd);
+#else
+    return fsync(xdb->fd);
+#endif
+}
+
 int rpmxdbSetUserGeneration(rpmxdb xdb, unsigned int usergeneration)
 {
     if (rpmxdbLockReadHeader(xdb, 1))
         return RPMRC_FAIL;
     /* sync before the update */
-    if (xdb->dofsync && fsync(xdb->fd)) {
+    if (xdb->dofsync && rpmxdbFsync(xdb)) {
 	rpmxdbUnlock(xdb, 1);
 	return RPMRC_FAIL;
     }

--- a/lib/backend/ndb/rpmxdb.h
+++ b/lib/backend/ndb/rpmxdb.h
@@ -7,6 +7,7 @@ int rpmxdbOpen(rpmxdb *xdbp, rpmpkgdb pkgdb, const char *filename, int flags, in
 void rpmxdbClose(rpmxdb xdb);
 void rpmxdbSetFsync(rpmxdb xdb, int dofsync);
 int rpmxdbIsRdonly(rpmxdb xdb);
+unsigned int rpmxdbPagesize(rpmxdb xdb);
 
 int rpmxdbLock(rpmxdb xdb, int excl);
 int rpmxdbUnlock(rpmxdb xdb, int excl);


### PR DESCRIPTION
This pull request contains backports of #895, #903, and #909 to rpm 4.15 to better support usage of the NDB backend.

I am currently using this for rpm on macOS, but it makes sense to backport for general exploration of using the NDB backend by RPM-based systems.