### PR TITLE
Fix isUnorderedReq() for multiple qualifiers

### DIFF
--- a/lib/rpmds.h
+++ b/lib/rpmds.h
@@ -82,12 +82,14 @@ typedef rpmFlags rpmsenseFlags;
     _notpre(RPMSENSE_SCRIPT_PREUN|RPMSENSE_SCRIPT_POSTUN)
 #define _UNORDERED_ONLY_MASK \
     _notpre(RPMSENSE_RPMLIB|RPMSENSE_CONFIG|RPMSENSE_PRETRANS|RPMSENSE_POSTTRANS|RPMSENSE_SCRIPT_VERIFY)
+#define _FORCE_ORDER_ONLY_MASK \
+    _notpre(RPMSENSE_SCRIPT_PRE|RPMSENSE_SCRIPT_POST|RPMSENSE_SCRIPT_PREUN|RPMSENSE_SCRIPT_POSTUN)
 
 #define	isLegacyPreReq(_x)  (((_x) & _ALL_REQUIRES_MASK) == RPMSENSE_PREREQ)
 #define	isInstallPreReq(_x)	((_x) & _INSTALL_ONLY_MASK)
 #define	isErasePreReq(_x)	((_x) & _ERASE_ONLY_MASK)
-#define	isUnorderedReq(_x)	((_x) & _UNORDERED_ONLY_MASK)
-
+#define	isUnorderedReq(_x)	((_x) & _UNORDERED_ONLY_MASK && \
+				 !((_x) & _FORCE_ORDER_ONLY_MASK))
 
 
 /** \ingroup rpmds


### PR DESCRIPTION
isUnorderedReq() returned True as soon as any qualifier that does not
require ordering is passed. But some qulifiers - basically the scriptlets
run during installation and erasure of the package - may still require
the dependency to be taken into account during ordering.

Now isUnorderedReq() returns 0 if any of those are also set.

Resolves: #1030