### PR TITLE
Cleanups for running external programs

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -293,7 +293,6 @@ static int getOutputFrom(ARGV_t argv,
 	if (buildRoot)
 	    setenv("RPM_BUILD_ROOT", buildRoot, 1);
 
-	unsetenv("MALLOC_CHECK_");
 	execvp(argv[0], (char *const *)argv);
 	rpmlog(RPMLOG_ERR, _("Couldn't exec %s: %s\n"),
 		argv[0], strerror(errno));

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -294,7 +294,11 @@ static int getOutputFrom(ARGV_t argv,
 	    setenv("RPM_BUILD_ROOT", buildRoot, 1);
 
 	execvp(argv[0], (char *const *)argv);
-	rpmlog(RPMLOG_ERR, _("Couldn't exec %s: %s\n"),
+	/*
+	 * We are in a child which is a separate process, do not use rpmlog()
+	 * since locking is not safe across [v]fork.
+	 */
+	fprintf(stderr, _("Couldn't exec %s: %s\n"),
 		argv[0], strerror(errno));
 	_exit(EXIT_FAILURE);
     }

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -216,9 +216,6 @@ static void doScriptExec(ARGV_const_t argv, ARGV_const_t prefixes,
     }
 	
     if (chdir("/") == 0) {
-	/* XXX Don't mtrace into children. */
-	unsetenv("MALLOC_CHECK_");
-
 	xx = execv(argv[0], argv);
 	if (xx) {
 	    rpmlog(RPMLOG_ERR,

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -267,7 +267,11 @@ static int runGPG(sigTarget sigt, const char *sigfile)
 	if (!rc)
 	    rc = execve(av[0], av+1, environ);
 
-	rpmlog(RPMLOG_ERR, _("Could not exec %s: %s\n"), "gpg",
+	/*
+	 * We are in a child which is a separate process, do not use rpmlog()
+	 * since locking is not safe across [v]fork.
+	 */
+	fprintf(stderr, _("Could not exec %s: %s\n"), "gpg",
 			strerror(errno));
 	_exit(EXIT_FAILURE);
     }

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -262,7 +262,6 @@ static int runGPG(sigTarget sigt, const char *sigfile)
 	if (gpg_path && *gpg_path != '\0')
 	    (void) setenv("GNUPGHOME", gpg_path, 1);
 
-	unsetenv("MALLOC_CHECK_");
 	cmd = rpmExpand("%{?__gpg_sign_cmd}", NULL);
 	rc = poptParseArgvString(cmd, NULL, (const char ***)&av);
 	if (!rc)


### PR DESCRIPTION
Do not unset $MALLOC_CHECK_ for external processes
Do not use rpmlog() after fork (locking is not safe across fork)