### PR TITLE
Only permit comments at beginning of line in file manifests (RhBug:112727)

### DIFF
--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -84,7 +84,8 @@ rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
 	}
 
 	/* Skip comments. */
-	if ((se = strchr(s, '#')) != NULL) *se = '\0';
+	if (*s == '#')
+	    continue;
 
 	/* Trim white space. */
 	se = s + strlen(s);


### PR DESCRIPTION
We only permit comments at beginning of line in specs and macro
files too, of all things file manifests don't need anything fancier.
Resolves the oldest rpm bug in RH bugzilla, only took 16 years...