### PR TITLE
Use git apply --reject to assist with modifying patches

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1231,7 +1231,7 @@ package or when debugging this package.\
 %{expand:%__scm_setup_git %{-q}}
 
 %__scm_apply_git_am(qp:m:)\
-%{__git} am %{-q} %{-p:-p%{-p*}}
+%{__git} am --reject %{-q} %{-p:-p%{-p*}}
 
 # Quilt
 %__scm_setup_quilt(q) %{nil}

--- a/macros.in
+++ b/macros.in
@@ -1223,7 +1223,7 @@ package or when debugging this package.\
 	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"
 
 %__scm_apply_git(qp:m:)\
-%{__git} apply --index %{-p:-p%{-p*}} -\
+%{__git} apply --index --reject %{-p:-p%{-p*}} -\
 %{__git} commit %{-q} -m %{-m*} --author "%{__scm_author}"
 
 # Git, using "git am" (-m is unused)


### PR DESCRIPTION
I find %autosetup -S git very hard to use when a patch needs updating for a new release of a project.  This gives us the standard patch behavior of applying what it can and giving .rej files for what it cannot.  I don't know how far back the --reject argument is valid, but it at least appears to be present in git 2.3.3: https://git-scm.com/docs/git-apply/2.3.3