### PR TITLE
Support file classification by MIME type

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -523,6 +523,22 @@ runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^
 [])
 AT_CLEANUP
 
+AT_SETUP([Dependency generation 5])
+AT_KEYWORDS([build])
+AT_CHECK([
+
+runroot rpmbuild -bb --quiet \
+		--define '__script_mime text/plain' \
+		--undefine '__script_magic' \
+		/data/SPECS/shebang.spec
+runroot rpm -qp --requires /build/RPMS/noarch/shebang-0.1-1.noarch.rpm|grep -v ^rpmlib
+],
+[0],
+[/bin/blabla
+],
+[])
+AT_CLEANUP
+
 # ------------------------------
 # Test spec query functionality
 AT_SETUP([rpmspec query 1])


### PR DESCRIPTION
In addition to "magic" strings, support classifying files by matches
on their MIME types which are far more predictable than the notoriously
volatile magic strings which are intended for human consumption.

This adds an optional %__foo_mime and %__foo_exclude_mime patterns
to file attributes. If the mime-variant is present, magic is ignored
if present (with a warning).

The testcase is a fine example of how the grass not necessarily being
any greener on the other side: the actual output is far more predictable,
but the actual classification is not. Our "script" with an arbitrary
unknown interpreter is considered text/plain by libmagic.

Fixes: #1097