### PR TITLE
Bunch of macro fixes and cleanups

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1166,7 +1166,6 @@ doFoo(MacroBuf mb, int chkexist, int negate, const char * f, size_t fn,
     char *b = NULL;
     int verbose = (rpmIsVerbose() != 0);
     int expand = (g != NULL && gn > 0);
-    int expandagain = 1;
 
     /* Don't expand %{verbose:...} argument on false condition */
     if (STREQ("verbose", f, fn) && (verbose == negate))
@@ -1224,7 +1223,6 @@ doFoo(MacroBuf mb, int chkexist, int negate, const char * f, size_t fn,
 	if (expr) {
 	    free(buf);
 	    b = buf = expr;
-	    expandagain = 0;
 	} else {
 	    mb->error = 1;
 	}
@@ -1242,11 +1240,7 @@ doFoo(MacroBuf mb, int chkexist, int negate, const char * f, size_t fn,
     }
 
     if (b) {
-	if (expandagain) {
-	    (void) expandMacro(mb, b, 0);
-	} else {
-	    mbAppendStr(mb, b);
-	}
+	mbAppendStr(mb, b);
     }
     free(buf);
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -263,6 +263,7 @@ AT_CHECK([
 runroot rpm --eval "%{dirname}"
 runroot rpm --eval "%{dirname:}"
 runroot rpm --eval "%{dirname:dir}"
+runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
 runroot rpm --eval "%{getncpus:}"
@@ -273,6 +274,7 @@ runroot rpm --eval "%{dump:foo}"
 [1],
 [
 dir
+/hello/%%
 
 ],
 [error: %dirname: argument expected

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -189,7 +189,7 @@ runroot rpm \
 ])
 AT_CLEANUP
 
-AT_SETUP([uncompress macro])
+AT_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 AT_CHECK([
 runroot rpm \
@@ -201,6 +201,18 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([uncompress macro 2])
+AT_KEYWORDS([macros])
+AT_CHECK([
+echo xxxxxxxxxxxxxxxxxxxxxxxxx > ${RPMTEST}/tmp/"some%%ath"
+runroot rpm \
+    --eval "%{uncompress:/tmp/some%%%%ath}"
+],
+[0],
+[/usr/bin/cat /tmp/some%%ath
+])
+
+AT_CLEANUP
 AT_SETUP([basename macro])
 AT_KEYWORDS([macros])
 AT_CHECK([
@@ -251,6 +263,8 @@ AT_CHECK([
 runroot rpm --eval "%{dirname}"
 runroot rpm --eval "%{dirname:}"
 runroot rpm --eval "%{dirname:dir}"
+runroot rpm --eval "%{uncompress}"
+runroot rpm --eval "%{uncompress:}"
 runroot rpm --eval "%{getncpus:}"
 runroot rpm --eval "%{getncpus:5}"
 runroot rpm --eval "%{define:}"
@@ -259,8 +273,10 @@ runroot rpm --eval "%{dump:foo}"
 [1],
 [
 dir
+
 ],
 [error: %dirname: argument expected
+error: %uncompress: argument expected
 error: %getncpus: unexpected argument
 error: %getncpus: unexpected argument
 error: %define: unexpected argument


### PR DESCRIPTION
Fix double-expansion of arguments to built-in macros (except for %{expand:..} whose sole purpose is to double-expand) refactoring the more special cases out of doFoo() and fixing misc other related bugs in the process. Details in the individual commit messages.