### PR TITLE
Enable undefined behavior sanitizer in CI

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -40,6 +40,7 @@ RUN dnf -y install \
   lua-devel readline-devel \
   python3-devel \
   dbus-devel \
+  libubsan \
   fakechroot which \
   elfutils binutils \
   findutils sed grep gawk diffutils file patch \
@@ -58,7 +59,9 @@ RUN ./configure \
   --with-audit \
   --enable-python \
   --enable-silent-rules \
-  --enable-werror
+  --enable-werror \
+  CFLAGS="-fsanitize=undefined -fno-sanitize=shift" \
+  LDFLAGS="-lubsan"
 RUN make
 
 CMD make distcheck; rc=$?; find . -name rpmtests.log|xargs cat; exit $rc


### PR DESCRIPTION
Extra checks never hurt... but disable shift sanitizer at least initially,
it traps on silly things like "(1 << 31) not being representable as int"
and I'm not in the mood of sprinkling 'u's all over the codebase.

Unfortunately the leak and address sanitizers cannot be used in our
environment, fakechroot and python bindings being some of the major
obstacles.