### PR TITLE
Allow to keep a minimum number of changelog entries

### DIFF
--- a/build/parseChangelog.c
+++ b/build/parseChangelog.c
@@ -203,6 +203,8 @@ static rpmRC addChangelog(Header h, ARGV_const_t sb)
     time_t time;
     time_t lastTime = 0;
     time_t trimtime = rpmExpandNumeric("%{?_changelog_trimtime}");
+    int minchangescount = rpmExpandNumeric("%{?_changelog_mincount}");
+    int changescount = 0;
     char *date, *name, *text, *next;
     int date_words;      /* number of words in date string */
 
@@ -284,7 +286,7 @@ static rpmRC addChangelog(Header h, ARGV_const_t sb)
 	    *s-- = '\0';
 	}
 	
-	if ( !trimtime || time >= trimtime ) {
+	if ( !trimtime || time >= trimtime || changescount++ < minchangescount ) {
 	    addChangelogEntry(h, time, name, text);
 	} else break;
 	

--- a/macros.in
+++ b/macros.in
@@ -234,6 +234,10 @@ package or when debugging this package.\
 #	Any older entry is not packaged in binary packages.
 %_changelog_trimtime	0
 
+#	When using %_changelog_trimtime, ensure to keep at least
+#	this many entries to reduce confusion of users and tools
+%_changelog_mincount	1
+
 #	If true, set the SOURCE_DATE_EPOCH environment variable
 #	to the timestamp of the topmost changelog entry
 %source_date_epoch_from_changelog 0


### PR DESCRIPTION
Allow to keep a minimum number of changelog entries
because some tools and workflows break when `%_changelog_trimtime`
dropped all entries.

This also helps reproducible builds because
`%source_date_epoch_from_changelog` can only work when there is an
entry left

Note: test looks good. e.g. mtimes get adjusted again with `%clamp_mtime_to_source_date_epoch Y`