### PR TITLE
Print all build errors and do not stop after the first error

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -3107,7 +3107,7 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 			int didInstall, int test)
 {
     Package pkg;
-    rpmRC rc = RPMRC_OK;
+    rpmRC res = RPMRC_OK;
     char *buildroot;
     char *uniquearch = NULL;
     Package maindbg = NULL;		/* the (existing) main debuginfo package */
@@ -3182,8 +3182,8 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	rpmlog(RPMLOG_NOTICE, _("Processing files: %s\n"), nvr);
 	free(nvr);
 
-	if ((rc = processPackageFiles(spec, pkgFlags, pkg, didInstall, test)) != RPMRC_OK)
-	    goto exit;
+	if ((processPackageFiles(spec, pkgFlags, pkg, didInstall, test)) != RPMRC_OK)
+	    res = RPMRC_FAIL;
 
 	if (maindbg)
 	    filterDebuginfoPackage(spec, pkg, maindbg, dbgsrcpkg,
@@ -3191,8 +3191,8 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	else if (deplink && pkg != deplink)
 	    addPackageDeps(pkg, deplink, RPMTAG_REQUIRENAME);
 
-        if ((rc = rpmfcGenerateDepends(spec, pkg)) != RPMRC_OK)
-	    goto exit;
+        if ((rpmfcGenerateDepends(spec, pkg)) != RPMRC_OK)
+	    res = RPMRC_FAIL;
 
 	a = headerGetString(pkg->header, RPMTAG_ARCH);
 	header_color = headerGetNumber(pkg->header, RPMTAG_HEADERCOLOR);
@@ -3209,8 +3209,7 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 	    rpmlog(terminate ? RPMLOG_ERR : RPMLOG_WARNING, 
 		   _("Arch dependent binaries in noarch package\n"));
 	    if (terminate) {
-		rc = RPMRC_FAIL;
-		goto exit;
+		res = RPMRC_FAIL;
 	    }
 	}
     }
@@ -3222,12 +3221,12 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
     
     
     if (checkFiles(spec->buildRoot, check_fileList) > 0) {
-	rc = RPMRC_FAIL;
+	res = RPMRC_FAIL;
     }
-exit:
+
     check_fileList = freeStringBuf(check_fileList);
     _free(buildroot);
     _free(uniquearch);
     
-    return rc;
+    return res;
 }


### PR DESCRIPTION
Example situation:
in the spec file, I had: "%{_libdir}/pulse/gsettings-helper" and I got an error that this file had not been found,
but in reality that file existed but in %{_libexecdir}/pulse/gsettings-helper.
I had to _guess_ that it exists. According to RPM log, it was not obvious.

RPM 5 printed both not found and unpackaged files, and this RPM 4 behaviour seems to cause waste of a lot of time.

Let's print both not found and not packaged files and all other errors that have happened.

TODO: eliminate `*.debug` from the output. Current output is like this:
```
error: Installed (but unpackaged) file(s) found:
   /usr/lib/debug/usr/lib64/pulse-13.0/modules/module-gsettings.so-13.0-2.x86_64.debug
   /usr/lib/debug/usr/libexec/pulse/gsettings-helper-13.0-2.x86_64.debug
   /usr/libexec/pulse/gsettings-helper
    File not found: /tmp/abf/rpmbuild/BUILDROOT/pulseaudio-13.0-2.x86_64/usr/lib64/pulse/gsettings-helper
    Installed (but unpackaged) file(s) found:
   /usr/lib/debug/usr/lib64/pulse-13.0/modules/module-gsettings.so-13.0-2.x86_64.debug
   /usr/lib/debug/usr/libexec/pulse/gsettings-helper-13.0-2.x86_64.debug
   /usr/libexec/pulse/gsettings-helper
```

I do not know yet how to deal with `*.debug`, any ideas?
Also I am not sure about possible side effects.