### PR TITLE
Stop adding rpm v3 header+payload signatures by default where not needed

### DIFF
--- a/doc/rpmsign.8
+++ b/doc/rpmsign.8
@@ -11,6 +11,7 @@ rpmsign \- RPM Package Signing
 
 .SS "rpmsign-options"
 .PP
+[\fb--rpmv3\fR]
 [\fb--fskpath \fIKEY\fb\fR] [\fB--signfiles\fR]
 
 .SH DESCRIPTION
@@ -31,6 +32,14 @@ Delete all signatures from each package \fIPACKAGE_FILE\fR given.
 
 .SS "SIGN OPTIONS"
 .PP
+.TP
+\fB--rpmv3\fR
+Force RPM V3 header+payload signature addition.
+These are expensive and redundant baggage on packages where a separate
+payload digest exists (packages built with rpm >= 4.14).  Rpm will
+automatically detect the need for V3 signatures, but this option can be
+used to force their creation if the packages must be fully 
+signature verifiable with rpm < 4.14 or other interoperability reasons.
 .TP
 \fB--fskpath \fIKEY\fB\fR
 Used with \fB--signfiles\fR, use file signing key \fIKey\fR.

--- a/rpmsign.c
+++ b/rpmsign.c
@@ -32,6 +32,9 @@ static struct poptOption signOptsTable[] = {
 	N_("sign package(s) (identical to --addsign)"), NULL },
     { "delsign", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_DELSIGN,
 	N_("delete package signatures"), NULL },
+    { "rpmv3", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR),
+	&sargs.signflags, RPMSIGN_FLAG_RPMV3,
+	N_("create rpm v3 header+payload signatures") },
 #ifdef WITH_IMAEVM
     { "signfiles", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR),
 	&sargs.signflags, RPMSIGN_FLAG_IMA,

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -519,10 +519,10 @@ static int checkPkg(FD_t fd, char **msg)
  * Create/modify elements in signature header.
  * @param rpm		path to package
  * @param deleting	adding or deleting signature?
- * @param signfiles	sign files if non-zero
+ * @param flags
  * @return		0 on success, -1 on error
  */
-static int rpmSign(const char *rpm, int deleting, int signfiles)
+static int rpmSign(const char *rpm, int deleting, int flags)
 {
     FD_t fd = NULL;
     FD_t ofd = NULL;
@@ -578,7 +578,7 @@ static int rpmSign(const char *rpm, int deleting, int signfiles)
     unloadImmutableRegion(&sigh, RPMTAG_HEADERSIGNATURES);
     origSigSize = headerSizeof(sigh, HEADER_MAGIC_YES);
 
-    if (signfiles) {
+    if (flags & RPMSIGN_FLAG_IMA) {
 	if (includeFileSignatures(&sigh, &h))
 	    goto exit;
     }
@@ -716,7 +716,7 @@ int rpmPkgSign(const char *path, const struct rpmSignArgs * args)
 	}
     }
 
-    rc = rpmSign(path, 0, args ? args->signfiles : 0);
+    rc = rpmSign(path, 0, args ? args->signflags : 0);
 
     if (args) {
 	if (args->hashalgo) {

--- a/sign/rpmsign.h
+++ b/sign/rpmsign.h
@@ -16,6 +16,7 @@ extern "C" {
 enum rpmSignFlags_e {
     RPMSIGN_FLAG_NONE		= 0,
     RPMSIGN_FLAG_IMA		= (1 << 0),
+    RPMSIGN_FLAG_RPMV3		= (1 << 1),
 };
 typedef rpmFlags rpmSignFlags;
 

--- a/sign/rpmsign.h
+++ b/sign/rpmsign.h
@@ -13,10 +13,16 @@
 extern "C" {
 #endif
 
+enum rpmSignFlags_e {
+    RPMSIGN_FLAG_NONE		= 0,
+    RPMSIGN_FLAG_IMA		= (1 << 0),
+};
+typedef rpmFlags rpmSignFlags;
+
 struct rpmSignArgs {
     char *keyid;
     pgpHashAlgo hashalgo;
-    int signfiles;
+    rpmSignFlags signflags;
     /* ... what else? */
 };
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -437,6 +437,40 @@ AT_CLEANUP
 
 # ------------------------------
 # Test --addsign
+AT_SETUP([rpmsign --addsign --rpmv3 <unsigned>])
+AT_KEYWORDS([rpmsign signature])
+AT_CHECK([
+RPMDB_CLEAR
+RPMDB_INIT
+rm -rf "${TOPDIR}"
+
+cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
+run rpmsign --key-id 1964C5FC --rpmv3 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+echo PRE-IMPORT
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+echo POST-IMPORT
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+run rpmsign --delsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+echo POST-DELSIGN
+runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
+],
+[0],
+[PRE-IMPORT
+/tmp/hello-2.0-1.x86_64.rpm:
+    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+    V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
+POST-IMPORT
+/tmp/hello-2.0-1.x86_64.rpm:
+    Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
+POST-DELSIGN
+/tmp/hello-2.0-1.x86_64.rpm:
+],
+[])
+AT_CLEANUP
+
+# Test --addsign
 AT_SETUP([rpmsign --addsign <unsigned>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
@@ -459,11 +493,9 @@ runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 [PRE-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
     Header V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: NOKEY
 POST-IMPORT
 /tmp/hello-2.0-1.x86_64.rpm:
     Header V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
-    V4 RSA/SHA256 Signature, key ID 1964c5fc: OK
 POST-DELSIGN
 /tmp/hello-2.0-1.x86_64.rpm:
 ],


### PR DESCRIPTION
On packages where a separate payload digest exists (ie those built with rpm >= 4.14), rpm v3 header+payload signatures are nothing but expensive legacy baggage, as the payload digest will be signed by a header-only signature already, without having to recalculate the entire file.
    
Automatically detect the payload digest presence and only add V3 signatures on packages that need it, but also add an override switch to force their addition if needed for compatibility or so.

Fixes: #863

