### PR TITLE
elfdeps: Add full multiarch deps support

### DIFF
--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,3 +1,3 @@
-%__elf_provides		%{_rpmconfigdir}/elfdeps --provides
-%__elf_requires		%{_rpmconfigdir}/elfdeps --requires
+%__elf_provides		%{_rpmconfigdir}/elfdeps --provides --biarch-deps %{?__multiarch_deps:--multiarch-deps}
+%__elf_requires		%{_rpmconfigdir}/elfdeps --requires %{!?__multiarch_deps:--biarch-deps} %{?__multiarch_deps:--multiarch-deps}
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$


### PR DESCRIPTION
This changes elfdeps to emit dependency strings that contain full architecture names instead of just declaring whether something is `64bit`. This means that systems that allow more than two architectures to be installed on the same computer will actually be able to resolve library dependencies correctly.

This means that RPM dependencies would be compatible with system library install schemes like Debian's, where libraries are installed into subdirectories under `/usr/lib` that are named after the platform triple. It also allows for multiarch installations where foreign architecture packages are automatically relocated to be installed under a system root target location (e.g. `/usr/<triple>/lib(64)`) as is done in distributions like Exherbo.

As part of this change, the legacy behavior is now encoded behind the `--biarch-deps` flag, which is passed in for both Provides and Requires by default.

This behavior can be enabled by passing `--multiarch-deps` or by setting `%__multiarch_deps` to 1 in the spec or vendor configuration.

When setting `%__multiarch_deps` to 1 in the spec or vendor configuration, legacy Provides are still generated to allow distributions to support packages generated with the legacy ELF dependency generator behavior.