### PR TITLE
Generate file class dictionary after file classification for stability

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1120,7 +1120,7 @@ rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
 	#pragma omp cancel parallel
     }
 
-    #pragma omp for ordered reduction(+:nerrors)
+    #pragma omp for reduction(+:nerrors)
     for (int ix = 0; ix < fc->nfiles; ix++) {
 	rpmsid ftypeId;
 	const char * ftype;
@@ -1164,6 +1164,7 @@ rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
 		/* only executable files are critical to dep extraction */
 		if (is_executable) {
 		    nerrors++;
+		    #pragma omp cancel for
 		}
 		/* unrecognized non-executables get treated as "data" */
 		ftype = "data";
@@ -1184,7 +1185,6 @@ rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
 	fc->fcolor[ix] = fcolor;
 
 	/* Add to file class dictionary and index array */
-	#pragma omp ordered
 	if (fcolor != RPMFC_WHITE && (fcolor & RPMFC_INCLUDE)) {
 	    ftypeId = rpmstrPoolId(fc->cdict, ftype, 1);
 	    #pragma omp atomic


### PR DESCRIPTION
 Store the file type strings in the classifier, and generate the dictionary and its ids serially after the parallel section completes to ensure stable order. Besides making the classifying really run in parallel again, this also moves the pool- and file-counting related constraints out of the parallel section for theoretically better parallelization.
    
This is an alternative fix to #934, using omp order clause simply made the classification run serially.
