### PR TITLE
Fix POPT_ARG_STRING memleaks in librpmbuild

### DIFF
--- a/build/parseDescription.c
+++ b/build/parseDescription.c
@@ -19,8 +19,8 @@ int parseDescription(rpmSpec spec)
     int rc, argc;
     int arg;
     const char **argv = NULL;
-    const char *name = NULL;
-    const char *lang = RPMBUILD_DEFAULT_LANG;
+    char *name = NULL;
+    char *lang = NULL;
     const char *descr = "";
     poptContext optCon = NULL;
     struct poptOption optionsTable[] = {
@@ -52,7 +52,7 @@ int parseDescription(rpmSpec spec)
 
     if (poptPeekArg(optCon)) {
 	if (name == NULL)
-	    name = poptGetArg(optCon);
+	    name = xstrdup(poptGetArg(optCon));
 	if (poptPeekArg(optCon)) {
 	    rpmlog(RPMLOG_ERR, _("line %d: Too many names: %s\n"),
 		     spec->lineNum,
@@ -75,12 +75,15 @@ int parseDescription(rpmSpec spec)
     }
 
     if (addLangTag(spec, pkg->header,
-		   RPMTAG_DESCRIPTION, descr, lang)) {
+		   RPMTAG_DESCRIPTION, descr,
+		   lang ? lang : RPMBUILD_DEFAULT_LANG)) {
 	nextPart = PART_ERROR;
     }
      
 exit:
     freeStringBuf(sb);
+    free(lang);
+    free(name);
     free(argv);
     poptFreeContext(optCon);
     return nextPart;

--- a/build/parseFiles.c
+++ b/build/parseFiles.c
@@ -17,7 +17,7 @@ int parseFiles(rpmSpec spec)
     int rc, argc;
     int arg;
     const char ** argv = NULL;
-    const char *name = NULL;
+    char *name = NULL;
     int flag = PART_SUBNAME;
     poptContext optCon = NULL;
     struct poptOption optionsTable[] = {
@@ -52,7 +52,7 @@ int parseFiles(rpmSpec spec)
 
     if (poptPeekArg(optCon)) {
 	if (name == NULL)
-	    name = poptGetArg(optCon);
+	    name = xstrdup(poptGetArg(optCon));
 	if (poptPeekArg(optCon)) {
 	    rpmlog(RPMLOG_ERR, _("line %d: Too many names: %s\n"),
 		     spec->lineNum,
@@ -89,6 +89,7 @@ int parseFiles(rpmSpec spec)
 exit:
     rpmPopMacro(NULL, "license");
     free(argv);
+    free(name);
     poptFreeContext(optCon);
 	
     return res;

--- a/build/parsePolicies.c
+++ b/build/parsePolicies.c
@@ -19,7 +19,7 @@ int parsePolicies(rpmSpec spec)
     int rc, argc;
     int arg;
     const char **argv = NULL;
-    const char *name = NULL;
+    char *name = NULL;
     int flag = PART_SUBNAME;
     poptContext optCon = NULL;
 
@@ -50,7 +50,7 @@ int parsePolicies(rpmSpec spec)
 
     if (poptPeekArg(optCon)) {
 	if (name == NULL)
-	    name = poptGetArg(optCon);
+	    name = xstrdup(poptGetArg(optCon));
 	if (poptPeekArg(optCon)) {
 	    rpmlog(RPMLOG_ERR, _("line %d: Too many names: %s\n"),
 		   spec->lineNum, spec->line);
@@ -66,6 +66,7 @@ int parsePolicies(rpmSpec spec)
 
   exit:
     free(argv);
+    free(name);
     poptFreeContext(optCon);
 
     return res;

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -241,7 +241,7 @@ static int doSetupMacro(rpmSpec spec, const char *line)
     uint32_t num;
     int leaveDirs = 0, skipDefaultAction = 0;
     int createDir = 0, quietly = 0;
-    const char * dirName = NULL;
+    char * dirName = NULL;
     struct poptOption optionsTable[] = {
 	    { NULL, 'a', POPT_ARG_STRING, NULL, 'a',	NULL, NULL},
 	    { NULL, 'b', POPT_ARG_STRING, NULL, 'b',	NULL, NULL},
@@ -368,6 +368,7 @@ exit:
     freeStringBuf(before);
     freeStringBuf(after);
     poptFreeContext(optCon);
+    free(dirName);
     free(argv);
 
     return rc;
@@ -479,6 +480,9 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
 
 exit:
     argvFree(patchnums);
+    free(opt_b);
+    free(opt_d);
+    free(opt_o);
     free(argv);
     poptFreeContext(optCon);
     return rc;

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -100,9 +100,9 @@ int parseScript(rpmSpec spec, int parsePart)
     int arg;
     const char **argv = NULL;
     poptContext optCon = NULL;
-    const char *name = NULL;
-    const char *prog = "/bin/sh";
-    const char *file = NULL;
+    char *name = NULL;
+    char *prog = xstrdup("/bin/sh");
+    char *file = NULL;
     int priority = 1000000;
     struct poptOption optionsTable[] = {
 	{ NULL, 'p', POPT_ARG_STRING, &prog, 'p',	NULL, NULL},
@@ -326,7 +326,7 @@ int parseScript(rpmSpec spec, int parsePart)
 
     if (poptPeekArg(optCon)) {
 	if (name == NULL)
-	    name = poptGetArg(optCon);
+	    name = xstrdup(poptGetArg(optCon));
 	if (poptPeekArg(optCon)) {
 	    rpmlog(RPMLOG_ERR, _("line %d: Too many names: %s\n"),
 		     spec->lineNum,
@@ -465,6 +465,9 @@ exit:
     free(reqargs);
     freeStringBuf(sb);
     free(progArgv);
+    free(prog);
+    free(name);
+    free(file);
     free(argv);
     poptFreeContext(optCon);
     

--- a/build/policies.c
+++ b/build/policies.c
@@ -276,16 +276,20 @@ static rpmRC processPolicies(rpmSpec spec, Package pkg, int test)
 	}
 
 	if (writeModuleToHeader(mod, pkg) != RPMRC_OK) {
-	    freeModule(mod);
 	    goto exit;
 	}
 
-	freeModule(mod);
+	mod = freeModule(mod);
+	name = _free(name);
+	types = _free(types);
     }
 
     rc = RPMRC_OK;
 
   exit:
+    freeModule(mod);
+    free(name);
+    free(types);
 
     return rc;
 }


### PR DESCRIPTION
popt always returned malloc'ed memory for POPT_ARG_STRING items, but
for whatever historical reason rpm systematically passed const char *
pointers as targets, making them look non-freeable. Besides changing
just the types and adding free()'s, const-correctness requires extra
tweaks as there's mixed use from string literals and poptGetArg() which
does return const pointers.