### PR TITLE
Deprecate Berkeley DB backend and beecrypt support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -533,7 +533,7 @@ AM_CONDITIONAL(HAVE_LIBDW_STRTAB,[test "$HAVE_LIBDW_STRTAB" = yes])
 #=================
 # Check for BDB support
 AC_ARG_ENABLE([bdb],
-              [AS_HELP_STRING([--enable-bdb=@<:@yes/no/auto@:>@],
+              [AS_HELP_STRING([--enable-bdb=@<:@yes/no/auto@:>@ (DEPRECATED)],
                               [build with Berkeley DB rpm database format support (default=yes)])],
               [enable_bdb="$enableval"],
               [enable_bdb=yes])

--- a/configure.ac
+++ b/configure.ac
@@ -276,12 +276,6 @@ AC_ARG_WITH(crypto,
                             ],[],
                             [with_crypto=libgcrypt])
 
-# Refuse to proceed if someone specified --with-beecrypt (removed)
-AC_ARG_WITH(beecrypt,
-    [AC_HELP_STRING([--with-beecrypt (OBSOLETE)], [Obsolete argument. Use --with-crypto=beecrypt])
-    ],[AC_MSG_ERROR([--with-beecrypt no longer supported. Use --with-crypto=beecrypt])],
-    [])
-
 # Check for beecrypt library if requested.
 AC_ARG_WITH(internal_beecrypt, [  --with-internal-beecrypt build with internal beecrypt library ],,[with_internal_beecrypt=no])
 AM_CONDITIONAL([WITH_INTERNAL_BEECRYPT],[test "$with_internal_beecrypt" = yes])

--- a/configure.ac
+++ b/configure.ac
@@ -272,12 +272,12 @@ AM_CONDITIONAL(LIBDWARF,[test "$WITH_LIBDWARF" = yes])
 # Select crypto library
 AC_ARG_WITH(crypto,
             [AC_HELP_STRING([--with-crypto=CRYPTO_LIB],
-                            [The cryptographic library to use (nss|beecrypt|openssl|libgcrypt). The default is libgcrypt.])
+                            [The cryptographic library to use (nss|beecrypt|openssl|libgcrypt). The default is libgcrypt. beecrypt is DEPRECATED.])
                             ],[],
                             [with_crypto=libgcrypt])
 
 # Check for beecrypt library if requested.
-AC_ARG_WITH(internal_beecrypt, [  --with-internal-beecrypt build with internal beecrypt library ],,[with_internal_beecrypt=no])
+AC_ARG_WITH(internal_beecrypt, [  --with-internal-beecrypt build with internal beecrypt library (DEPRECATED)],,[with_internal_beecrypt=no])
 AM_CONDITIONAL([WITH_INTERNAL_BEECRYPT],[test "$with_internal_beecrypt" = yes])
 if test "$with_internal_beecrypt" = yes ; then
   with_crypto=beecrypt


### PR DESCRIPTION
Both components are dead upstream for about seven years, deprecate them for later removal, now that we have alternatives. 