### PR TITLE
Add a key-only rpmdb iterator to optimize rpmtsCheck()

### DIFF
--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -400,15 +400,15 @@ static rpmRC ndb_idxdbIter(dbiIndex dbi, dbiCursor dbc, dbiIndexSet *set)
 	}
 	k = dbc->listdata + dbc->list[dbc->ilist];
 	kl = dbc->list[dbc->ilist + 1];
-#if 0
-	if (searchType == DBC_KEY_SEARCH) {
+
+	if (set == NULL) {
 	    dbc->ilist += 2;
 	    dbc->key = k;
 	    dbc->keylen = kl;
 	    rc = RPMRC_OK;
 	    break;
 	}
-#endif
+
 	pkglist = 0;
 	pkglistn = 0;
 	rc = rpmidxGet(dbc->dbi->dbi_db, k, kl, &pkglist, &pkglistn);

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -578,15 +578,17 @@ static rpmRC sqlite_idxdbIter(dbiIndex dbi, dbiCursor dbc, const char *keyp, siz
 	rc = sqlite3_step(dbc->stmt);
 
     if (rc == SQLITE_ROW) {
-	dbiCursor kc = dbiCursorInit(dbi, 0);
 	if (dbc->ctype == SQLITE_TEXT) {
 	    dbc->key = sqlite3_column_text(dbc->stmt, 0);
 	} else {
 	    dbc->key = sqlite3_column_blob(dbc->stmt, 0);
 	}
 	dbc->keylen = sqlite3_column_bytes(dbc->stmt, 0);
-	rc = sqlite_idxdbByKey(dbi, kc, dbc->key, dbc->keylen, set);
-	dbiCursorFree(dbi, kc);
+	if (set) {
+	    dbiCursor kc = dbiCursorInit(dbi, 0);
+	    rc = sqlite_idxdbByKey(dbi, kc, dbc->key, dbc->keylen, set);
+	    dbiCursorFree(dbi, kc);
+	}
 	rc = RPMRC_OK;
     } else if (rc == SQLITE_DONE) {
 	if (searchType == DBC_PREFIX_SEARCH && (*set))

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -938,7 +938,7 @@ static void addIndexToDepHashes(rpmts ts, rpmDbiTag tag,
 {
     char *key;
     size_t keylen;
-    rpmdbIndexIterator ii = rpmdbIndexIteratorInit(rpmtsGetRdb(ts), tag);
+    rpmdbIndexIterator ii = rpmdbIndexKeyIteratorInit(rpmtsGetRdb(ts), tag);
 
     if (!ii)
 	return;

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -298,6 +298,7 @@ struct rpmdbIndexIterator_s {
     dbiCursor		ii_dbc;
     dbiIndexSet		ii_set;
     unsigned int	*ii_hdrNums;
+    int			ii_skipdata;
 };
 
 static rpmdb rpmdbRock;
@@ -1885,6 +1886,13 @@ rpmdbIndexIterator rpmdbIndexIteratorInit(rpmdb db, rpmDbiTag rpmtag)
     return ii;
 }
 
+rpmdbIndexIterator rpmdbIndexKeyIteratorInit(rpmdb db, rpmDbiTag rpmtag)
+{
+    rpmdbIndexIterator ki = rpmdbIndexIteratorInit(db, rpmtag);
+    ki->ii_skipdata = 1;
+    return ki;
+}
+
 int rpmdbIndexIteratorNext(rpmdbIndexIterator ii, const void ** key, size_t * keylen)
 {
     int rc;
@@ -1899,7 +1907,8 @@ int rpmdbIndexIteratorNext(rpmdbIndexIterator ii, const void ** key, size_t * ke
     /* free old data */
     ii->ii_set = dbiIndexSetFree(ii->ii_set);
 
-    rc = idxdbGet(ii->ii_dbi, ii->ii_dbc, NULL, 0, &ii->ii_set, DBC_NORMAL_SEARCH);
+    rc = idxdbGet(ii->ii_dbi, ii->ii_dbc, NULL, 0,
+		ii->ii_skipdata ? NULL : &ii->ii_set, DBC_NORMAL_SEARCH);
 
     *key = idxdbKey(ii->ii_dbi, ii->ii_dbc, &iikeylen);
     *keylen = iikeylen;

--- a/lib/rpmdb.h
+++ b/lib/rpmdb.h
@@ -154,6 +154,14 @@ Header rpmdbNextIterator(rpmdbMatchIterator mi);
 rpmdbMatchIterator rpmdbFreeIterator(rpmdbMatchIterator mi);
 
 /** \ingroup rpmdb
+ * Get an iterator for index keys
+ * @param db		rpm database
+ * @param rpmtag	the index to iterate over
+ * @return		the index iterator
+ */
+rpmdbIndexIterator rpmdbIndexKeyIteratorInit(rpmdb db, rpmDbiTag rpmtag);
+
+/** \ingroup rpmdb
  * Get an iterator for an index
  * @param db		rpm database
  * @param rpmtag	the index to iterate over


### PR DESCRIPTION
rpmtsCheck() builds some hashes over rpmdb keys, whose buildup is barely measurable in normal install/update/erase transactions, but when repeated thousands of times during rpm -Va, things start adding up. Add a new interface to avoid fetching tonnes of unused data and use it. More details in the commits.