### PR TITLE
Reset global macro state after each spec query/parse

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -564,12 +564,17 @@ int rpmcliArgIter(rpmts ts, QVA_t qva, ARGV_const_t argv)
     }
     case RPMQV_SPECRPMS:
     case RPMQV_SPECBUILTRPMS:
-    case RPMQV_SPECSRPM:
+    case RPMQV_SPECSRPM: {
+	char *target = rpmExpand("%{_target}", NULL);
 	for (ARGV_const_t arg = argv; arg && *arg; arg++) {
 	    ec += ((qva->qva_specQuery != NULL)
 		    ? qva->qva_specQuery(ts, qva, *arg) : 1);
+	    rpmFreeMacros(NULL);
+	    rpmReadConfigFiles(rpmcliRcfile, target);
 	}
+	free(target);
 	break;
+    }
     default:
 	for (ARGV_const_t arg = argv; arg && *arg; arg++) {
 	    int ecLocal;

--- a/rpmspec.c
+++ b/rpmspec.c
@@ -80,18 +80,22 @@ int main(int argc, char *argv[])
 
     case MODE_PARSE: {
 	const char * spath;
+	char *target = rpmExpand("%{_target}", NULL);
 	if (!poptPeekArg(optCon))
 	    argerror(_("no arguments given for parse"));
 
 	while ((spath = poptGetArg(optCon)) != NULL) {
 	    rpmSpec spec = rpmSpecParse(spath, (RPMSPEC_ANYARCH|RPMSPEC_FORCE), NULL);
-	    if (spec == NULL) {
+	    if (spec) {
+		fprintf(stdout, "%s", rpmSpecGetSection(spec, RPMBUILD_NONE));
+		rpmSpecFree(spec);
+	    } else {
 		ec++;
-		continue;
 	    }
-	    fprintf(stdout, "%s", rpmSpecGetSection(spec, RPMBUILD_NONE));
-	    rpmSpecFree(spec);
+	    rpmFreeMacros(NULL);
+	    rpmReadConfigFiles(rpmcliRcfile, target);
 	}
+	free(target);
 	break;
     }
 


### PR DESCRIPTION
Parsing a spec, even unsuccessfully, will affect the global macro
state in any number of ways that may affect the following operations
in unpredictable ways. Lacking any saner way to do this, reset the
entire global macro state after each spec parse in rpmspec and spec
query code (rpmbuild already does this) while maintaining possible
cli-specified target and rcfile.