### PR TITLE
Don't require signature header to be in single contiguous region part II

### DIFF
--- a/lib/signature.c
+++ b/lib/signature.c
@@ -65,7 +65,7 @@ rpmRC rpmReadSignature(FD_t fd, Header * sighp, char ** msg)
     if (sighp)
 	*sighp = NULL;
 
-    if (hdrblobRead(fd, 1, 1, RPMTAG_HEADERSIGNATURES, &blob, &buf) != RPMRC_OK)
+    if (hdrblobRead(fd, 1, 0, RPMTAG_HEADERSIGNATURES, &blob, &buf) != RPMRC_OK)
 	goto exit;
     
     /* OK, blob looks sane, load the header. */


### PR DESCRIPTION
The generic case was reported in #270 and fixed quite a while ago in
commit 34c2ba3c6a80a778cdf2e42a9193b3264e08e1b3, but signing uses a
different code path and require the same treatment.

Fixes: #1002