### PR TITLE
Fix --querybynumber on non-existent record, add test

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -490,7 +490,7 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 	}
 	rpmlog(RPMLOG_DEBUG, "package record number: %u\n", recOffset);
 	/* RPMDBI_PACKAGES */
-	mi = rpmtsInitIterator(ts, RPMDBI_PACKAGES, &recOffset, sizeof(recOffset));
+	mi = matchesIterator(ts, RPMDBI_PACKAGES, &recOffset, sizeof(recOffset));
 	if (mi == NULL) {
 	    rpmlog(RPMLOG_ERR, _("record %u could not be read\n"), recOffset);
 	}

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -84,6 +84,37 @@ runroot rpm -q foo-
 [])
 AT_CLEANUP
 
+AT_SETUP([rpm -q --querybynumber])
+AT_KEYWORDS([rpmdb query])
+AT_CHECK([
+RPMDB_CLEAR
+RPMDB_INIT
+
+runroot rpm -i \
+  /data/RPMS/foo-1.0-1.noarch.rpm
+
+],
+[0],
+[],
+[])
+
+AT_CHECK([
+runroot rpm -q --querybynumber 1
+],
+[0],
+[foo-1.0-1.noarch
+],
+[])
+
+AT_CHECK([
+runroot rpm -q --querybynumber 999
+],
+[1],
+[],
+[error: record 999 could not be read
+])
+AT_CLEANUP
+
 # ------------------------------
 # install a noarch package into a local rpmdb without --relocate and --nodeps
 # * Should always succeed


### PR DESCRIPTION
RPMDBI_PACKAGES differs from the indexes in how record searches behave, indexes return NULL for non-existent values but with RPMDBI_PACKAGES (and the pseudo index LABEL) we always get an iterator which we need to walk to determine whether there's data or not. Use the newly introduced helper to get the query return right.
    
One could argue that this should be done in the database code, but then the behavior is kinda consistent other iteration over RPMDBI_PACKAGES: you don't know how many, if any, matches there are until you walk it.
