### PR TITLE
Fix support of MIPS r6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1073,6 +1073,14 @@ if echo "$host_os" | grep '.*-gnueabi' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnueabi$//'`
 	host_os_gnu=-gnueabi
 fi
+if echo "$host_os" | grep '.*-gnuabi64' > /dev/null ; then
+	host_os=`echo "${host_os}" | sed 's/-gnuabi64$//'`
+	host_os_gnu=-gnuabi64
+fi
+if echo "$host_os" | grep '.*-gnuabin32' > /dev/null ; then
+	host_os=`echo "${host_os}" | sed 's/-gnuabin32$//'`
+	host_os_gnu=-gnuabin32
+fi
 if echo "$host_os" | grep '.*-gnu' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnu$//'`
 fi

--- a/installplatform
+++ b/installplatform
@@ -144,28 +144,28 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2`; do
 	CANONARCH=mips64el
 	CANONCOLOR=3
 	;;
-    mipsr6)
+    mipsisa32r6)
 	ISANAME=mipsr6
 	ISABITS=32
-	CANONARCH=mipsr6
+	CANONARCH=mipsisa32r6
 	CANONCOLOR=0
 	;;
-    mipsr6el)
+    mipsisa32r6el)
 	ISANAME=mipsr6
 	ISABITS=32
-	CANONARCH=mipsr6el
+	CANONARCH=mipsisa32r6el
 	CANONCOLOR=0
 	;;
-    mips64r6)
+    mipsisa64r6)
 	ISANAME=mipsr6
 	ISABITS=64
-	CANONARCH=mips64r6
+	CANONARCH=mipsisa64r6
 	CANONCOLOR=3
 	;;
-    mips64r6el)
+    mipsisa64r6el)
 	ISANAME=mipsr6
 	ISABITS=64
-	CANONARCH=mips64r6el
+	CANONARCH=mipsisa64r6el
 	CANONCOLOR=3
 	;;
     m68k)

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1084,7 +1084,7 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 			    strcpy(un.machine, "mips64el");
 #			else
 			    /* r6 */
-			    strcpy(un.machine, "mips64r6el");
+			    strcpy(un.machine, "mipsisa64r6el");
 #			endif
 #		else
 		    /* 32-bit */
@@ -1093,7 +1093,7 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 			    strcpy(un.machine, "mipsel");
 #			else
 			    /* r6 */
-			    strcpy(un.machine, "mipsr6el");
+			    strcpy(un.machine, "mipsisa32r6el");
 #			endif
 #		endif
 #	elif defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB)
@@ -1105,7 +1105,7 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 			    strcpy(un.machine, "mips64");
 #			else
 			    /* r6 */
-			    strcpy(un.machine, "mips64r6");
+			    strcpy(un.machine, "mipsisa64r6");
 #			endif
 #		else
 		    /* 32-bit */
@@ -1114,7 +1114,7 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 			    strcpy(un.machine, "mips");
 #			else
 			    /* r6 */
-			    strcpy(un.machine, "mipsr6");
+			    strcpy(un.machine, "mipsisa32r6");
 #			endif
 #		endif
 #	endif

--- a/macros.in
+++ b/macros.in
@@ -1125,19 +1125,27 @@ package or when debugging this package.\
 
 #------------------------------------------------------------------------------
 # arch macro for 32-bit MIPS processors
-%mips32	mips mipsel mipsr6 mipsr6el
+%mips32	mips mipsel mipsisa32r6 mipsisa32r6el
 
 #------------------------------------------------------------------------------
 # arch macro for 64-bit MIPS processors
-%mips64	mips64 mips64el mips64r6 mips64r6el
+%mips64	mips64 mips64el mipsisa64r6 mipsisa64r6el
 
 #------------------------------------------------------------------------------
 # arch macro for big endian MIPS processors
-%mipseb	mips mipsr6 mips64 mips64r6
+%mipseb	mips mipsisa32r6 mips64 mipsisa64r6
 
 #------------------------------------------------------------------------------
 # arch macro for little endian MIPS processors
-%mipsel	mipsel mipsr6el mips64el mips64r6el
+%mipsel	mipsel mipsisa32r6el mips64el mipsisa64r6el
+
+#------------------------------------------------------------------------------
+# arch macro for all supported MIPSr6 processors
+%mipsr6	mipsisa32r6 mipsisa32r6el mipsisa64r6 mipsisa64r6el
+
+#------------------------------------------------------------------------------
+# arch macro for all supported MIPS pre-r6 processors
+%mipslegacy	mips mipsel mips64 mips64el
 
 #------------------------------------------------------------------------------
 # arch macro for all supported MIPS processors

--- a/rpmrc.in
+++ b/rpmrc.in
@@ -62,10 +62,10 @@ optflags: mipsel -O2 -g
 optflags: mips64 -O2 -g
 optflags: mips64el -O2 -g
 
-optflags: mipsr6 -O2 -g
-optflags: mipsr6el -O2 -g
-optflags: mips64r6 -O2 -g
-optflags: mips64r6el -O2 -g
+optflags: mipsisa32r6 -O2 -g
+optflags: mipsisa32r6el -O2 -g
+optflags: mipsisa64r6 -O2 -g
+optflags: mipsisa64r6el -O2 -g
 
 optflags: armv3l -O2 -g -march=armv3
 optflags: armv4b -O2 -g -march=armv4
@@ -132,10 +132,10 @@ archcolor: mipsel 1
 archcolor: mips64 2
 archcolor: mips64el 2
 
-archcolor: mipsr6 1
-archcolor: mipsr6el 1
-archcolor: mips64r6 2
-archcolor: mips64r6el 2
+archcolor: mipsisa32r6 1
+archcolor: mipsisa32r6el 1
+archcolor: mipsisa64r6 2
+archcolor: mipsisa64r6el 2
 
 archcolor: m68k 1
 
@@ -249,10 +249,10 @@ arch_canon:	sh4a: sh4a	17
 arch_canon:	xtensa: xtensa	18
 arch_canon:	aarch64: aarch64 19
 
-arch_canon:	mipsr6: mipsr6	20
-arch_canon:	mipsr6el: mipsr6el	20
-arch_canon:	mips64r6: mips64r6	21
-arch_canon:	mips64r6el: mips64r6el	21
+arch_canon:	mipsisa32r6: mipsisa32r6	20
+arch_canon:	mipsisa32r6el: mipsisa32r6el	20
+arch_canon:	mipsisa64r6: mipsisa64r6	21
+arch_canon:	mipsisa64r6el: mipsisa64r6el	21
 
 arch_canon:	riscv: riscv64	22
 arch_canon:	riscv64: riscv64	22
@@ -355,10 +355,10 @@ buildarchtranslate: mipsel: mipsel
 buildarchtranslate: mips64: mips64
 buildarchtranslate: mips64el: mips64el
 
-buildarchtranslate: mipsr6: mipsr6
-buildarchtranslate: mipsr6el: mipsr6el
-buildarchtranslate: mips64r6: mips64r6
-buildarchtranslate: mips64r6el: mips64r6el
+buildarchtranslate: mipsr6: mipsisa32r6
+buildarchtranslate: mipsr6el: mipsisa32r6el
+buildarchtranslate: mips64r6: mipsisa64r6
+buildarchtranslate: mips64r6el: mipsisa64r6el
 
 buildarchtranslate: m68k: m68k
 
@@ -444,10 +444,10 @@ arch_compat: mipsel: noarch
 arch_compat: mips64: mips
 arch_compat: mips64el: mipsel
 
-arch_compat: mipsr6: noarch
-arch_compat: mipsr6el: noarch
-arch_compat: mips64r6: mipsr6
-arch_compat: mips64r6el: mipsr6el
+arch_compat: mipsisa32r6: noarch
+arch_compat: mipsisa32r6el: noarch
+arch_compat: mipsisa64r6: mipsisa32r6
+arch_compat: mipsisa64r6el: mipsisa32r6el
 
 arch_compat: hppa2.0: hppa1.2
 arch_compat: hppa1.2: hppa1.1
@@ -581,10 +581,10 @@ buildarch_compat: mipsel: noarch
 buildarch_compat: mips64: noarch
 buildarch_compat: mips64el: noarch
 
-buildarch_compat: mipsr6: noarch
-buildarch_compat: mipsr6el: noarch
-buildarch_compat: mips64r6: noarch
-buildarch_compat: mips64r6el: noarch
+buildarch_compat: mipsisa32r6: noarch
+buildarch_compat: mipsisa32r6el: noarch
+buildarch_compat: mipsisa64r6: noarch
+buildarch_compat: mipsisa64r6el: noarch
 
 buildarch_compat: armv4b: noarch
 buildarch_compat: armv8l: armv7l


### PR DESCRIPTION
in the current code of rpm, the arch for MIPS r6 is set as
  mipsr6 mipsr6el mips64r6 mips64r6el
While in fact rpm ask for the same as `CPU` section of triple.

gcc/config.guess/config.sub set them as:
  mipsisa32r6 mipsisa32r6el mipsisa64r6 mipsisa64r6el

config.guess also use the abi as:
  -gnuabi64
  -gnuabi64
which is the same as Debian.
So, for rpm we should strip them out.