### PR TITLE
Handle incomplete escape seq in queryformat (RhBug:1755230)

### DIFF
--- a/lib/headerfmt.c
+++ b/lib/headerfmt.c
@@ -469,6 +469,10 @@ static int parseFormat(headerSprintfArgs hsa, char * str,
 
 	    if (*start == '\\') {
 		start++;
+		if (*start == '\0') {
+		    hsaError(hsa, _("escaped char expected after \\"));
+		    goto errxit;
+		}
 		*dst++ = escapedChar(*start++);
 	    } else {
 		*dst++ = *start++;

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -850,3 +850,18 @@ runroot rpm \
 ],
 [])
 AT_CLEANUP
+
+# ------------------------------
+AT_SETUP([incomplete escape sequence for format query])
+AT_KEYWORDS([query])
+AT_CHECK([
+runroot rpm \
+  --queryformat='%{NAME}\n\' \
+  -qp /data/RPMS/foo-1.0-1.noarch.rpm
+],
+[0],
+[],
+[error: incorrect format: escaped char expected after \
+],
+)
+AT_CLEANUP


### PR DESCRIPTION
Previously, we assumed a backslash character would always be followed by
a character to be escaped, and advanced our "start" pointer by two
places before the next iteration.  However, this assumption breaks if
the lonely backslash happens to be the last character in the query
string, in which case we would end up pointing beyond the \0 and let the
parser wander into the unknown, possibly crashing later.

This commit ensures we detect this corner case and error out gracefully
with a message.