### PR TITLE
Fix Arm detection improvements

### DIFF
--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -82,7 +82,6 @@ struct rpmOption {
 static struct rpmat_s {
     const char *platform;
     uint64_t hwcap;
-    uint64_t hwcap2;
 } rpmat;
 
 typedef struct defaultEntry_s {
@@ -949,11 +948,7 @@ static int is_geode(void)
 }
 #endif
 
-
 #if defined(__linux__)
-#ifndef AT_HWCAP2 /* glibc < 2.18 */
-#define AT_HWCAP2 26
-#endif
 /**
  * Populate rpmat structure with auxv values
  */
@@ -967,7 +962,6 @@ static void read_auxv(void)
 	if (!rpmat.platform)
 	    rpmat.platform = "";
 	rpmat.hwcap = getauxval(AT_HWCAP);
-	rpmat.hwcap2 = getauxval(AT_HWCAP2);
 #else
 	rpmat.platform = "";
 	int fd = open("/proc/self/auxv", O_RDONLY);
@@ -989,9 +983,6 @@ static void read_auxv(void)
                     case AT_HWCAP:
                         rpmat.hwcap = auxv.a_un.a_val;
                         break;
-		    case AT_HWCAP2:
-			rpmat.hwcap2 = auxv.a_un.a_val;
-			break;
                 }
 	    }
 	    close(fd);
@@ -1225,9 +1216,6 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 #	if !defined(HWCAP_ARM_VFPv3)
 #	    define HWCAP_ARM_VFPv3	(1 << 13)
 #	endif
-#	if !defined(HWCAP2_AES)
-#	    define HWCAP2_AES		(1 << 0)
-#	endif
 	/*
 	 * un.machine is armvXE, where X is version number and E is
 	 * endianness (b or l)
@@ -1238,11 +1226,9 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 		/* keep armv7, armv8, armv9, armv10, ... */
 		while(risdigit(*modifier)) 
 			modifier++;
-		if (rpmat.hwcap & HWCAP_ARM_VFPv3)
+		if (rpmat.hwcap & (HWCAP_ARM_VFP || HWCAP_ARM_VFPv3))
 			*modifier++ = 'h';
-		if (rpmat.hwcap2 & HWCAP2_AES)
-			*modifier++ = 'c';
-		if (rpmat.hwcap & HWCAP_ARM_NEON)
+		if ((atoi(un.machine+4) == 7) && (rpmat.hwcap & HWCAP_ARM_NEON))
 			*modifier++ = 'n';
 		*modifier++ = endian;
 		*modifier++ = 0;


### PR DESCRIPTION
There's some issues with the detection of particular Arm hardware
features. We never want to use the crypto feature as part of rpm
functionality, it's deployment is widely variable, and the HW
optimisation should be run time detected with fall back through
various optimisation paths.

The 8c3a7b8fa commit where this functionality also has other issues
it didn't include the VFP HWCAP for armv6 which rpm included
previously, but just the VFP3, and NEON is a requirement, and hence
always present in armv8 so it's assumed that it's part of armv8.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>