### PR TITLE
A saner way for marco argument escaping

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2234,7 +2234,7 @@ int readManifest(rpmSpec spec, const char *path, const char *descr, int flags,
 	goto exit;
     }
 
-    rpmPushMacro(spec->macros, "__file_name", NULL, fn, RMIL_SPEC);
+    rpmPushMacroFlags(spec->macros, "__file_name", NULL, fn, RMIL_SPEC, RPMMACRO_LITERAL);
 
     nlines = 0;
     while (fgets(buf, sizeof(buf), fd)) {
@@ -2279,7 +2279,7 @@ static rpmRC readFilesManifest(rpmSpec spec, Package pkg, const char *path)
 	flags |= ALLOW_EMPTY;
 
     /* XXX unmask %license while parsing files manifest*/
-    rpmPushMacro(spec->macros, "license", NULL, "%%license", RMIL_SPEC);
+    rpmPushMacroFlags(spec->macros, "license", NULL, "%license", RMIL_SPEC, RPMMACRO_LITERAL);
 
     nlines = readManifest(spec, path, "%files", flags, &(pkg->fileList), NULL);
 

--- a/build/parseFiles.c
+++ b/build/parseFiles.c
@@ -27,7 +27,7 @@ int parseFiles(rpmSpec spec)
     };
 
     /* XXX unmask %license while parsing %files */
-    rpmPushMacro(spec->macros, "license", NULL, "%%license", RMIL_SPEC);
+    rpmPushMacroFlags(spec->macros, "license", NULL, "%license", RMIL_SPEC, RPMMACRO_LITERAL);
 
     if ((rc = poptParseArgvString(spec->line, &argc, &argv))) {
 	rpmlog(RPMLOG_ERR, _("line %d: Error parsing %%files: %s\n"),

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -302,7 +302,7 @@ static int doSetupMacro(rpmSpec spec, const char *line)
 		  headerGetString(spec->packages->header, RPMTAG_NAME),
 		  headerGetString(spec->packages->header, RPMTAG_VERSION));
     }
-    rpmPushMacro(spec->macros, "buildsubdir", NULL, spec->buildSubdir, RMIL_SPEC);
+    rpmPushMacroFlags(spec->macros, "buildsubdir", NULL, spec->buildSubdir, RMIL_SPEC, RPMMACRO_LITERAL);
     
     /* cd to the build dir */
     {	char * buildDir = rpmGenPath(spec->rootDir, "%{_builddir}", "");

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -144,7 +144,7 @@ static OFI_t * pushOFI(rpmSpec spec, const char *fn)
     ofi->readPtr = NULL;
     ofi->next = spec->fileStack;
 
-    rpmPushMacro(spec->macros, "__file_name", NULL, fn, RMIL_SPEC);
+    rpmPushMacroFlags(spec->macros, "__file_name", NULL, fn, RMIL_SPEC, RPMMACRO_LITERAL);
 
     spec->fileStack = ofi;
     return spec->fileStack;
@@ -202,7 +202,7 @@ int specExpand(rpmSpec spec, int lineno, const char *sbuf,
     int rc;
 
     snprintf(lnobuf, sizeof(lnobuf), "%d", lineno);
-    rpmPushMacro(spec->macros, "__file_lineno", NULL, lnobuf, RMIL_SPEC);
+    rpmPushMacroFlags(spec->macros, "__file_lineno", NULL, lnobuf, RMIL_SPEC, RPMMACRO_LITERAL);
 
     rc = (rpmExpandMacros(spec->macros, sbuf, obuf, 0) < 0);
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1657,7 +1657,7 @@ static int loadMacroFile(rpmMacroContext mc, const char * fn)
     if (fd == NULL)
 	goto exit;
 
-    pushMacro(mc, "__file_name", NULL, fn, RMIL_MACROFILES, ME_NONE);
+    pushMacro(mc, "__file_name", NULL, fn, RMIL_MACROFILES, ME_LITERAL);
 
     buf[0] = '\0';
     while ((nlines = rdcl(buf, blen, fd)) > 0) {
@@ -1673,7 +1673,7 @@ static int loadMacroFile(rpmMacroContext mc, const char * fn)
 	n++;	/* skip % */
 
 	snprintf(lnobuf, sizeof(lnobuf), "%d", lineno);
-	pushMacro(mc, "__file_lineno", NULL, lnobuf, RMIL_MACROFILES, ME_NONE);
+	pushMacro(mc, "__file_lineno", NULL, lnobuf, RMIL_MACROFILES, ME_LITERAL);
 	if (defineMacro(mc, n, RMIL_MACROFILES))
 	    nfailed++;
 	popMacro(mc, "__file_lineno");

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1740,13 +1740,20 @@ rpmDumpMacroTable(rpmMacroContext mc, FILE * fp)
     rpmmctxRelease(mc);
 }
 
+int rpmPushMacroFlags(rpmMacroContext mc,
+	      const char * n, const char * o, const char * b,
+	      int level, rpmMacroFlags flags)
+{
+    mc = rpmmctxAcquire(mc);
+    pushMacro(mc, n, o, b, level, flags & RPMMACRO_LITERAL ? ME_LITERAL : ME_NONE);
+    rpmmctxRelease(mc);
+    return 0;
+}
+
 int rpmPushMacro(rpmMacroContext mc,
 	      const char * n, const char * o, const char * b, int level)
 {
-    mc = rpmmctxAcquire(mc);
-    pushMacro(mc, n, o, b, level, ME_NONE);
-    rpmmctxRelease(mc);
-    return 0;
+    return rpmPushMacroFlags(mc, n, o, b, level, RPMMACRO_DEFAULT);
 }
 
 int rpmPopMacro(rpmMacroContext mc, const char * n)

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1453,41 +1453,24 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	    }
 	}
 
