### PR TITLE
Use autodetect for _minimize_writes and _flush_io

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1471,9 +1471,27 @@ static int rpmtsSetup(rpmts ts, rpmprobFilterFlags ignoreSet)
 static void setSSD(int enable)
 {
     if (enable) {
-	rpmlog(RPMLOG_DEBUG, "optimizing for non-rotational disks\n");
-	rpmPushMacro(NULL, "_minimize_writes", NULL, "1", 0);
-	rpmPushMacro(NULL, "_flush_io", NULL, "1", 0);
+	/* Push a value no matter what */
+	if (!rpmMacroIsDefined(NULL, "_minimize_writes") ||
+	    rpmExpandNumeric("%{_minimize_writes}") == -1 ) {
+	    rpmlog(RPMLOG_DEBUG,
+		   "enabling _minimize_writes for non-rotational disks\n");
+	    rpmPushMacro(NULL, "_minimize_writes", NULL, "1", 0);
+	} else {
+	    char * val = rpmExpand("%{_minimize_writes}", NULL);
+	    rpmPushMacro(NULL, "_minimize_writes", NULL, val, 0);
+	    _free(val);
+	}
+	if (!rpmMacroIsDefined(NULL, "_flush_io") ||
+	    rpmExpandNumeric("%{_flush_io}") == -1) {
+	    rpmlog(RPMLOG_DEBUG,
+		   "enabling _flush_io for non-rotational disks\n");
+	    rpmPushMacro(NULL, "_flush_io", NULL, "1", 0);
+	} else {
+	    char * val = rpmExpand("%{_flush_io}", NULL);
+	    rpmPushMacro(NULL, "_flush_io", NULL, val, 0);
+	    _free(val);
+	}
     } else {
 	rpmPopMacro(NULL, "_minimize_writes");
 	rpmPopMacro(NULL, "_flush_io");

--- a/macros.in
+++ b/macros.in
@@ -745,12 +745,14 @@ package or when debugging this package.\
 %_pkgverify_flags 0x0
 
 # Set to 1 to minimize writing (at the cost of more reads) to
-# conserve eg SSD disks.
-%_minimize_writes      0
+# conserve eg SSD disks. Set to -1 for enabling when runnning on SSDs.
+# Set to 0 for always off.
+%_minimize_writes      -1
 
 # Set to 1 to flush file IO during transactions (at a severe cost in
-# performance for rotational disks)
-#%_flush_io	0
+# performance for rotational disks). Set to -1 for enabling when running on
+# SSDs. Set to 0 for always off.
+%_flush_io	-1
 
 # Set to 1 to have IMA signatures written also on %config files.
 # Note that %config files may be changed and therefore end up with


### PR DESCRIPTION
This is a take on #949 as described in https://github.com/rpm-software-management/rpm/pull/949#issuecomment-580354653
Original Patch is rebased to have access to the new rpmMacroIsDefined() function.
Patches should probably be squashed before merging. Kept them separate to make review easier.
Resolves: #949