### PR TITLE
Fix Icon tag crash on src.rpm build, regression in 4.15.0 (RhBug:1769579)

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -566,6 +566,7 @@ exit:
     free(rpmio_flags);
     free(SHA1);
     free(SHA256);
+    free(upld);
 
     /* XXX Fish the pkgid out of the signature header. */
     if (pkgidp != NULL) {

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -893,6 +893,7 @@ static rpmRC handlePreambleTag(rpmSpec spec, Package pkg, rpmTagVal tag,
 	SINGLE_TOKEN_ONLY;
 	if (addIcon(pkg, field))
 	    goto exit;
+	spec->numSources++;
 	break;
     case RPMTAG_NOSOURCE:
     case RPMTAG_NOPATCH:


### PR DESCRIPTION
Commit e68eb68c4a6c3635b8cf58a05277f7da49058d16 introduced a regression
on Icon tag causing a crash on source rpm build, due to spec->numSources
being off by one if an icon was present.
    
A nicer fix would be eliminating numSources entirely but it's not as
easy as it should be due to dynamic buildrequires messing with it,
leaving that for another time.

The second commit fixes an unrelated, recently introduced memory leak.