### PR TITLE
fix zstd magic

### DIFF
--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -188,7 +188,7 @@ int rpmFileIsCompressed(const char * file, rpmCompressedMagic * compressed)
 	       (magic[4] == 0x5a) && (magic[5] == 0x00)) {
 	/* new style xz (lzma) with magic */
 	*compressed = COMPRESSED_XZ;
-    } else if ((magic[0] == 0x28) && (magic[1] == 0x85) &&
+    } else if ((magic[0] == 0x28) && (magic[1] == 0xB5) &&
 	       (magic[2] == 0x2f)                     ) {
 	*compressed = COMPRESSED_ZSTD;
     } else if ((magic[0] == 'L') && (magic[1] == 'Z') &&


### PR DESCRIPTION
I spot it while adding support for zstd compressed metadata in
URPM/urpmi, which was broken by this typo

typo introduced in commit 3684424fe297c996bb05bb64631336fa2903df12

This fixes issue #990