### PR TITLE
Eliminate uses of non-threadsafe locatime() and ctime() functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -813,7 +813,7 @@ AC_CHECK_FUNCS([secure_getenv __secure_getenv])
 
 AC_CHECK_FUNCS(
    [mkstemp getcwd basename dirname realpath setenv unsetenv regcomp lchown \
-    utimes getline],
+    utimes getline localtime_r ],
    [], [AC_MSG_ERROR([function required by rpm])])
 
 AC_LIBOBJ(fnmatch)

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -96,10 +96,10 @@ static char * hexFormat(rpmtd td, char **emsg)
 static char * realDateFormat(rpmtd td, const char * strftimeFormat, char **emsg)
 {
     char * val = NULL;
-    struct tm * tstruct;
+    struct tm * tstruct, _tm;
     char buf[1024];
     time_t dateint = rpmtdGetNumber(td);
-    tstruct = localtime(&dateint);
+    tstruct = localtime_r(&dateint, &_tm);
 
     buf[0] = '\0';
     if (tstruct)
@@ -361,7 +361,7 @@ static char * pgpsigFormat(rpmtd td, char **emsg)
 	char *keyid = pgpHexStr(sigp->signid, sizeof(sigp->signid));
 	unsigned int dateint = sigp->time;
 	time_t date = dateint;
-	struct tm * tms = localtime(&date);
+	struct tm _tm, * tms = localtime_r(&date, &_tm);
 	unsigned int key_algo = pgpDigParamsAlgo(sigp, PGPVAL_PUBKEYALGO);
 	unsigned int hash_algo = pgpDigParamsAlgo(sigp, PGPVAL_HASHALGO);
 

--- a/lib/query.c
+++ b/lib/query.c
@@ -37,7 +37,7 @@ static void printFileInfo(const char * name,
     char ownerfield[8+1], groupfield[8+1];
     char timefield[100];
     time_t when = mtime;  /* important if sizeof(int32_t) ! sizeof(time_t) */
-    struct tm * tm;
+    struct tm * tm, _tm;
     char * perms = rpmPermsString(mode);
     char *link = NULL;
 
@@ -62,7 +62,7 @@ static void printFileInfo(const char * name,
     }
 
     /* Convert file mtime to display format */
-    tm = localtime(&when);
+    tm = localtime_r(&when, &_tm);
     timefield[0] = '\0';
     if (tm != NULL)
     {	const char *fmt;

--- a/lib/rpmchecksig.c
+++ b/lib/rpmchecksig.c
@@ -24,8 +24,6 @@
 
 #include "debug.h"
 
-int _print_pkts = 0;
-
 static int doImport(rpmts ts, const char *fn, char *buf, ssize_t blen)
 {
     char const * const pgpmark = "-----BEGIN PGP ";

--- a/rpmio/rpmkeyring.c
+++ b/rpmio/rpmkeyring.c
@@ -13,6 +13,8 @@
 
 #include "debug.h"
 
+int _print_pkts = 0;
+
 struct rpmPubkey_s {
     uint8_t *pkt;
     size_t pktlen;
@@ -227,7 +229,7 @@ pgpDig rpmPubkeyDig(rpmPubkey key)
     dig = pgpNewDig();
 
     pthread_rwlock_rdlock(&key->lock);
-    rc = pgpPrtPkts(key->pkt, key->pktlen, dig, 0);
+    rc = pgpPrtPkts(key->pkt, key->pktlen, dig, _print_pkts);
     pthread_rwlock_unlock(&key->lock);
 
     if (rc == 0) {
@@ -302,7 +304,7 @@ rpmRC rpmKeyringLookup(rpmKeyring keyring, pgpDig sig)
  	 * on (successful) return, sigh. No need to check for return
  	 * here as this is validated at rpmPubkeyNew() already.
  	 */
-	pgpPrtPkts(key->pkt, key->pktlen, sig, 0);
+	pgpPrtPkts(key->pkt, key->pktlen, sig, _print_pkts);
 	res = RPMRC_OK;
     }
 

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -254,8 +254,11 @@ static void pgpPrtTime(const char * pre, const uint8_t *p, size_t plen)
     if (pre && *pre)
 	fprintf(stderr, "%s", pre);
     if (plen == 4) {
+	char buf[1024];
 	time_t t = pgpGrab(p, plen);
-	fprintf(stderr, " %-24.24s(0x%08x)", ctime(&t), (unsigned)t);
+	struct tm _tm, *tms = localtime_r(&t, &_tm);
+	if (strftime(buf, sizeof(buf), "%c", tms) > 0)
+	    fprintf(stderr, " %-24.24s(0x%08x)", buf, (unsigned)t);
     } else {
 	pgpPrtHex("", p+1, plen-1);
     }


### PR DESCRIPTION
LGTM pointed out localtime() and ctime() are not thread-safe, and additionally ctime() is considered obsolete since POSIX.1-2008. Replace with localtime_r() and strftime() instead. 

Long broken --prtpkts debug switch is fixed in a separate commit to have means of testing the strftime() change.