### PR TITLE
Add ability to calculate filedigests using Streebog-256 and Streebog-…

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1246,6 +1246,11 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	rpmlibNeedsFeature(pkg, "FileDigests", "4.6.0-1");
     }
 
+    if (digestalgo == PGPHASHALGO_GOST12_256 || digestalgo == PGPHASHALGO_GOST12_512) {
+	headerPutUint32(h, RPMTAG_FILEDIGESTALGO, &digestalgo, 1);
+	rpmlibNeedsFeature(pkg, "FileDigestsGOST12", "4.16.0-1");
+    }
+
     if (fl->haveCaps) {
 	rpmlibNeedsFeature(pkg, "FileCaps", "4.6.1-1");
     }

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,7 @@ AC_SUBST(WITH_OPENSSL_LIB)
 WITH_LIBGCRYPT_INCLUDE=
 WITH_LIBGCRYPT_LIB=
 if test "$with_crypto" = libgcrypt ; then
+  AC_DEFINE(WITH_LIBGCRYPT, 1, [Build with libgcrypt instead of nss3 support?])
   # libgcrypt 1.8.5 onwards ships a pkg-config file so prefer that
   PKG_CHECK_MODULES([LIBGCRYPT], [libgcrypt], [have_libgcrypt=yes], [have_libgcrypt=no])
   if test "$have_libgcrypt" = "yes"; then

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1229,6 +1229,17 @@ static const struct rpmlibProvides_s rpmlibProvides[] = {
     { "rpmlib(FileDigests)", 		"4.6.0-1",
 	(		 RPMSENSE_EQUAL),
     N_("file digest algorithm is per package configurable") },
+#ifdef WITH_LIBGCRYPT
+    /*
+     * As rpmlib(FileDigestsGOST12) is available only when RPM is built with libcgrypt,
+     * to avoid other versions of RPM from misunderatanding hashes
+     * (see e.g. https://github.com/rpm-software-management/rpm/issues/959),
+     * require FileDigestsGOST12 separately
+     */
+    { "rpmlib(FileDigestsGOST12)", 		"4.16.0-1",
+	(		 RPMSENSE_RPMLIB|RPMSENSE_EQUAL),
+    N_("file digest can be GOST R 34.11 2012 (STREEBOG256, STREEBOG512)") },
+#endif
 #ifdef WITH_CAP
     { "rpmlib(FileCaps)", 		"4.6.1-1",
 	(		 RPMSENSE_EQUAL),

--- a/rpmio/digest_libgcrypt.c
+++ b/rpmio/digest_libgcrypt.c
@@ -40,10 +40,12 @@ size_t rpmDigestLength(int hashalgo)
 	return 20;
     case PGPHASHALGO_SHA224:
 	return 28;
+    case PGPHASHALGO_GOST12_256:
     case PGPHASHALGO_SHA256:
 	return 32;
     case PGPHASHALGO_SHA384:
 	return 48;
+    case PGPHASHALGO_GOST12_512:
     case PGPHASHALGO_SHA512:
 	return 64;
     default:
@@ -66,6 +68,10 @@ static int hashalgo2gcryalgo(int hashalgo)
 	return GCRY_MD_SHA384;
     case PGPHASHALGO_SHA512:
 	return GCRY_MD_SHA512;
+    case PGPHASHALGO_GOST12_256:
+	return GCRY_MD_STRIBOG256;
+    case PGPHASHALGO_GOST12_512:
+	return GCRY_MD_STRIBOG512;
     default:
 	return 0;
     }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -96,6 +96,8 @@ static struct pgpValTbl_s const pgpHashTbl[] = {
     { PGPHASHALGO_SHA384,	"SHA384" },
     { PGPHASHALGO_SHA512,	"SHA512" },
     { PGPHASHALGO_SHA224,	"SHA224" },
+    { PGPHASHALGO_GOST12_256,	"MD_GOST12_256" },
+    { PGPHASHALGO_GOST12_512,	"MD_GOST12_512" },
     { -1,			"Unknown hash algorithm" },
 };
 

--- a/rpmio/rpmpgp.h
+++ b/rpmio/rpmpgp.h
@@ -266,6 +266,8 @@ typedef enum pgpHashAlgo_e {
     PGPHASHALGO_SHA384		=  9,	/*!< SHA384 */
     PGPHASHALGO_SHA512		= 10,	/*!< SHA512 */
     PGPHASHALGO_SHA224		= 11,	/*!< SHA224 */
+    PGPHASHALGO_GOST12_256	= 100,	/*!< GOST R 34.11-2012 256 */
+    PGPHASHALGO_GOST12_512	= 101,	/*!< GOST R 34.11-2012 512 */
 } pgpHashAlgo;
 
 /** \ingroup rpmpgp


### PR DESCRIPTION
…512 RFC 6986.

This patch adds ability to calculate filedigests (hashsums of files inside rpm package) using Streebog-256 and Streebog-512 - hashsum calculating algorithms standartized by GOST R 34.10-2012, Russian national standard.

Streebog (another name is Stribog) has existed for quite long time in libgcrypt, and now, after RPM switched to libgcrypt as the default crypto backend, this patch adds ability to use Streebog-256 and Streebog-512 to calculate file digest.

Our plan is to use these digests to sign them using rpmsign --signfile. First, I would like to receive feedback and get this initial implemetation merged. After that I am planning to extend usage of GOST.

I previously implemented the same in rpm5 (https://abf.io/soft/rpm5/commits/master), and it works. As ROSA is switching from rpm5 to rpm4, we would like to contribute our work to upstream. It may be useful for other people who have to follow some special information security requirements or those who do not trust other algorithms for some reasons.