### PR TITLE
Speed up dependency solving by using pool ids

### DIFF
--- a/lib/depends.c
+++ b/lib/depends.c
@@ -881,22 +881,23 @@ static void checkInstFileDeps(rpmts ts, depCache dcache, rpmte te,
     filedepHashGetEntry(cache, basename, &dirnames, &ndirnames, NULL);
     if (!ndirnames)
 	return;
-    if (!fpc)
-	*fpcp = fpc = fpCacheCreate(1001, NULL);
     dirname = rpmfiDN(fi);
-    fpLookup(fpc, dirname, basename, &fp);
     for (i = 0; i < ndirnames; i++) {
 	char *fpdep = 0;
 	const char *dep;
 	if (!strcmp(dirnames[i], dirname)) {
 	    dep = rpmfiFN(fi);
-	} else if (fpLookupEquals(fpc, fp, dirnames[i], basename)) {
+	} else {
+	    if (!fpc)
+		*fpcp = fpc = fpCacheCreate(1001, NULL);
+	    if (!fp)
+		fpLookup(fpc, dirname, basename, &fp);
+	    if (!fpLookupEquals(fpc, fp, dirnames[i], basename))
+		continue;
 	    fpdep = rmalloc(strlen(dirnames[i]) + strlen(basename) + 1);
 	    strcpy(fpdep, dirnames[i]);
 	    strcat(fpdep, basename);
 	    dep = fpdep;
-	} else {
-	    continue;
 	}
 	checkInstDeps(ts, dcache, te, depTag, dep, NULL, is_not);
 	_free(fpdep);

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -384,10 +384,8 @@ rpmal rpmtsCreateAl(rpmts ts, rpmElementTypes types)
     if (ts) {
 	rpmte p;
 	rpmtsi pi;
-	rpmstrPool tspool = rpmtsPool(ts);
 
-	al = rpmalCreate(tspool, (rpmtsNElements(ts) / 4) + 1, rpmtsFlags(ts),
-				rpmtsColor(ts), rpmtsPrefColor(ts));
+	al = rpmalCreate(ts, (rpmtsNElements(ts) / 4) + 1);
 	pi = rpmtsiInit(ts);
 	while ((p = rpmtsiNext(pi, types)))
 	    rpmalAdd(al, p);
@@ -455,8 +453,7 @@ static int addPackage(rpmts ts, Header h,
     }
     
     if (tsmem->addedPackages == NULL) {
-	tsmem->addedPackages = rpmalCreate(rpmtsPool(ts), 5, rpmtsFlags(ts),
-					   tscolor, rpmtsPrefColor(ts));
+	tsmem->addedPackages = rpmalCreate(ts, 5);
     }
     rpmalAdd(tsmem->addedPackages, p);
 

--- a/lib/fprint.c
+++ b/lib/fprint.c
@@ -248,6 +248,15 @@ int fpLookup(fingerPrintCache cache,
     return doLookup(cache, dirName, baseName, *fp);
 }
 
+int fpLookupId(fingerPrintCache cache,
+               rpmsid dirNameId, rpmsid baseNameId,
+               fingerPrint **fp)
+{
+    if (*fp == NULL)
+	*fp = xcalloc(1, sizeof(**fp));
+    return doLookupId(cache, dirNameId, baseNameId, *fp);
+}
+
 /**
  * Return hash value for a finger print.
  * Hash based on dev and inode only!
@@ -299,6 +308,14 @@ int fpLookupEquals(fingerPrintCache cache, fingerPrint *fp,
 {
     struct fingerPrint_s ofp;
     doLookup(cache, dirName, baseName, &ofp);
+    return FP_EQUAL(*fp, ofp);
+}
+
+int fpLookupEqualsId(fingerPrintCache cache, fingerPrint *fp,
+	          rpmsid dirNameId, rpmsid baseNameId)
+{
+    struct fingerPrint_s ofp;
+    doLookupId(cache, dirNameId, baseNameId, &ofp);
     return FP_EQUAL(*fp, ofp);
 }
 

--- a/lib/fprint.h
+++ b/lib/fprint.h
@@ -57,6 +57,10 @@ int fpLookupEquals(fingerPrintCache cache, fingerPrint * fp,
 	           const char * dirName, const char * baseName);
 
 RPM_GNUC_INTERNAL
+int fpLookupEqualsId(fingerPrintCache cache, fingerPrint * fp,
+	             rpmsid dirNameId, rpmsid baseNameId);
+
+RPM_GNUC_INTERNAL
 const char *fpEntryDir(fingerPrintCache cache, fingerPrint *fp);
 
 RPM_GNUC_INTERNAL
@@ -74,6 +78,19 @@ RPM_GNUC_INTERNAL
 int fpLookup(fingerPrintCache cache,
 	     const char * dirName, const char * baseName,
 	     fingerPrint **fp);
+
+/**
+ * Return finger print of a file path given as ids.
+ * @param cache		pointer to fingerprint cache
+ * @param dirNameId	id of leading directory name of file path
+ * @param baseNameId	id of base name of file path
+ * @retval fp		pointer of fingerprint struct to fill out
+ * @return		0 on success
+ */
+RPM_GNUC_INTERNAL
+int fpLookupId(fingerPrintCache cache,
+	       rpmsid dirNameId, rpmsid BaseNameId,
+	       fingerPrint **fp);
 
 /**
  * Compare two finger print entries.

--- a/lib/rpmal.c
+++ b/lib/rpmal.c
@@ -421,8 +421,8 @@ static rpmte * rpmalAllFileSatisfiesDepend(const rpmal al, const char *fileName,
 	    rpmsid dirName = rpmstrPoolIdn(al->pool, fileName, bnStart, 1);
 
 	    if (!al->fpc)
-		al->fpc = fpCacheCreate(1001, NULL);
-	    fpLookup(al->fpc, rpmstrPoolStr(al->pool, dirName), fileName + bnStart, &fp);
+		al->fpc = fpCacheCreate(1001, al->pool);
+	    fpLookupId(al->fpc, dirName, baseName, &fp);
 
 	    for (found = i = 0; i < resultCnt; i++) {
 		availablePackage alp = al->list + result[i].pkgNum;
@@ -432,7 +432,7 @@ static rpmte * rpmalAllFileSatisfiesDepend(const rpmal al, const char *fileName,
 		if (filterds && rpmteDS(alp->p, rpmdsTagN(filterds)) == filterds)
 		    continue;
 		if (result[i].dirName != dirName &&
-		    !fpLookupEquals(al->fpc, fp, rpmstrPoolStr(al->pool, result[i].dirName), fileName + bnStart))
+		    !fpLookupEqualsId(al->fpc, fp, result[i].dirName, baseName))
 		    continue;
 
 		ret[found] = alp->p;

--- a/lib/rpmal.c
+++ b/lib/rpmal.c
@@ -14,6 +14,7 @@
 #include "lib/rpmte_internal.h"
 #include "lib/rpmds_internal.h"
 #include "lib/rpmfi_internal.h"
+#include "lib/rpmts_internal.h"
 
 #include "debug.h"
 
@@ -92,26 +93,22 @@ static void rpmalFreeIndex(rpmal al)
     al->fpc = fpCacheFree(al->fpc);
 }
 
-rpmal rpmalCreate(rpmstrPool pool, int delta, rpmtransFlags tsflags,
-		  rpm_color_t tscolor, rpm_color_t prefcolor)
+rpmal rpmalCreate(rpmts ts, int delta)
 {
     rpmal al = xcalloc(1, sizeof(*al));
 
-    /* transition time safe-guard */
-    assert(pool != NULL);
-
-    al->pool = rpmstrPoolLink(pool);
+    al->pool = rpmstrPoolLink(rpmtsPool(ts));
     al->delta = delta;
     al->size = 0;
     al->alloced = al->delta;
-    al->list = xmalloc(sizeof(*al->list) * al->alloced);;
+    al->list = xmalloc(sizeof(*al->list) * al->alloced);
 
     al->providesHash = NULL;
     al->obsoletesHash = NULL;
     al->fileHash = NULL;
-    al->tsflags = tsflags;
-    al->tscolor = tscolor;
-    al->prefcolor = prefcolor;
+    al->tsflags = rpmtsFlags(ts);
+    al->tscolor = rpmtsColor(ts);
+    al->prefcolor = rpmtsPrefColor(ts);
 
     return al;
 }

--- a/lib/rpmal.h
+++ b/lib/rpmal.h
@@ -16,17 +16,13 @@ extern "C" {
 typedef struct rpmal_s * rpmal;
 
 /**
- * Initialize available packckages, items, and directory list.
- * @param pool		shared string pool with base, dir and dependency names
+ * Initialize available packages, items, and directory list.
+ * @param ts		transaction set
  * @param delta		no. of entries to add on each realloc
- * @param tsflags	transaction control flags
- * @param tscolor	transaction color bits
- * @param prefcolor	preferred color
  * @return al		new available list
  */
 RPM_GNUC_INTERNAL
-rpmal rpmalCreate(rpmstrPool pool, int delta, rpmtransFlags tsflags,
-		  rpm_color_t tscolor, rpm_color_t prefcolor);
+rpmal rpmalCreate(rpmts ts, int delta);
 
 /**
  * Free available packages, items, and directory members.


### PR DESCRIPTION
This gets rid of a couple of id->str->id roundtrips and also makes the dependency hashes in rpmtsCheck() use pool ids instead of strings.