### PR TITLE
ndb: fix ftruncate return value warning

### DIFF
--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -963,7 +963,9 @@ int rpmxdbDelAllBlobs(rpmxdb xdb)
 	rpmxdbUnlock(xdb, 1);
 	return RPMRC_FAIL;
     }
-    ftruncate(xdb->fd, xdb->pagesize);
+    if (ftruncate(xdb->fd, xdb->pagesize)) {
+	/* ftruncate failed, but that is not a problem */
+    }
     rpmxdbUnlock(xdb, 1);
     return RPMRC_OK;
 }


### PR DESCRIPTION
Fixes #1008