### PR TITLE
rpmio: initialise libgcrypt

### DIFF
--- a/rpmio/digest_libgcrypt.c
+++ b/rpmio/digest_libgcrypt.c
@@ -20,6 +20,8 @@ struct DIGEST_CTX_s {
 /****************************  init   ************************************/
 
 int rpmInitCrypto(void) {
+    gcry_check_version (NULL);
+    gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
     return 0;
 }
 


### PR DESCRIPTION
If we're using libgcrypt for hashing we need to initialise libgcrypt, otherwise
it will crash when used in parallel packaging runs.

Fixes #968