### PR TITLE
Auto-enable optimizations for non-rotational disks on Linux

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -218,7 +218,7 @@ static void wfd_close(FD_t *wfdp)
 	static int oneshot = 0;
 	static int flush_io = 0;
 	if (!oneshot) {
-	    flush_io = rpmExpandNumeric("%{?_flush_io}");
+	    flush_io = (rpmExpandNumeric("%{?_flush_io}") > 0);
 	    oneshot = 1;
 	}
 	if (flush_io) {

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -1143,7 +1143,7 @@ rpmts rpmtsCreate(void)
 
     ts->trigs2run = rpmtriggersCreate(10);
 
-    ts->min_writes = rpmExpandNumeric("%{_minimize_writes}");
+    ts->min_writes = (rpmExpandNumeric("%{?_minimize_writes}") > 0);
 
     return rpmtsLink(ts);
 }

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -6,6 +6,16 @@
 
 #include <inttypes.h>
 #include <libgen.h>
+#include <errno.h>
+
+/* duplicated from cpio.c */
+#if MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#else
+#include <sys/types.h> /* already included from system.h */
+#endif
 
 #include <rpm/rpmlib.h>		/* rpmMachineScore, rpmReadPackageFile */
 #include <rpm/rpmmacro.h>	/* XXX for rpmExpand */
@@ -64,6 +74,8 @@ struct diskspaceInfo_s {
     int64_t oineeded;	/*!< Bookkeeping to avoid duplicate reports */
     int64_t bdelta;	/*!< Delta for temporary space need on updates */
     int64_t idelta;	/*!< Delta for temporary inode need on updates */
+
+    int rotational;	/*!< Rotational media? */
 };
 
 /* Adjust for root only reserved space. On linux e2fs, this is 5%. */
@@ -107,6 +119,27 @@ static char *getMntPoint(const char *dirName, dev_t dev)
 	}
     }
     return res;
+}
+
+static int getRotational(const char *dirName, dev_t dev)
+{
+    int rotational = 1;	/* Be a good pessimist, assume the worst */
+#if defined(__linux__)
+    char *devpath = NULL;
+    FILE *f = NULL;
+
+    rasprintf(&devpath, "/sys/dev/block/%d:%d/queue/rotational",
+			major(dev), minor(dev));
+    if ((f = fopen(devpath, "r")) != NULL) {
+	int v;
+	if (fscanf(f, "%d", &v) == 1)
+	    rotational = (v == 1);
+	fclose(f);
+    }
+    free(devpath);
+#endif
+
+    return rotational;
 }
 
 static int rpmtsInitDSI(const rpmts ts)
@@ -177,6 +210,9 @@ static rpmDiskSpaceInfo rpmtsCreateDSI(const rpmts ts, dev_t dev,
     /* Find mount point belonging to this device number */
     dsi->mntPoint = getMntPoint(dirName, dsi->dev);
 
+    /* Initialized on demand */
+    dsi->rotational = -1;
+
     /* normalize block size to 4096 bytes if it is too big. */
     if (dsi->bsize > 4096) {
 	uint64_t old_size = dsi->bavail * dsi->bsize;
@@ -188,9 +224,9 @@ static rpmDiskSpaceInfo rpmtsCreateDSI(const rpmts ts, dev_t dev,
     }
 
     rpmlog(RPMLOG_DEBUG,
-	   "0x%08x %8" PRId64 " %12" PRId64 " %12" PRId64" %s\n",
+	   "0x%08x %8" PRId64 " %12" PRId64 " %12" PRId64" rotational:%d %s\n",
 	   (unsigned) dsi->dev, dsi->bsize,
-	   dsi->bavail, dsi->iavail,
+	   dsi->bavail, dsi->iavail, dsi->rotational,
 	   dsi->mntPoint);
     return dsi;
 }
@@ -208,6 +244,22 @@ static rpmDiskSpaceInfo rpmtsGetDSI(const rpmts ts, dev_t dev,
 	}
     }
     return dsi;
