### PR TITLE
Support sed 'in-place' replacement on BSD.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -53,6 +53,7 @@
 %__rm			@__RM@
 %__rsh			@__RSH@
 %__sed			@__SED@
+%__sed_i		%{__sed} -i
 %__semodule		@__SEMODULE@
 %__ssh			@__SSH@
 %__tar			@__TAR@


### PR DESCRIPTION
BSD's sed _requires_ an `extension` for the `-i` option, even an 'empty' (`-i ""`) extension to suppress creation of a backup for 'in-place' editing, while GNU sed's `-i` defaults to 'no backup' without an express `suffix`. With `%{__sed_i}` it should be easier to write portable specfiles for both GNU/Linux and BSD based systems. The latter should simply redefine
```
   %__sed_i /bin/sed -i ""
```
in a local macro file or
```
   %global __sed_i /bin/sed -i ""
```
in a specfile.