### PR TITLE
Explicitly mention that the rpmio/ sub dir is under LGPL

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,8 +2,8 @@ RPM is covered under two separate licenses.
 
 The entire code base may be distributed under the terms of the GNU General
 Public License (GPL), which appears immediately below.  Alternatively,
-all of the source code in the lib subdirectory of the RPM source code
-distribution as well as any code derived from that code may instead be
+all of the source code in the lib and rpmio subdirectories of the RPM source
+code distribution as well as any code derived from that code may instead be
 distributed under the GNU Library General Public License (LGPL), at the
 choice of the distributor. The complete text of the LGPL appears
 at the bottom of this file.


### PR DESCRIPTION
As the code in the rpmio sub directory was split out of the lib sub dir
it is already under LGPL as "code derived from" "the source code in the
lib subdirectory" according to the license. But not having the sub directory
mentioned in the license confuses users and contributers.

So this change does not change the license of any code but only clearifies the
current situation.

Resolves: #516