### PR TITLE
Visibly deprecate RPM v3 support

### DIFF
--- a/lib/package.c
+++ b/lib/package.c
@@ -275,6 +275,7 @@ exit:
 static
 void applyRetrofits(Header h)
 {
+    int v3 = 0;
     /*
      * Make sure that either RPMTAG_SOURCERPM or RPMTAG_SOURCEPACKAGE
      * is set. Use a simple heuristic to find the type if both are unset.
@@ -302,10 +303,18 @@ void applyRetrofits(Header h)
      * packages might have been built with --nodirtokens, test and handle
      * the non-compressed filelist case separately.
      */
-    if (!headerIsEntry(h, RPMTAG_HEADERIMMUTABLE))
+    if (!headerIsEntry(h, RPMTAG_HEADERIMMUTABLE)) {
+	v3 = 1;
 	headerConvert(h, HEADERCONV_RETROFIT_V3);
-    else if (headerIsEntry(h, RPMTAG_OLDFILENAMES))
+    } else if (headerIsEntry(h, RPMTAG_OLDFILENAMES)) {
 	headerConvert(h, HEADERCONV_COMPRESSFILELIST);
+	v3 = 1;
+    }
+    if (v3) {
+	char *s = headerGetAsString(h, RPMTAG_NEVRA);
+	rpmlog(RPMLOG_WARNING, _("RPM v3 packages are deprecated: %s\n"), s);
+	free(s);
+    }
 }
 
 static void loghdrmsg(struct rpmsinfo_s *sinfo, struct pkgdata_s *pkgdata,


### PR DESCRIPTION
"RPM v3 is dead" has been repeated over and over in various forums for
the last 15+ years but as long as rpm itself silently accepts it, most
users will have no clue. Log a deprecation warning on V3 retrofits,
in anticipation of eventual removal.

Related: #1107