### PR TITLE
rpmplugins.c: call dlerror() prior to dlsym()

### DIFF
--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -68,6 +68,8 @@ static rpmPlugin rpmPluginNew(const char *name, const char *path,
 
     /* make sure the plugin has the supported hooks flag */
     hooks_name = rstrscat(NULL, name, "_hooks", NULL);
+    /* clear out any old errors that weren't fetched */
+    dlerror();
     hooks = dlsym(handle, hooks_name);
     if ((error = dlerror()) != NULL) {
 	rpmlog(RPMLOG_ERR, _("Failed to resolve symbol %s: %s\n"),


### PR DESCRIPTION
This is the recommended way in the manpage; if there is
a lingering error from an unrelated dl*() call that was
never obtained via dlerror(), it needs to be cleared
prior to calling dlsym().