### PR TITLE
Implement %{macrobody:...} built-in for retrieving the literal macro body

### DIFF
--- a/doc/manual/macros
+++ b/doc/manual/macros
@@ -73,6 +73,8 @@ to perform useful operations. The current list is
 	%undefine ...	undefine a macro
 	%global ...	define a macro whose body is available in global context
 
+	%{macrobody:...}	literal body of a macro
+
 	%{basename:...}	basename(1) macro analogue
 	%{dirname:...}	dirname(1) macro analogue
 	%{suffix:...}	expand to suffix part of a file name

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -257,6 +257,23 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([macrobody macro])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --define "somedir %{_exec_prefix}/%{_lib}" \
+    --eval "%{macrobody:somedir}"
+runroot rpm \
+    --define "something somedir" \
+    --define "somedir %{_exec_prefix}/%{_lib}" \
+    --eval "%{macrobody:%{something}}"
+],
+[0],
+[%{_exec_prefix}/%{_lib}
+%{_exec_prefix}/%{_lib}
+])
+AT_CLEANUP
+
 AT_SETUP([builtin macro arguments])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
Fixes: #582