### PR TITLE
Don't store file classification errors into headers

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1117,7 +1117,7 @@ static int initAttrs(rpmfc fc)
 
 rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
 {
-    int msflags = MAGIC_CHECK | MAGIC_COMPRESS | MAGIC_NO_CHECK_TOKENS;
+    int msflags = MAGIC_CHECK | MAGIC_COMPRESS | MAGIC_NO_CHECK_TOKENS | MAGIC_ERROR;
     int nerrors = 0;
     rpmRC rc = RPMRC_FAIL;
 
@@ -1201,6 +1201,10 @@ rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
 		ftype = "";
 	    else
 		ftype = magic_file(ms, s);
+
+	    /* Silence errors from immaterial %ghosts */
+	    if (ftype == NULL && errno == ENOENT)
+		ftype = "";
 
 	    if (ftype == NULL) {
 		rpmlog(is_executable ? RPMLOG_ERR : RPMLOG_WARNING, 

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -459,7 +459,7 @@ for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
 	--define "filetype link" \
-	--define "filedata foo" \
+	--define "filedata doh" \
           /data/SPECS/replacetest.spec
 done
 
@@ -502,8 +502,8 @@ runroot rpm -Va  --nouser --nogroup replacetest
 readlink "${tf}"
 ],
 [0],
-[foo
-foo
+[doh
+doh
 fox
 xx
 fox
@@ -526,7 +526,7 @@ for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
 	--define "filetype link" \
-	--define "filedata foo" \
+	--define "filedata doh" \
           /data/SPECS/replacetest.spec
 done
 
@@ -573,9 +573,9 @@ grep -c  "touch" output.txt
 readlink "${tf}"
 ],
 [0],
-[foo
+[doh
 2
-foo
+doh
 1
 fox
 xx


### PR DESCRIPTION
Immaterial %ghosts (ie those that only exist in spec, not disk) trip
up ENOENT errors which end up in package headers, so we have gems like
this in CLASSDICT:

    cannot open `/builddir/build/BUILDROOT/crypto-policies-20191128-2.gitcd267a5.fc31.noarch/etc/crypto-policies/back-ends/krb5.config' (No such file or directory)

Treat errors in classify as errors, and filter out ENOENT to handle
the above case, others we'll want to have rpm error or at least warn on.

Notably this trips up an error from a symlink loop in two of our test-cases
that have gone unnoticed until now.