### PR TITLE
Fixup few issues found by PVS

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -72,7 +72,7 @@ static rpmRC addOrAppendListEntry(Header h, rpmTagVal tag, const char * line)
     }
     if (argc) 
 	headerPutStringArray(h, tag, argv, argc);
-    argv = _free(argv);
+    _free(argv);
 
     return RPMRC_OK;
 }

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1319,7 +1319,7 @@ static void printDeps(rpmfc fc)
 	    if (!((Flags & dm->mask) ^ dm->xormask))
 		continue;
 	    if (bingo == 0) {
-		rpmlog(RPMLOG_NOTICE, "%s:", (dm->msg ? dm->msg : ""));
+		rpmlog(RPMLOG_NOTICE, "%s:", dm->msg);
 		bingo = 1;
 	    }
 	    if ((DNEVR = rpmdsDNEVR(ds)) == NULL)

--- a/tools/rpmgraph.c
+++ b/tools/rpmgraph.c
@@ -207,7 +207,7 @@ exit:
         pkgURL[i] = _free(pkgURL[i]);
     pkgState = _free(pkgState);
     pkgURL = _free(pkgURL);
-    argv = _free(argv);
+    _free(argv);
 
     return rc;
 }


### PR DESCRIPTION
build/files.c:
* Expression 'rc == 0' is always true.
* The 'path' variable is assigned but is not used by the end of the function.

build/parsePreamble.c:
* The 'argv' variable is assigned but is not used by the end of the function.

tools/rpmgraph.c:
* The 'argv' variable is assigned but is not used by the end of the function.

build/rpmfc.c:
* Expression 'dm->msg' is always true.

Signed-off-by: Igor Raits <i.gnatenko.brain@gmail.com>