### PR TITLE
Add architecture macro for all RISC-V processors

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1155,6 +1155,13 @@ package or when debugging this package.\
 # arch macro for all supported PowerPC 64 processors
 %power64	ppc64 ppc64p7 ppc64le
 
+#------------------------------------------------------------------------------
+# arch macro for all supported RISC-V processors
+%riscv32	riscv32
+%riscv64	riscv64
+%riscv128	riscv128
+%riscv		%{riscv32} %{riscv64} %{riscv128}
+
 #------------------------------------------------------------------------
 # Use in %install to generate locale specific file lists. For example,
 #


### PR DESCRIPTION
This makes it easier to reference all RISC-V architectures supported by RPM in the same way that ARM and POWER architectures are.

Like ARM, RISC-V has a lot of subarchitecture variants, so having the structure in place to be able to reference all of them easily will be very useful in the near future.
