### PR TITLE
Make parametric macro arguments available as native Lua table

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -486,6 +486,26 @@ runroot rpm --eval '%{lua:print(5*5)}'
 ])
 AT_CLEANUP
 
+AT_SETUP([lua macro arguments])
+AT_KEYWORDS([macros lua])
+AT_CHECK([
+AT_SKIP_IF([$LUA_DISABLED])
+[
+runroot rpm --define "foo() %{lua:for i, a in ipairs(arg) do print('arg '..i..': '..arg[i]..'\\\n') end}" \
+	--eval "%foo a b" \
+	--eval "%foo 6 %{quote:5 4} 3"
+]],
+[0],
+[arg 1: a
+arg 2: b
+
+arg 1: 6
+arg 2: 5 4
+arg 3: 3
+
+])
+AT_CLEANUP
+
 AT_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 AT_CHECK([


### PR DESCRIPTION
Accessing macro arguments via rpm.expand("%1") etc is tedious,
non-intuitive and subject to all sorts of expansion issues. Make
the argument macros available as a native Lua table (named "arg"
for consistency with -p <lua> scriptlet arguments) with their
literal values - the arguments are already macro-expanded, so if
further expansion is desired that is entirely up to the caller.

rpmluav indexes unfortunately start at 1, so this leaves out the
%0 macro from the arguments for sanity with the rest of the values.