### PR TITLE
find-debuginfo.sh: speed up %dir generation

### DIFF
--- a/scripts/find-debuginfo.sh
+++ b/scripts/find-debuginfo.sh
@@ -660,8 +660,8 @@ while ((i < nout)); do
   ((++i))
 done
 if ((nout > 0)); then
-  # Now add the right %dir lines to each output list.
-  add_percent_dir()
+  # Generate %dir lines for each output list.
+  generate_percent_dir()
   {
     while read -r line; do
       while test "${line:0:15}" = "/usr/lib/debug/"; do
@@ -676,12 +676,12 @@ if ((nout > 0)); then
   }
   i=0
   while ((i < nout)); do
-    add_percent_dir < "${outs[$i]}" > "${outs[$i]}.new"
+    generate_percent_dir < "${outs[$i]}" > "${outs[$i]}.new"
     cat "${outs[$i]}" >> "${outs[$i]}.new"
     mv -f "${outs[$i]}.new" "${outs[$i]}"
     ((++i))
   done
-  add_percent_dir < "${LISTFILE}" > "${LISTFILE}.new"
+  generate_percent_dir < "${LISTFILE}" > "${LISTFILE}.new"
   cat "$LISTFILE" >> "${LISTFILE}.new"
   mv "${LISTFILE}.new" "$LISTFILE"
 fi


### PR DESCRIPTION
Submitting on behalf of Denys Vlasenko:

For kernel build, "${LISTFILE}.dirs.sed" is debugfiles.list.dirs.sed
and it contains 1782 lines of sed script.
It is applied to two files, both are about 4450 lines long.

This is slow (~30 seconds) because of ~16 million regex matches
performed by sed.

But we don't need or want regex match here
(and it's buggy, since dots in pattern match will be treated
as "any character", which is wrong here. For example,
      /usr/lib/debug/lib/modules/5@4@0-0@rc7@0@fc31@test@x86_64/vdso/
would match
      /usr/lib/debug/lib/modules/5.4.0-0.rc7.0.fc31.test.x86_64/vdso/
pattern, but it should not).

This change performs matching using shell string comparison ops.
For kernel build, this change results in run time of about one second.

Signed-off-by: Denys Vlasenko <dvlasenk@redhat.com>