### PR TITLE
ndb: add verify method and cleanup code

### DIFF
--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -179,7 +179,13 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 
 static int ndb_Verify(dbiIndex dbi, unsigned int flags)
 {
-    return 0;
+    int rc;
+    if (dbi->dbi_type == DBI_PRIMARY) {
+	rc = rpmpkgVerify(dbi->dbi_db);
+    } else {
+	rc = 0;		/* cannot verify the index databases */
+    }
+    return rc;
 }
 
 static void ndb_SetFSync(rpmdb rdb, int enable)

--- a/lib/backend/ndb/rpmpkg.c
+++ b/lib/backend/ndb/rpmpkg.c
@@ -136,10 +136,6 @@ static int rpmpkgReadHeader(rpmpkgdb pkgdb)
     if (pkgdb->slots && (pkgdb->generation != generation || pkgdb->slotnpages != slotnpages)) {
 	free(pkgdb->slots);
 	pkgdb->slots = 0;
-	if (pkgdb->slothash) {
-	    free(pkgdb->slothash);
-	    pkgdb->slothash = 0;
-	}
     }
     pkgdb->generation = generation;
     pkgdb->slotnpages = slotnpages;
@@ -201,14 +197,14 @@ static int rpmpkgHashSlots(rpmpkgdb pkgdb)
     int i;
     pkgslot *slot;
 
-    pkgdb->nslothash = 0;
-    num = pkgdb->nslots;
+    num = pkgdb->nslots + 32;
     while (num & (num - 1))
 	num = num & (num - 1);
     num *= 4;
     hash = pkgdb->slothash;
     if (!hash || pkgdb->nslothash != num) {
-	free(pkgdb->slothash);
+	if (hash)
+	    free(hash);
 	hash = pkgdb->slothash = xcalloc(num, sizeof(unsigned int));
 	pkgdb->nslothash = num;
     } else {
@@ -221,8 +217,6 @@ static int rpmpkgHashSlots(rpmpkgdb pkgdb)
 	    ;
 	hash[h] = i + 1;
     }
-    pkgdb->slothash = hash;
-    pkgdb->nslothash = num;
     return RPMRC_OK;
 }
 
@@ -239,10 +233,6 @@ static int rpmpkgReadSlots(rpmpkgdb pkgdb)
     if (pkgdb->slots) {
 	free(pkgdb->slots);
 	pkgdb->slots = 0;
-    }
-    if (pkgdb->slothash) {
-	free(pkgdb->slothash);
-	pkgdb->slothash = 0;
     }
     pkgdb->nslots = 0;
     pkgdb->freeslot = 0;

--- a/lib/backend/ndb/rpmpkg.c
+++ b/lib/backend/ndb/rpmpkg.c
@@ -45,7 +45,6 @@ typedef struct rpmpkgdb_s {
     unsigned int nextpkgidx;
 
     struct pkgslot_s *slots;
-    unsigned int aslots;	/* allocated slots */
     unsigned int nslots;	/* used slots */
 
     unsigned int *slothash;
@@ -256,8 +255,7 @@ static int rpmpkgReadSlots(rpmpkgdb pkgdb)
     fileblks = stb.st_size / BLK_SIZE;
 
     /* read (and somewhat verify) all slots */
-    pkgdb->aslots = slotnpages * (PAGE_SIZE / SLOT_SIZE);
-    pkgdb->slots = xcalloc(pkgdb->aslots, sizeof(*pkgdb->slots));
+    pkgdb->slots = xcalloc(slotnpages * (PAGE_SIZE / SLOT_SIZE), sizeof(*pkgdb->slots));
     i = 0;
     slot = pkgdb->slots;
     minblkoff = slotnpages * (PAGE_SIZE / BLK_SIZE);

--- a/lib/backend/ndb/rpmpkg.h
+++ b/lib/backend/ndb/rpmpkg.h
@@ -12,6 +12,7 @@ int rpmpkgGet(rpmpkgdb pkgdb, unsigned int pkgidx, unsigned char **blobp, unsign
 int rpmpkgPut(rpmpkgdb pkgdb, unsigned int pkgidx, unsigned char *blob, unsigned int blobl);
 int rpmpkgDel(rpmpkgdb pkgdb, unsigned int pkgidx);
 int rpmpkgList(rpmpkgdb pkgdb, unsigned int **pkgidxlistp, unsigned int *npkgidxlistp);
+int rpmpkgVerify(rpmpkgdb pkgdb);
 
 int rpmpkgNextPkgIdx(rpmpkgdb pkgdb, unsigned int *pkgidxp);
 int rpmpkgGeneration(rpmpkgdb pkgdb, unsigned int *generationp);


### PR DESCRIPTION
This commit adds a verify method for ndb's Packages.db database.
It also cleans up the pkgdb code a bit:

* removed unused lzo compression code
* added some more comments and fixed spelling mistakes
* made "ordered slots" flag a boolean
* fixed a corner case where a package id lookup could segfault
  if no packages were in the database
* no longer free the pkgid hash all the time