### PR TITLE
Set Build Date from changelog again

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -254,6 +254,8 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 		/* make sure it is in the past, so that clamping times works */
 		sdeint -= 43200;
 	    snprintf(sdestr, sizeof(sdestr), "%lli", sdeint);
+	    if (rpmExpandNumeric("%{?use_source_date_epoch_as_buildtime}"))
+	        spec->buildTime = sdeint;
 	    rpmlog(RPMLOG_NOTICE, _("setting %s=%s\n"), "SOURCE_DATE_EPOCH", sdestr);
 	    setenv("SOURCE_DATE_EPOCH", sdestr, 0);
 	    rpmtdFreeData(&td);


### PR DESCRIPTION
Set Build Date from changelog again

This is needed because fa303d5ba6 had moved the code that used `getenv("SOURCE_DATE_EPOCH")` to run before we do `setenv` here.

See https://reproducible-builds.org/ for why this is good.

Fixes #932