### PR TITLE
Introduce a new qualifier for meta dependencies (RhBug:1648721)

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -363,6 +363,7 @@ typedef const struct tokenBits_s {
  */
 static struct tokenBits_s const installScriptBits[] = {
     { "interp",		RPMSENSE_INTERP },
+    { "meta",		RPMSENSE_META },
     { "preun",		RPMSENSE_SCRIPT_PREUN },
     { "pre",		RPMSENSE_SCRIPT_PRE },
     { "postun",		RPMSENSE_SCRIPT_POSTUN },

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -692,7 +692,7 @@ retry:
     }
 
     /* Dont look at pre-requisites of already installed packages */
-    if (!adding && isInstallPreReq(dsflags) && !isErasePreReq(dsflags))
+    if (!adding && isTransientReq(dsflags))
 	goto exit;
 
     /* Handle rich dependencies */

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -206,6 +206,8 @@ static char * deptypeFormat(rpmtd td, char **emsg)
 	argvAdd(&sdeps, "config");
     if (item & RPMSENSE_MISSINGOK)
 	argvAdd(&sdeps, "missingok");
+    if (item & RPMSENSE_META)
+	argvAdd(&sdeps, "meta");
 
     if (sdeps) {
 	val = argvJoin(sdeps, ",");

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2243,8 +2243,7 @@ rpmRC tag2index(dbiIndex dbi, rpmTagVal rpmtag,
 	case RPMTAG_REQUIRENAME: {
 	    /* Filter out install prerequisites. */
 	    rpm_flag_t *rflag = rpmtdNextUint32(&reqflags);
-	    if (rflag && isInstallPreReq(*rflag) &&
-			 !isErasePreReq(*rflag))
+	    if (rflag && isTransientReq(*rflag))
 		continue;
 	    break;
 	    }

--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -90,7 +90,8 @@ typedef rpmFlags rpmsenseFlags;
 #define	isErasePreReq(_x)	((_x) & _ERASE_ONLY_MASK)
 #define	isUnorderedReq(_x)	((_x) & _UNORDERED_ONLY_MASK && \
 				 !((_x) & _FORCE_ORDER_ONLY_MASK))
-
+#define isTransientReq(_x)	(isInstallPreReq(_x) && \
+				 !isErasePreReq(_x))
 
 /** \ingroup rpmds
  * Return only those flags allowed for given type of dependencies

--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -49,7 +49,8 @@ enum rpmsenseFlags_e {
     RPMSENSE_TRIGGERPREIN = (1 << 25),	/*!< %triggerprein dependency. */
     RPMSENSE_KEYRING	= (1 << 26),
     /* bit 27 unused */
-    RPMSENSE_CONFIG	= (1 << 28)
+    RPMSENSE_CONFIG	= (1 << 28),
+    RPMSENSE_META	= (1 << 29),	/*!< meta dependency. */
 };
 
 typedef rpmFlags rpmsenseFlags;
@@ -73,6 +74,7 @@ typedef rpmFlags rpmsenseFlags;
     RPMSENSE_PRETRANS | \
     RPMSENSE_POSTTRANS | \
     RPMSENSE_PREREQ | \
+    RPMSENSE_META | \
     RPMSENSE_MISSINGOK)
 
 #define	_notpre(_x)		((_x) & ~RPMSENSE_PREREQ)
@@ -81,7 +83,7 @@ typedef rpmFlags rpmsenseFlags;
 #define	_ERASE_ONLY_MASK  \
     _notpre(RPMSENSE_SCRIPT_PREUN|RPMSENSE_SCRIPT_POSTUN)
 #define _UNORDERED_ONLY_MASK \
-    _notpre(RPMSENSE_RPMLIB|RPMSENSE_CONFIG|RPMSENSE_PRETRANS|RPMSENSE_POSTTRANS|RPMSENSE_SCRIPT_VERIFY)
+    _notpre(RPMSENSE_RPMLIB|RPMSENSE_CONFIG|RPMSENSE_PRETRANS|RPMSENSE_POSTTRANS|RPMSENSE_SCRIPT_VERIFY|RPMSENSE_META)
 #define _FORCE_ORDER_ONLY_MASK \
     _notpre(RPMSENSE_SCRIPT_PRE|RPMSENSE_SCRIPT_POST|RPMSENSE_SCRIPT_PREUN|RPMSENSE_SCRIPT_POSTUN)
 
@@ -91,7 +93,8 @@ typedef rpmFlags rpmsenseFlags;
 #define	isUnorderedReq(_x)	((_x) & _UNORDERED_ONLY_MASK && \
 				 !((_x) & _FORCE_ORDER_ONLY_MASK))
 #define isTransientReq(_x)	(isInstallPreReq(_x) && \
-				 !isErasePreReq(_x))
+				 !isErasePreReq(_x) &&	\
+				 !((_x) & RPMSENSE_META))
 
 /** \ingroup rpmds
  * Return only those flags allowed for given type of dependencies


### PR DESCRIPTION
Add a new "meta" qualifier for expressing dependencies that are not
concrete install- or run-time dependencies, and thus should not take
part in install ordering.

There are quite a lot of such dependencies in the wild, for example
versioned sub-package cross-dependencies are typically of this type
and a common source of unnecessary dependency loops. Another common
case are dependencies of meta-packages.