### PR TITLE
Fixes to rpmlib(DynamicBuildrequires) dependencies

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -209,10 +209,6 @@ static int doBuildRequires(rpmSpec spec, int test)
 	*packageDependencies(spec->sourcePackage, RPMTAG_REQUIRENAME),
 	spec->sourcePackage->header);
 
-    parseRCPOT(spec, spec->sourcePackage,
-	       "rpmlib(DynamicBuildRequires) = 4.15.0-1",
-	       RPMTAG_PROVIDENAME, 0, RPMSENSE_FIND_PROVIDES | RPMSENSE_RPMLIB,
-	       addReqProvPkg, NULL);
     rc = RPMRC_MISSINGBUILDREQUIRES;
 
  exit:

--- a/build/reqprov.c
+++ b/build/reqprov.c
@@ -51,12 +51,16 @@ rpmRC addReqProvPkg(void *cbdata, rpmTagVal tagN,
 int rpmlibNeedsFeature(Package pkg, const char * feature, const char * featureEVR)
 {
     char *reqname = NULL;
+    int flags = RPMSENSE_RPMLIB|RPMSENSE_LESS|RPMSENSE_EQUAL;
     int res;
+
+    /* XXX HACK: avoid changing rpmlibNeedsFeature() for just one user */
+    if (rstreq(feature, "DynamicBuildRequires"))
+	flags |= RPMSENSE_MISSINGOK;
 
     rasprintf(&reqname, "rpmlib(%s)", feature);
 
-    res = addReqProv(pkg, RPMTAG_REQUIRENAME, reqname, featureEVR,
-		     RPMSENSE_RPMLIB|(RPMSENSE_LESS|RPMSENSE_EQUAL), 0);
+    res = addReqProv(pkg, RPMTAG_REQUIRENAME, reqname, featureEVR, flags, 0);
 
     free(reqname);
 

--- a/lib/psm.c
+++ b/lib/psm.c
@@ -140,6 +140,8 @@ static int rpmlibDeps(Header h)
     while (rpmdsNext(req) >= 0) {
 	if (!(rpmdsFlags(req) & RPMSENSE_RPMLIB))
 	    continue;
+	if (rpmdsFlags(req) & RPMSENSE_MISSINGOK)
+	    continue;
 	if (rpmdsSearch(rpmlib, req) < 0) {
 	    if (!nvr) {
 		nvr = headerGetAsString(h, RPMTAG_NEVRA);

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1656,7 +1656,7 @@ runroot rpm -qpvR /build/SRPMS/buildrequires-1.0-1.buildreqs.nosrc.rpm
 auto: foo > 1.3
 auto: foo-bar = 2.0
 rpmlib: rpmlib(CompressedFileNames) <= 3.0.4-1
-rpmlib: rpmlib(DynamicBuildRequires) <= 4.15.0-1
+rpmlib,missingok: rpmlib(DynamicBuildRequires) <= 4.15.0-1
 rpmlib: rpmlib(FileDigests) <= 4.6.0-1
 rpmlib: rpmlib(RichDependencies) <= 4.12.0-1
 ],


### PR DESCRIPTION
Details in the commit messages, executive summary:
- Packages are not permitted to provide rpmlib() capabilities, so don't (the use-case is covered by other means)
- src.rpm requires are generally build-time requires, rpmlib() is the odd man out. Mark build-time rpmlib() dependencies with MISSINGOK to allow install-time to skip them.

This replaces the earlier PR #878. Original issue reported at https://pagure.io/copr/copr/issue/1038