### PR TITLE
Add support for macro-only dependency generators

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1813,6 +1813,29 @@ rpmDefineMacro(rpmMacroContext mc, const char * macro, int level)
     return rc;
 }
 
+int rpmMacroIsDefined(rpmMacroContext mc, const char *n)
+{
+    int defined = 0;
+    if ((mc = rpmmctxAcquire(mc)) != NULL) {
+	if (findEntry(mc, n, 0, NULL))
+	    defined = 1;
+	rpmmctxRelease(mc);
+    }
+    return defined;
+}
+
+int rpmMacroIsParametric(rpmMacroContext mc, const char *n)
+{
+    int parametric = 0;
+    if ((mc = rpmmctxAcquire(mc)) != NULL) {
+	rpmMacroEntry *mep = findEntry(mc, n, 0, NULL);
+	if (mep && (*mep)->opts)
+	    parametric = 1;
+	rpmmctxRelease(mc);
+    }
+    return parametric;
+}
+
 void
 rpmLoadMacros(rpmMacroContext mc, int level)
 {

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -122,6 +122,22 @@ int	rpmPopMacro	(rpmMacroContext mc, const char * n);
 int	rpmDefineMacro	(rpmMacroContext mc, const char * macro,
 				int level);
 
+/*
+ * Test whether a macro is defined
+ * @param mc		macro context (NULL uses global context).
+ * @param n		macro name
+ * @return		1 if defined, 0 if not
+ */
+int rpmMacroIsDefined(rpmMacroContext mc, const char *n);
+
+/*
+ * Test whether a macro is parametric (ie takes arguments)
+ * @param mc		macro context (NULL uses global context).
+ * @param n		macro name
+ * @return		1 if parametric, 0 if not
+ */
+int rpmMacroIsParametric(rpmMacroContext mc, const char *n);
+
 /** \ingroup rpmmacro
  * Load macros from specific context into global context.
  * @param mc		macro context (NULL does nothing).

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -508,6 +508,21 @@ runroot rpmbuild -bb --quiet \
 ])
 AT_CLEANUP
 
+AT_SETUP([Dependency generation 4])
+AT_KEYWORDS([build])
+AT_CHECK([
+
+runroot rpmbuild -bb --quiet \
+		--define '__script_requires() foo(%{basename:%{1}})' \
+		/data/SPECS/shebang.spec
+runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^rpmlib
+],
+[0],
+[foo(shebang)
+],
+[])
+AT_CLEANUP
+
 # ------------------------------
 # Test spec query functionality
 AT_SETUP([rpmspec query 1])


### PR DESCRIPTION
In some cases generators are remarkably simple, such as just echoing back the basename of the file in some namespace such as foo(lib.so), and forking out a shell to perform such a mundane task is both hideously slow and plain dumb, when we have quite some string processing facilities and even a full-blown programming language embedded in rpm itself.
    
This adds support for using macro functions as generators: if the generator macro is a parametric macro, then we call that macro with the file name as the first argument instead of shelling out, and the expansion of the macro is used as the output. Multiple lines in output are allowed, and generator styles can be mixed freely (eg shell out for provides but use macro function for requires etc).
