### PR TITLE
Remove --sign from rpmbuild

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -217,10 +217,9 @@ rpmbuild alias --scm		--define '__scm !#:+' \
 rpmbuild alias --buildpolicy --define '__os_install_post %{_rpmconfigdir}/brp-!#:+' \
 	--POPTdesc=$"set buildroot <policy> (e.g. compress man pages)" \
 	--POPTargs=$"<policy>"
-# Minimally preserve rpmbuild's --sign functionality
-rpmbuild alias --sign \
-	--pipe 'rpm --addsign `grep ".*: .*\.rpm$"|cut -d: -f2` < "/dev/"`ps -p $$ -o tty | tail -n 1`' \
-	--POPTdesc=$"generate GPG signature (deprecated, use command rpmsign instead)"
+# Print error on rpmbuild --sign
+rpmbuild alias --sign --eval "%{error:rpmbuild --sign is no longer supported. Use the rpmsign command instead!}"
+	--POPTdesc=$"Obsolete, use command rpmsign instead!"
 rpmbuild alias --trace		--eval '%trace' \
 	--POPTdesc=$"trace macro expansion"
 rpmbuild alias --nodebuginfo	--define 'debug_package %{nil}' \


### PR DESCRIPTION
When splitting rpmsign from rpmbuild this command line parameter was kept
as an popt alias. But this limits what other parameter can be passed to
the rpmsign command in a difficult to understand way. In the end everyone
is better off using the rpmsign command directly.

Issue a error message stating the parameter is no longer supported

Resolves: #153