### PR TITLE
Small updates to the ARM macros

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1128,6 +1128,10 @@ package or when debugging this package.\
 %arm	%{arm32}
 
 #------------------------------------------------------------------------------
+# arch macro for all supported 64-bit ARM processors
+%arm64	aarch64
+
+#------------------------------------------------------------------------------
 # arch macro for 32-bit MIPS processors
 %mips32	mips mipsel mipsr6 mipsr6el
 

--- a/macros.in
+++ b/macros.in
@@ -1120,8 +1120,12 @@ package or when debugging this package.\
 %ix86   i386 i486 i586 i686 pentium3 pentium4 athlon geode
 
 #------------------------------------------------------------------------------
-# arch macro for all supported ARM processors
-%arm	armv3l armv4b armv4l armv4tl armv5tl armv5tel armv5tejl armv6l armv6hl armv7l armv7hl armv7hnl armv8l armv8hl armv8hnl armv8hcnl
+# arch macro for all supported 32-bit ARM processors
+%arm32	armv3l armv4b armv4l armv4tl armv5tl armv5tel armv5tejl armv6l armv6hl armv7l armv7hl armv7hnl armv8l armv8hl armv8hnl armv8hcnl
+
+#------------------------------------------------------------------------------
+# arch macro for all supported 32-bit ARM processors (legacy, use %%arm32 instead)
+%arm	%{arm32}
 
 #------------------------------------------------------------------------------
 # arch macro for 32-bit MIPS processors


### PR DESCRIPTION
This PR renames the `%arm` macro to `%arm32` and adds an `%arm64` macro as a simple alias for current and future 64-bit ARM architectures. This makes it consistent with other architectures we have, such as MIPS, POWER, and x86.

In order to maintain legacy compatibility, the `%arm` macro still exists as an alias for `%arm32` to prevent _massive_ breakage across Linux distributions that use it for ARM architecture handling.