+}
+
+static int rpmtsGetDSIRotational(rpmts ts)
+{
+    int rc = 1;
+    int nrot = 0;
+    rpmDiskSpaceInfo dsi = ts->dsi;
+    while (dsi && dsi->bsize != 0) {
+	if (dsi->rotational < 0)
+	    dsi->rotational = getRotational(dsi->mntPoint, dsi->dev);
+	nrot += dsi->rotational;
+	dsi++;
+    }
+    if (dsi != ts->dsi && nrot == 0)
+	rc = 0;
+    return rc;
 }
 
 static void rpmtsUpdateDSI(const rpmts ts, dev_t dev, const char *dirName,
@@ -1415,8 +1467,35 @@ static int rpmtsSetup(rpmts ts, rpmprobFilterFlags ignoreSet)
     return 0;
 }
 
+/* Push a macro with current value or default if no previous value exists */
+static void ensureMacro(const char *name, const char *def)
+{
+    char *s = rpmExpand("%{?", name, "}", NULL);
+
+    if (*s != '\0' && atoi(s) >= 0)
+	def = s;
+
+    rpmPushMacro(NULL, name, NULL, def, 0);
+    free(s);
+}
+
+/* Enable / disable optimizations for solid state disks */
+static void setSSD(int enable)
+{
+    if (enable) {
+	rpmlog(RPMLOG_DEBUG, "optimizing for non-rotational disks\n");
+	ensureMacro("_minimize_writes", "1");
+	ensureMacro("_flush_io", "1");
+    } else {
+	rpmPopMacro(NULL, "_minimize_writes");
+	rpmPopMacro(NULL, "_flush_io");
+    }
+}
+
 static int rpmtsFinish(rpmts ts)
 {
+    if (rpmtsGetDSIRotational(ts) == 0)
+	setSSD(0);
     rpmtsFreeDSI(ts);
     return rpmChrootSet(NULL);
 }
@@ -1514,6 +1593,9 @@ static int rpmtsPrepare(rpmts ts)
 	}
 	rpmtsiFree(pi);
     }
+
+    if (rpmtsGetDSIRotational(ts) == 0)
+	setSSD(1);
 
 exit:
     fpCacheFree(fpc);

--- a/macros.in
+++ b/macros.in
@@ -746,7 +746,7 @@ package or when debugging this package.\
 
 # Set to 1 to minimize writing (at the cost of more reads) to
 # conserve eg SSD disks.
-%_minimize_writes      0
+#%_minimize_writes      0
 
 # Set to 1 to flush file IO during transactions (at a severe cost in
 # performance for rotational disks)

--- a/macros.in
+++ b/macros.in
@@ -744,13 +744,21 @@ package or when debugging this package.\
 # Disabler flags for package verification (similar to vsflags)
 %_pkgverify_flags 0x0
 
-# Set to 1 to minimize writing (at the cost of more reads) to
+# Minimize writes during transactions (at the cost of more reads) to
 # conserve eg SSD disks.
-#%_minimize_writes      0
+# 1			enable
+# 0 			disable
+# -1 (or undefined)	autodetect on platforms where supported, otherwise
+# 			default to disabled
+#%_minimize_writes      -1
 
-# Set to 1 to flush file IO during transactions (at a severe cost in
-# performance for rotational disks)
-#%_flush_io	0
+# Flush file IO during transactions (at a severe cost in performance
+# for rotational disks).
+# 1			enable
+# 0 			disable
+# -1 (or undefined)	autodetect on platforms where supported, otherwise
+# 			default to disabled
+#%_flush_io		-1
 
 # Set to 1 to have IMA signatures written also on %config files.
 # Note that %config files may be changed and therefore end up with


### PR DESCRIPTION
Try to auto-detect non-rotational disks on start of transactions,
and if all involved disks are non-rotational enable optimizations:
%_minimize_io to conserve writes, and %_flush_io to avoid trashing
the system caches.

Caveat: this potentially overrides values from system macro configuration
which is not ok, hence it's only an RFC until this is addressed. Macros
are awfully clumsy for the internal interfaces anyway...