### PR TITLE
Trying to upstream Debian patches: warning about non-native package manager

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -846,6 +846,8 @@ AS_IF([test "$enable_python" = yes],[
 
 AM_CONDITIONAL(ENABLE_PYTHON,[test "$WITH_PYTHON_SUBPACKAGE" = 1])
 
+AC_ARG_WITH(debian, [  --with-debian		build rpm for usage on Debian],[AC_DEFINE(ON_DEBIAN, 1, [Define as 1 if you do not want to use rpm for installing packages])])
+
 AC_PATH_PROG(DOXYGEN, doxygen, no)
 dnl
 dnl Only build internal API + source hacking docs on request

--- a/lib/poptI.c
+++ b/lib/poptI.c
@@ -145,6 +145,11 @@ struct poptOption rpmInstallPoptTable[] = {
 
  { "force", '\0', 0, NULL, RPMCLI_POPT_FORCE,
 	N_("short hand for --replacepkgs --replacefiles"), NULL},
+#if defined(ON_DEBIAN)
+ { "force-debian", '\0', POPT_BIT_SET, &rpmIArgs.probFilter,
+	(RPMPROB_FILTER_DEBIAN),
+	N_("force installation of rpm on Debian system"), NULL},
+#endif
 
  { "freshen", 'F', POPT_BIT_SET, &rpmIArgs.installInterfaceFlags,
 	(INSTALL_UPGRADE|INSTALL_FRESHEN|INSTALL_INSTALL),

--- a/lib/rpmprob.h
+++ b/lib/rpmprob.h
@@ -30,6 +30,7 @@ enum rpmprobFilterFlags_e {
     RPMPROB_FILTER_DISKSPACE	= (1 << 7),	/*!< from --ignoresize */
     RPMPROB_FILTER_DISKNODES	= (1 << 8),	/*!< from --ignoresize */
     RPMPROB_FILTER_VERIFY	= (1 << 9),	/*!< from --noverify */
+    RPMPROB_FILTER_DEBIAN	= (1 << 10),	/*!< from --force-debian */
 };
 
 typedef rpmFlags rpmprobFilterFlags;

--- a/rpm.c
+++ b/rpm.c
@@ -122,6 +122,14 @@ int main(int argc, char *argv[])
 	    bigMode = MODE_ERASE;
     }
 
+#if defined(ON_DEBIAN)
+    if ((bigMode == MODE_INSTALL || bigMode == MODE_ERASE) &&
+        (ia->probFilter & RPMPROB_FILTER_DEBIAN) == 0) {
+        fprintf(stderr, _("%s: %s\n"), __progname, _("RPM should not be used directly install RPM packages, use Alien instead!"));
+        fprintf(stderr, _("%s: %s\n"), __progname, _("However assuming you know what you are doing..."));
+    }
+#endif
+
     if (!( bigMode == MODE_INSTALL ) &&
 (ia->probFilter & (RPMPROB_FILTER_REPLACEPKG | RPMPROB_FILTER_OLDPACKAGE)))
 	argerror(_("only installation and upgrading may be forced"));


### PR DESCRIPTION
>In Debian, rpm should be used to install packages, but rather as a tool to work with rpm packages or as a helper in alien. Because of this we protect complain, when user tries to install a package. This warning can be hidden by --force-debian.
Forwarded: http://rpm.org/ticket/79

>https://salsa.debian.org/pkg-rpm-team/rpm/raw/master/debian/patches/debian-disable-rpm.patch

Should I change the text to be suitable to other distros? Are the patches having nothing to do with Fedora acceptable to this repo at all?