### PR TITLE
platform: Ensure empty buildroot for %install

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -68,6 +68,16 @@
 # ---- Build policy macros.
 #
 #---------------------------------------------------------------------
+#	Expanded at beginning of %install scriptlet.
+#
+
+%__spec_install_pre %{___build_pre}\
+    %{__rm} -rf "%{buildroot}"\
+    %{__mkdir_p} "%{dirname:%{buildroot}}"\
+    %{__mkdir} "%{buildroot}"\
+%{nil}
+
+#---------------------------------------------------------------------
 #	Expanded at end of %install scriptlet.
 #
 


### PR DESCRIPTION
This change ensures that any existing buildroot contents are wiped
and a fresh empty one is created for usage in `%install`.

Variations of this exist in virtually every RPM-based Linux distribution
for more than a decade. At this point, it is expected behavior everywhere
and it is amazing that it has not yet been put in RPM itself until now...

Credit goes to Michael Schroeder from openSUSE for the original work
and Tom Calloway for the variant adapted for Fedora that is the basis
for this change.