### PR TITLE
Restore flagless variants of rpmExprBool() and rpmExprStr() for ABI c…

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -506,7 +506,7 @@ retry:
 	else
 	    checkCondition = spec->readStack->readable;
 	if (checkCondition) {
-	    match = rpmExprBool(s, 0);
+	    match = rpmExprBoolFlags(s, 0);
 	    if (match < 0) {
 		rpmlog(RPMLOG_ERR,
 			    _("%s:%d: bad %s condition: %s\n"),

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -826,7 +826,7 @@ err:
   return NULL;
 }
 
-int rpmExprBool(const char *expr, int flags)
+int rpmExprBoolFlags(const char *expr, int flags)
 {
   struct _parseState state;
   int result = -1;
@@ -863,7 +863,7 @@ exit:
   return result;
 }
 
-char *rpmExprStr(const char *expr, int flags)
+char *rpmExprStrFlags(const char *expr, int flags)
 {
   struct _parseState state;
   char *result = NULL;
@@ -907,4 +907,14 @@ exit:
   state.str = _free(state.str);
   valueFree(v);
   return result;
+}
+
+int rpmExprBool(const char *expr)
+{
+    return rpmExprBoolFlags(expr, 0);
+}
+
+char *rpmExprStr(const char *expr)
+{
+    return rpmExprStrFlags(expr, 0);
 }

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -526,7 +526,7 @@ static void doExpressionExpansion(MacroBuf mb, const char * expr, size_t len)
     char *result;
     strncpy(buf, expr, len);
     buf[len] = 0;
-    result = rpmExprStr(buf, RPMEXPR_EXPAND);
+    result = rpmExprStrFlags(buf, RPMEXPR_EXPAND);
     if (!result) {
 	mb->error = 1;
 	goto exit;
@@ -1246,7 +1246,7 @@ doFoo(MacroBuf mb, int chkexist, int negate, const char * f, size_t fn,
 	if ((b = strrchr(buf, '.')) != NULL)
 	    b++;
     } else if (STREQ("expr", f, fn)) {
-	char *expr = rpmExprStr(buf, 0);
+	char *expr = rpmExprStrFlags(buf, 0);
 	if (expr) {
 	    free(buf);
 	    b = buf = expr;

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -198,7 +198,7 @@ const char *rpmConfigDir(void);
  * @param flags		parser flags
  * @return
  */
-int rpmExprBool(const char * expr, int flags);
+int rpmExprBoolFlags(const char * expr, int flags);
 
 /** \ingroup rpmmacro
  * Evaluate string expression.
@@ -206,8 +206,21 @@ int rpmExprBool(const char * expr, int flags);
  * @param flags		parser flags
  * @return
  */
-char * rpmExprStr(const char * expr, int flags);
+char * rpmExprStrFlags(const char * expr, int flags);
 
+/** \ingroup rpmmacro
+ * Evaluate boolean expression.
+ * @param expr		expression to parse
+ * @return
+ */
+int rpmExprBool(const char * expr);
+
+/** \ingroup rpmmacro
+ * Evaluate string expression.
+ * @param expr		expression to parse
+ * @return
+ */
+char * rpmExprStr(const char * expr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
…ompat

Commit cb4e5e755aa77b132569249c1ac6d87b9c2c76ba added flags arguments
to rpmExprBool() and rpmExprStr(), but unfortunately rpm 4.15 sailed
with flagless versions them. It's extremely unlikely that anything out
there is actually using these, but then you never really know.
Rpm soname bumps are so inconvenient that we really do not want to do
that just for these two, so preserve binary compatibility and restore
flagless variants of both, adjust internal code to use flagged versions
always. If only we had symbol versioning, sigh.