### PR TITLE
Fix a minor memory leak on suppressed inhibition lock warning message

### DIFF
--- a/plugins/systemd_inhibit.c
+++ b/plugins/systemd_inhibit.c
@@ -52,12 +52,14 @@ static int inhibit(void)
 	dbus_message_unref(reply);
     }
     
-    if (dbus_error_is_set(&err)
-	&& !dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER)
-	&& !dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND)) {
-	rpmlog(RPMLOG_WARNING,
+    if (dbus_error_is_set(&err)) {
+	if (!dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) &&
+	    !dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND))
+	{
+	    rpmlog(RPMLOG_WARNING,
 	       "Unable to get systemd shutdown inhibition lock: %s\n",
 		err.message);
+	}
 	dbus_error_free(&err);
     }
 


### PR DESCRIPTION
Commit 708e61307bc3fd027b016fdf5a1d1a5274c1843c introduced a memory leak
on the error object: if the message is suppressed then the error object
is never freed. Test for the suppression conditions separately to fix.