### PR TITLE
Move <dlfcn.h> out of system.h

### DIFF
--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -8,6 +8,8 @@
 #include <rpm/rpmts.h>
 
 #include "lib/rpmplugins.h"
+#include <dlfcn.h>
+
 
 #define STR1(x) #x
 #define STR(x) STR1(x)

--- a/system.h
+++ b/system.h
@@ -125,6 +125,4 @@ extern int fdatasync(int fildes);
 
 #include "misc/fnmatch.h"
 
-#include <dlfcn.h>
-
 #endif	/* H_SYSTEM */


### PR DESCRIPTION
It is needed in lib/rpmplugins.c only anyway.