### PR TITLE
Make database backends self-aware

### DIFF
--- a/lib/backend/db3.c
+++ b/lib/backend/db3.c
@@ -1365,6 +1365,9 @@ static unsigned int db3_pkgdbKey(dbiIndex dbi, dbiCursor dbc)
 }
 
 struct rpmdbOps_s db3_dbops = {
+    .name   = "bdb",
+    .path   = "Packages",
+
     .open   = db3_dbiOpen,
     .close  = db3_dbiClose,
     .verify = db3_dbiVerify,

--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -84,7 +84,7 @@ dbDetectBackend(rpmdb rdb)
 
     if (rdb->db_ops == NULL) {
 	rdb->db_ops = &dummydb_dbops;
-	rpmlog(RPMLOG_DEBUG, "using dummy database, installs not possible\n");
+	rpmlog(RPMLOG_WARNING, "using dummy database, installs not possible\n");
     }
 
     if (db_backend)

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -59,7 +59,7 @@ struct rpmdb_s {
     dbiIndex 	* db_indexes;	/*!< Tag indices. */
     int		db_buildindex;	/*!< Index rebuild indicator */
 
-    struct rpmdbOps_s * db_ops;	/*!< backend ops */
+    const struct rpmdbOps_s * db_ops;	/*!< backend ops */
 
     /* dbenv and related parameters */
     void * db_dbenv;		/*!< Backend private handle */
@@ -245,6 +245,9 @@ RPM_GNUC_INTERNAL
 const void * idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen);
 
 struct rpmdbOps_s {
+    const char *name; /* backend name */
+    const char *path; /* main database name */
+
     int (*open)(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags);
     int (*close)(dbiIndex dbi, unsigned int flags);
     int (*verify)(dbiIndex dbi, unsigned int flags);

--- a/lib/backend/dummydb.c
+++ b/lib/backend/dummydb.c
@@ -88,6 +88,9 @@ static const void * dummydb_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *
 
 
 struct rpmdbOps_s dummydb_dbops = {
+    .name	= "dummy",
+    .path	= NULL,
+
     .open	= dummydb_Open,
     .close	= dummydb_Close,
     .verify	= dummydb_Verify,

--- a/lib/backend/lmdb.c
+++ b/lib/backend/lmdb.c
@@ -922,6 +922,9 @@ static unsigned int lmdb_pkgdbKey(dbiIndex dbi, dbiCursor dbc)
 }
 
 struct rpmdbOps_s lmdb_dbops = {
+    .name   = "lmdb",
+    .path   = "data.mdb",
+
     .open   = lmdb_dbiOpen,
     .close  = lmdb_dbiClose,
     .verify = lmdb_dbiVerify,

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -496,6 +496,9 @@ static const void * ndb_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keyl
 
 
 struct rpmdbOps_s ndb_dbops = {
+    .name	= "ndb",
+    .path	= "Packages.db",
+
     .open	= ndb_Open,
     .close	= ndb_Close,
     .verify	= ndb_Verify,

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -101,7 +101,7 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
     
     if (dbi->dbi_type == DBI_PRIMARY) {
 	rpmpkgdb pkgdb = 0;
-	char *path = rstrscat(NULL, dbhome, "/Packages.db", NULL);
+	char *path = rstrscat(NULL, dbhome, "/", rdb->db_ops->path, NULL);
 	rpmlog(RPMLOG_DEBUG, "opening  db index       %s mode=0x%x\n", path, rdb->db_mode);
 	rc = rpmpkgOpen(&pkgdb, path, oflags, 0666);
  	if (rc && errno == ENOENT) {

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -593,6 +593,9 @@ static const void * sqlite_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *k
 
 
 struct rpmdbOps_s sqlite_dbops = {
+    .name	= "sqlite",
+    .path	= "rpmdb.sqlite",
+
     .open	= sqlite_Open,
     .close	= sqlite_Close,
     .verify	= sqlite_Verify,

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -110,7 +110,7 @@ static int sqlite_init(rpmdb rdb, const char * dbhome)
     char *dbfile = NULL;
 
     if (rdb->db_dbenv == NULL) {
-	dbfile = rpmGenPath(dbhome, "rpmdb.sqlite", NULL);
+	dbfile = rpmGenPath(dbhome, rdb->db_ops->path, NULL);
 	sqlite3 *sdb = NULL;
 	int xx, flags = 0;
 	int retry_open = 1;

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2647,3 +2647,30 @@ char *rpmdbCookie(rpmdb db)
     rpmdbIndexIteratorFree(ii);
     return cookie;
 }
+
+int rpmdbFStat(rpmdb db, struct stat *statbuf)
+{
+    int rc = -1;
+    if (db) {
+	const char *dbfile = db->db_ops->path;
+	if (dbfile) {
+	    char *path = rpmGenPath(rpmdbHome(db), dbfile, NULL);
+	    rc = stat(path, statbuf);
+	    free(path);
+	}
+    }
+    return rc;
+}
+
+int rpmdbStat(const char *prefix, struct stat *statbuf)
+{
+    rpmdb db = NULL;
+    int flags = RPMDB_FLAG_VERIFYONLY;
+    int rc = -1;
+
+    if (openDatabase(prefix, NULL, &db, O_RDONLY, 0644, flags) == 0) {
+	rc = rpmdbFStat(db, statbuf);
+	rpmdbClose(db);
+    }
+    return rc;
+}

--- a/lib/rpmdb.h
+++ b/lib/rpmdb.h
@@ -8,6 +8,7 @@
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmsw.h>
+#include <sys/stat.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -225,6 +226,22 @@ int rpmdbCtrl(rpmdb db, rpmdbCtrlOp ctrl);
  * @return 		cookie string (malloced), or NULL on error
  */
 char *rpmdbCookie(rpmdb db);
+
+/** \ingroup rpmdb
+ * Perform stat() on rpm database
+ * @param prefix	prefix or NULL for /
+ * @retval statbuf	returned data from stat()
+ * @return 		0 on success, -1 on error
+ */
+int rpmdbStat(const char *prefix, struct stat *statbuf);
+
+/** \ingroup rpmdb
+ * Perform stat() on an open rpm database
+ * @param db		rpm database
+ * @retval statbuf	returned data from stat()
+ * @return 		0 on success, -1 on error
+ */
+int rpmdbFStat(rpmdb db, struct stat *statbuf);
 
 #ifdef __cplusplus
 }

--- a/macros.in
+++ b/macros.in
@@ -619,6 +619,7 @@ package or when debugging this package.\
 # lmdb Lightning Memory-mapped Database
 # ndb new data base format
 # sqlite Sqlite database
+# dummy dummy backend (no actual functionality)
 #
 %_db_backend	      bdb
 


### PR DESCRIPTION
Okay okay, maybe not...

Add name and path members to backend db_ops struct, use them for configuring and detecting, and misc related tweaks.

Started doing this for implementing rpmdbStat(), but got stuck wondering about the API: my initial version requires an open rpmdb for stat'ing, which limits its usefulness. Perhaps there should be separate calls for an open database and non-open one, just like there's fstat() and stat(). Thoughts?