### PR TITLE
Only calculate buildhost and buildtime during an actual build

### DIFF
--- a/build/spec.c
+++ b/build/spec.c
@@ -5,8 +5,6 @@
 
 #include "system.h"
 #include <errno.h>
-#include <netdb.h>
-#include <time.h>
 
 #include <rpm/header.h>
 #include <rpm/rpmds.h>
@@ -199,59 +197,11 @@ rpmds * packageDependencies(Package pkg, rpmTagVal tag)
     return NULL;
 }
 
-static rpm_time_t getBuildTime(void)
-{
-    rpm_time_t buildTime = 0;
-    char *srcdate;
-    time_t epoch;
-    char *endptr;
-
-    srcdate = getenv("SOURCE_DATE_EPOCH");
-    if (srcdate && rpmExpandNumeric("%{?use_source_date_epoch_as_buildtime}")) {
-        errno = 0;
-        epoch = strtol(srcdate, &endptr, 10);
-        if (srcdate == endptr || *endptr || errno != 0)
-            rpmlog(RPMLOG_ERR, _("unable to parse SOURCE_DATE_EPOCH\n"));
-        else
-            buildTime = (int32_t) epoch;
-    } else
-        buildTime = (int32_t) time(NULL);
-
-    return buildTime;
-}
-
-static char * buildHost(void)
-{
-    char* hostname;
-    struct hostent *hbn;
-    char *bhMacro;
-
-    bhMacro = rpmExpand("%{?_buildhost}", NULL);
-    if (strcmp(bhMacro, "") != 0) {
-        rasprintf(&hostname, "%s", bhMacro);
-    } else {
-        hostname = rcalloc(1024, sizeof(*hostname));
-        (void) gethostname(hostname, 1024);
-        hbn = gethostbyname(hostname);
-        if (hbn)
-            strcpy(hostname, hbn->h_name);
-        else
-            rpmlog(RPMLOG_WARNING,
-                    _("Could not canonicalize hostname: %s\n"), hostname);
-    }
-    free(bhMacro);
-    return(hostname);
-}
-
-
 rpmSpec newSpec(void)
 {
     rpmSpec spec = xcalloc(1, sizeof(*spec));
     
     spec->specFile = NULL;
-
-    spec->buildHost = buildHost();
-    spec->buildTime = getBuildTime();
 
     spec->fileStack = NULL;
     spec->lbufSize = BUFSIZ * 10;

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -165,13 +165,22 @@ runroot rpmbuild -bb --quiet \
 	--define "%_target_platform noarch-linux" \
 	--define "%_binary_payload w.ufdio" \
 	--define "%_buildhost localhost" \
+	--define "%use_source_date_epoch_as_buildtime 1" \
 	--define "%source_date_epoch_from_changelog 1" \
 	--define "%clamp_mtime_to_source_date_epoch 1" \
 	/data/SPECS/attrtest.spec 
+for v in SHA256HEADER SHA1HEADER SIGMD5 PAYLOADDIGEST PAYLOADDIGESTALT; do
+    runroot rpm -q --qf "${v}: %{${v}}\n" /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm
+done
 runroot rpmkeys -Kv /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm
 ],
 [0],
-[/build/RPMS/noarch/attrtest-1.0-1.noarch.rpm:
+[SHA256HEADER: 272c5eb30fb2caf7abf5ab02ab7a53ef52c71c88545b9ab08a940f724f920baf
+SHA1HEADER: 4d630ee2a75757adfdbd2aed1fe803b5e3c8664d
+SIGMD5: ef85784d929890a1653ed0b959784f50
+PAYLOADDIGEST: 749d8980cc5889419da8cdbe9a5b3292742af8a227db3635f84966481b7612a8
+PAYLOADDIGESTALT: 749d8980cc5889419da8cdbe9a5b3292742af8a227db3635f84966481b7612a8
+/build/RPMS/noarch/attrtest-1.0-1.noarch.rpm:
     Header SHA256 digest: OK
     Header SHA1 digest: OK
     Payload SHA256 ALT digest: OK


### PR DESCRIPTION
Commit fa303d5ba6bef5b4a44b884c6dadadc27b594caa moved buildhost and
buildtime calculation out of the package generation to early spec
initialization, but this broke reproducable builds: if buildtime is
to be set from changelog, changelog needs to be parsed first.

So either we need to do it twice or we need to do it right, and
besides avoiding duplication, conceptually these values are only
meaningful during a build and not a parse, so this restores that part
of the original code while keeping things thread-safe.

Fixes: #932