### PR TITLE
Python dist deps: Put bounded requirements into parenthesis

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -247,7 +247,7 @@ for name in names:
         spec_list = []
         for spec in py_deps[name]:
             if spec[0] == '!=':
-                spec_list.append('{n} < {v} or {n} >= {v}.0'.format(n=name, v=spec[1]))
+                spec_list.append('({n} < {v} or {n} >= {v}.0)'.format(n=name, v=spec[1]))
             elif spec[0] == '~=':
                 # Parse the current version
                 next_ver = parse_version(spec[1]).base_version.split('.')
@@ -256,7 +256,7 @@ for name in names:
                 # Increment the minor version
                 next_ver[-1] = str(int(next_ver[-1]) + 1)
                 next_ver = '.'.join(next_ver)
-                spec_list.append('{n} >= {v} with {n} < {vnext}'.format(n=name, v=spec[1], vnext=next_ver))
+                spec_list.append('({n} >= {v} with {n} < {vnext})'.format(n=name, v=spec[1], vnext=next_ver))
             elif spec[0] == '==' and spec[1].endswith('.*'):
                 # Parse the current version
                 next_ver = parse_version(spec[1]).base_version.split('.')
@@ -266,7 +266,7 @@ for name in names:
                 # Increment the minor version
                 next_ver[-1] = str(int(next_ver[-1]) + 1)
                 next_ver = '.'.join(next_ver)
-                spec_list.append('{n} >= {v} with {n} < {vnext}'.format(n=name, v=spec[1], vnext=next_ver))
+                spec_list.append('({n} >= {v} with {n} < {vnext})'.format(n=name, v=spec[1], vnext=next_ver))
             else:
                 spec_list.append('{} {} {}'.format(name, spec[0], spec[1]))
         if len(spec_list) == 1:


### PR DESCRIPTION
Fixes https://github.com/rpm-software-management/rpm/issues/995

For this input: pyparsing>=2.0.1,!=2.0.4,!=2.1.2,!=2.1.6

Instead of (invalid):
(python3.8dist(pyparsing) >= 2.0.1 with
 python3.8dist(pyparsing) < 2.1.2 or python3.8dist(pyparsing) >= 2.1.2.0 with
 python3.8dist(pyparsing) < 2.1.6 or python3.8dist(pyparsing) >= 2.1.6.0 with
 python3.8dist(pyparsing) < 2.0.4 or python3.8dist(pyparsing) >= 2.0.4.0)

Produces (valid):
(python3.8dist(pyparsing) >= 2.0.1 with
 (python3.8dist(pyparsing) < 2.1.2 or python3.8dist(pyparsing) >= 2.1.2.0) with
 (python3.8dist(pyparsing) < 2.0.4 or python3.8dist(pyparsing) >= 2.0.4.0) with
 (python3.8dist(pyparsing) < 2.1.6 or python3.8dist(pyparsing) >= 2.1.6.0))

For this input: babel>=1.3,!=2.0

Instead of (invalid):
(python3.8dist(babel) >= 1.3 with
 python3.8dist(babel) < 2 or python3.8dist(babel) >= 2.0)

Produces (valid):
(python3.8dist(babel) >= 1.3 with
 (python3.8dist(babel) < 2 or python3.8dist(babel) >= 2.0))

For this input: pbr!=2.1.0,>=2.0.0

Instead of (invalid):
(python3.8dist(pbr) >= 2 with
 python3.8dist(pbr) < 2.1 or python3.8dist(pbr) >= 2.1.0)

Produces (valid):
(python3.8dist(pbr) >= 2 with
 (python3.8dist(pbr) < 2.1 or python3.8dist(pbr) >= 2.1.0))