### PR TITLE
Fix regression on v3 package handling on database rebuild

### DIFF
--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2557,7 +2557,7 @@ int rpmdbRebuild(const char * prefix, rpmts ts,
 	    /* Deleted entries are eliminated in legacy headers by copy. */
 	    if (headerIsEntry(h, RPMTAG_HEADERIMAGE)) {
 		Header nh = headerReload(headerCopy(h), RPMTAG_HEADERIMAGE);
-		rc = rpmdbAdd(newdb, h);
+		rc = rpmdbAdd(newdb, nh);
 		headerFree(nh);
 	    } else {
 		rc = rpmdbAdd(newdb, h);


### PR DESCRIPTION
Introduced in commit 27ea3f8624560bd158fc7bc801639310a0ffab10, the
wrong header is being added in case of v3 packages.

Fixes: #1017