### PR TITLE
brp-strip-static-archive: Do not use xargs -d

### DIFF
--- a/scripts/brp-strip-static-archive
+++ b/scripts/brp-strip-static-archive
@@ -13,6 +13,5 @@ Darwin*) exit 0 ;;
 esac
 
 # Strip static libraries.
-find "$RPM_BUILD_ROOT" -type f | \
-    grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug" | \
-    xargs -d '\n' -r -P$NCPUS -n32 sh -c "file \"\$@\" | sed 's/:  */: /' | grep 'current ar archive' | sed -n -e 's/^\(.*\):[  ]*current ar archive/\1/p' | xargs -d '\n' -I\{\} $STRIP -g \{\}" ARG0
+find "$RPM_BUILD_ROOT" -type f \! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" -print0 | \
+    xargs -0 -r -P$NCPUS -n32 sh -c "file \"\$@\" | sed 's/:  */: /' | grep 'current ar archive' | sed -n -e 's/^\(.*\):[  ]*current ar archive/\1/p' | xargs -d '\n' -I\{\} $STRIP -g \{\}" ARG0


### PR DESCRIPTION
as it is not POSIX compliant and not supported on BSD and others

Dropping the use of grep here and using -regex of find instead to get rid of
the need for looking at lines terminated by newline.

Using only basic regular expressions for portability.

Resolves: #948