### PR TITLE
Explicitly enable all our database backends in CI

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -56,6 +56,10 @@ RUN ./configure \
   --with-acl \
   --with-lua \
   --with-audit \
+  --enable-bdb \
+  --enable-ndb \
+  --enable-lmdb \
+  --enable-sqlite \
   --enable-python \
   --enable-silent-rules \
   --enable-werror


### PR DESCRIPTION
BDBD, LMDB and SQLite were already implicitly enabled via build
dependencies, but NDB build has not been enabled at all.
Came up when discussing read-only BDB in #980.