-	/* XXX Special processing for flags */
-	if (*f == '-') {
-	    if ((me == NULL && !negate) ||	/* Without -f, skip %{-f...} */
-		    (me != NULL && negate)) {	/* With -f, skip %{!-f...} */
+	/* XXX Special processing for flags and existance test */
+	if (*f == '-' || chkexist) {
+	    if ((me == NULL && !negate) ||	/* Without existance, skip %{?...} */
+		    (me != NULL && negate)) {	/* With existance, skip %{!?...} */
 		s = se;
 		continue;
 	    }
 
-	    if (g && g < ge) {		/* Expand X in %{-f:X} */
+	    if (g && g < ge) {		/* Expand X in %{...:X} */
 		expandMacro(mb, g, gn);
 	    } else
-		if (me && me->body && *me->body) {/* Expand %{-f}/%{-f*} */
+		if (me && me->body && *me->body) {/* Expand macro body */
 		    expandMacro(mb, me->body, 0);
 		}
 	    s = se;
 	    continue;
 	}
 
-	/* XXX Special processing for macro existence */
-	if (chkexist) {
-	    if ((me == NULL && !negate) ||	/* Without -f, skip %{?f...} */
-		    (me != NULL && negate)) {	/* With -f, skip %{!?f...} */
-		s = se;
-		continue;
-	    }
-	    if (g && g < ge) {		/* Expand X in %{?f:X} */
-		expandMacro(mb, g, gn);
-	    } else
-		if (me && me->body && *me->body) { /* Expand %{?f}/%{?f*} */
-		    expandMacro(mb, me->body, 0);
-		}
-	    s = se;
-	    continue;
-	}
-	
 	if (me == NULL) {	/* leave unknown %... as is */
 	    /* XXX hack to permit non-overloaded %foo to be passed */
 	    c = '%';	/* XXX only need to save % */

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -52,6 +52,11 @@ extern const char * macrofiles;
 /* rpm expression parser flags */
 #define RPMEXPR_EXPAND		(1 << 0)	/*!< expand primary terms */
 
+typedef enum rpmMacroFlags_e {
+    RPMMACRO_DEFAULT	= 0,
+    RPMMACRO_LITERAL	= (1 << 0),		/*!< do not expand body of macro */
+} rpmMacroFlags;
+
 /** \ingroup rpmmacro
  * Print macros to file stream.
  * @param mc		macro context (NULL uses global context).
@@ -83,6 +88,21 @@ int	rpmExpandMacros	(rpmMacroContext mc, const char * sbuf,
 int	rpmPushMacro	(rpmMacroContext mc, const char * n,
 				const char * o,
 				const char * b, int level);
+
+/** \ingroup rpmmacro
+ * Push macro to context.
+ * @param mc		macro context (NULL uses global context).
+ * @param n		macro name
+ * @param o		macro parameters
+ * @param b		macro body
+ * @param level		macro recursion level (0 is entry API)
+ * @param flags		macro flags
+ * @return		0 on success
+ */
+int	rpmPushMacroFlags	(rpmMacroContext mc, const char * n,
+					const char * o,
+					const char * b, int level,
+					rpmMacroFlags flags);
 
 /** \ingroup rpmmacro
  * Pop macro from context.


### PR DESCRIPTION
This adds a ME_NOEXPAND macro flag that turns off body expansion.

This is much simpler than the weird % character doubling. It's also a bit faster
because there's less calls to expandMacro().