### PR TITLE
Prepare for rpm 4.16.0 alpha

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:49+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:49-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/rpm-team/rpm/language/ar/)\n"
 "Language: ar\n"
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -335,31 +335,36 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "تهيئة قاعدة البيانات"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "تحقّق من ملفات قاعدة البيانات"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "تهيئة قاعدة البيانات"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "خيارات قاعدة البيانات:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -383,7 +388,7 @@ msgstr "أظهر قائمة المفاتيح من حلقة مفاتيح RPM"
 msgid "Keyring options:"
 msgstr "خيارات حلقة المفاتيح:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -548,38 +553,42 @@ msgid "delete package signatures"
 msgstr "احذف توقيعات الحُزم"
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "خيارات التّوقيع:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -611,40 +620,49 @@ msgstr ""
 msgid "Spec options:"
 msgstr "خيارات المُحدّد:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "يجري تنفيذ(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "نهاية غير سليمة في %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -653,55 +671,6 @@ msgstr ""
 "\n"
 "\n"
 "أخطاء بناء الحزمة:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -797,283 +766,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, c-format
+msgid "Can't read content of file: %s\n"
+msgstr ""
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "تعذّر فتح %s: %s\n"
 
 #: build/files.c:2258
+#, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "تعذّر فتح %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "تعذّرت كتابة الحزمة: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "تمت كتابة: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "يجري تنفيذ \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1118,18 +1087,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1185,154 +1154,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "نوع الرّمز غير معروف: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1342,12 +1311,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "مصدر خاطئ: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1357,27 +1326,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1462,101 +1431,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s: السّطر: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "%s: السّطر: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1622,98 +1591,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "تعذّر تنفيذ %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "تعذّر تنفيذ %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "يجري إبجاد  %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "تعذّر إيجاد %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1748,90 +1713,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "مُشتركة"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "تعذّرت كتابة الحزمة: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1848,7 +1835,7 @@ msgstr "(ليس رقمًا)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(نوع غير سليم)"
 
@@ -1861,146 +1848,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "عادية"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "مُستبدلة"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "غير مثبّتة"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "لون خاطئ"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "مفقودة"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(غير معروفة)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s حُفت كـ %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s أُنشئت كـ %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "دليل"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "ملف"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2044,35 +2031,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2618,25 +2614,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2686,137 +2682,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "الملف %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "غير موافق"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "موافق"
 
@@ -2830,116 +2826,116 @@ msgstr "%s: فشل فتح: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3276,22 +3272,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3337,12 +3333,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3466,7 +3463,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3509,15 +3506,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr "صيغة غير معروفة"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "ثبّت"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "أزِل"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3526,96 +3523,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "مُبادلة"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "الترويسة"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3623,19 +3620,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "تعذّر تحميل رأس التّوقيع.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "مُستثناة"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3676,83 +3673,167 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+msgid "unexpected end of expression"
+msgstr ""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3796,27 +3877,27 @@ msgstr ""
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3826,17 +3907,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(لا شيء)"
 
@@ -3925,44 +4006,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3991,12 +4072,3 @@ msgstr ""
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "فشل تنفيذ %s (%s): %s\n"
-
-#~ msgid "line: %s\n"
-#~ msgstr "السّطر: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "السّطر %d: %s\n"

--- a/po/br.po
+++ b/po/br.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:52+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:52-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Breton (http://www.transifex.com/rpm-team/rpm/language/br/)\n"
 "Language: br\n"
@@ -274,7 +274,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -333,31 +333,35 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Dibaboù ar stlennvon:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -381,7 +385,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "n'eo ket bet roet arguzenn ebet"
 
@@ -546,38 +550,42 @@ msgid "delete package signatures"
 msgstr "lemel sinadurioù pakad"
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Dibaboù ar sinadur:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -609,93 +617,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr "Dibaboù Spec :"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "O seveniñ(%s) : %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -792,283 +760,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "N'eo ket bet kavet ar renkell : %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "N'eo ket bet kavet ar rstr : %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "N'eo ket ur renkell: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "N'hell ket bet lennet ar restr %s : %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "N'hell ket bet digoret ar restr %s : %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "sac'het eo bet %s : %x\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Muioc'h evit ur restr war ul linenn : %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "N'eo ket ur restr mat : %s : %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "N'hell ket bet digoret ar restr %s : %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "N'hell ket bet digoret ar restr %s : %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "N'hell ket bet skrivet ar pakad: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrivet: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "O seveniñ « %s » :\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Sac'het eo bet seveniñ « %s ».\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Sac'het eo bet ar gwiriekaat pakad « %s ».\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "n'hell ket bet krouet %s : %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1113,18 +1081,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1180,154 +1148,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s e: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1337,12 +1305,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1352,27 +1320,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s : %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1457,101 +1425,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "fazi en ur zigeriñ %s : %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "linenn %d : %s : %s\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "linenn %d : %s : %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1617,98 +1585,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "N'hell bet bet sevenet %s : %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "N'hell bet bet sevenet %s : %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "sac'het eo bet %s : %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "sac'het eo bet magic_open(0x%x) : %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "sac'het eo bet magic_load : %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "O klask  %s : %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Sac'het eo bet klask %s :\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1743,90 +1707,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "n'hellan ket krouiliñ %s war %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "rannet"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "fazi en ur zigeriñ %s : %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "Un Delta RPM eo %s neuez ne c'hell ket bezañ staliet\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "Bet eo ouzhpennet ar pakad %s dija, o tremen e-biou %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "Bet eo ouzhpennet ar pakad %s dija, o erlec'hiañ gant %s\n"
@@ -1843,7 +1829,7 @@ msgstr "(n'eo ket un niverenn)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1856,146 +1842,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "reizh"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "erlec'hiet"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "ket staliet"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "ket rannet"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "mankout a ra"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(dianav)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s : sac'het eo bet lemel : %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "renkell"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "restr"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2039,35 +2025,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2613,25 +2608,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " war restr "
 
@@ -2681,137 +2676,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "KET MAT"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "MAT"
 
@@ -2825,116 +2820,116 @@ msgstr "%s : sac'het eo bet digeriñ : %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader : o tremen e-biou"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s : sac'het eo bet regexec : %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s : sac'het eo bet regcomp : %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator : o tremen e-biou"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3271,22 +3266,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr "o c'hortoz evit krouiliñ %s war %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Sac'het eo bet dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3332,12 +3327,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3461,7 +3457,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3504,15 +3500,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr "Furmad dianav"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "staliañ"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "lemel"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3521,96 +3517,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "N'hell ket bet digoret stlennvon ar pakadoù e %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "gra"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3618,19 +3614,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "tremenet en e biou"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "sac'het"
 
@@ -3671,83 +3667,167 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+msgid "unexpected end of expression"
+msgstr ""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3791,27 +3871,27 @@ msgstr "hoc'h evezh : "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3821,17 +3901,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID alc'hwez %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(hini ebet)"
 
@@ -3920,44 +4000,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s : sac'het eo bet rpmReadSignature : %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s : sac'het eo bet headerRead : %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s : sac'het eo bet rpmWriteSignature : %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "sac'het eo rpmMkTemp\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s : sac'het eo bet writeLead : %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "sach'et eo bet erlec'hiañ %s : %s\n"
@@ -3987,14 +4067,6 @@ msgstr ""
 msgid "don't verify header+payload signature"
 msgstr ""
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Sac'het eo bet seveniñ %s (%s) : %s\n"
-
-#~ msgid "line: %s\n"
-#~ msgstr "linenn : %s\n"
-
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s : linenn : %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "linenn %d : %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Fazi en ur lenn %%files eus ar restr %s : %m\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2018-02-15 09:14+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2018-02-15 09:14-0500\n"
 "Last-Translator: Robert Antoni Buj Gelonch <robert.buj@gmail.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/rpm-team/rpm/language/ca/)\n"
 "Language: ca\n"
@@ -123,10 +123,9 @@ msgid "build source package only from <specfile>"
 msgstr "construeix només el paquet de les fonts des del <fitxer spec>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "construeix només el paquet de les fonts des del <fitxer spec>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -174,11 +173,10 @@ msgid "build source package only from <source package>"
 msgstr "construeix només el paquet de les fonts des del <paquet de les fonts>"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "construeix només el paquet de les fonts des del <paquet de les fonts>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -222,10 +220,9 @@ msgid "build source package only from <tarball>"
 msgstr "construeix el paquet de les fonts només des de l'<arxiu tar>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "construeix el paquet de les fonts només des de l'<arxiu tar>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -305,7 +302,7 @@ msgstr ""
 "Opcions de construcció amb [ <fitxer spec> | <arxiu tar> | <paquet de les "
 "fonts> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opcions comunes per a tots els modes rpm i executables:"
@@ -364,36 +361,41 @@ msgstr "Construcció per a l'objectiu %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "els arguments a --root (-r) han de començar per /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inicialitza la base de dades"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "reconstrueix la base de dades de les llistes inverses des de les capçaleres "
 "dels paquets instal·lats"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "verifica els fitxers de la base de dades"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inicialitza la base de dades"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 "exporta la base de dades al llistat de capçaleres de la sortida estàndard"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 "importa la base de dades des de la llista de capçaleres de l'entrada "
 "estàndard"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opcions de la base de dades:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "només es pot especificar un mode principal"
 
@@ -417,7 +419,7 @@ msgstr "llista les claus des de l'anell de claus RPM"
 msgid "Keyring options:"
 msgstr "Opcions de l'anell de claus:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "no s'han donat arguments"
 
@@ -612,38 +614,43 @@ msgid "delete package signatures"
 msgstr "suprimeix les signatures dels paquets"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "no verifiquis la signatura de la capçalera i la càrrega"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opcions de la signatura:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Heu d'establir «%%_gpg_name» al vostre fitxer de macros\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -675,40 +682,49 @@ msgstr "utilitza el següent format de consulta"
 msgid "Spec options:"
 msgstr "Opcions de spec:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "no s'ha proporcionat arguments per analitzar sintàcticament"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "El nom de màquina no es pot fer canònic: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "No es pot obrir el fitxer temporal: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "No es pot obrir el flux: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Execució(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Estat incorrecte de sortida de %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Han fallat les dependències de la construcció:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -717,55 +733,6 @@ msgstr ""
 "\n"
 "\n"
 "Errors de construcció del RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "error de sintaxi mentre s'analitzava ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "error de sintaxi mentre s'analitzava &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "error de sintaxi mentre s'analitzava ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "error d'anàlisi a l'expressió\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "no hi ha hagut coincidències (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- només als nombres\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! només als nombres\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "els tipus han de coincidir\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / no és disponible per a les cadenes\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- no és disponible per a les cadenes\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& i || no són disponibles per a les cadenes\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "error de sintaxi a l'expressió\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -861,172 +828,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "L'enllaç simbòlic apunta a l'arrel de la construcció: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "El camí està fora de l'arrel de la construcció: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "No es va trobar el directori: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "No s'ha trobat el fitxer: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "No és un directori: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Ha fallat la lectura del pitxer de política: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: no es pot carregar l'etiqueta incorrecta (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: ha fallat la lectura de la clau pública.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: no és una clau pública armada.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: ha fallat la codificació\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "no s'ha pogut crear el directori"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "El fitxer necessita el «/» principal: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "No s'ha pogut obrir el fitxer %s del %%files: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "S'ha produït un error en llegir %%files del fitxer %s: %m\n"
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "Classificador buit de fitxer\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "El glob no ha trobat el fitxer: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Més d'un fitxer en una línia: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Fitxer incorrecte: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Comprovació per si hi ha fitxers no empaquetats: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1035,111 +1007,106 @@ msgstr ""
 "Hi ha fitxers instal·lats però no empaquetats:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Processament dels fitxers: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Els binaris dependents de l'arquitectura estan en el paquet noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "ha fallat la creació de l'arxiu al fitxer %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "ha fallat la creació de l'arxiu: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "No s'ha pogut obrir el fitxer %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Càrrega desconeguda de compressió: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "No es pot obrir %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "No es pot escriure el paquet: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "S'ha escrit: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "S'està executant «%s»:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Ha fallat l'execució de «%s».\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Ha fallat la verificació del paquet «%s».\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "no es pot crear %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "No es pot generar el nom de fitxer de sortida per al paquet %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "línia %d: segon %s\n"
@@ -1184,20 +1151,20 @@ msgstr "sense descripció al %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "línia %d: segon %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 "línia %d: S'ha produït un error en analitzar sintàcticament el "
 "%%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "línia %d: Opció %s incorrecta: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1256,154 +1223,154 @@ msgstr "línia %d: número incorrecte %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d es va definir diverses vegades\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "S'ha exclòs l'arquitectura: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "No s'ha inclòs l'arquitectura: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "S'ha exclòs el SO: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "No s'ha inclòs el SO: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "El camp %s ha d'estar present al paquet: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "L'entrada %s està duplicada al paquet: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "No s'ha pogut obrir la icona %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "No s'ha pogut llegir la icona %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Tipus desconegut d'icona: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "línia %d: L'etiqueta pren un únic testimoni: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "línia %d: %s a: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s a: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "línia %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "línia %d: l'etiqueta és buida: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "línia %d: els prefixos no poden acabar amb «/»: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "línia %d: «Docdir» ha de començar per «/»: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "línia %d: el camp Epoch ha d'ésser un nombre sense signe: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "línia %d: %s incorrecte: qualificadors: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "línia %d: Format incorrecte del BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "línia %d: Només els subpaquets noarch estan suportats: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "S'ha produït un error intern: l'etiqueta %d és incorrecta\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "línia %d: %s està en desús: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificació incorrecta del paquet: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "línia %d: Etiqueta desconeguda: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} no pot estar buit\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} no pot ser \"/\"\n"
@@ -1413,12 +1380,12 @@ msgstr "%%{buildroot} no pot ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fonts incorrectes: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "No existeix el pedaç número %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "No existeix la font número %u\n"
@@ -1428,27 +1395,27 @@ msgstr "No existeix la font número %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "S'ha produït un error en analitzar sintàcticament el %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "línia %d: Argument incorrecte al %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "línia %d: Opció %s incorrecta del %%setup: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "El número de pedaç %s no és vàlid: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "línia %d: segon %%prep\n"
@@ -1533,101 +1500,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "línia %d: Segon %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "línia %d: el script intern no està disponible: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "No es pot obrir %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: S'esperava l'argument per %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "línia %d: %%if sense tancar\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: s'ha obtingut un %%else sense %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "línia %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: condició incorrecta del %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "No s'ha trobat cap arquitectura compatible per a la construcció\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "El paquet no té %%description: %s\n"
@@ -1693,98 +1660,94 @@ msgstr "Falta el camí al mòdul en la línia: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Hi ha massa arguments en la línia: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Processament de les polítiques: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "S'ignora l'expressió regular incorrecta %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "No s'ha pogut crear la canonada per a %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "No s'ha pogut executar %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "No s'ha pogut crear el procés fill de «%s»: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "No s'ha pogut executar %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "ha fallat %s: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "ha fallat l'escriptura de totes les dades a %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Classificador buit de fitxer\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Sense atributs de fitxer configurats\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "Ha fallat magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "Ha fallat magic_load: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Ha fallat el reconeixement del fitxer «%s»: mode %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "S'està cercant %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Ha fallat la cerca de %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "El nom de màquina no es pot fer canònic: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1823,90 +1786,112 @@ msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 "%s té un valor de tipus «enter» massa gran o massa petit i s'ha ignorat\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "no es pot obtenir el blocatge %s a %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "compartit"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exclusiu"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "tipus d'índex %x no vàlid a %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "error(%d) en obtenir «%s» registres de l'índex %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "error(%d) en emmagatzemar el registre «%s» en %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "error(%d) en suprimir el registre «%s» de %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "error(%d) en afegir el registre #%d a la capçalera\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "error(%d) en treure el registre #%d de la capçalera\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "error(%d) en assignar la instància de nou paquet\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "No s'ha pogut obrir el fitxer d'especificacions %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s és un Delta RPM i no es pot instal·lar directament\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Càrrega (%s) no admesa al paquet %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "el paquet %s ja es va afegir i s'ignora %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "el paquet %s ja es va afegir, s'està substituint amb %s\n"
@@ -1923,7 +1908,7 @@ msgstr "(no és un número)"
 msgid "(not a string)"
 msgstr "(no és una cadena)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(tipus no vàlid)"
 
@@ -1936,146 +1921,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %-d %b de %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(no és base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(tipus no vàlid d'XML)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(no és una signatura d'OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Data no vàlida %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "substituït"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "no instal·lat"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "compartit per xarxa"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "color incorrecte"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "falta"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(desconegut)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s s'ha desat com a %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s s'ha creat com a %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: ha fallat la supressió: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "directori"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "fitxer"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "hdr load: DOLENT"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "hdr magic: DOLENT"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "sigh pad(%zd): DOLENT, ha llegit %zd bytes"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2119,43 +2104,52 @@ msgstr "no s'esperava ]"
 msgid "unexpected }"
 msgstr "no s'esperava }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "s'esperava ? a l'expressió"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "s'esperava { després de ? a l'expressió"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "s'esperava } a l'expressió"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "s'esperava : després de ? a la subexpressió"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "s'esperava { després de : a l'expressió"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "s'esperava | al final de l'expressió"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iterador de seqüència que s'utilitza amb seqüències de diferents mides"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "línia %d: %s està en desús: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "els arguments a --prefix han de començar amb una /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2700,26 +2694,26 @@ msgstr "no verifiquis les relacions de dependència del paquet"
 msgid "don't execute verify script(s)"
 msgstr "no executis els scripts de verificació"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Falten les funcionalitats rpmlib per a %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 "s'esperava un paquet de les fonts, però se n'ha trobat un dels binaris\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "el paquet de les fonts no conté cap fitxer .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "ha fallat el desempaquetatge de l'arxiu%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " al fitxer "
 
@@ -2769,137 +2763,137 @@ msgstr "el paquet no té propietari dels fitxers/llistes de grup\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "el paquet no té ni propietari de fitxer ni llistes d'id.\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "el grup %s no conté cap paquet\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "cap paquet dispara %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "%s mal format: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "cap paquet concorda amb %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "cap paquet necessita %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "no hi ha cap paquet que recomani %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "no hi ha cap paquet que suggereixi %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "no hi ha cap paquet que ampliï %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "no hi ha cap paquet que millori %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "cap paquet proporciona %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fitxer %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "el fitxer %s no pertany a cap paquet\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de paquet invàlid: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "no s'ha pogut llegir el registre %u\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "el paquet %s no està instal·lat\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconeguda: «%s»\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: ha fallat la importació de la clau %d.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: ha fallat la lectura de la importació (%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NO ÉS CORRECTE"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "D'ACORD"
 
@@ -2913,118 +2907,118 @@ msgstr "%s: ha fallat l'obertura: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "No es pot obrir el directori actual: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: directori chroot sense establir\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "No s'ha pogut canviar el directori root: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "No es pot restaurar el directori arrel: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "S'estan generant els %d índexs que falten, si us plau, espereu...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "no es pot obrir l'índex %s mitjançant %s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "no s'ha establert cap dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: s'ignora"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "s'ha produït un error (%d) en emmagatzemar el registre #%d a %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: ha fallat regexec: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: ha fallat regcomp: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: s'ignora"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: s'ha obtingut malmesa la capçalera #%u -- s'ignora.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: no s'ha pogut llegir la capçalera a 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "no s'ha establert el dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "ha fallat en crear el directori %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "la capçalera #%u en la base de dades és incorrecta -- s'ignora.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "no es pot afegir el registre originalment a %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "no s'ha pogut reconstruir la base de dades: la base de dades original "
 "continua al seu lloc\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "no s'ha pogut substituir l'antiga base de dades amb la nova\n"
 
@@ -3121,9 +3115,8 @@ msgid "support for rich dependencies."
 msgstr "compatibilitat per a les dependències enriquides."
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "compatibilitat per a les dependències enriquides."
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3370,22 +3363,22 @@ msgstr "no es pot crear el bloqueig %s a %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "a l'espera del bloqueig %s a %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Ha fallat el dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "La resolució del símbol %s ha fallat: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Complement %%__%s_%s no configurat\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Complement %s no carregat\n"
@@ -3433,14 +3426,15 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "ja s'ha instal·lat el paquet %s, que és més nou que %s"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "la instal·lació del paquet %s necessita %<PRIu64>%cB al sistema de fitxers %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "la instal·lació del paquet %s necessita %<PRIu64> nodes-i al sistema de "
 "fitxers %s"
@@ -3566,7 +3560,7 @@ msgstr "No s'ha cridat cap exec() després del fork() a l'scriptlet de lua\n"
 msgid "Unable to restore current directory: %m"
 msgstr "No s'ha pogut restaurar el directori actual: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "no s'ha construït amb la compatibilitat cap als scriptlets <lua>\n"
 
@@ -3609,15 +3603,15 @@ msgstr "Ha fallat el scriptlet %s, estat de sortida %d\n"
 msgid "Unknown format"
 msgstr "Format desconegut"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "instal·la"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "esborra"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3626,96 +3620,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "no es pot obrir la base de dades Packages a %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "hi ha un «(» de més a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "falta «(» a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "falta un «)» a l'etiqueta del paquet: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: ha fallat la lectura de la clau pública.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transacció"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Capçalera "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3723,19 +3717,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "No es pot tornar a carregar la capçalera de signatura.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "s'ha ignorat"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "ha fallat"
 
@@ -3776,67 +3770,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "error de sintaxi mentre s'analitzava ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "error de sintaxi mentre s'analitzava &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "error de sintaxi mentre s'analitzava ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "línia %d: %s a: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "s'esperava { després de ? a l'expressió"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "error d'anàlisi a l'expressió\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "no hi ha hagut coincidències (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- només als nombres\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "s'esperava | al final de l'expressió"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "error de sintaxi a l'expressió\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "els tipus han de coincidir\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / no és disponible per a les cadenes\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- no és disponible per a les cadenes\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(buit)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Ha fallat l'obertura de la canonada per al tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s té opcions inacabades\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s té un cos inacabat\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s té un cos buit\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La macro %%%s necessita un espai en blanc abans del cos\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Ha fallat l'expansió de la macro %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "S'ha definit la macro %%%s però no s'utilitza dins de l'àmbit\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opció desconeguda %c a %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "ha fallat la càrrega del fitxer de les macros %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3844,17 +3926,27 @@ msgstr ""
 "Hi ha massa nivells de recursivitat en l'expansió de la macro. És probable "
 "que sigui a causa de la declaració recursiva de la macro.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c sense terminar: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% precedeix una macro que no es pot analitzar\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "no s'esperava ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "no s'esperava ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== actiu %d buit %d\n"
@@ -3898,27 +3990,27 @@ msgstr "advertència: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxi no vàlida en el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxi no vàlida en el script lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "ha fallat el script lua: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxi no vàlida al fitxer lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Ha fallat el hook lua: %s\n"
@@ -3928,17 +4020,17 @@ msgstr "Ha fallat el hook lua: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "l'assignació de memòria (%u bytes) ha retornat NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, id. de la clau %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(cap)"
 
@@ -4027,44 +4119,44 @@ msgstr "el gpg no ha escrit la signatura\n"
 msgid "unable to read the signature\n"
 msgstr "no es pot llegir la signatura\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: El rpmReadSignature ha fallat: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: ha fallat el headerRead: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "No es poden signar els paquets RPM v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s ja conté una signatura idèntica i s'ignora\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: ha fallat el rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "Ha fallat el rpmMkTemp\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: ha fallat el writeLead: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "ha fallat la substitució %s: %s\n"
@@ -4094,23 +4186,20 @@ msgstr "%s: ha fallat la lectura del manifest: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "no verifiquis la signatura de la capçalera i la càrrega"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Ha fallat l'execució de %s (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! només als nombres\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "S'ha produït un error en executar el scriptlet %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& i || no són disponibles per a les cadenes\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "línia: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "S'ha produït un error en llegir %%files del fitxer %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: línia: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "No s'ha pogut obrir el fitxer %s: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Sense \"Source:\" etiqueta al fitxer spec\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "línia %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: s'ha obtingut un %%endif sense %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "ha fallat la càrrega del fitxer de les macros %s"

--- a/po/cmn.po
+++ b/po/cmn.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
 "PO-Revision-Date: 2017-08-10 07:39+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Chinese (Mandarin) (http://www.transifex.com/rpm-team/rpm/"
@@ -277,7 +277,7 @@ msgstr "無視目標平臺"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "組建選項中使用 [ <specfile> | <tarball> | <source package> ]："
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "用於所有 rpm 模式和可執行檔案的共同選項："
@@ -336,31 +336,36 @@ msgstr "建置目標 %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的引數必須以「/」開頭"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "初始化資料庫"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "從安裝的套件標頭重建資料庫的反向列表"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "驗證資料庫檔案"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "初始化資料庫"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "資料庫選項："
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "只能指定一個主要工作模式"
 
@@ -384,7 +389,7 @@ msgstr "列出 RPM 鑰匙圈的金鑰"
 msgid "Keyring options:"
 msgstr "鑰匙圈選項："
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "沒有給定引數"
 
@@ -550,38 +555,43 @@ msgid "delete package signatures"
 msgstr "刪除套件簽名"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "不驗證標頭+酬載簽名"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "簽名選項："
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "您必須在您的巨集檔案中設定「%%_gpg_name」\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -613,40 +623,49 @@ msgstr "使用以下的查詢格式"
 msgid "Spec options:"
 msgstr "規格選項："
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "沒有任何引數用於剖析"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "無法標準化主機名稱：%s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "無法開啟暫存檔案：%s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "無法開啟串流：%s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "正在執行(%s)：%s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "來自 %s 的不當離開狀態 (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "相依性建置失敗：\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -655,55 +674,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM 建置錯誤：\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "剖析 == 時有語法錯誤\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "剖析 && 時有語法錯誤\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "剖析 || 時有語法錯誤\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "表述式剖析錯誤\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "不符合的 (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- 只能用於數字\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! 只能用於數字\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "類型必須符合\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "字串不支援 *、/\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "字串不支援 -\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "字串不支援 && 和 ||\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "表述式中有語法錯誤\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -799,172 +769,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "指向 BuildRoot 的符號鏈結：%s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "找不到目錄：%s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "找不到檔案：%s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "讀取策略檔案時失敗：%s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：無法呼叫不明的標籤 (%d)。\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公鑰讀入失敗。\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s：不是一個受保護的公鑰。\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：編碼失敗\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "無法建立目錄"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "檔案需要以「/」開頭：%s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev 不允許透過 glob 解析：%s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "無法開啟 %%files 檔案 %s：%m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "讀取 %%files 檔案 %s 時發生錯誤：%m\n"
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "空的檔案分類器\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "不合法的 _docdir_fmt %s：%s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "透過 glob 解析找不到檔案：%s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "無法混合特殊 %s 與其他表單：%s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一列中超過一個檔案：%s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不當檔案：%s：%s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "正在檢查未打包的檔案：%s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -973,111 +948,106 @@ msgstr ""
 "找到已安裝 (但未打包) 的檔案：\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "正在處理檔案：%s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二進位架構 (%d) 無法匹配套件架構 (%d)。\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 套件中有依賴架構的二進位檔\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "建立檔案 %s 封存時失敗：%s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "建立封存時失敗：%s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "無法開啟 %s 檔案：%s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "不明酬載壓縮：%s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, fuzzy, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr "讀取策略檔案時失敗：%s\n"
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "無法寫入套件：%s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已寫入：%s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在執行「%s」：\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」執行失敗。\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "套件檢查「%s」失敗。\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "無法建立 %s：%s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "無法產生套件 %s 的檔案名稱輸出：%s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "第 %d 列：第二個 %s\n"
@@ -1122,18 +1092,18 @@ msgstr "%%changelog 中沒有描述\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "第 %d 列：剖析 %%description 時發生錯誤：%s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "第 %d 列：不當選項 %s：%s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1189,154 +1159,154 @@ msgstr "第 %d 列：不當的 %s 數字：%s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d 被定義許多次\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "被排除的架構：%s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "未包含的架構：%s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "被排除的作業系統：%s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "未包含的作業系統：%s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s 欄位必須出現於套件中：%s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "套件中有重複的 %s 條目：%s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "無法開啟圖示 %s：%s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "無法讀取圖示 %s：%s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "不明的圖示類型：%s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "第 %d 列：標籤只需單一符記：%s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "第 %d 列：格式不當的標籤：%s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "第 %d 列：空的標籤：%s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "第 %d 列：前綴不能以「/」結尾：%s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "第 %d 列：Docdir 必須以「/」開頭：%s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "第 %d 列：Epoch 欄位必須是無正負號的數字：%s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "第 %d 列：不當 %s：修飾詞：%s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "第 %d 列：不當 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "第 %d 列：只有支援 noarch 子套裝模組：%s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "內部錯誤：假造的標籤 %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "第 %d 列：%s 已過時：%s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不當套件規格：%s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "第 %d 列：不明標籤：%s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不可是空的\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不可為「/」\n"
@@ -1346,12 +1316,12 @@ msgstr "%%{buildroot} 不可為「/」\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不當原始碼：%s：%s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "沒有修補編號 %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "沒有原始碼編號 %u\n"
@@ -1361,27 +1331,27 @@ msgstr "沒有原始碼編號 %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "剖析 %%setup 時發生錯誤：%s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "第 %d 列：%%setup 中出現不當引數：%s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "第 %d 列：不當 %%setup 選項 %s：%s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無效的修補編號 %s：%s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "第 %d 列：第二個 %%prep\n"
@@ -1466,101 +1436,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "第 %d 列：第二個 %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "第 %d 列：不支援的內部指令稿：%s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "第 %d 列：解譯器引數不允許存在觸發器中：%s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d：預期用於 %s 的引數\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "第 %d 列：未關閉的 %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "第 %d 列：未關閉的巨集或不當的列延續\n"
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, fuzzy, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr "%s:%d：有個 %%else 沒有對應 %%if\n"
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, fuzzy, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr "第 %d 列：%s：%s\n"
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, fuzzy, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr "%s:%d：不當的 %%if 條件\n"
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d：異常的 %%include 敘述\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "找不到可供建置的相容架構\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "套件沒有 %%description：%s\n"
@@ -1626,98 +1596,94 @@ msgstr "缺少模組路徑於列號：%s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "太多引數於列號：%s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "處理策略：%s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略無效的正規表示式 %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "無法為 %s 建立管線：%m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "無法執行 %s：%s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "無法分支 %s：%s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "無法執行 %s：%s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失敗：%x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "無法寫入所有資料至 %s：%s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "空的檔案分類器\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "無設定檔案特性\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失敗：%s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失敗：%s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "檔案「%s」辨識失敗：模式 %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在尋找 %s：%s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "找不到 %s：\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "無法標準化主機名稱：%s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s 規格檔查詢失敗，無法剖析\n"
@@ -1752,90 +1718,112 @@ msgstr "%s 有過大或過小的 long 數值，略過\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s 有過大或過小的整數值，略過\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "已共享"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "無效的索引類型 %x 於 %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "錯誤(%d) 發生於取得「%s」記錄自 %s 索引：%s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "錯誤(%d) 發生於加入標頭 #%d 記錄\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "錯誤(%d) 發生於移除標頭 #%d 記錄\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "分配新套件實體時發生錯誤(%d)\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "無法開啟 %s 規格檔：%s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 是個差異 RPM 而無法直接安裝\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "未支援的酬載 (%s) 於套件 %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "套件 %s 已被加入，跳過 %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "套件 %s 已被加入，以 %s 替換\n"
@@ -1852,7 +1840,7 @@ msgstr "(不是一個數字)"
 msgid "(not a string)"
 msgstr "(不是字串)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(無效型態)"
 
@@ -1865,146 +1853,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%Y %b %d %a"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(不是 base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(無效 xml 類型)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(不是個 OpenPGP 簽名)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "無效的日期 %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "一般"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "已替換"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "未安裝"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "已網路分享"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "錯誤色彩"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "遺失"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(不明)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已被另存為 %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立為 %s \n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s：移除失敗：%s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "目錄"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "檔案"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2048,35 +2036,44 @@ msgstr "未預期的 ]"
 msgid "unexpected }"
 msgstr "未預期的 }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? 預期於表述式中"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ 預期於表述式中的 ? 之後"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} 預期於表述式中"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": 預期跟著 ? 子表述式"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ 預期於表述式中 : 之後"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| 預期於表述式的結尾"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "用於不同大小陣列的陣列迭代器"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "第 %d 列：%s 已過時：%s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, fuzzy, c-format
 msgid "failed to load macro file %s\n"
 msgstr "讀取策略檔案時失敗：%s\n"
@@ -2629,25 +2626,25 @@ msgstr "不驗證套件的相依關係"
 msgid "don't execute verify script(s)"
 msgstr "不執行驗證指令稿"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "缺少 rpmlib 的特色用於 %s：\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "預期是原始碼套件，但卻找到二進位套件\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "原始碼套件內未包含 .spec 檔案\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解包封存檔失敗 %s%s：%s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr "  於檔案 "
 
@@ -2697,137 +2694,137 @@ msgstr "套件內沒有檔案擁有者/群組記錄\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "套件內沒有檔案擁有者及 ID 列表\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "群組 %s 內不包含任何套件\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "沒有套件會觸發 %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "格式不當的 %s：%s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "沒有套件符合 %s：%s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, fuzzy, c-format
 msgid "no package conflicts %s\n"
 msgstr "沒有套件提供 %s\n"
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, fuzzy, c-format
 msgid "no package obsoletes %s\n"
 msgstr "沒有套件需要 %s\n"
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "沒有套件需要 %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "沒有套件提供 %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "檔案 %s：%s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "檔案 %s 不被任何套件擁有\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無效的套件編號：%s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "記錄 %u 無法讀取\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "套件 %s 尚未安裝\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "不明的標籤：「%s」\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s：金鑰 %d 匯入失敗。\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：金鑰 %d 不是受保護的公鑰。\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：匯入時讀取失敗(%d)。\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "不正確"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "正確"
 
@@ -2841,116 +2838,116 @@ msgstr "%s：開啟失敗：%s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "無法開啟目前的目錄：%m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s：chroot 目錄未設定\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "無法變更根目錄：%m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "無法還原根目錄：%m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "正在產生 %d 個缺少的索引，請稍待…\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "尚未設定 dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳過"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "儲存記錄 #%2$d 到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s：regexec 失敗：%s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s：regcomp 失敗：%s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳過"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：已擷取損壞的標頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：無法讀取位於 0x%x 的標頭\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "尚未設定 dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "建立目錄 %s 時失敗：%s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "在資料庫中有不當的標頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "無法加入原本位於 %u 的記錄\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建資料庫時失敗：原來的資料庫保持原狀\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "以新的資料庫取代舊的資料庫時失敗！\n"
 
@@ -3290,22 +3287,22 @@ msgstr "無法建立 %s 鎖定於 %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "等待 %s 鎖定於 %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "dlopen %s %s 時失敗\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "解析符號 %s 時失敗：%s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "%s 插件未載入\n"
@@ -3350,13 +3347,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "套件 %s (比 %s 還新) 已經安裝"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "安裝套件 %s 需要 %<PRIu64>%cB 於 %s 檔案系統之上"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr "安裝套件 %s 需要 %<PRIu64> inodes 於 %s 檔案系統之上"
 
 #: lib/rpmprob.c:159
@@ -3480,7 +3478,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr "無法還原目前的目錄：%m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 指令稿片段支援未內建\n"
 
@@ -3523,15 +3521,15 @@ msgstr "%s 指令稿片段失敗，離開狀態 %d\n"
 msgid "Unknown format"
 msgstr "不明格式"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "安裝"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "抹除"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3540,96 +3538,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "無法開啟套件資料庫 %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的「(」存在於套件標貼中：%s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "套件標貼遺漏「(」：%s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "套件標貼遺漏「)」：%s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s：讀取公鑰時失敗。\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, fuzzy, c-format
 msgid "invalid package verify level %s\n"
 msgstr "無效的套件編號：%s\n"
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "異動作業"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "標頭 "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3637,20 +3635,20 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "無法重新載入簽名標頭。\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 #, fuzzy
 msgid "no signature"
 msgstr "(不是個 OpenPGP 簽名)"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "已跳過"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "已失敗"
 
@@ -3691,83 +3689,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "剖析 == 時有語法錯誤\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "剖析 && 時有語法錯誤\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "剖析 || 時有語法錯誤\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ 預期於表述式中的 ? 之後"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "表述式剖析錯誤\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "不符合的 (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- 只能用於數字\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| 預期於表述式的結尾"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "表述式中有語法錯誤\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "類型必須符合\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "字串不支援 *、/\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "字串不支援 -\n"
+
+#: rpmio/macro.c:348
 #, fuzzy, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr "%3d>%*s(清空)"
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "無法開啟 tar 管線：%m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, fuzzy, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "巨集 %%%s 具有未終結的主體\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "巨集 %%%s 具有空的主體\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "巨集 %%%s 展開時失敗\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中有不明的選項 %1$c\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "在巨集展開中有太多層的遞迴。它似乎是遞迴的巨集宣告所造成的。\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未終結的 %c：%s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在無法剖析的巨集之後跟著一個 %%\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "未預期的 ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "未預期的 ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3811,27 +3907,27 @@ msgstr "警告："
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "無效的語法於 lua 指令稿片段：%s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "無效的語法於 lua 指令稿：%s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 指令稿失敗：%s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua 檔案內有無效語法：%s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua 攔截指令失敗：%s\n"
@@ -3841,17 +3937,17 @@ msgstr "lua 攔截指令失敗：%s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "記憶體配置 (%u 位元組) 回傳 NULL。\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s，金鑰識別號 %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(無)"
 
@@ -3940,44 +4036,44 @@ msgstr "寫入簽名時 gpg 失敗\n"
 msgid "unable to read the signature\n"
 msgstr "無法讀取簽名\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 失敗：%s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s：headerRead 失敗：%s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "無法簽署 RPM v3 套件\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已經含有相同的簽名，跳過\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失敗：%s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp 失敗\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失敗：%s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "置換 %s 時失敗：%s\n"
@@ -4006,6 +4102,20 @@ msgstr "%s：讀取清單失敗：%s\n"
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr "不驗證標頭+酬載簽名"
+
+#~ msgid "! only on numbers\n"
+#~ msgstr "! 只能用於數字\n"
+
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "字串不支援 && 和 ||\n"
+
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "讀取 %%files 檔案 %s 時發生錯誤：%m\n"
+
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "無法開啟 %s 檔案：%s\n"
 
 #~ msgid "Exec of %s failed (%s): %s\n"
 #~ msgstr "執行 %s 失敗 (%s)：%s\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:49+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:49-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Czech (http://www.transifex.com/rpm-team/rpm/language/cs/)\n"
 "Language: cs\n"
@@ -114,10 +114,9 @@ msgid "build source package only from <specfile>"
 msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -157,11 +156,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "vytvoření zdrojového balíčku podle <spec_soubor>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -201,10 +199,9 @@ msgid "build source package only from <tarball>"
 msgstr "vytvoření pouze zdrojového balíčku z <tar_soubor>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "vytvoření pouze zdrojového balíčku z <tar_soubor>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -282,7 +279,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "Sestavovací volby s [ <spec_soubor> | <tar_soubor> | <zdrojový_balíček> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Společné volby pro všechny rpm režimy a spustitelné soubory:"
@@ -341,31 +338,36 @@ msgstr "Sestavuji pro cíl %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametry pro --root (-r) musejí začínat znakem /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inicializuj databázi"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "znovu sestav obrácené seznamy z instalovaných hlaviček balíčků"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "zkontrolovat databázové soubory"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inicializuj databázi"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Volby databáze:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "specifikovat lze jen jeden hlavní režim"
 
@@ -389,7 +391,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "nezadány žádné parametry"
 
@@ -559,38 +561,43 @@ msgid "delete package signatures"
 msgstr "vymazat podpisy balíčku"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "neověřuj podpis hlavičky a payloadu"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Volby signatury:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Je nutné nastavit \"%%_gpg_name\" ve vašem souboru maker\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -622,40 +629,49 @@ msgstr "použij následující formát dotazů"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Nemohu získat jméno počítače: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Provádění(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Špatný návratový kód z %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Chybné závislosti při sestavování:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -664,55 +680,6 @@ msgstr ""
 "\n"
 "\n"
 "chyby sestavení RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "chyba syntaxe při zpracování ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "chyba syntaxe při zpracování &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "chyba syntaxe při zpracování ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "chyba při parsování ve výrazu\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "nedoplněná (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- jen na číslech\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! jen na číslech\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "typy musí souhlasit\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / nejsou podporovány pro řetězce\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- není podporováno pro řetězce\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& a || není podporováno pro řetězce\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "chyba syntaxe ve výrazu\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -808,172 +775,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolická linka ukazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Soubor nenalezen: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: čtení seznamu selhalo: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nemohu nahrát neznámou značku (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: čtení veřejného klíče selhalo.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: není obrněný veřejný klíč.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Soubor potřebuje úvodní \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Nemohu otevřít %%files soubor %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "otevření %s selhalo: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Soubor nenalezen globem: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Špatný soubor: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontroluji nezabalené soubory: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -982,111 +954,106 @@ msgstr ""
 "Nalezeny instalované, ale nezabalené soubory:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Neznámá komprese payloadu: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nemohu otevřít %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nemohu zapsat balíček: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapsáno: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nemohu vytvořit %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nemohu vygenerovat jméno souboru pro balíček %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "řádek: %d: druhý %s\n"
@@ -1131,18 +1098,18 @@ msgstr "žádný popis v %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "řádek %d: Chyba při parsování %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "řádek %d: špatná volba %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1198,154 +1165,154 @@ msgstr "řádek %d: Špatné číslo %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Architektura je vyřazena: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Architektura není zahrnuta: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS je vyřazen: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS není zahrnut: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Položka %s musí být v balíčku přítomna: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Duplikovaná položka %s v balíčku: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Nemohu otevřít ikonu %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Nemohu přečíst ikonu %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Neznámý typ ikony: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "řádek %d: Značka má jen jeden token: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "řádek %d: Počkozená značka: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "řádek %d: Prázdná značka: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "řádek %d: Prefixy nesmí končit znakem \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "řádek %d: Docdir musí začínat na '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "řádek %d: Špatné určení %s: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "řádek %d: Špatný formát BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interní chyba: Špatná značka: %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Špatná specifikace balíčku: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "řádek %d: Neznámá značka: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1355,12 +1322,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Špatný zdrojový soubor: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1370,27 +1337,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr "Chyba při parsování %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "řádek %d: Špatný parametr v %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "řádek %d: Špatná volba v %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neplatné číslo záplaty %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "řádek %d: druhý %%prep\n"
@@ -1475,101 +1442,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "řádek %d: Druhý %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "řádek %d: nepodporovaný interní skript: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nemohu otevřít %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%else bez počítečního %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "řádek %d: Špatné určení %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "řádek %d: Špatná volba v %%setup %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Nenalezeny žádné kompatibilní architektury pro sestavení\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Balíček nemá žádné %%description: %s\n"
@@ -1635,98 +1602,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nemohu vytvořit rouru pro %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Nemohu spustit %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nemohu provést fork %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Nemohu spustit %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) selhalo: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load selhal: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Hledám   %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Selhalo vyhledání %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Nemohu získat jméno počítače: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "dotaz na spec soubor %s selhal, nemohu parsovat\n"
@@ -1761,90 +1724,112 @@ msgstr "%s má příliš velkou nebo příliš malou long hodnotu, přeskakuji\n
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s má příliš velkou nebo příliš malou int hodnotu, přeskakuji\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "nemohu získat zámek %s na %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "sdílen"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exkluzivní"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "chyba(%d) při ukládání záznamu \"%s\" do %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "chyba(%d) v odstraňování \"%s\" z %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "chyba(%d) při alokaci nové instance balíčku\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Nelze otevřít spec soubor %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s is a Delta RPM a nemůže být přímo instalován\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodporovaný payload (%s) in balíčku %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "balíček %s byl již přidán, přeskakuji %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "balíček %s byl již přidán, nahrazuji ho s %s\n"
@@ -1861,7 +1846,7 @@ msgstr "(není číslo)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(neplatný typ)"
 
@@ -1874,146 +1859,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(není base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(neplatný typ xml)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(není OpenPGP podpis)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s uloženo jako %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s vytvořen jako %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2057,43 +2042,52 @@ msgstr "neočekávaná ]"
 msgid "unexpected }"
 msgstr "neočekávaná }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "ve výrazu očekáván ?"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "ve výrazu je po ? očekávána {"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "ve výrazu je očekávána }"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "v podvýrazu je po ? očekávána :"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "ve výrazu je po : očekávána {"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "na konci výrazu je očekáváno |"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iterátor pole použitý s poli jiné délky"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "parametry pro --prefix musejí začínat znakem /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2636,25 +2630,25 @@ msgstr "nekontrolovat závislosti balíčků"
 msgid "don't execute verify script(s)"
 msgstr "nespouštět kontrolní skripty"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "očekávám balíček se zdrojovými kódy, nalezen však binární\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "zdrojový balíček neobsahuje .spec soubor\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozbalování archívu selhalo %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " na souboru "
 
@@ -2704,137 +2698,137 @@ msgstr "balíček nemá vlastníka souboru ani seznamy skupin\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "balíček nemá vlastníka souboru ani seznamy id\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "skupina %s neobsahuje žádné balíčky\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "žádný balíček neaktivuje %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "poškozený %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "žádný balíček se neshoduje s %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "žádný balíček nevyžaduje %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "žádný balíček neposkytuje %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "soubor %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "soubor %s nevlastní žádný balíček\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neplatné číslo balíčku: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "balíček %s není nainstalován\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "neznámá značka: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importní čtení selhalo(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NENÍ OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2848,116 +2842,116 @@ msgstr "%s: otevření selhalo: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Není možné změnit kořenový adresář: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "nebyla nastavena dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: přeskakuji"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "chyba(%d) ukládání záznamu #%d do %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec selhal: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp selhal: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: přeskakuji"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: poškozená hlavička #%u získáno -- přeskakuji.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nemohu číst hlavičku na 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "žádný dbpath nebyl nastaven"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "selhání při vytváření adresáře %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "hlavička #%u v databázi je špatná -- přeskakuji.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nemohu přidat záznam původně na %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "selhalo znovusestavení databáze: původní databáze zůstává na místě\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "selhalo nahrazení staré databáze novou databází!\n"
 
@@ -3294,22 +3288,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3355,12 +3349,13 @@ msgstr "balíček %s (který je novější, než %s) je již nainstalován"
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3484,7 +3479,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3527,15 +3522,15 @@ msgstr "provedení %s skripletu selhalo, návratový kód: %d\n"
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3544,96 +3539,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "nemohu otevřít Packages databázi v %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "nadbytečná '(' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "chybějící '(' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "chybějící ')' v názvu balíčku: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Hlavička "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3641,19 +3636,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Nemohu znovu přečíst hlavičku podpisu.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3694,83 +3689,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "chyba syntaxe při zpracování ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "chyba syntaxe při zpracování &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "chyba syntaxe při zpracování ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "ve výrazu je po ? očekávána {"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "chyba při parsování ve výrazu\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "nedoplněná (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- jen na číslech\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "na konci výrazu je očekáváno |"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "chyba syntaxe ve výrazu\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "typy musí souhlasit\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / nejsou podporovány pro řetězce\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- není podporováno pro řetězce\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prázdné)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Nelze otevřít rouru pro tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s má neukončené parametry\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s má neukončené tělo\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s má prázdné tělo\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Selhalo vyhodnocení makra %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Neznámý parametr %c v %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neukončené %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Po %% následuje nezpracovatelné makro\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "neočekávaná ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "neočekávaná ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivní %d prázdné %d\n"
@@ -3814,27 +3907,27 @@ msgstr "varování: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "neplatná syntax v lua skriptletu: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "neplatná syntax v lua skriptu: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skript selhal: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "neplatné syntax v lua souboru: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua obsloužení selhalo: %s\n"
@@ -3844,17 +3937,17 @@ msgstr "lua obsloužení selhalo: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokace paměti (%u bajtů) vrátila NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3943,44 +4036,44 @@ msgstr "gpg selhal při zápisu podpisu\n"
 msgid "unable to read the signature\n"
 msgstr "nemohu přečíst podpis\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature selhalo: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: Fwrite selhalo: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp selhal\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead selhalo: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4010,17 +4103,8 @@ msgstr "%s: čtení seznamu selhalo: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "neověřuj podpis hlavičky a payloadu"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Spuštění %s selhalo (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! jen na číslech\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "řádek: %s\n"
-
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: řádek: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "řádek %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif bez počátečního %%if\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& a || není podporováno pro řetězce\n"

--- a/po/da.po
+++ b/po/da.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:49+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:49-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Danish (http://www.transifex.com/rpm-team/rpm/language/da/)\n"
 "Language: da\n"
@@ -113,10 +113,9 @@ msgid "build source package only from <specfile>"
 msgstr "opbyg kun kildepakke ud fra <spec-fil>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "opbyg kun kildepakke ud fra <spec-fil>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -157,11 +156,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "opbyg kun kildepakke ud fra <spec-fil>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -199,10 +197,9 @@ msgid "build source package only from <tarball>"
 msgstr "opbyg kun kildepakke ud fra <tararkiv>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "opbyg kun kildepakke ud fra <tararkiv>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -279,7 +276,7 @@ msgstr "gennemtving målplatform"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opbygningstilvalg med [ <spec-fil> | <tararkiv> | <kildepakke> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -338,31 +335,36 @@ msgstr "Opbygger for mål %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parameteren til --root (-r) skal starte med et /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "initialisér database"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "genopbyg omvendte databaselister ud fra installerede pakkehoveder"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "initialisér database"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Databasetilvalg:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "kun ét hovedtilvalg kan angives"
 
@@ -386,7 +388,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -551,38 +553,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Signaturtilvalg"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Du skal angive \"%%_gpg_name\" i din makrofil\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -614,40 +620,49 @@ msgstr "brug følgende forespørgselsformat"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Kunne ikke kanonisere værtsnavn: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Udfører(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Fejl-afslutningsstatus fra %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -656,55 +671,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM opbygningsfejl:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "syntaksfejl under tolkning af ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "syntaksfejl under tolkning af &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "syntaksfejl under tolkning af ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "tolkningsfejl i udtryk\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "uparret (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- kun for tal\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! kun for tal\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "typer skal passe sammen\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / understøttes ikke for strenge\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- understøttes ikke for strenge\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& og || understøttes ikke for strenge\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "syntaksfejl i udtryk\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -800,283 +766,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolsk lænke peger på BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fil ikke fundet: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: læs manifest mislykkedes: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Fil kræver foranstillet \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Kunne ikke åbne %s: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "åbning af %s mislykkedes %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Fil ikke fundet med glob: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ugyldig fil: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunne ikke åbne %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunne ikke skrive pakke: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "kan ikke oprette %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Kunne ikke generere filnavn til oprettelse af pakke %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linie %d: anden %s\n"
@@ -1121,18 +1087,18 @@ msgstr "ingen beskrivelse i %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linie %d: Fejl ved tolkning af %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linie %d: Ugyldigt tilvalg %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1188,154 +1154,154 @@ msgstr "linie %d: Ugyldigt %s-tal: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Arkitekturen er ekskluderet: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Arkitekturen er ikke inkluderet: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS er ekskluderet: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS is ikke inkluderet: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "'%s'-felt skal være tilstede i pakke : %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Flere '%s'-indgange i pakke: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Kunne ikke åbne ikon %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Kunne ikke læse ikon %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Ukendt ikontype: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linie %d: Forkert udformet mærke: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linie %d: Tomt mærke: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linie %d: Præfikser kan ikke ende på \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linie %d: Docdir skal starte med '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linie %d: Ugyldig %s: angivere: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linie %d: Ugyldigt 'BuildArchitecture'-format: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Intern fejl: Falsk mærke %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ugyldig pakkeangivelse: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linie %d: Ukendt mærke: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1345,12 +1311,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Ugyldig kilde: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1360,27 +1326,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fejl ved tolking af %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linie %d: Ugyldigt '%%setup'-tilvalg %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linie %d: anden %%prep\n"
@@ -1465,103 +1431,103 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "linie %d: Anden %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 "Kunne ikke åbne %s: %s\n"
 "\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Fik et %%else uden et %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "linie %d: Ugyldig %s: angivere: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "linie %d: Ugyldigt '%%setup'-tilvalg %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakke har ingen %%description: %s\n"
@@ -1627,98 +1593,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Kunne ikke udføre %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Kunne ikke fraspalte ny proces til %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Kunne ikke udføre %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Kunne ikke finde %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Kunne ikke kanonisere værtsnavn: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "forespørgsel af spec-fil %s mislykkedes, kunne ikke tolkes\n"
@@ -1753,90 +1715,112 @@ msgstr "%s har for stor eller lille 'long'-værdi, overspringes\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s har for stor eller lille heltalsværdi, overspringes\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "kan ikke opnå %s lås på %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "delt"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "eksklusiv"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "fejl(%d) under allokering af ny pakkeinstans\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Kan ikke åbne spec-fil %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1853,7 +1837,7 @@ msgstr "(ikke et tal)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1866,146 +1850,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s gemt som %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s oprettet som %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2049,43 +2033,52 @@ msgstr "uventet ]"
 msgid "unexpected }"
 msgstr "uventet }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? forventet i udtryk"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ forventet efter ? i udtryk"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} forventet i udtryk"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": forventet efter ?-underudtryk"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ forventet efter : i udtryk"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| forventet ved slutningen af udtryk"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "parametre til --prefix skal starte med et /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2630,25 +2623,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "kildepakke forventet, binær fundet\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "kildepakke indeholder ingen .spec-fil\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "udpakning af arkiv mislykkedes%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " for fil "
 
@@ -2698,137 +2691,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr "pakke har hverken filejerskabs- eller id-lister\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "gruppe %s indeholder ingen pakker\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "ingen pakker udløser %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "ingen pakker kræver %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ingen pakker tilfører %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s tilhører ingen pakke\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "ugyldigt pakkenummer: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakken %s er ikke installeret\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "IKKE O.K."
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "O.K."
 
@@ -2842,116 +2835,116 @@ msgstr "%s: åbning mislykkedes: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "der er ikke sat nogen dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: kan ikke læse hoved ved 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "der ikke sat nogen dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "kunne ikke genopbygge database: original-databasen beholdes\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "kunne ikke erstatte gammel database med ny database!\n"
 
@@ -3288,22 +3281,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3350,12 +3343,13 @@ msgstr "pakke %s (som er nyere end %s) er allerede installeret"
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3481,7 +3475,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3524,15 +3518,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3541,96 +3535,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "kunne ikke åbne Packages-database i %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3638,19 +3632,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3691,83 +3685,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "syntaksfejl under tolkning af ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "syntaksfejl under tolkning af &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "syntaksfejl under tolkning af ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ forventet efter ? i udtryk"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "tolkningsfejl i udtryk\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "uparret (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- kun for tal\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| forventet ved slutningen af udtryk"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "syntaksfejl i udtryk\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "typer skal passe sammen\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / understøttes ikke for strenge\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- understøttes ikke for strenge\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tom)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Kunne ikke åbne tar-videreførsel: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makroen %%%s har uafsluttede parametre\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makroen %%%s har et uafsluttet indhold (body)\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makroen %%%s har intet indhold\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makroen %%%s kunne ikke udfoldes\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Ukendt tilvalg %c i %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Uafsluttet %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Et %% efterfølges af en makro, der ikke kan tolkes\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "uventet ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "uventet ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiv %d tom %d\n"
@@ -3811,27 +3903,27 @@ msgstr "advarsel: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3841,17 +3933,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "hukommelsesallokering (%u byte) returnerede NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3940,44 +4032,44 @@ msgstr "gpg kunne ikke skrive signaturen\n"
 msgid "unable to read the signature\n"
 msgstr "kunne ikke læse signaturen\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead mislykkedes: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4007,14 +4099,8 @@ msgstr "%s: læs manifest mislykkedes: %s\n"
 msgid "don't verify header+payload signature"
 msgstr ""
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Udførelse af %s mislykkedes (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! kun for tal\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "linie: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "linie %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: Fik et %%endif uden et %%if\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& og || understøttes ikke for strenge\n"

--- a/po/de.po
+++ b/po/de.po
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2019-03-24 03:53+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2019-11-10 07:23-0500\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: German (http://www.transifex.com/rpm-team/rpm/language/de/)\n"
 "Language: de\n"
@@ -112,21 +112,22 @@ msgstr "%files-Abschnitt der <Spec-Datei> überprüfen"
 
 #: rpmbuild.c:157
 msgid "build source and binary packages from <specfile>"
-msgstr "Quell- und Binär-Paket von <Spec-Datei> bauen"
+msgstr "Quell- und Binärpaket von <Spec-Datei> bauen"
 
 #: rpmbuild.c:160
 msgid "build binary package only from <specfile>"
-msgstr "Nur ein Binär-Paket von <Spec-Datei> bauen"
+msgstr "Nur ein Binärpaket von <Spec-Datei> bauen"
 
 #: rpmbuild.c:163
 msgid "build source package only from <specfile>"
-msgstr "Nur ein Quell-Paket von <Spec-Datei> bauen"
+msgstr "Nur ein Quellpaket von <Spec-Datei> bauen"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "Nur ein Quell-Paket von <Spec-Datei> bauen"
+msgstr ""
+"Nur ein Quellpaket von <Spec-Datei> bauen - dynamische Build-Abhängigkeiten "
+"ermitteln"
 
 #: rpmbuild.c:170
 #, c-format
@@ -137,7 +138,7 @@ msgstr ""
 #: rpmbuild.c:171 rpmbuild.c:174 rpmbuild.c:177 rpmbuild.c:180 rpmbuild.c:183
 #: rpmbuild.c:186 rpmbuild.c:189 rpmbuild.c:192 rpmbuild.c:220 rpmbuild.c:223
 msgid "<source package>"
-msgstr "<Quell-Paket>"
+msgstr "<Quellpaket>"
 
 #: rpmbuild.c:173
 msgid "build through %build (%prep, then compile) from <source package>"
@@ -147,32 +148,33 @@ msgstr ""
 msgid ""
 "build through %install (%prep, %build, then install) from <source package>"
 msgstr ""
-"%install (%prep, %build, anschließendes Installieren) des <Quell-Pakets> "
+"%install (%prep, %build, anschließendes Installieren) des <Quellpakets> "
 "durchlaufen"
 
 #: rpmbuild.c:179
 #, c-format
 msgid "verify %files section from <source package>"
-msgstr ""
+msgstr "%files-Abschnitt im <Quellpaket> überprüfen"
 
 #: rpmbuild.c:182
 msgid "build source and binary packages from <source package>"
-msgstr ""
+msgstr "Quell- und Binärpakete aus <Quellpaket> bauen"
 
 #: rpmbuild.c:185
 msgid "build binary package only from <source package>"
-msgstr ""
+msgstr "Nur Binärpaket aus <Quellpaket> bauen"
 
 #: rpmbuild.c:188
 msgid "build source package only from <source package>"
-msgstr ""
+msgstr "Nur Quellpaket aus <Quellpaket> bauen"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "Nur ein Quell-Paket von <Spec-Datei> bauen"
+msgstr ""
+"Nur ein Quellpaket von <Quellpaket> bauen - dynamische Build-Abhängigkeiten "
+"ermitteln"
 
 #: rpmbuild.c:195
 #, c-format
@@ -203,25 +205,26 @@ msgstr "%files-Abschnitt des <Tar-Archivs> überprüfen"
 
 #: rpmbuild.c:207
 msgid "build source and binary packages from <tarball>"
-msgstr "Quell- und Binär-Paket vom <Tar-Archiv> bauen"
+msgstr "Quell- und Binärpaket vom <Tar-Archiv> bauen"
 
 #: rpmbuild.c:210
 msgid "build binary package only from <tarball>"
-msgstr "Nur ein Binär-Paket vom <Tar-Archiv> bauen"
+msgstr "Nur ein Binärpaket vom <Tar-Archiv> bauen"
 
 #: rpmbuild.c:213
 msgid "build source package only from <tarball>"
-msgstr "Nur ein Quell-Paket vom <Tar-Archiv> bauen"
+msgstr "Nur ein Quellpaket vom <Tarball> bauen"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "Nur ein Quell-Paket vom <Tar-Archiv> bauen"
+msgstr ""
+"Nur ein Quellpaket aus <Tarball> bauen - dynamische Build-Abhängigkeiten "
+"ermitteln"
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
-msgstr "Ein Quell-Paket vom <Source-Paket> bauen"
+msgstr "Ein Quellpaket vom <Quellpaket> bauen"
 
 #: rpmbuild.c:226
 msgid "override build root"
@@ -229,7 +232,7 @@ msgstr "BuildRoot überschreiben"
 
 #: rpmbuild.c:228
 msgid "run build in current directory"
-msgstr ""
+msgstr "Bau im aktuellen Verzeichnis ausführen"
 
 #: rpmbuild.c:230
 msgid "remove build tree when done"
@@ -264,7 +267,7 @@ msgstr "%clean-Abschnitt des Bauvorgangs nicht ausführen"
 #: rpmbuild.c:246
 #, c-format
 msgid "do not execute %prep stage of the build"
-msgstr ""
+msgstr "%prep-Abschnitt des Bauvorgangs nicht ausführen"
 
 #: rpmbuild.c:248
 #, c-format
@@ -294,9 +297,9 @@ msgstr "Zielplattform überschreiben"
 #: rpmbuild.c:276
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
-"Erstellungsoptionen mit [ <Spec-Datei> | <Tar-Archiv> | <Quell-Paket> ]:"
+"Erstellungsoptionen mit [ <Spec-Datei> | <Tar-Archiv> | <Quellpaket> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Gemeinsame Optionen für alle RPM-Modi und Ausführungen:"
@@ -355,32 +358,37 @@ msgstr "Für das Ziel %s wird gebaut\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "Argumente für --root (-r) müssen mit einem / beginnen"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "Datenbank initialisieren"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "Invertierte Datenbank-Liste anhand der installierten Paket-Header erstellen"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "Datenbank-Dateien überprüfen"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "Datenbank initialisieren"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "Datenbank in die Header-Liste in der Standardeingabe exportieren"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "Datenbank aus der Header-Liste in der Standardeingabe importieren"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Datenbank-Optionen:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "Nur ein Hauptmodus kann angegeben werden"
 
@@ -405,7 +413,7 @@ msgstr "Schlüssel des RPM-Schlüsselbundes auflisten"
 msgid "Keyring options:"
 msgstr "Signatur-Optionen:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "Es wurden keine Argumente angegeben"
 
@@ -415,7 +423,7 @@ msgstr "Abfragen/überprüfen der Paketauswahl:"
 
 #: rpm.c:38
 msgid "Query/Verify file selection options:"
-msgstr ""
+msgstr "Abfragen/überprüfen der Dateiauswahl:"
 
 #: rpm.c:41
 msgid "Query options (with -q or --query):"
@@ -590,38 +598,45 @@ msgid "delete package signatures"
 msgstr "Paket-Signatur(en) löschen"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "Keine Überprüfung der Header- und Nutzdaten-Signatur"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr "Paketdatei(en) signieren"
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
-msgstr ""
+msgstr "Datei-Signaturschlüssel <Schlüssel> verwenden"
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr "<Schlüssel>"
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
-msgstr ""
+msgstr "Um Eingabe des Passworts für Datei-Signaturschlüssel bitten"
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Signatur-Optionen:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "»%%_gpg_name« muss in der Makro-Datei gesetzt sein\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
+"»%%_file_signing_key« muss in der Makro-Datei gesetzt sein oder in der "
+"Befehlszeile mit --fskpath übergeben werden\n"
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr "--fskpath darf nur beim Signieren von Dateien angegeben werden"
 
@@ -657,40 +672,49 @@ msgstr "Folgendes Abfrage-Format benutzen"
 msgid "Spec options:"
 msgstr "Spec-Optionen:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "Keine Argumente zur Auswertung angegeben"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr "SOURCE_DATE_EPOCH konnte nicht ausgewertet werden\n"
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Rechnername konnte nicht erkannt werden: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Temp-Datei konnte nicht geöffnet werden: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Datenstrom konnte nicht geöffnet werden: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Ausführung(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Fehler-Status beim Beenden von %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Fehlgeschlagene Paket-Abhängigkeiten:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr "Einstellung %s=%s\n"
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -699,55 +723,6 @@ msgstr ""
 "\n"
 "\n"
 "Fehler beim Bauen des RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "Syntax-Fehler beim Auswerten von ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "Syntax-Fehler beim Auswerten von &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "Syntax-Fehler beim Auswerten von ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "Fehler beim Auswerten des Ausdrucks\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "Unerwartete (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- nur bei Zahlen\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! nur bei Zahlen\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "Typen müssen übereinstimmen\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / nicht unterstützt für Zeichenketten\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- nicht unterstützt für Zeichenketten\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& und || nicht unterstützt für Zeichenketten\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "Syntax-Fehler im Ausdruck\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -836,179 +811,185 @@ msgstr "Lesen des symbolischen Links %s fehlgeschlagen: %s\n"
 #: build/files.c:1204
 #, c-format
 msgid "absolute symlink: %s -> %s\n"
-msgstr ""
+msgstr "Absoluter symbolischer Link: %s -> %s\n"
 
 #: build/files.c:1210
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolischer Link zeigt auf den BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Ungültiges Zeichen '%c' (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Pfad ist außerhalb von BuildRoot: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Verzeichnis nicht gefunden: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Datei nicht gefunden: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Kein Verzeichnis: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Lesen der Richtlinien-Datei fehlgeschlagen: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: Unbekannter Tag (%d) kann nicht geladen werden.\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: Lesen des öffentlichen Schlüssels fehlgeschlagen.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: Ist kein gepanzerter öffentlicher Schlüssel.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: Verschlüsselung fehlgeschlagen\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
-msgstr ""
+msgstr "Makro _build_id_links ist nicht gesetzt, »compat« wird angenommen\n"
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
-msgstr ""
+msgstr "Makro _build_id_links ist auf den unbekannten Wert »%s« gesetzt\n"
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr "Fehler beim Lesen der build-id in %s: %s\n"
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr "build-id fehlt in %s\n"
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr "in %s gefundene build-id ist zu klein\n"
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr "in %s gefundene build-id ist zu groß\n"
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "Erzeugen des Verzeichnisses fehlgeschlagen"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
-msgstr ""
+msgstr "ELF-Hauptdateien und Debug-Dateien im Paket vermischt"
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Datei benötigt führenden »/«: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev-glob ist unzulässig: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
+"Verzeichnis von »glob« nicht gefunden: %s. Wird ohne Globbing versucht.\n"
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
-msgstr ""
+msgstr "Datei von »glob« nicht gefunden: %s. Wird ohne Globbing versucht.\n"
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Datei %s aus %%files konnte nicht geöffnet werden: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "Leere Datei %s in %%files\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Fehler beim Lesen der Datei %s in %%files: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "Ungültiges _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Datei von »glob« nicht gefunden: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
-msgstr ""
+msgstr "Spezielle Datei in erzeugter Dateiliste: %s\n"
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Spezielles %s kann nicht mit anderen Formen gemischt werden: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Mehr als eine Datei in einer Zeile: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ungültige Datei: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Auf nicht gepackte Datei(en) wird geprüft: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1017,113 +998,109 @@ msgstr ""
 "Installierte (aber nicht gepackte) Datei(en) gefunden:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr "%s wurde mehreren Dateinamen zugewiesen"
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Dateien werden verarbeitet: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "Architektur der Binärdateien (%d) entspricht nicht der Paketarchitektur "
 "(%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Architekturabhängige Binärdateien in »noarch«-Paket\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "Erstellen der Archivdatei fehlgeschlagen bei Datei %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "Erstellen der Archivdatei fehlgeschlagen: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "%s-Datei konnte nicht geöffnet werden: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Unbekannte Nutzdaten-Kompression: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Datei %s kann nicht durchsucht werden: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
-msgstr ""
+msgstr "%jd Bytes in Datei %s konnten nicht gelesen werden: %s\n"
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
-msgstr ""
+msgstr "Header konnte nicht nach %s geschrieben werden: %s\n"
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s konnte nicht geöffnet werden: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Paket konnte nicht geschrieben werden: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Erstellt: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "»%s« wird ausgeführt:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Ausführung von »%s« ist fehlgeschlagen.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paket-Prüfung »%s« fehlgeschlagen.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s konnte nicht erstellt werden: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Dateiname für das Paket %s konnte nicht generiert werden: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
+"Erstellen des Binärpakets wurde abgeschlossen, Ergebnis %d, Dateiname %s\n"
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "Zeile %d: Zweites %s\n"
@@ -1168,18 +1145,18 @@ msgstr "Keine Beschreibung im %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "Zeile %d: zweites %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "Zeile %d: Fehler beim Auswerten von %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "Zeile %d: Ungültige Option %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1193,7 +1170,7 @@ msgstr "Zeile %d: Fehler beim Auswerten von %%files: %s\n"
 #: build/parseFiles.c:73
 #, c-format
 msgid "line %d: multiple %%files for package '%s'\n"
-msgstr ""
+msgstr "Zeile %d: mehrere %%files-Abschnitte für Paket »%s«\n"
 
 #: build/parsePolicies.c:32
 #, c-format
@@ -1237,155 +1214,155 @@ msgstr "Zeile %d: Ungültige %s-Nummer: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d ist mehrfach definiert\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Architektur ist ausgeschlossen: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Architektur ist nicht einbezogen: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "Betriebssystem ist ausgeschlossen: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "Betriebssystem ist nicht einbezogen: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s-Feld muss im Paket vorhanden sein: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Doppelte %s-Einträge im Paket: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Symbol %s kann nicht geöffnet werden: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Symbol %s kann nicht gelesen werden: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Unbekannter Symbol-Typ: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "Zeile %d: Tag benötigt nur ein Zeichen: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "Zeile %d: %s in: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s in: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Ungültiges Zeichen '%c' (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
-msgstr ""
+msgstr "Möglicherweise unexpandiertes Makro"
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Ungültige Sequenz \"..\""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "Zeile %d: Missgebildeter Tag: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "Zeile %d: Leerer Tag: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "Zeile %d: Präfixe dürfen nicht mit einem »/« enden: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 "Zeile %d: Das Dokumentationsverzeichnis muss mit einem »/« beginnen: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "Zeile %d: Das Epoch-Feld muss eine vorzeichenlose Zahl sein: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "Zeile %d: Ungültig %s: Kennzeichner: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "Zeile %d: Ungültiges BuildArchitecture-Format: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
-msgstr ""
+msgstr "Zeile %d: Doppelter BuildArch-Eintrag: %s\n"
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "Zeile %d: Nur »noarch«-Unterpakete werden unterstützt: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interner Fehler: Falscher Tag %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "Zeile %d: %s ist veraltet: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ungültige Paket-Spezifikation: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
-msgstr ""
+msgstr "RPM-Binärpaket wurde gefunden, aber spec-Datei erwartet!\n"
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "Zeile %d: Unbekannter Tag: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} kann nicht leer sein\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} kann nicht »/« sein\n"
@@ -1395,12 +1372,12 @@ msgstr "%%{buildroot} kann nicht »/« sein\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Ungültige Quelle: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Kein Patch mit der Nummer %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Keine Quelle mit der Nummer %u\n"
@@ -1410,27 +1387,27 @@ msgstr "Keine Quelle mit der Nummer %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fehler beim Auswerten von %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "Zeile %d: Ungültiges Argument für %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "Zeile %d: Ungültige %%setup-Option %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Ungültige Patch-Nummer %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "Zeile %d: Zweites %%prep\n"
@@ -1459,19 +1436,19 @@ msgstr "Version wird benötigt"
 
 #: build/parseReqs.c:282
 msgid "Only package names are allowed in Obsoletes"
-msgstr ""
+msgstr "In »Obsoletes« sind nur Paketnamen erlaubt"
 
 #: build/parseReqs.c:287
 msgid "It's not recommended to have unversioned Obsoletes"
-msgstr ""
+msgstr "Einträge in »Obsoletes« ohne Versionsnummer werden nicht empfohlen"
 
 #: build/parseReqs.c:290
 msgid "It's not recommended to use '>' in Obsoletes"
-msgstr ""
+msgstr "Verwendung von »>« in »Obsoletes« wird nicht empfohlen"
 
 #: build/parseReqs.c:298
 msgid "Only absolute paths are allowed in file triggers"
-msgstr ""
+msgstr "In Datei-Triggern sind nur absolute Pfade erlaubt"
 
 #: build/parseReqs.c:311
 msgid "Trigger fired by the same package is already defined in spec file"
@@ -1490,7 +1467,7 @@ msgstr "Zeile %d: Trigger benötigen --: %s\n"
 #: build/parseScript.c:270
 #, c-format
 msgid "line %d: missing trigger condition: %s\n"
-msgstr ""
+msgstr "Zeile %d: fehlende Trigger-Bedingung: %s\n"
 
 #: build/parseScript.c:280 build/parseScript.c:350
 #, c-format
@@ -1510,108 +1487,109 @@ msgstr "Zeile %d: Skript/Programm muss mit »/« beginnen: %s\n"
 #: build/parseScript.c:312
 #, c-format
 msgid "line %d: Priorities are allowed only for file triggers : %s\n"
-msgstr ""
+msgstr "Zeile %d: Prioritäten sind nur für Datei-Trigger erlaubt: %s\n"
 
 #: build/parseScript.c:343
 #, c-format
 msgid "line %d: Second %s\n"
 msgstr "Zeile %d: Zweites %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "Zeile %d: Nicht unterstütztes internes Skript: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "Zeile %d: Interpreter-Argumente sind in Triggern nicht erlaubt: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
-msgstr ""
+msgstr "Makro expandiert im Kommentar in Zeile %d: %s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Öffnen von %s fehlgeschlagen: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argument wurde für %s erwartet\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "Zeile %d: Nicht geschlossenes %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "Zeile %d: Nicht geschlossenes Makro oder ungültige Zeilenfortsetzung\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%else ohne %%if erhalten\n"
+msgstr "%s: Zeile %d: %s ohne %%if\n"
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "Zeile %d: %s: %s\n"
+msgstr "%s: Zeile %d: %s nach %s\n"
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: Ungültige %%if-Bedingung\n"
+msgstr "%s:%d: unzulässige %s-Bedingung: %s\n"
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: missgebildete %%include-Anweisung\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "Kodierung %s wird vom System nicht unterstützt\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Pakt %s: Ungültige %s-Kodierung in %s: %s - %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
-msgstr ""
+msgstr "Zeile %d: %%end akzeptiert keine Argumente: %s\n"
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
+"Zeile %d: %%end wurde hier nicht erwartet, kein Abschnitt zum Schließen: %s\n"
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
-msgstr ""
+msgstr "Zeile %d gehört zu keinem der Abschnitte: %s\n"
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Keine für das Bauen kompatiblen Architekturen gefunden\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket hat keine %%description: %s\n"
@@ -1685,98 +1663,94 @@ msgstr "Fehlender Modul-Pfad in Zeile: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Zu viele Argumente in der Zeile: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Richtlinien werden verarbeitet: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ungültiger regulärer Ausdruck %s wird ignoriert\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Pipe für %s konnte nicht erzeugt werden: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "%s konnte nicht ausgeführt werden: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "fork %s konnte nicht ausgeführt werden: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "%s konnte nicht ausgeführt werden: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s fehlgeschlagen: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "Nicht alle Daten konnten nach %s geschrieben werden: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Leerer Dateiklassifizierer\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Keine Dateiattribute konfiguriert\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) fehlgeschlagen: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load fehlgeschlagen: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Erkennung der Datei »%s« fehlgeschlagen: Modus %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "%s wird gesucht: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s konnte nicht gefunden werden:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
-msgstr ""
+msgstr "Veraltete externe Abhängigkeitserzeugung wird verwendet!\n"
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr "Zeile %d: %s: Paket %s existiert nicht\n"
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr "Zeile %d: %s: Paket %s existiert bereits\n"
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr "SOURCE_DATE_EPOCH konnte nicht ausgewertet werden\n"
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Rechnername konnte nicht erkannt werden: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1813,90 +1787,114 @@ msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 "%s hat einen zu großen oder zu kleinen Integer-Wert, wird übersprungen\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "Keine %s-Sperre auf %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "gemeinsam"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exklusiv"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "Ungültiger Indextyp %x auf %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "Fehler(%d) beim Holen der Datensätze »%s« aus dem %s-Index: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "Fehler(%d) beim Speichern des Datensatzes »%s« in %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "Fehler(%d) beim Entfernen des Datensatzes »%s« aus %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "Fehler(%d) beim Hinzufügen des Datensatzes für Header #%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "Fehler(%d) beim Entfernen des Datensatzes für Header #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "Fehler(%d) beim Reservieren einer neuen Paket-Instanz\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
+#: lib/backend/ndb/glue.c:101
+#, fuzzy
+msgid "Detected outdated index databases\n"
+msgstr "Alte Datenbank in %s konnte nicht gelöscht werden\n"
+
+#: lib/backend/ndb/glue.c:103
+#, fuzzy
+msgid "Rebuilding outdated index databases\n"
+msgstr "Alte Datenbank in %s konnte nicht gelöscht werden\n"
+
+#: lib/backend/ndb/rpmidx.c:204
 #, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Die Spec-Datei %s kann nicht geöffnet werden: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s ist ein Delta-RPM und kann nicht direkt installiert werden\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nicht unterstütze Nutzdaten (%s) in Paket %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "Paket %s wurde bereits hinzugefügt, %s wird übersprungen\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "Paket %s wurde bereits hinzugefügt, wird durch %s ersetzt\n"
@@ -1913,7 +1911,7 @@ msgstr "(keine Nummer)"
 msgid "(not a string)"
 msgstr "(keine Zeichenkette)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(ungültiger Typ)"
 
@@ -1926,146 +1924,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(nicht Base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(ungültiger XML-Typ)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(keine OpenPGP-Signatur)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ungültiges Datum %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "ersetzt"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "nicht installiert"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "Netzwerk-Mitbenutzung"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "Falsche Farbe"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "fehlt"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s als %s gesichert\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s erstellt als %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: Entfernen fehlgeschlagen: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "Verzeichnis"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "Datei"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr "Signatur "
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2077,12 +2075,12 @@ msgstr "ungültige Feldbreite"
 #: lib/headerfmt.c:362
 #, c-format
 msgid "missing { after %%"
-msgstr ""
+msgstr "fehlende { nach %%"
 
 #: lib/headerfmt.c:384
 #, c-format
 msgid "missing } after %%{"
-msgstr ""
+msgstr "fehlende } nach %%{"
 
 #: lib/headerfmt.c:395
 msgid "empty tag format"
@@ -2109,43 +2107,52 @@ msgstr "Unerwartete ]"
 msgid "unexpected }"
 msgstr "Unerwartete }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? im Ausdruck erwartet"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ nach dem ? im Ausdruck erwartet"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} im Ausdruck erwartet"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": erwartet ein ? im Unterausdruck"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ nach dem : im Ausdruck erwartet"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| am Ende des Ausdrucks erwartet"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "Zählvariable wird mit ungleich großem Array benutzt"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "Zeile %d: %s ist veraltet: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
-msgstr ""
+msgstr "Makro-Datei %s konnte nicht geladen werden\n"
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "Argumente für --prefix müssen mit einem / beginnen"
+msgstr "Argumente zu --dbpath müssen mit  »/« beginnen\n"
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2184,11 +2191,11 @@ msgstr "»AUSDRUCK«"
 
 #: lib/poptALL.c:217
 msgid "Specify target platform"
-msgstr ""
+msgstr "Zielplattform angeben"
 
 #: lib/poptALL.c:217
 msgid "CPU-VENDOR-OS"
-msgstr ""
+msgstr "CPU-ANBIETER-BS"
 
 #: lib/poptALL.c:219 lib/poptALL.c:241
 msgid "read <FILE:...> instead of default file(s)"
@@ -2200,11 +2207,11 @@ msgstr "<DATEI:...>"
 
 #: lib/poptALL.c:222
 msgid "load a single macro file"
-msgstr ""
+msgstr "eine einzelne Makro-Datei laden"
 
 #: lib/poptALL.c:223
 msgid "<FILE>"
-msgstr ""
+msgstr "<DATEI>"
 
 #: lib/poptALL.c:228
 msgid "don't enable any plugins"
@@ -2276,7 +2283,7 @@ msgstr "rpmio-Ein-/Ausgabe debuggen"
 
 #: lib/poptALL.c:273
 msgid "disable user namespace support"
-msgstr ""
+msgstr "Unterstützung für Benutzer-Namensraum deaktivieren"
 
 #: lib/poptALL.c:332
 #, c-format
@@ -2375,7 +2382,7 @@ msgstr "Keine Überprüfung des Festplattenspeichers vor der Installation"
 
 #: lib/poptI.c:166
 msgid "short hand for --ignorepayload --ignoresignature"
-msgstr ""
+msgstr "Kürzel für --ignorepayload --ignoresignature"
 
 #: lib/poptI.c:168
 msgid "install documentation"
@@ -2608,15 +2615,15 @@ msgstr "Dateien nicht als Paket-Liste verarbeiten"
 
 #: lib/poptQV.c:193
 msgid "only include configuration files"
-msgstr ""
+msgstr "nur Konfigurationsdateien einbeziehen"
 
 #: lib/poptQV.c:196
 msgid "only include documentation files"
-msgstr ""
+msgstr "nur Dokumentationsdateien einbeziehen"
 
 #: lib/poptQV.c:199
 msgid "only include license files"
-msgstr ""
+msgstr "nur Lizenzdateien einbeziehen"
 
 #: lib/poptQV.c:202
 msgid "only include artifact files"
@@ -2625,17 +2632,17 @@ msgstr ""
 #: lib/poptQV.c:205
 #, c-format
 msgid "exclude %%ghost files"
-msgstr ""
+msgstr "%%ghost-Dateien ausschließen"
 
 #: lib/poptQV.c:208
 #, c-format
 msgid "exclude %%config files"
-msgstr ""
+msgstr "%%config-Dateien ausschließen"
 
 #: lib/poptQV.c:211
 #, c-format
 msgid "exclude %%artifact files"
-msgstr ""
+msgstr "%%artifact-Dateien ausschließen"
 
 #: lib/poptQV.c:223
 msgid "dump basic file information"
@@ -2693,25 +2700,25 @@ msgstr "Keine Überprüfung der Paket-Abhängigkeiten"
 msgid "don't execute verify script(s)"
 msgstr "Kein(e) Überprüfungsskript(e) ausführen"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Fehlende rpmlib-Features für %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
-msgstr "Quell-Paket erwartet, Binär-Paket entdeckt\n"
+msgstr "Quellpaket erwartet, Binärpaket entdeckt\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
-msgstr "Quell-Paket enthält keine Spec-Datei\n"
+msgstr "Quellpaket enthält keine Spec-Datei\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "Entpacken des Archivs fehlgeschlagen%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " bei Datei "
 
@@ -2761,139 +2768,139 @@ msgstr "Paket hat keine Eigentümer-/Gruppen-Liste\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "Paket weder Eigentümer- noch ID-Liste\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "Gruppe %s enthält keine Pakete\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "Keine Paket-Trigger %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "Missgebildet: %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "Kein Paket stimmt mit %s überein: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
-msgstr ""
+msgstr "Kein Paket steht im Konflikt mit %s\n"
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
-msgstr ""
+msgstr "Kein Paket markiert %s als obsolet\n"
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "Kein Paket benötigt %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "Kein Paket empfiehlt %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "Kein Paket schlägt %s vor\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
-msgstr ""
+msgstr "Kein Paket ergänzt %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "Kein Paket erweitert %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "Kein Paket stellt %s bereit\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "Datei %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "Die Datei %s gehört zu keinem Paket\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "Ungültige Paket-Nummer: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "Datensatz %u konnte nicht gelesen werden\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "Das Paket %s ist nicht installiert\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "Unbekannter Tag: »%s«\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 "%s: Import des Schlüssels %d fehlgeschlagen.\n"
 "\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: Schlüssel %d ist kein gesicherter öffentlicher Schlüssel.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: Importieren fehlgeschlagen (%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
-msgstr ""
+msgstr "PRÜFSUMMEN"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
-msgstr ""
+msgstr "Prüfsummen"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
-msgstr ""
+msgstr "SIGNATUREN"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
-msgstr ""
+msgstr "Signaturen"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NICHT OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2907,117 +2914,117 @@ msgstr "%s: Öffnen fehlgeschlagen: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Das aktuelle Verzeichnis kann nicht geöffnet werden: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: chroot-Verzeichnis nicht gesetzt\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Wechseln des Wurzelverzeichnisses fehlgeschlagen: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Wurzelverzeichnis kann nicht wiederhergestellt werden: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "%d fehlende(r) Index(e), bitte warten...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "%s-Index kann nicht mittels %s geöffnet werden - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "Datenbank-Pfad wurde nicht gesetzt\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: wird übersprungen"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "Fehler(%d) beim Speichern des Datensatzes #%d in %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: wird übersprungen"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: Beschädigten Header #%u erhalten -- wird übersprungen.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: Header bei 0x%x kann nicht gelesen werden\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
-msgstr ""
+msgstr "Alte Datenbank konnte auch nicht aus %s wiederhergestellt werden\n"
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
-msgstr ""
+msgstr "Öffentliche Schlüssel von %s konnten nicht erhalten werden\n"
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
-msgstr ""
+msgstr "Alte Datenbank in %s konnte nicht gelöscht werden\n"
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "Datenbank-Pfad wurde nicht gesetzt"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "Anlegen des Verzeichnisses %s fehlgeschlagen: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "Header #%u in der Datenbank ist ungültig -- wird übersprungen.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "Ursprünglicher Datensatz %u kann nicht hinzugefügt werden\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "Neu bauen der Datenbank fehlgeschlagen: Datenbank verbleibt entsprechend\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "Konnte die alte Datenbank nicht durch die neue ersetzen!\n"
 
@@ -3101,7 +3108,7 @@ msgstr "Abhängigkeitsvergleich unterstützt Versionen mit Tilde."
 
 #: lib/rpmds.c:1245
 msgid "dependency comparison supports versions with caret."
-msgstr ""
+msgstr "Abhängigkeitsvergleich unterstützt Versionen mit Caret."
 
 #: lib/rpmds.c:1248
 msgid "support files larger than 4GB"
@@ -3113,11 +3120,11 @@ msgstr ""
 
 #: lib/rpmds.c:1254
 msgid "support for dynamic buildrequires."
-msgstr ""
+msgstr "Dynamische Erstellungsabhängigkeiten werden unterstützt."
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
-msgstr ""
+msgstr "Paket-Nutzdaten können mit zstd komprimiert werden."
 
 #: lib/rpmds.c:1411
 #, c-format
@@ -3138,7 +3145,7 @@ msgstr ""
 
 #: lib/rpmds.c:1501
 msgid "Illegal context for 'if', please use 'and' instead"
-msgstr ""
+msgstr "Unzulässiger Kontext für »if«, bitte verwenden Sie stattdessen »and«"
 
 #: lib/rpmds.c:1517
 msgid "Rich dependency does not start with '('"
@@ -3159,11 +3166,11 @@ msgstr ""
 
 #: lib/rpmds.c:1560
 msgid "Cannot chain different ops"
-msgstr ""
+msgstr "Verschiedene Operatoren können nicht verkettet werden"
 
 #: lib/rpmds.c:1565
 msgid "Can only chain and/or/with ops"
-msgstr ""
+msgstr "Nur die Operatoren »and«, »or« und »with« können verkettet werden"
 
 #: lib/rpmds.c:1696
 msgid "Junk after rich dependency"
@@ -3172,22 +3179,23 @@ msgstr ""
 #: lib/rpmfi.c:799
 #, c-format
 msgid "user %s does not exist - using %s\n"
-msgstr ""
+msgstr "Benutzer %s existiert nicht - %s wird verwendet\n"
 
 #: lib/rpmfi.c:806
 #, c-format
 msgid "group %s does not exist - using %s\n"
-msgstr ""
+msgstr "Gruppe %s existiert nicht - %s wird verwendet\n"
 
 #: lib/rpmfi.c:1363
 #, c-format
 msgid "Wrong number of entries for tag %s: %u found but %u expected.\n"
 msgstr ""
+"Unzulässige Anzahl Einträge für Tag %s - %u gefunden, aber %u erwartet.\n"
 
 #: lib/rpmfi.c:1368
 #, c-format
 msgid "Malformed data for tag %s: %u bytes found but %lu expected.\n"
-msgstr ""
+msgstr "Unzulässige Daten für Tag %s - %u Bytes gefunden, aber %lu erwartet.\n"
 
 #: lib/rpmfi.c:2347
 msgid "Bad magic"
@@ -3227,7 +3235,7 @@ msgstr "Archiv-Datei nicht im Header"
 
 #: lib/rpmfi.c:2381
 msgid "File from package already exists as a directory in system"
-msgstr ""
+msgstr "Datei aus dem Paket existiert bereits als Verzeichnis im System"
 
 #: lib/rpmfi.c:2388
 msgid " failed - "
@@ -3270,7 +3278,7 @@ msgstr "Vorbereiten …"
 
 #: lib/rpminstall.c:191
 msgid "Verifying..."
-msgstr ""
+msgstr "Wird überprüft …"
 
 #: lib/rpminstall.c:194
 msgid "Preparing packages..."
@@ -3278,7 +3286,7 @@ msgstr "Pakete vorbereiten …"
 
 #: lib/rpminstall.c:194
 msgid "Verifying packages..."
-msgstr ""
+msgstr "Pakete werden überprüft …"
 
 #: lib/rpminstall.c:272 tools/rpmgraph.c:167
 msgid "Failed dependencies:\n"
@@ -3360,22 +3368,22 @@ msgstr "%s-Sperre auf %s kann nicht erstellt werden (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "Auf %s-Sperre auf %s wird gewartet\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "»dlopen« %s %s fehlgeschlagen\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Auflösen des Symbols %s fehlgeschlagen: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Plugin %%__%s_%s ist nicht konfiguriert\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Plugin %s ist nicht geladen\n"
@@ -3423,14 +3431,15 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "Paket %s (welches neuer als %s ist) ist bereits installiert"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "Installation des Pakets %s benötigt %<PRIu64>%cB auf dem %s-Dateisystem"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "Installation des Pakets %s benötigt %<PRIu64>-Inodes auf dem %s-Dateisystem"
 
@@ -3456,7 +3465,7 @@ msgstr "%s wird ersetzt durch %s%s"
 #: lib/rpmprob.c:171
 #, c-format
 msgid "package %s does not verify: %s"
-msgstr ""
+msgstr "Überprüfung des Pakets %s ist fehlgeschlagen: %s"
 
 #: lib/rpmprob.c:176
 #, c-format
@@ -3549,21 +3558,21 @@ msgstr ""
 
 #: lib/rpmscript.c:146
 msgid "No exec() called after fork() in lua scriptlet\n"
-msgstr ""
+msgstr "Kein exec() nach fork() im Lua-Scriptlet aufgerufen\n"
 
 #: lib/rpmscript.c:151
 #, c-format
 msgid "Unable to restore current directory: %m"
 msgstr "Aktuelles Verzeichnis kann nicht wiederhergestellt werden: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua>-Scriptlet-Unterstützung nicht eingebaut\n"
 
 #: lib/rpmscript.c:225
 #, c-format
 msgid "failed to exec scriptlet interpreter %s: %s\n"
-msgstr ""
+msgstr "Scriptlet-Interpreter %s konnte nicht ausgeführt werden: %s\n"
 
 #: lib/rpmscript.c:280
 #, c-format
@@ -3599,133 +3608,133 @@ msgstr "%s Scriptlet fehlgeschlagen, Beenden-Status %d\n"
 msgid "Unknown format"
 msgstr "Unbekanntes Format"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "installieren"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "löschen"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
-msgstr ""
+msgstr "rpmdb"
 
 #: lib/rpmts.c:100
 #, c-format
 msgid "cannot open Packages database in %s\n"
 msgstr "Paket-Datenbank in %s kann nicht geöffnet werden\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "Zusätzliche »(« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "Fehlende »(« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "Fehlende »)« in Paket-Bezeichnung: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: Lesen des öffentlichen Schlüssels fehlgeschlagen.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
-msgstr ""
+msgstr "Unzulässige Paketüberprüfungsstufe %s\n"
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "Transaktion"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
-msgstr ""
+msgstr "%s-Tag %u: unzulässiger Typ %u"
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
-msgstr ""
+msgstr "%s: Tag %u: ungültige Anzahl %u"
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
-msgstr ""
+msgstr "%s-Tag %u: ungültige Daten %p (%u)"
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
-msgstr ""
+msgstr "%s-Tag %u: invalid size %u"
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
-msgstr ""
+msgstr "%s-Tag %u: ungültige OpenPGP-Signatur"
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
-#, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
-msgstr ""
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
+#, fuzzy, c-format
+msgid "%s%s%s %s"
+msgstr "%s%s %s"
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr "Prüfsumme"
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
-msgstr ""
+msgstr "%s%s"
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
-msgstr ""
+msgstr "Signatur"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
-msgstr ""
+msgstr "Header"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
-msgstr ""
+msgstr "Paket"
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Header "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
-msgstr ""
+msgstr "Nutzdaten"
 
 #: lib/signature.c:213
 msgid "Unable to reload signature header.\n"
 msgstr "Header der Signatur kann nicht erneut geladen werden.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
-msgstr ""
+msgstr "keine Signatur"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
-msgstr ""
+msgstr "keine Prüfsumme"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "übersprungen"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "fehlgeschlagen"
 
@@ -3750,84 +3759,172 @@ msgstr "Unerfüllte Abhängigkeiten für %s:\n"
 #: plugins/prioreset.c:29
 #, c-format
 msgid "Unable to reset nice value: %s"
-msgstr ""
+msgstr "Nice-Wert konnte nicht zurückgesetzt werden: %s"
 
 #: plugins/prioreset.c:40
 #, c-format
 msgid "Unable to reset I/O priority: %s"
-msgstr ""
+msgstr "E/A-Priorität könnte nicht zurückgesetzt werden: %s"
 
 #: rpmio/digest_nss.c:69
 msgid "Failed to initialize NSS library\n"
-msgstr ""
+msgstr "NSS-Bibliothek konnte nicht initialisiert werden\n"
 
 #: rpmio/digest_nss.c:80
 #, c-format
 msgid "Failed to register fork handler: %m\n"
+msgstr "Fork-Handler konnte nicht registriert werden: %m\n"
+
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "Syntax-Fehler beim Auswerten von ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "Syntax-Fehler beim Auswerten von &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "Syntax-Fehler beim Auswerten von ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "Zeile %d: %s in: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ nach dem ? im Ausdruck erwartet"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "Fehler beim Auswerten des Ausdrucks\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "Unerwartete (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- nur bei Zahlen\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| am Ende des Ausdrucks erwartet"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "Syntax-Fehler im Ausdruck\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "Typen müssen übereinstimmen\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / nicht unterstützt für Zeichenketten\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- nicht unterstützt für Zeichenketten\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
-msgstr ""
+msgstr "%3d>%*s(leer)\n"
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(leer)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Die Tar-Pipe konnte nicht geöffnet werden: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
-msgstr ""
+msgstr "Makro %%%s hat einen ungültigen Namen (%s)\n"
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
-msgstr ""
+msgstr "Makro %%%s ist ein eingebautes Makro (%s)\n"
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s hat nicht terminierte Optionen\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s hat einen nicht terminierten Hauptteil\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s hat einen leeren Hauptteil\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makro %%%s benötigt Leerzeichen vor dem Hauptteil\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s konnte nicht erweitert werden\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 "Makro %%%s ist definiert, wird aber nicht innerhalb des Bereichs verwendet\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Unbekannte Option %c in %s (%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "Laden der Makro-Datei %s ist fehlgeschlagen"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3835,17 +3932,27 @@ msgstr ""
 "Zu viele Rekursionsebenen bei der Expansion des Makros. Dies wird "
 "wahrscheinlich durch eine rekursive Makro-Deklaration verursacht.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Nicht terminiertes %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Auf %% folgt ein nicht auswertbares Makro\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "Unerwartete ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "Unerwartete ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiv %d  leer %d\n"
@@ -3887,29 +3994,29 @@ msgstr "Warnung: "
 
 #: rpmio/rpmlog.c:269
 msgid "Error writing to log"
-msgstr ""
+msgstr "Fehler beim Schreiben in das Protokoll"
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "Ungültige Syntax in Lua-Scriptlet: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "Ungültige Syntax in Lua-Script: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "Lua-Script fehlgeschlagen: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "Ungültige Syntax in Lua-Datei: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Lua-Hook fehlgeschlagen: %s\n"
@@ -3919,44 +4026,44 @@ msgstr "Lua-Hook fehlgeschlagen: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "Speicherbelegung (%u Byte) lieferte NULL zurück.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
-msgstr ""
+msgstr "Nicht unterstützte Schlüsselversion: V%d\n"
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, Schlüssel-ID %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(keine)"
 
 #: rpmio/rpmsq.c:37
 #, c-format
 msgid "exiting on signal %d from pid %d\n"
-msgstr ""
+msgstr "Abbruch durch Signal %d von PID %d\n"
 
 #: sign/rpmgensig.c:55
 #, c-format
 msgid "error creating temp directory %s: %m\n"
-msgstr ""
+msgstr "Fehler beim Anlegen des temporären Verzeichnisses %s: %m\n"
 
 #: sign/rpmgensig.c:63
 #, c-format
 msgid "error creating fifo %s: %m\n"
-msgstr ""
+msgstr "Fehler beim Erzeugen der FIFO %s: %m\n"
 
 #: sign/rpmgensig.c:84
 #, c-format
 msgid "error delete fifo %s: %m\n"
-msgstr ""
+msgstr "Fehler beim Löschen der FIFO %s: %m\n"
 
 #: sign/rpmgensig.c:92
 #, c-format
 msgid "error delete directory %s: %m\n"
-msgstr ""
+msgstr "Fehler beim Löschen des Verzeichnisses %s: %m\n"
 
 #: sign/rpmgensig.c:168
 #, c-format
@@ -4018,63 +4125,63 @@ msgstr "GPG konnte die Signatur nicht schreiben\n"
 msgid "unable to read the signature\n"
 msgstr "Signatur konnte nicht gelesen werden\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
-msgstr ""
+msgstr "Unterstützung zum Signieren von Dateien ist nicht eingebaut\n"
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature fehlgeschlagen: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM-Pakete der Version 3 können nicht signiert werden\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s enthält bereits eine identische Signatur, wird übersprungen\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMk Temp fehlgeschlagen\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead fehlgeschlagen: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "Ersetzen von %s fehlgeschlagen: %s\n"
 
 #: sign/rpmsignfiles.c:55
 msgid "sign_hash failed\n"
-msgstr ""
+msgstr "sign_hash fehlgeschlagen\n"
 
 #: sign/rpmsignfiles.c:84
 msgid "File digest algorithm id is invalid"
-msgstr ""
+msgstr "Kennung des Datei-Prüfsummenalgorithmus ist ungültig"
 
 #: sign/rpmsignfiles.c:104
 msgid "signFile failed\n"
-msgstr ""
+msgstr "signFile fehlgeschlagen\n"
 
 #: sign/rpmsignfiles.c:109
 msgid "headerPutString failed\n"
-msgstr ""
+msgstr "headerPutString fehlgeschlagen\n"
 
 #: tools/rpmgraph.c:141
 #, c-format
@@ -4085,23 +4192,20 @@ msgstr "%s: Lesen der Paket-Liste fehlgeschlagen: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "Keine Überprüfung der Header- und Nutzdaten-Signatur"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Ausführung von %s fehlgeschlagen (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! nur bei Zahlen\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Fehler bei der Ausführung des Skriptlets %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& und || nicht unterstützt für Zeichenketten\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "Zeile: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Fehler beim Lesen der Datei %s in %%files: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: Zeile: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "%s-Datei konnte nicht geöffnet werden: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Kein »Source«-Tag in Spec-Datei\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "Zeile %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif ohne %%if erhalten\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "Laden der Makro-Datei %s ist fehlgeschlagen"

--- a/po/el.po
+++ b/po/el.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Greek (http://www.transifex.com/rpm-team/rpm/language/el/)\n"
 "Language: el\n"
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Κοινές επιλογές για όλα τα εκτελέσιμα και τις λειτουργίες rpm:"
@@ -335,31 +335,35 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -383,7 +387,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -548,38 +552,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -611,93 +619,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -794,283 +762,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, c-format
+msgid "Can't read content of file: %s\n"
+msgstr ""
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
+#: build/files.c:2233
 #, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
+msgid "Could not open %s file %s: %m\n"
 msgstr ""
 
 #: build/files.c:2258
 #, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
+#, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1115,18 +1083,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1182,154 +1150,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1339,12 +1307,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1354,27 +1322,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1459,101 +1427,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1619,98 +1587,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1745,90 +1709,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr ""
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1845,7 +1831,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1858,146 +1844,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2041,35 +2027,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2615,25 +2610,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2683,137 +2678,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr ""
 
@@ -2827,116 +2822,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3273,22 +3268,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3334,12 +3329,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3463,7 +3459,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3506,15 +3502,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3523,96 +3519,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3620,19 +3616,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3673,83 +3669,167 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+msgid "unexpected end of expression"
+msgstr ""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3793,27 +3873,27 @@ msgstr ""
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3823,17 +3903,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3922,44 +4002,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Esperanto (http://www.transifex.com/rpm-team/rpm/language/"
 "eo/)\n"
@@ -116,10 +116,9 @@ msgid "build source package only from <specfile>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <spec-dosiero>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "munti nur fontotekstan pakaĵon laŭ <spec-dosiero>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -162,11 +161,10 @@ msgid "build source package only from <source package>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <fontoteksta pakaĵo>"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "munti nur fontotekstan pakaĵon laŭ <fontoteksta pakaĵo>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -204,10 +202,9 @@ msgid "build source package only from <tarball>"
 msgstr "munti nur fontotekstan pakaĵon laŭ <tar-dosiero>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "munti nur fontotekstan pakaĵon laŭ <tar-dosiero>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -285,7 +282,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "Multaj elektoj je [ <spec-dosiero> |  <tar-dosiero> | <fontoteksta pakaĵo> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Kutimaj elektoj por ĉiuj rpm-aj reĝimoj kaj programoj:"
@@ -344,32 +341,37 @@ msgstr "Muntanta por celon %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumentoj de --root (-r) devas komenciĝi per /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "iniciati datumbazon"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "remunti listojn inversigitajn de la datumbazo el instalitaj pakaĵo-kapoj"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "konstati datumbazajn dosierojn"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "iniciati datumbazon"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "eksporta datumbazo al ĉefeliga ĉapolisto"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "importa datumbazo el ĉefeniga ĉapolisto"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Datumbazo-elektoj:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "nur unu ĉefa reĝimo povas esti specifita"
 
@@ -393,7 +395,7 @@ msgstr "listigi ŝlosilojn el RPM-ŝlosilaro"
 msgid "Keyring options:"
 msgstr "Ŝlosilaro-elektoj:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "neniuj parametroj donitaj"
 
@@ -569,38 +571,43 @@ msgid "delete package signatures"
 msgstr "forigi pakaĵo-pretendojn"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "ne konstati pretendojn de kapo+ŝarĝo"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Pretendo-elektojn:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Vi devas valorizi \"%%_gpg_name\" en via makro-dosiero\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -632,40 +639,49 @@ msgstr "uzu la jenan mendo-formaton"
 msgid "Spec options:"
 msgstr "Spec-elektoj:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "neniuj parametroj donitaj por analizi"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Ne eblis kanonigi gastiganto-nomon: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Ne eblas malfermi provizoran dosieron: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Ne eblas malfermi fluon: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Plenumiganta (%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Misa elirstato el %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Malsukcesintaj muntaj dependaĵoj:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -674,55 +690,6 @@ msgstr ""
 "\n"
 "\n"
 "Muntaj eraroj ĉe RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "sintaksa eraro dum analizi ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "sintaksa eraro dum analizi &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "Sintaksa eraro dum analizi ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "analiza eraro ĉe esprimo\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "( sen )\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- nur por nobroj\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! nur por nombroj\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "tipoj devas esti kongruaj\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / ne por ĉenoj\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- no por ĉenoj\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& kaj || ne por ĉenoj\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "sintaksa eraro en esprimo\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -818,172 +785,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Mola ligilo almontriĝas al BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Nevalida signo '%c' (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Vojo estas ekster buildroot: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Dosierujo ne trovita: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Dosiero ne trovita: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Ne dosierujo: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Malsukcesis legi konduto-dosieron: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: ne eblas ŝargi nekonatan etikedon (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: legi publikan ŝlosilon malsukcesis.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ne ŝirmita publika ŝlosilo.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: malsukcesis kodiĝi\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "malsukcesis krei dosierujon"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Dosiero devas havi antaŭan \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Amaso %%dev ne permesata:%s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Ne eblis malfermi %%files file %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "Vaka dosiero %%files %s\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "eraro dum legi dosieron %%files %s: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "nepermesita _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Dosiero ne trovita laŭ amaso: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Ne eblas kunmiksi specialan %s-on kun aliaj formoj: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Pli ol unu dosiero en linio: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Fuŝa dosiero: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontrolanta ne pakita(j)n dosiero(j)n: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -992,113 +964,108 @@ msgstr ""
 "Insalita(j) (sed ne pakita(j) dosiero(j) trovita(j):\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Procedanta dosierojn: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "Platformo (%d) de la plenumebla dosiero ne kongruas la pakaĵan platformon "
 "(%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Platformo-dependaj dosieroj en platformo-sendependa pakaĵo\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "kreado de arkivo malsukcesis ĉe dosiero %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "kreado de arkivo malsukcesis: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Ne eblis malfermi dosieron %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nekonata kunpremo-tipo de ŝarĝo: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Ne eblis serĉi en dosiero %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ne eblas malfermi: %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Ne eblas skribi pakaĵon: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skribis: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Plenumigo de \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Plenumigo de \"%s\" malsukcesis.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Pakaĵo-kontrolo \"%s\" malsukcesis.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ne eblas krei %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne eblas generi eligan dosiernomon por pakaĵo %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "line %d: dua %s\n"
@@ -1143,18 +1110,18 @@ msgstr "neniu priskribo en %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "linio %d: dua %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linio %d: Eraro dum analizo de %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linio %d: Fuŝa elekto %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1210,154 +1177,154 @@ msgstr "linio %d: Fuŝa numero %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d difinita plurfoje\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Platformo estas ne malpermesata: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Platformo estas ne inkluzivita: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "Operaciumo estas ekskluzivita: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "Operaciumo estas ne inkluzivita: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "kampo %s devas ĉeesti en pakaĵo: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Duplikaj eroj %s en pakaĵo: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Ne eblas malfermi piktogramon %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Ne eblas legi piktogramon %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Nekonata piktogramo-tipo: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linio %d: Etikedo devas havi nur unu eron: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "linio %d: %s en: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s en: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Nevalida signo '%c' (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Vevalida sinsekvo \"..\""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linio %d: Misformita etikedo: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linio %d: Vaka etikedo: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linio %d: Oni ne rajtas fini prefikson kun \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linio %d: Docdir devas komenciĝi per '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "linio %d: Epoko-kampo devas esti sensignuma: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linio %d: Fuŝa %s: kvalifikiloj: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linio %d: Fuŝa aranĝo de BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linio %d: Nur subpakaĵoj noarch estas permesataj: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interna eraro: Fuŝa etikedo %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "linio %d: %s estas malfavorita: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Fuŝa pakaĵo-specifo: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linio %d: Nekonata etikedo: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} devas ne vaki\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "ne eblas, ke %%{buildroot} estu \"/\"\n"
@@ -1367,12 +1334,12 @@ msgstr "ne eblas, ke %%{buildroot} estu \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fuŝa fonto: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Neniu flikaĵa numero %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Neniu fonta numero %u\n"
@@ -1382,27 +1349,27 @@ msgstr "Neniu fonta numero %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Eraro dum analizo de %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linio %d: Fuŝa elekto ĉe %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linio %d: Fuŝa elekto ĉe %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Nevalida flikaĵo-numero %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linio %d: dua %%prep\n"
@@ -1489,102 +1456,102 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "linio %d: Dua %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linio %d: ne rekonas internan skripton: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 "lino %d: interpretilaj parametroj ne estas permesataj en instigiloj: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr "Makroo etendita en komento en linio %d: %s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ne eblas malfermi: %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s: %d: Parametroj anticipitaj por %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "linio %d: Nefermita %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "linio %d: nefinita makroo aŭ fuŝa linio-daŭrigo\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d %%else sen %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "linio %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: fuŝa kondiĉo ĉe %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: misformita frazo %%include\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "kodoprezento %s ne regata de sistemo\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Pakaĵo %s: nevalida kodoprezento %s en %s: %s - %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Neniuj kongruaj platformoj trovitaj por muntaĵo\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakaĵo ne enhavas: %%description: %s\n"
@@ -1652,98 +1619,94 @@ msgstr "Manka modulo-pado en linio: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Tro da parametroj en linio: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Traktanta kondutojn: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignoris nevalidan regulesprimon %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ne eblis krei tubon por %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Ne eblis plenumigi: %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ne eblis forki: %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Ne eblis plenumigi: %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s malsukcesis: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "malsukcesis skribi ĉiujn datumojn al %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Vaka dosiero-klasifikilo\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Neniuj dosieraj atributoj elektitaj\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) malsukcesis: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load malsukcesis: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rekono de dosiero \"%s\" malsukcesis: reĝimo %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Serĉi:  %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Malsukcesis trovi: %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Ne eblis kanonigi gastiganto-nomon: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "mendo de spec-dosiero %s malsukcesis, ne eblas analizi\n"
@@ -1780,90 +1743,112 @@ msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 "%s havas tro grandan aŭ malgrandan mallongentjeran valoron, preterlasita\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "ne eblas atingi ŝloson %s ĉe %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "kunuzata"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "ekskluziva"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "nevalida indeksa tipo %x ĉe %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "eraro(%d) dum ricevi rikordojn \"%s\" el indekso %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "eraro(%d) konservi rikordon \"%s\" en %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "eraro(%d) dum forigi rikordon \"%s\" el %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "eraro(%d) aldonanta en kapo rikordon #%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "eraro(%d) foriganta el kapo rikordon #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "eraro(%d) dum generi novan okazon de pakaĵo\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Ne eblas malfermi spec-dosieron %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s estas Pera RPM kaj ne estas rekte instalebla\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Ne komprenata ŝarĝo (%s) en pakaĵo %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "pakaĵo %s jam aldoniĝis, preterlasanta %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "pakaĵo %s jam aldoniĝis, anstataŭigante per %s\n"
@@ -1880,7 +1865,7 @@ msgstr "(ne cifero)"
 msgid "(not a string)"
 msgstr "(ne ĉeno)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(nevalida tipo)"
 
@@ -1893,146 +1878,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%Y-%d-%b (%a)"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(ne base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(nevalida XML-tipo)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(ne OpenPGP-pretendo)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Nevalida dato %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normala"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "anstataŭita"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "ne instalita"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "rete kunuzita"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "malĝusta koloro"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "manka"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(nekonata)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s konservita kiel %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s kreita kiel %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: forigo malsukcesis: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "dosierujo"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "dosiero"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "hdr-ŝarĝo: FUŜA"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "regiona etikedo: FUŜA, etikedo %d tipo %d deŝovo %d nombro %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "regiona deŝovo: FUŜA, etikedo %d tipo %d deŝovo %d nombro %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "regiona vosto: FUŜA, etikedo %d tipo %d deŝovo %d nombro %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "hdr-grando (%d): FUŜA, legado donis valoron %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "hdr-magio: FUŜA"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "hdr-etikedoj: FUŜA, nombro da etikedoj(%d) ekster skalo"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "hdr-datumoj: FUŜAJ, nombro da bajto(%d) ekster skalo"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "hdr-maso(%zd): FUŜA, legado donis la valoron %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "suspira pad(%zd): FUŜA, legis %zd bajtojn"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "maso-grando (%d): FUŜA, 8 + 16 * il(%d) + dl(%d)"
@@ -2076,43 +2061,52 @@ msgstr "neatendita ]"
 msgid "unexpected }"
 msgstr "neatendita }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? atendita en esprimo"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ atendita post ? en esprimo"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} atendita en esprimo"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": atendita post subesprimo kun ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ atendita post : en esprimo"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| atendita je la fino de la esprimo"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "tabela iteraciilo uzata kun tabeloj kun diversaj grandoj"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "linio %d: %s estas malfavorita: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "parametroj de --prefix devas komenciĝi per /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2655,25 +2649,25 @@ msgstr "ne konstati pakaĵo-dependaĵojn"
 msgid "don't execute verify script(s)"
 msgstr "ne plenumigi konstato-skripto(j)n"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Mankantaj trajtoj en rpmlib por %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "fontoteksta pakaĵo atendita, plenumebla trovita\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "fontoteksta pakaĵo enhavas neniun spec-dosieron\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "Elpakado de arkivo malsukcesis%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " ĉe dosiero"
 
@@ -2723,137 +2717,137 @@ msgstr "pakaĵo ne enhavas listojn de dosieraj estroj kaj grupoj\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "pakaĵo enhavas nek dosieran estron nek identigilajn listojn\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "grupo %s ne enhavas iujn pakaĵojn\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "neniuj pakaĵo-instigiloj %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "misformita %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "neniu pakaĵo kongruas kun %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "neniu pakaĵo postulas: %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "neniuj pakaĵoj rekomendas je %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "neniuj pakaĵoj konsilas je %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "neniuj pakaĵoj kompletigas je %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "neniuj pakaĵoj plibonigas je %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "neniu pakaĵo provizas: %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "dosiero %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "neniu pakaĵo estras dosieron %s\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "nevalida pakaĵo-numero: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "ne eblas legi rikordon %u\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakaĵo %s ne estas instalita\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nekonata etikedo: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: malsukcesis importi ŝlosilon %d.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: ŝlosilo %d ne estas ŝirmita publika ŝlosilo.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importa legado malsukcesis (%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NEBONA"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "BONA"
 
@@ -2867,116 +2861,116 @@ msgstr "%s: malsukcesis malfermi: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Ne eblas malfermi nunan dosierujon: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: radika dosierujo ne elektita\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Ne eblas ŝanĝi radikan dosierujon: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Ne eblas restarigi radikan dosierujon: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generanta %d mankajn indekso(j)n, bonvolu atendi...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "ne eblas malfermi indekson %s per %s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "neniu dbpath estis valorizita\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preterlasanta"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "eraro (%d) konservanta rikordon #%d al en %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec malsukcesis: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp malsukcesis: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preterlasanta"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: difektita kapo #%u akirita -- preterlasanta.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ne eblas legi kapon en 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "neniu dbpath estis valorizita"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "malsukcesis krei dosierujon %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "kapo #%u en datumbazo estas fuŝa -- preterlasanta.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "ne eblas aldoni rikordon devene el %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "malsukcesis remunti datumbazon: neŝanĝita datumbazo restas\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "malsukcesis anstataŭigi la malnovan datumbazon per la nova!\n"
 
@@ -3067,9 +3061,8 @@ msgid "support for rich dependencies."
 msgstr "rego por riĉaj dependaĵoj."
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "rego por riĉaj dependaĵoj."
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3316,22 +3309,22 @@ msgstr "ne eblas krei ŝloson %s ĉe %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "atendis ŝloson %s ĉe %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "ddlopen malsukcesis ĉe %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Solvi simbolon %s malsukcesis: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Kromprogramo %%__%s_%s ne agordita\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Kromprogramo %s ne ŝargita\n"
@@ -3376,13 +3369,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "pakaĵo %s (kiu estas pli freŝa ol %s) jam instaliĝis"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "instali pakaĵon %s bezonas iun %<PRIu64>%cB en la dosiersistemo %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr "instali pakaĵon %s bezonas inodojn %<PRIu64> en la dosiersistemo %s"
 
 #: lib/rpmprob.c:159
@@ -3506,7 +3500,7 @@ msgstr "Neniu exec() vokita post fork() en lua-skripteto\n"
 msgid "Unable to restore current directory: %m"
 msgstr "Ne eblas restarigi nunan dosierujon: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "rego por <lua>-programetojn ne estas integraj\n"
 
@@ -3549,15 +3543,15 @@ msgstr "skripteto %s malsukcesis, elira stato %d\n"
 msgid "Unknown format"
 msgstr "nekonata formato"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "instali"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "forviŝi"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3566,96 +3560,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "ne eblas malfermi pakaĵo-datumbazon en %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "aldona '(' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "manka '(' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "manka ')' en pakaĵo-etikedo: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: legi la publikan ŝlosilon malsukcesis.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "interago"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Ĉapo"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3663,19 +3657,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Ne eblas reŝargi pretendo-kapon.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "preterlasita"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "malsukcesa"
 
@@ -3716,67 +3710,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "sintaksa eraro dum analizi ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "sintaksa eraro dum analizi &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "Sintaksa eraro dum analizi ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "linio %d: %s en: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ atendita post ? en esprimo"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "analiza eraro ĉe esprimo\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "( sen )\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- nur por nobroj\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| atendita je la fino de la esprimo"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "sintaksa eraro en esprimo\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "tipoj devas esti kongruaj\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / ne por ĉenoj\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- no por ĉenoj\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vaka)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Malsukcesis malfermi tar-tubon: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makroo %%%s havas nefinitajn elektojn\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makroo %%%s havas nefinitan korpon\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makroo %%%s havas vakan korpon\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makroo %%%s postulas blankspacon antaŭ korpo\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makroo %%%s malsukcesis etendiĝi\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Makroo %%%s difinita sed ne uzata en amplekso\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nekonata elekto %c en %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "malsukcesis ŝargi makroan dosieron %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3784,17 +3866,27 @@ msgstr ""
 "Tro da niveloj de rekursioj en makroa etendado. Verŝajne kaŭzate de rekursia "
 "makro-deklaro.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Nefinita %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% estas sekvata de sensenca makroo\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "neatendita ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "neatendita ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiva %d vaka %d\n"
@@ -3838,27 +3930,27 @@ msgstr "averto: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nevalida sintakso en lua-skripteto: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nevalida sintakso en lua-skripto: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skripto malsukcesis: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nevalida sintakso en lua-dosiero: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hoko malsukcesis: %s\n"
@@ -3868,17 +3960,17 @@ msgstr "lua hoko malsukcesis: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "memora generado (%u bajtoj) donis nulon.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ŝlosila identigilo %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(neniu)"
 
@@ -3967,44 +4059,44 @@ msgstr "gpg malsukcesis skribi pretendon\n"
 msgid "unable to read the signature\n"
 msgstr "ne eblas legi la pretendon\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignure malsucksis: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Ne povas pretendi pakaĵojn el RPM-v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s jam enhavas identan pretendon, preterlasanta\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp malsukcesis\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead malsukcesis: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "anstataŭigo de %s malsukcesis: %s\n"
@@ -4034,23 +4126,20 @@ msgstr "%s: legi manifeston malsukcesis: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "ne konstati pretendojn de kapo+ŝarĝo"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Plenumigo de %s malsukcesis (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! nur por nombroj\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Eraro dum plenumigi pakaĵo-skripteton %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& kaj || ne por ĉenoj\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "linio: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "eraro dum legi dosieron %%files %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: linio: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Ne eblis malfermi dosieron %s: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Neniu etikedo \"Source:\" en la spec-dosiero\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "linio %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif sen %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "malsukcesis ŝargi makroan dosieron %s"

--- a/po/es.po
+++ b/po/es.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/rpm-team/rpm/language/es/)\n"
 "Language: es\n"
@@ -125,10 +125,9 @@ msgid "build source package only from <specfile>"
 msgstr "construir paquete fuente únicamente desde <specfile>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "construir paquete fuente únicamente desde <specfile>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -170,11 +169,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "construir paquete fuente únicamente desde <specfile>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -216,10 +214,9 @@ msgid "build source package only from <tarball>"
 msgstr "construir paquete fuente desde <tarball> "
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "construir paquete fuente desde <tarball> "
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -300,7 +297,7 @@ msgstr ""
 "Opciones de construcción con [ <archivo spec> | <tarball> | <paquete "
 "fuente> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opciones comunes para todos los modos rpm y ejecutables:"
@@ -359,33 +356,38 @@ msgstr "Construyendo para el destino %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "los argumentos de --root (-r) deben iniciar con una /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inicializar base de datos"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "reconstruir lista invertida de la base de datos desde los encabezados de "
 "paquetes instalados"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "verificar archivos de la base de datos"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inicializar base de datos"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opciones de la base de datos:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "solo puede especificarse un modo principal"
 
@@ -409,7 +411,7 @@ msgstr "lista las llaves del administrador de llaves RPM"
 msgid "Keyring options:"
 msgstr "Opciones del llavero:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "no ha sido indicado ningún argumento"
 
@@ -599,38 +601,43 @@ msgid "delete package signatures"
 msgstr "eliminar las firmas del paquete"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "no verificar firma de encabezado+carga"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opciones de firma:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Debe establecer \"%%_gpg_name\" en su archivo de macro\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -662,40 +669,49 @@ msgstr "utilizar el siguiente formato de consulta"
 msgid "Spec options:"
 msgstr "Opciones de spec:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "no se han ofrecido argumentos para analizar"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "No se pudo canonizar el nombre de host: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "No es posible abrir el archivo temporal: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "No es posible abrir flujo: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Ejecutando(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Estado de salida erróneo de %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Fallo al construir las dependencias:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -704,55 +720,6 @@ msgstr ""
 "\n"
 "\n"
 "Errores de construcción RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "error de sintaxis durante el análisis ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "error de sintaxis durante el análisis &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "error de sintaxis durante el análisis ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "error de análisis en la expresión\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "no coincidente (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- solo en números\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! solo en números\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "los tipos deben coincidir\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / no está soportado en cadenas\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- no está soportado en cadenas\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& y || no están soportados en cadenas\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "error de sintaxis en la expresión\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -848,172 +815,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "El enlace simbólico apunta a BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "No se ha encontrado el directorio: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Archivo no encontrado: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Falló al leer el archivo de política: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: no se puede cargar, etiqueta (%d) desconocida.\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: falló la lectura de la clave publica.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: no es una clave pública con armadura.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: falló la codificación\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "falló al crear el directorio"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "El archivo necesita comenzar con \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob no permitido: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "No se pudo abrir el archivo %%files %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Error leyendo %%files archivo %s: %m\n"
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "Clasificador de archivo vacío\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Archivo no encontrado por glob: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "No se puede mezclar el %s especial con otros formatos: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Más de un archivo en una línea: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Archivo erróneo: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Comprobando si hay archivos desempaquetados: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1022,114 +994,109 @@ msgstr ""
 "Se encontraron archivos instalados (pero desempaquetados):\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Procesando archivos: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "Los archivos binarios (%d) no coinciden con los archivos del paquete (%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 "Binarios dependientes de la arquitectura en paquetes sin arquitectura\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "falló al crear el archivo %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "falló la creación del archivo: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "No es posible abrir el archivo %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compresion de carga útil desconocida: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "No se pudo abrir %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "No ha sido possible escribir el paquete: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Escrito: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Ejecutando \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Falló la ejecución de \"%s\":\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Falló la verificación \"%s\" del paquete\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "no es posible crear %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 "No se pudo generar el nombre de archivo de salida para el paquete %s: %s \n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "línea %d: segundo %s\n"
@@ -1174,18 +1141,18 @@ msgstr "ninguna descripción en %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "línea %d: Error al analizar %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "línea %d: Opción errónea %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1241,154 +1208,154 @@ msgstr "línea %d: Número %s erróneo: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d definido múltiples veces\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "La arquitectura es excluida: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "La arquitectura no es incluida: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "SO es excluido: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "SO no es incluido: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "el campo %s debe estar presente en el paquete: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Duplicar entradas %s en el paquete: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "No ha sido posible abrir el icono %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "No ha sido posible leer el icono %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Tipo de icono desconocido: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "línea %d: La etiqueta solo recibe patrones individuales: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "línea %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "línea %d: Etiqueta vacía: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "línea %d: Los prefijos deben finalizar en \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "línea %d: Docdir debe iniciar con '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "línea %d: El campo epoch debe ser un número sin signo: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "línea %d: %s erróneo: calificadores: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "línea %d: Formato BuildArchitecture erróneo: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linea %d: Solo existe soporte para subpaquetes sin arquitectura: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Error interno: Etiqueta errónea %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "línea %d: %s se encuentra obsoleta: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificación de paquete errónea: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "línea %d: Etiqueta desconocida: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} no puede ser vacío\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{BuildRoot} no puede ser \"/\"\n"
@@ -1398,12 +1365,12 @@ msgstr "%%{BuildRoot} no puede ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fuente errónea: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Ningún número de parche %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Ningún número fuente %u\n"
@@ -1413,27 +1380,27 @@ msgstr "Ningún número fuente %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Error al analizar %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "línea %d: Argumento erróneo para %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "línea %d: opción %%setup errónea %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Número de parche %s inválido: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "línea %d: segundo %%prep\n"
@@ -1520,103 +1487,103 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "línea %d: Segundo %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "línea %d: script interno no soportado: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 "línea %d: los argumentos de intérprete no son permitidos en disparadores: "
 "%s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "No ha sido posible abrir %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argumento esperado para %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "línea %d: %%if no cerrado\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "línea %d: macro no cerrado o continuación de línea errónea\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Tiene un %%else sin %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "línea %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: mal %%si condición\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: instrucción %%include con formato incorrecto\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "No se encontraron arquitecturas compatibles para la construcción\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "El paquete no tiene %%description: %s\n"
@@ -1686,98 +1653,94 @@ msgstr "No se encuentra ruta de módulo en la línea: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Demasiados argumentos en la línea: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Procesando políticas: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorando regex no válido %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "No se pudo crear una tuberia para %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "No se pudo ejecutar la llamada exec %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "No se pudo ejecutar la llamada al sistema fork para %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "No se pudo ejecutar la llamada exec %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "Falló %s: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "falló la escritura de todos los datos a %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Clasificador de archivo vacío\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "No han sido configurados atributos de archivo\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "falló magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "falló magic_load: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Falló la identificación del archivo \"%s\": modo %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Buscando %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Falló la búsqueda de %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "No se pudo canonizar el nombre de host: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "la consulta del archivo spec %s falló, no se pudo analizar\n"
@@ -1814,90 +1777,112 @@ msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 "%s tiene un valor entero demasiado grande o demasiado pequeño, omitido\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "no se pudo obtener bloqueo %s en %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "compartido"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "tipo de índice %x inválido en  %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "error(%d) al obtener registros «%s» desde el índice %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "error(%d) almacenando registros \"%s\" en %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "error(%d) eliminando registro \"%s\" de %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "error(%d) estableciendo registro de encabezado #%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "error(%d) eliminando registro de encabezado #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "error(%d) asignando nueva instancia de paquete\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "No se puede abrir el archivo spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s es un RPM Delta y no puede ser instalado directamente\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Carga útil (%s) no soportada en el paquete %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "el paquete %s ya fue añadido, omitiendo %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "el paquete %s ya fue añadido, reemplazando con %s\n"
@@ -1914,7 +1899,7 @@ msgstr "(no es un número)"
 msgid "(not a string)"
 msgstr "(no es una cadena)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(tipo no válido)"
 
@@ -1927,146 +1912,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(no base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(tipo xml no válido)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(no es una firma OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Fecha no válida %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal        "
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "reemplazado"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "no instalado"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "compartido en red"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "color incorrecto"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "no se encuentra"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(desconocido) "
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s guardado como %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s creado como %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: falló al eliminar: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "directorio"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "archivo"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2110,43 +2095,52 @@ msgstr "] inesperado"
 msgid "unexpected }"
 msgstr "} inesperado"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "se esperaba ? en la expresión"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "se esperaba { después de ? en la expresión"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "se esperaba } en la expresión"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "se esperaba : después de la subexpresión ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "se esperaba { después de : en la expresión"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "se esperaba | al final de la expresión"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iterador de arreglo usado con arreglos de diferente tamaño"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "línea %d: %s se encuentra obsoleta: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "los argumentos de --prefix deber iniciar con una /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2691,25 +2685,25 @@ msgstr "no verificar las dependencias de paquetes"
 msgid "don't execute verify script(s)"
 msgstr "no ejecutar scripts de verificación"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "No se encuentran características rpmlib para %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "se esperaba el paquete fuente, paquete binario encontrado\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "el paquete fuente no contiene archivo .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "falló el desempaquetado de archivos %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " en archivo"
 
@@ -2759,137 +2753,137 @@ msgstr "el paquete no tiene lista de propietario/grupo de archivo\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "el paquete no tiene ni lista de propietario de archivos ni id\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "grupo %s no contiene ningún paquete\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "sin detonante de paquetes %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "%s mal formado: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "ningún paquete coincide con %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "ningún paquete requiere %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ningún paquete proporciona %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "archivo %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "el archivo %s no es propiedad de ningún paquete\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de paquete inválido: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "el registro %u no pudo ser leído\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "el paquete %s no está instalado\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconocida:\"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: falló la importación de la llave %d\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: la llave %d no es una llave pública protegida.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: falló la lectura para importar(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NO ESTA BIEN"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "BIEN"
 
@@ -2903,118 +2897,118 @@ msgstr "%s: falló la apertura: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "No es posible abrir directorio actual: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: no se ha definido chroot de directorio\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "No se puede cambiar el directorio raíz: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "No es posible restablecer el directorio raíz: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generando %d índice(s) faltante(s), espere…\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "no se ha establecido dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: omitiendo"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "error(%d) almacenando registro #%d en %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s:  regexec falló: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp falló: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: omitiendo"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: encabezado dañado #%u recuperada -- omitiendo.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: no se pudo leer encabezado en 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "no se ha establecido dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "no se pudo crear el directorio %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "encabezado #%u erróneo en la base de datos -- omitiendo.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "no se puede añadir el registro original en %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "falló la reconstrucción de la base de datos: la base de datos original "
 "permanece en su lugar\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 "¡falló el remplazo de la base de datos antigua con la nueva base de datos!\n"
@@ -3362,22 +3356,22 @@ msgstr "no es posible crear el bloqueo %s sobre %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "esperando el bloqueo %s sobre %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Falló al abrir dl %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Falló al resolver el símbolo %s: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "El complemento %s no ha sido cargado\n"
@@ -3424,15 +3418,16 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "el paquete %s (que es más nuevo que %s) ya está instalado"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "para la instalación del paquete %s es necesario %<PRIu64>%cB en el sistema "
 "de archivos %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "para la instalación del paquete %s es necesario %<PRIu64> inodos en el "
 "sistema de archivos %s"
@@ -3559,7 +3554,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr "No es posible restaurar el directorio actual: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 "soporte interno para macro de inclución de guiones <lua>, no fue construido\n"
@@ -3603,15 +3598,15 @@ msgstr "%s: macro de ejecución de guión fallido, estado de terminación %d\n"
 msgid "Unknown format"
 msgstr "formato desconocido"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "instalar "
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "borrar"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3620,96 +3615,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "no se puede abrir la base de datos Packages en %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' extra en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' ausente en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' ausente en la etiqueta del paquete: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: lectura de la clave publica fallida.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transacción"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Encabezado"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3717,19 +3712,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Incapaz de recargar el encabezado de la firma\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "ignorado"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "falló"
 
@@ -3770,67 +3765,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "error de sintaxis durante el análisis ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "error de sintaxis durante el análisis &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "error de sintaxis durante el análisis ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "se esperaba { después de ? en la expresión"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "error de análisis en la expresión\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "no coincidente (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- solo en números\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "se esperaba | al final de la expresión"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "error de sintaxis en la expresión\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "los tipos deben coincidir\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / no está soportado en cadenas\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- no está soportado en cadenas\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vacío)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Falló la apertura de la tuberia para tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "El macro %%%s tiene opciones no terminadas\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "El macro %%%s tiene un cuerpo incompleto\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "El macro %%%s tiene un cuerpo vacío\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Falló la expansión del macro macro %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opción desconocida %c en %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3838,17 +3921,27 @@ msgstr ""
 "Demasiados niveles de recursión en la expansión macro. Esto seguramente haya "
 "sido provocado por una declaración macro recursiva.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "No terminado %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% está seguido por un macro no analizable\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "] inesperado"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "] inesperado"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== activo %d vacío %d\n"
@@ -3892,27 +3985,27 @@ msgstr "advertencia:"
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxis no válida en el macro de ejecución de scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxis no valida en el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "falló el scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxis no valida en el archivo de scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "falló el enlace de lua: %s\n"
@@ -3922,17 +4015,17 @@ msgstr "falló el enlace de lua: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "la asignación de memoria (%u bytes) retornó NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID de clave %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -4021,44 +4114,44 @@ msgstr "gpg falló al escribir la firma\n"
 msgid "unable to read the signature\n"
 msgstr "incapaz de leer la firma\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature falló: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: falló headerRead: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "No es posible firmar paquetes RPM v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s ya contiene una firma idéntica, ignorando\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature falló: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "faló makeTempFile\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead falló: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "falló el reemplazo %s: %s\n"
@@ -4088,23 +4181,16 @@ msgstr "%s: falló la lectura del manifiesto: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "no verificar firma de encabezado+carga"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Falló exec sobre %s  (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! solo en números\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Error ejecutando scriptlet %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& y || no están soportados en cadenas\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "línea: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Error leyendo %%files archivo %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: línea: %s\n"
-
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "No hay etiqueta \"Source:\" en el archivo spec\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "línea %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: Tiene un %%endif sin %%if\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "No es posible abrir el archivo %s: %s\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/rpm-team/rpm/language/fi/)\n"
 "Language: fi\n"
@@ -112,10 +112,9 @@ msgid "build source package only from <specfile>"
 msgstr "käännä vain lähdepaketti spec-tiedostosta"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "käännä vain lähdepaketti spec-tiedostosta"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -155,11 +154,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "käännä vain lähdepaketti spec-tiedostosta"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -198,10 +196,9 @@ msgid "build source package only from <tarball>"
 msgstr "käännä vain lähdepaketti tar-tiedostosta"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "käännä vain lähdepaketti tar-tiedostosta"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -278,7 +275,7 @@ msgstr "ohita kohdealusta"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Käännösvalitsimet:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Yhteiset valitsimet kaikille rpm moodeille:"
@@ -337,31 +334,36 @@ msgstr "Käännetään kohteelle %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametrit --root (-r):lle alettava /-merkillä"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "alusta tietokanta"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "rakenna tietokanta uudestaan asennettujen pakettien tiedoista"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "tarkista tietokanta"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "alusta tietokanta"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Tietokantavalitsimet:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "vain yksi päätila voidaan määritellä"
 
@@ -385,7 +387,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "ei annettu parametrejä"
 
@@ -557,38 +559,43 @@ msgid "delete package signatures"
 msgstr "poista paketin allekirjoitus"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "älä tarkista otsikon ja kuorman allekirjoitusta"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Allekirjoitusvalitsimet:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Sinun pitää asettaa \"gpg_name:\" makrotiedostossasi\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -620,40 +627,49 @@ msgstr "käytä seuraava kyselyformaattia"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Suoritetaan(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Puuttuvia käännösriippuvuuksia:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -661,55 +677,6 @@ msgid ""
 msgstr ""
 "\n"
 "RPM käännösvirheitä:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "syntaksivirhe jäsentäessä ==:aa\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "syntaksivirhe jäsentäessä &&:aa\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "syntaksivirhe jäsentäessä ||:aa\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "jäsennysvirhe lausekkeessa\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "pariton (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- vain numeroissa\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! vain numeroissa\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "tyyppien täytyy olla yhtenevät\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / ei tuettu merkkijonoille\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- ei tuettu merkkijoinoille\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& ja || ei tuettu merkkijoinoille\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "syntaksivirhe lausekkeessa\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -805,172 +772,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolinen linkki osoittaa BuildRoot:iin: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Tiedostoa ei löytynyt: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: pakettilistan luku epäonnistui: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: julkisen avaimen luku epäonnistui\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ei ole panssaroitu julkinen avain.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "hakemiston luonti epäonnistui"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Tiedosto tarvitsee aloitusmerkin \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "%%files tiedostoa %s ei voitu avata: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "%s:n avaus ei onnistunut: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Tiedostoa ei löytynyt täydennyksellä: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Virheellinen tiedosto: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Tarkistetaan paketoimattomia tiedostoja: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -979,111 +951,106 @@ msgstr ""
 "Löytyi asennettuja (mutta paketoimattomia) tiedostoja:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Käsitellään tiedostoja: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Tuntematon kuorman pakkaus: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s:aa ei voitu avata: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Pakettia ei voitu kirjoittaa: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Kirjoitettiin: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Suoritetaan \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "%s:n suoritus epäonnistui.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paketin tarkistus \"%s\" epäonnistui.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s:n luonti ei onnistu: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Tiedostonimen muodostus paketille %s ei onnistu: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "rivi %d: toinen %s\n"
@@ -1128,18 +1095,18 @@ msgstr "ei kuvausta %%changelog:issa\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "rivi %d: virhe jäsennettäessä %%description-osiota %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "rivi %d: virheellinen valinta %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1195,154 +1162,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d määritelty useita kertoja\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Arkkitehtuuri on poissuljettu: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Arkkitehtuuri ei ole mukaanluettu: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "Käyttöjärjestelmä on poissuljettu: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "Käyttöjärjestelmä ei ole mukaanluettu: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "kenttä %s on vaadittu kenttä paketissa: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Useita %s-merkintöjä paketissa: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Ikonia %s ei voida avata: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Ikonia %s ei voida lukea: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Tuntematon ikonityyppi: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "rivi %d: Epoch-kentän täytyy olla etumerkitön numero: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "rivi %d: virheellinen käännösarkkitehtuurin muoto: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Virheellinen pakettimäärittely: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "rivi %d: tuntematon nimiö: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ei voi olla tyhjä\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ei voi olla \"/\"\n"
@@ -1352,12 +1319,12 @@ msgstr "%%{buildroot} ei voi olla \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Virheellinen lähde: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Ei patchia numero %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Ei lähdettä numero %u\n"
@@ -1367,27 +1334,27 @@ msgstr "Ei lähdettä numero %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Virhe jäsennettäessä %%setup-osiota: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "rivi %d: virheellinen argumentti %%setup:ille: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "rivi %d: virheellinen %%setup valitsin %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Virheellinen patch-numero %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "rivi %d: toinen %%prep-osio\n"
@@ -1472,101 +1439,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "rivi %d: toinen %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ei voi avata %s:ää: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%else ilman %%if:iä\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "%s: rivi: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "rivi %d: virheellinen %%setup valitsin %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Ei yhteensopivia arkkitehtureeja käännökselle\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paketissa ei ole %%description-osiota: %s\n"
@@ -1632,98 +1599,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ei voitu luoda putkea %s:lle: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Ei voitu suorittaa %s:ää: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ei voitu suorittaa %s:ää: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Ei voitu suorittaa %s:ää: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) epäonnistui: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load epäonnistui: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Tiedoston \"%s\" tunnistaminen epäonnistui: moodi %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Etsitään %s:ää: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s:ää ei löytynyt\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "määrittelytiedoston %s kysely epäonnistui\n"
@@ -1758,90 +1721,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "en saa %s lukitusta tietokantaan %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "jaettua"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "poissulkevaa"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "virhe(%d) tallennettaessa tietuetta %s %s:ään\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "virhe(%d) poistettaessa tietuetta %s %s:stä\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "virhe(%d) lisättäessä otsikkon #%d tietuetta\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "virhe(%d) poistettaessa otsikon #%d tietuetta\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "virhe(%d) varattaessa uutta paketti-instanssia\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "En voi avata spec-tiedostoa %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s on Delta RPM eikä sitä voida suoraan asentaa\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Tuntematon kuorma (%s) paketissa %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paketti %s on jo lisätty, ohitetaan %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paketti %s oli jo lisätty, korvataan %s:lla\n"
@@ -1858,7 +1843,7 @@ msgstr "(ei ole luku)"
 msgid "(not a string)"
 msgstr "(ei ole merkkijono)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(virheellinen tyyppi)"
 
@@ -1871,146 +1856,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(ei ole base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(virheellinen xml-tyyppi)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(ei ole OpenPGP-allekirjoitus)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normaali"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "korvattu"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "ei asennettu"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "verkkojaettu"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "väärä väri"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(tuntematon)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s talletettiin %s:nä\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s luotu %s:na\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2054,43 +2039,52 @@ msgstr "odottamaton ']'"
 msgid "unexpected }"
 msgstr "odottamaton '}'"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "odotin '?'-merkkiä ilmauksessa"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "odotin '{' '?'-merkin jälkeen lausekkeessa"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "odotin '}'-merkkiä lausekkeessa"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "odotin ':' '?'-merkin jälkeen ali-lausekkeessa "
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "odotin '{' ':'-merkin jälkeen lausekkeessa "
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "odotin '}'-merkkiä ilmauksen lopussa"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "--prefix parametrien pitää alkaa /-merkillä"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2633,25 +2627,25 @@ msgstr "älä tarkista paketin riippuvuuksia"
 msgid "don't execute verify script(s)"
 msgstr "älä suorita tarkistusskriptejä"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "arkiston %s%s purkaminen epäonnistui: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " tiedostolle "
 
@@ -2701,137 +2695,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "ryhmässä %s ei ole paketteja\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "mikään paketti ei laukaise %s:a\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "epämuodostunut %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "mikään paketti ei tarvitse %s:a\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "mikään paketti ei tarjoa %s:a\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "tiedosto %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "tiedostoa %s ei omista mikään paketti\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "virheellinen paketin numero: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "tietuetta %u ei voitu lukea\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paketti %s ei ole asennettu\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tuntematon nimiö: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "EI OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr ""
 
@@ -2845,117 +2839,117 @@ msgstr "%s: avaus epäonnistui: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: juurihakemistoa ei ole asetettu\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Juurihakemiston vaihto ei onnistu: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Juurihakemiston palautus ei onnistu: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "dbpath ei ole asetettu\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: ohitetaan"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "virhe(%d) tallennettaessa tietuetta #%d %s:ään\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec epäonnistui: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp epäonnistui: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: ohitetaan"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: ohitetaan vioittunut otsikkotietue #%u.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: otsikkoa ei voida lukea (0x%x)\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "dbpath ei ole asetettu"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "hakemiston %s luonti epäonnistui: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "tietue numero %u tietokannassa viallinen -- ohitetaan.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "alkupäisen tietueen %u lisäys ei onnistu\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "tietokannan uudelleenrakennus epäonnistui: alkuperäinen kanta paikallaan\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "vanhan tietokannan korvaus uudella epäonnistui!\n"
 
@@ -3292,22 +3286,22 @@ msgstr "%s-lukon luonti %s:een ei onnistu (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "odotetaan %s-lukkoa %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3352,14 +3346,15 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "paketti %s (joka on uudempi kuin %s) on jo asennettuna"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "paketin %s asennus tarvitsee %<PRIu64>%c tavua tiedostojärjestelmällä %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "paketin %s asennus tarvitsee %<PRIu64> inodea tiedostojärjestelmällä %s"
 
@@ -3484,7 +3479,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3527,15 +3522,15 @@ msgstr "%s skripti epäonnistui, palautti %d\n"
 msgid "Unknown format"
 msgstr "Tuntematon formaatti"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3544,96 +3539,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "Pakettitietokantaa %s ei voida avata\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: julkisen avaimen luku epäonnistui.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Otsikko "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3641,19 +3636,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Allekirjoitusotsikon uudelleenlataus ei onnistu\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "epäonnistui"
 
@@ -3694,83 +3689,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "syntaksivirhe jäsentäessä ==:aa\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "syntaksivirhe jäsentäessä &&:aa\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "syntaksivirhe jäsentäessä ||:aa\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "odotin '{' '?'-merkin jälkeen lausekkeessa"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "jäsennysvirhe lausekkeessa\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "pariton (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- vain numeroissa\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "odotin '}'-merkkiä ilmauksen lopussa"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "syntaksivirhe lausekkeessa\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "tyyppien täytyy olla yhtenevät\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / ei tuettu merkkijonoille\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- ei tuettu merkkijoinoille\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tyhjä)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "tar-putken avaus epäonnistui: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makrossa %%%s on päättämättömiä valitsimia\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makrossa %%%s on päättämätön runko\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makron %%%s runko on tyhjä\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makron %%%s laajennos ei onnistunut\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Tuntematon valitsin %c %s(%s):ssä\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Päättämätön %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% seuraa makro jota ei voida jäsentää\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "odottamaton ']'"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "odottamaton ']'"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiivisia %d tyhjiä %d\n"
@@ -3814,27 +3907,27 @@ msgstr "varoitus: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "virheellinen syntaksi lua-skriptissä: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "virheellinen syntaksi lua-skriptissä: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skripti epäonnistui: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "virheellinen syntaksi lua-tiedostossa: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua-koukku epäonnistui: %s\n"
@@ -3844,17 +3937,17 @@ msgstr "lua-koukku epäonnistui: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "muistin varaus (%u tavua) palautti NULL:in.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(ei mitään)"
 
@@ -3943,44 +4036,44 @@ msgstr "gpg ei voinut kirjoittaa allekirjoitusta\n"
 msgid "unable to read the signature\n"
 msgstr "en voinut lukea allekirjoitusta\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature epäonnistui: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp epäonnistui\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead epäonnistui: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4010,14 +4103,8 @@ msgstr "%s: pakettilistan luku epäonnistui: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "älä tarkista otsikon ja kuorman allekirjoitusta"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "%s:n suoritus epäonnistui (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! vain numeroissa\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "rivi: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "rivi %d: %s:\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif ilman %%if:iä\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& ja || ei tuettu merkkijoinoille\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: French (http://www.transifex.com/rpm-team/rpm/language/fr/)\n"
 "Language: fr\n"
@@ -121,10 +121,9 @@ msgid "build source package only from <specfile>"
 msgstr "construction du paquet source seulement à partir du <fichier_spec>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "construction du paquet source seulement à partir du <fichier_spec>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -166,11 +165,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "construction du paquet source seulement à partir du <fichier_spec>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -214,10 +212,9 @@ msgid "build source package only from <tarball>"
 msgstr "construire seulement le paquet source à partir du <tarball>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "construire seulement le paquet source à partir du <tarball>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -298,7 +295,7 @@ msgstr ""
 "Options de construction avec [ <fichier_spec> | <tarball> | <paquet "
 "source> ] :"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Options communes à tous les modes et exécutables rpm :"
@@ -357,33 +354,38 @@ msgstr "Construction pour cible %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "les arguments ed --root (-r) doivent commencer par un /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "initialiser la base de données"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "refaire les listes inversées de la base de données à partir des entêtes des "
 "paquets installés"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "vérifier les fichiers de la base de données"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "initialiser la base de données"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Options de la base de données :"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "un seul mode majeur peut être spécifié"
 
@@ -407,7 +409,7 @@ msgstr "listes les clés du trousseau RPM"
 msgid "Keyring options:"
 msgstr "Options du trousseau :"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "aucun argument fournit"
 
@@ -587,40 +589,45 @@ msgid "delete package signatures"
 msgstr "supprimer les signatures de paquets"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "ne pas vérifier la signature de l'entête+charge_utile"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Options de signatures :"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 "Vous devez affecter une valeur à \"%%_gpg_name\" dans votre fichier de "
 "macros\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -652,40 +659,49 @@ msgstr "utiliser le format de requête suivant"
 msgid "Spec options:"
 msgstr "Options spec :"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "pas d'arguments donnés pour analyser"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Ne peut canoniser le nom d'hôte : %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Impossible d'ouvrir le fichier temporaire : %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Impossible d'ouvrir le flux : %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Exécution_de(%s) : %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Mauvais statut de sortie pour %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Dépendances de construction manquantes:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -694,55 +710,6 @@ msgstr ""
 "\n"
 "\n"
 "Erreur de construction de RPM :\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "erreur de syntaxe en analysant ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "erreur de syntaxe en analysant &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "erreur de syntaxe en analysant ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "erreur de syntaxe dans l'expression\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "( non fermée\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- seulement sur des nombres\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! seulement sur des nombres\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "les types doivent correspondre\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / non supportés sur des chaînes de caractères\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- non prix en charge sur des chaînes de caractères\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& et || ne sont pas prix en charge sur des chaînes de caractères\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "erreur de syntaxe dans l'expression\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -838,172 +805,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Lien symbolique pointant sur BuildRoot : %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Répertoire introuvable : %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fichier non trouvé : %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Pas de répertoire: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Impossible de lire les fichier de stratégie : %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s : ne peut pas charger le tag (%d) inconnu.\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s : échec de la lecture de la clé publique.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s : n'est pas une clé publique blindée.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s : échec de l'encodage.\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "échec de création du répertoire"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Le fichier non précédé d'un \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "globale %%dev non autorisée : %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Impossible d'ouvrir le fichier %%files %s : %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Erreur de lecture du fichiers %%files %s : %m\n"
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "Classificateur de fichier vide\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Fichier non trouvé par la substitution : %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Impossible de mélanger un %s spécial avec d'autres formes : %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Plus d'un fichier sur la ligne : %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Mauvais fichier : %s : %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Vérification des fichiers non empaquetés : %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1012,112 +984,107 @@ msgstr ""
 "Fichier(s) installé(s) (mais non empaquetés) :\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Traitement des fichiers : %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "L'architecture de binaire (%d) ne correspond pas à celle du paquet (%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binaires dépendants d'une arch dans un paquet noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "échec de la création de l'archive dans le fichier %s : %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "échec de la création de l'archive : %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Impossible d'ouvrir le fichier %s : %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compression de charge inconnue : %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Impossible d'ouvrir %s : %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Impossible d'écrire le paquet : %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Écrit : %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Exécution_de « %s » :\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "L'exécution de « %s » a échouée.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "La vérification du paquet « %s » a échouée.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "Ne peut créer %s : %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne peut générer le nom de fichier pour le paquet %s : %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "ligne %d : deuxième %s\n"
@@ -1162,18 +1129,18 @@ msgstr "absence de description dans le %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "ligne %d : erreur dans l'analyse syntaxique de la %%description : %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "ligne %d : mauvaise option %s : %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1229,154 +1196,154 @@ msgstr "ligne %d : mauvais numéro %s : %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d définie plusieurs fois\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Architecture exclue : %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Architecture non incluse : %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS exclus : %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS non inclus : %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Le champ %s doit être présent dans le paquet : %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Entrée dupliquée %s dans le paquet : %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Impossible d'ouvrir l'icône %s : %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Impossible de lire l'icône %s : %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Type d'icône inconnu : %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "ligne %d : le tag n'accepte qu'un seul lexème : %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "ligne %d : tag mal formé : %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "ligne %d : tag vide : %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "ligne %d : les préfixes ne doivent pas finir par un « / » : %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "ligne %d : le docdir doit commencer par un « / » : %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "ligne %d : le champ Epoch doit être un nombre : %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "ligne %d : mauvais %s : qualificatifs : %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "ligne %d : mauvais format pour BuildArchitecture : %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "ligne %d seuls les sous-paquets noarch sont pris en charge : %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erreur interne : tag bidon %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "ligne %d : %s est obsolète : %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Mauvaise spécification de paquet : %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "ligne %d : tag inconnu : %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ne peux pas être vide\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ne peut pas être « / »\n"
@@ -1386,12 +1353,12 @@ msgstr "%%{buildroot} ne peut pas être « / »\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Mauvaise source : %s : %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Pas de numéro de patch %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Pas de numéro de source %u\n"
@@ -1401,27 +1368,27 @@ msgstr "Pas de numéro de source %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erreur d'analyse syntaxique du %%setup : %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "ligne %d : mauvais argument à %%setup : %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "ligne %d : mauvaise option à %%setup %s : %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s : %s : %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Numéro du patch invalide %s :%s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "ligne %d : deuxième %%prep\n"
@@ -1508,102 +1475,102 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "ligne %d : deuxième %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "ligne %d : script interne non pris en charge :%s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 "ligne %d : arguments interprète non autorisé dans les déclencheurs : %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Impossible d'ouvrir %s : %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s :%d : argument attendu pour %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "ligne %d : %%if non terminé\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "ligne %d : macro non fermée ou mauvaise continuation de ligne\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s : %d : j'ai là un %%else sans %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "ligne %d : %s : %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s : %d : mauvaise condition %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: directive %%include mal-formée\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Pas d'architecture compatible pour construction\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Le paquet n'a pas de %%description : %s\n"
@@ -1672,98 +1639,94 @@ msgstr "Manque le chemin du module à la ligne : %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Trop nombreux arguments en ligne : %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Traitement de la stratégie : %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorer l'expression régulière %s invalide\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Impossible de créer le pipe pour %s : %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Impossible d'exécuter %s : %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Impossible de forker %s : %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Impossible d'exécuter %s : %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s a échoué : %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "échec de l'écriture de toutes les données de %s : %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Classificateur de fichier vide\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Aucun fichier attributs configurés\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) a échoué : %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load a échoué : %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "La reconnaissance du fichier « %s » a échoué : mode %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Trouver %s : %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Impossible de trouver %s :\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Ne peut canoniser le nom d'hôte : %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1800,90 +1763,112 @@ msgstr "%s est une valeur 'long' trop petite ou trop grande, ignoré\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s est une valeur entière trop petite ou trop grande, ignoré\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "impossible d'avoir le verrou %s sur %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "partagé"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exclusif"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "type d'index %x invalide sur %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "erreur(%d) en attrapant les articles « %s » de l'index %s : %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "erreur(%d) en stockant l'article « %s » dans %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "erreur(%d) en enlevant l'article « %s » de %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "Erreur(%d) ajout de l'enregistrement de l'en-tête #%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "Erreur (%d) suppression de l'enregistrement de l'en-tête #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "erreur(%d) en allouant une nouvelle instance de paquet\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Impossible d'ouvrir le fichier spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s est un Delta RPM et ne peut être installé directement\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Charge (%s) non pris en charge dans le paquet %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "le paquet %s a déjà été rajouté, %s ignoré\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "le paquet %s a déjà été rajouté, replacé par %s\n"
@@ -1900,7 +1885,7 @@ msgstr "(n'est pas un nombre)"
 msgid "(not a string)"
 msgstr "(pas une chaîne)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(type invalide)"
 
@@ -1913,146 +1898,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(pas base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(type xml invalide)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(pas une signature OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Date invalide %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "remplacé"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "pas installé"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "sur le réseau"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "fausse couleur"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "manquant"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(inconnu)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sauvé en tant que %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s créé en tant que %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s : échec de la suppression : %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "répertoire"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "fichier"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2096,43 +2081,52 @@ msgstr "] inattendu"
 msgid "unexpected }"
 msgstr "} inattendu"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? attendu dans l'expression"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ attendu après ? dans l'expression"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} attendu dans l'expression"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": attendu derrière la sous-expression de ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ attendu après : dans l'expression"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| attendu a la fin de l'expression"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "itérateur de tableau utilisé avec des tableaux de tailles différentes"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "ligne %d : %s est obsolète : %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "les arguments de --prefix doivent commencer par un /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2683,25 +2677,25 @@ msgstr "ne pas vérifier les dépendances du paquet"
 msgid "don't execute verify script(s)"
 msgstr "ne pas exécuter le(s) script(s) de vérification"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Éléments rpmlib manquants pour %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "paquet source attendu, paquet binaire trouvé\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "le paquet source ne contient pas de fichier .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "échec du déballage de l'archive %s%s : %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " dans fichier "
 
@@ -2752,137 +2746,137 @@ msgid "package has neither file owner or id lists\n"
 msgstr ""
 "le paquet n'a ni la liste des id ni celle des possesseurs de fichiers\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "le groupe %s ne contient aucun paquet\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "aucun paquet ne surveille %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "%s malformé : %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "aucun paquet ne correspond à %s : %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "aucun paquet ne requiert %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "aucun paquet ne fournit %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fichier %s : %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "le fichier %s n'appartient à aucun paquet\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "numéro de paquet invalide : %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "l'enregistrement %u n'a pas pu être lu\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "le paquet %s n'est pas installé\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tag inconnu: « %s »\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s : importation de la clé %d échouée.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s : la clés %d n'est pas une clé publique blindée.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s : l'importation de lecture a échoué (%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "PAS OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2896,118 +2890,118 @@ msgstr "%s : échec de l'ouverture : %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Impossible d'ouvrir le répertoire courant : %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s : répertoire chroot non établies\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Impossible de changer le répertoire racine : %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Impossible de restaurer le répertoire racine : %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Génération d'index manquant(s) %d, merci d'attendre...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "impossible d'ouvrir l'index %s en utilisant %s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "aucun dbpath n'a été fourni\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader : ignoré"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "erreur(%d) en stockant l'article nº%d dans %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s : regexec a échoué :%s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s : regcomp a échoué :%s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator : ignoré"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb : l'entête #%u endommagée a été récupérée -- ignoré.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s : impossible de lire l'entête à 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "aucun dbpath fournit"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "Impossible de créer le répertoire %s : %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "l'entête #%u dans la base de données n'est pas bon -- ignoré.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "impossible d'ajouter l'article qui était au départ à %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "Ne peut reconstruire la base de données : la base originale reste telle "
 "qu'elle est\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "Ne peut remplacer la vieille base de données par la nouvelle!\n"
 
@@ -3354,22 +3348,22 @@ msgstr "Impossible de créer %s verrou sur %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "attente pour %s verrou sur %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Impossible de dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Impossible de résoudre le symbole %s : %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Plugin %%__%s_%s non configuré\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Plugin %s non chargé\n"
@@ -3417,15 +3411,16 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "le paquet %s (plus récent que %s) est déjà installé"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "installer le paquetage %s nécessite %<PRIu64>%cB sur le système de fichiers "
 "%s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "installer le paquet %s nécessite %<PRIu64> inodes sur le système de fichiers "
 "%s"
@@ -3553,7 +3548,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr "Impossible de restaurer le répertoire courant : %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "le support du scriptlet <lua> n'est pas intégrer\n"
 
@@ -3596,15 +3591,15 @@ msgstr "%s scriptlet échoué, état de sortie %d\n"
 msgid "Unknown format"
 msgstr "Format inconnu"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "installer"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "effacer"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3613,96 +3608,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "impossible d'ouvrir la base de données paquet dans %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' supplémentaire dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' manquante dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' manquante dans le label du paquet : %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: la lecture de la clé publique a échoué.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transaction"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Entête "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3710,19 +3705,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Impossible de recharger l'entête de la signature.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "sauté"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "échoué"
 
@@ -3763,67 +3758,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "erreur de syntaxe en analysant ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "erreur de syntaxe en analysant &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "erreur de syntaxe en analysant ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ attendu après ? dans l'expression"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "erreur de syntaxe dans l'expression\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "( non fermée\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- seulement sur des nombres\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| attendu a la fin de l'expression"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "erreur de syntaxe dans l'expression\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "les types doivent correspondre\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / non supportés sur des chaînes de caractères\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- non prix en charge sur des chaînes de caractères\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vide)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Impossible d'ouvrir le pipe de tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s a des options non-terminées\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s a un corps sans fin\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s a un corps vide\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La macro %%%s a besoin d'un espace avant le corps\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "La macro %%%s ne peut être expansée\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Macro %%%s définie mais non utilisée sans portée\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Option inconnue %c dans %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "Impossible de charger le fichier macro %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3831,17 +3914,27 @@ msgstr ""
 "Trop de niveaux de récursivité dans l'expansion de la macro. Il est "
 "probablement causée par une déclaration de macro récursive.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c non terminé: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% est suivi d'une macro in-analysable\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "] inattendu"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "] inattendu"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d actif(s) %d vide(s)\n"
@@ -3885,27 +3978,27 @@ msgstr "attention : "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "syntaxe invalide dans le scriptlet lua : %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "syntaxe invalide dans le script lua : %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "script lua échoué : %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "syntaxe invalide dans le fichier lua : %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "crochet lua échoué : %s\n"
@@ -3915,17 +4008,17 @@ msgstr "crochet lua échoué : %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "l'allocation de mémoire (%u octets) a retourné NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, clé ID %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(none)"
 
@@ -4014,44 +4107,44 @@ msgstr "échec de gpg à écrire la signature\n"
 msgid "unable to read the signature\n"
 msgstr "impossible de lire la signature\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s : échec de rpmReadSignature : %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s : échec de headerRead %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Ne peut signer les paquets RPM v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s contient déjà une signature identique, ignoré\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s : échec de rpmWriteSignature : %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp échoué\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s : échec de writeLead : %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "remplacer %s à échouer : %s\n"
@@ -4081,23 +4174,20 @@ msgstr "%s : échec de la lecture de la liste de paquetages : %s\n"
 msgid "don't verify header+payload signature"
 msgstr "ne pas vérifier la signature de l'entête+charge_utile"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "L'exec de %s a échoué (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! seulement sur des nombres\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Erreur d'exécution du scriptlet %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& et || ne sont pas prix en charge sur des chaînes de caractères\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "Ligne : %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Erreur de lecture du fichiers %%files %s : %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s : ligne : %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Impossible d'ouvrir le fichier %s : %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Pas de tag « Source: » dans le fichier spec\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "ligne %d : %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s : %d : j'ai là un %%endif sans %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "Impossible de charger le fichier macro %s"

--- a/po/id.po
+++ b/po/id.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/rpm-team/rpm/language/"
 "id/)\n"
@@ -118,10 +118,9 @@ msgid "build source package only from <specfile>"
 msgstr "membangun paket sumber dari <specfile>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "membangun paket sumber dari <specfile>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -163,11 +162,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "membangun paket sumber dari <specfile>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -208,10 +206,9 @@ msgid "build source package only from <tarball>"
 msgstr "pembangunan paket sumber saja dari <tarball>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "pembangunan paket sumber saja dari <tarball>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -288,7 +285,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opsi umum untuk semua mode rpm dan eksekutabel:"
@@ -347,31 +344,35 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumen untuk --root (-r) harus diawali dengan /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "hanya satu mode utama yang bisa ditentukan"
 
@@ -395,7 +396,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -569,38 +570,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -632,93 +637,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -815,283 +780,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, c-format
+msgid "Can't read content of file: %s\n"
+msgstr ""
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
+#: build/files.c:2233
 #, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
+msgid "Could not open %s file %s: %m\n"
 msgstr ""
 
 #: build/files.c:2258
 #, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
+#, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1136,18 +1101,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1203,154 +1168,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1360,12 +1325,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1375,27 +1340,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1480,101 +1445,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1640,98 +1605,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1766,90 +1727,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr ""
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1866,7 +1849,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1879,146 +1862,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2062,43 +2045,52 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "argumen untuk --prefix harus dimulai dengan /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2636,25 +2628,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2704,137 +2696,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr ""
 
@@ -2848,116 +2840,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3294,22 +3286,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3355,12 +3347,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3484,7 +3477,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3527,15 +3520,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3544,96 +3537,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3641,19 +3634,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3694,83 +3687,169 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "sumber kueri tak sesuai dengan yang diharapkan"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "format kueri tak sesuai dengan yang diharapkan"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3814,27 +3893,27 @@ msgstr ""
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3844,17 +3923,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3943,44 +4022,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/is.po
+++ b/po/is.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Icelandic (http://www.transifex.com/rpm-team/rpm/language/"
 "is/)\n"
@@ -274,7 +274,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -333,31 +333,35 @@ msgstr "Þýði fyrir markkerfi %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -381,7 +385,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -546,38 +550,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -609,93 +617,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -792,283 +760,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Skráin fannst ekki: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "ekki yfirfara eiganda skráa"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Get ekki opnað spec skrána %s: %s\n"
 
 #: build/files.c:2258
+#, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Skráin fannst ekki með 'glob': %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ógild skrá %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Get ekki ritað í pakka: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrifaði: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1113,18 +1081,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "lína %d: Óleyfilegur rofi %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1180,154 +1148,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Get ekki opnað táknmynd %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Gat ekki lesið táknmynd %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Óþekkt tegund táknmyndar: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "lína %d: Tag tekur einungis eitt tákn: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "lína %d: Skemmt tag: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "lína %d: Tómt tag: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1337,12 +1305,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Slæmt ílag: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1352,27 +1320,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "lína %d: Ógilt viðfang við %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1457,101 +1425,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Get ekki opnað %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "lína %d: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "lína %d: Óleyfilegur rofi %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1617,98 +1585,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Gat ekki keyrt %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Gat ekki búið til undirferli (fork) %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Gat ekki keyrt %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "gat ekki fundið %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1743,90 +1707,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "deildann"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "einka"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Get ekki opnað spec skrána %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1843,7 +1829,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1856,146 +1842,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s vistað sem %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s búið til sem %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2039,35 +2025,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2613,25 +2608,25 @@ msgstr "ekki skoða pakkaskilyrðin"
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "pakkinn inniheldur enga .spec skrá\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2681,137 +2676,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr ""
 
@@ -2825,116 +2820,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3271,22 +3266,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3332,12 +3327,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3461,7 +3457,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3504,15 +3500,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3521,96 +3517,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "get ekki opnað pakka gagnagrunn í %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3618,19 +3614,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3671,83 +3667,167 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+msgid "unexpected end of expression"
+msgstr ""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tómt)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Gat ekki opnað pípu í tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Óþekkt viðfang %c í %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== virkt %d tómt %d\n"
@@ -3791,27 +3871,27 @@ msgstr "aðvörun: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3821,17 +3901,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "minnisfrátekt (%u bæta) skilaði NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3920,44 +4000,44 @@ msgstr "gpg get ekki lesið undirskriftina\n"
 msgid "unable to read the signature\n"
 msgstr "get ekki lesið undirskriftina\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3986,9 +4066,3 @@ msgstr ""
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Gat ekki keyrt %s (%s): %s\n"
-
-#~ msgid "line: %s\n"
-#~ msgstr "lína: %s\n"

--- a/po/it.po
+++ b/po/it.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Italian (http://www.transifex.com/rpm-team/rpm/language/it/)\n"
 "Language: it\n"
@@ -118,10 +118,9 @@ msgid "build source package only from <specfile>"
 msgstr "compila solo il pacchetto sorgente da <specfile>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "compila solo il pacchetto sorgente da <specfile>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -162,11 +161,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "compila solo il pacchetto sorgente da <specfile>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -206,10 +204,9 @@ msgid "build source package only from <tarball>"
 msgstr "compila solo il pacchetto sorgente da <tarball>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "compila solo il pacchetto sorgente da <tarball>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -286,7 +283,7 @@ msgstr "override della piattaforma target"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opzioni di build con [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opzioni comuni per tutte le modalità e gli eseguibili rpm:"
@@ -345,33 +342,38 @@ msgstr "Creazione per il target %s in corso\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "gli argomenti per --root (-r) devono iniziare con /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inizializza database"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "ricompila gli elenchi invertiti del database dalle intestazioni dei "
 "pacchetti installati"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "verifica dei file del database"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inizializza database"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "esporta database in una lista header su stdout"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "importa database da una lista di header su stdin"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opzioni del database:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "è possibile specificare solo una modalità principale"
 
@@ -397,7 +399,7 @@ msgstr "elenca le chiavi del keyring RPM"
 msgid "Keyring options:"
 msgstr "Opzioni keyring:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "non è stato specificato alcun argomento"
 
@@ -592,38 +594,43 @@ msgid "delete package signatures"
 msgstr "cancella le firme del pacchetto"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "non verificare firma header+payload"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opzioni della firma:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "È necessario impostare \"%%_gpg_name\" nel file macro\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -655,40 +662,49 @@ msgstr "usare il seguente formato di interrogazione"
 msgid "Spec options:"
 msgstr "Opzioni specfile:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "nessun argomento passato per il parsing"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Impossibile regolarizzare l'hostname: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Impossibile aprire il file temporaneo: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Impossibile aprire lo stream: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Esecuzione(%s) in corso: %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Stato d'uscita errato da %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Dipendenze di build fallite:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -697,55 +713,6 @@ msgstr ""
 "\n"
 "\n"
 "Errori di compilazione RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "errore di sintassi durante il parsing di ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "errore di sintassi durante il parsing di &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "errore di sintassi durante il parsing di ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "errore durante il parsing dell'espressione\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "non corrispondente (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- solo sui numeri\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! solo sui numeri\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "i diversi tipi devono corrispondere\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / non supportato per le stringhe\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- non supportato per le stringhe\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& e || non supportati per le stringhe\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "errore di sintassi nell'espressione\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -841,174 +808,179 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Il collegamento simbolico punta alla BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Carattere non valido '%c' (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Percorso esterno alla buildroot: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Directory non trovata: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "File non trovato: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Non è una directory: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Impossibile leggere il file policy: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: impossibile caricare tag sconosciuto (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: lettura chiave pubblica fallita.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: non è una chiave pubblica con formato 'armored'.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: errore durante l'encoding\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "impossibile creare la directory"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Il file deve essere preceduto da \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "glob %%dev non consentito: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Impossibile aprire %%files file %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr ""
 "File %s vuoto nella sezione %%files\n"
 "\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Errore nella lettura del file %s in %%files: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "_docdir_fmt %s non valido: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "File non trovato dal glob: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Impossibile unire %s speciali con altre forme: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Più di un file su una riga: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "File errato: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Controllo per file non pacchettizzati in corso: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1017,112 +989,107 @@ msgstr ""
 "Trovati file installati (ma non inclusi nel pacchetto):\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Elaborazione file: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "L'architettura dei binari (%d) non corrisponde a quella del pacchetto (%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binari dipendenti dall'architettura presenti in un pacchetto noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "creazione archivio fallita sul file %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "creazione archivio fallita: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Impossibile aprire il file %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compressione payload sconosciuta: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Impossibile eseguire seek nel file %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Impossibile aprire %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Impossibile scrivere il pacchetto: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Scritto: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Esecuzione \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Esecuzione di \"%s\" fallita.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Controllo pacchetto \"%s\" fallito.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "impossibile creare %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Impossibile generare nome del file di output per il pacchetto %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "riga %d: secondo %s\n"
@@ -1167,18 +1134,18 @@ msgstr "nessuna descrizione in %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "linea %d: seconda sezione %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "riga %d: Errore durante il parsing di %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "riga  %d: Opzione %s errata: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1234,154 +1201,154 @@ msgstr "riga %d: Numero %s errato: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d specificato più volte\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "L'architettura è esclusa: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "L'architettura non è inclusa: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS è escluso: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS non è incluso: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "il campo %s deve essere presente nel pacchetto: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Voci %s duplicate nel pacchetto: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Impossibile aprire l'icona %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Impossibile leggere l'icona %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Tipo di icona sconosciuto: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "riga %d: Il tag necessita di un solo token: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "linea %d: %s in: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s in: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Carattere non valido '%c' (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Sequenza non valida \"..\""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "riga %d: Tag malformato: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "riga %d: Tag vuoto: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "riga %d: I prefissi non devono finire con \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "riga %d: Docdir deve iniziare con '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "riga %d: Il tag Epoch deve essere un numero: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "riga %d: %s errati: qualificatori: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "riga %d: Formato BuildArchitecture errato: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "riga %d: Sono supportati solo sottopacchetti noarch: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Errore interno: tag incorretto %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "riga %d: %s è deprecato: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Specifiche errate del pacchetto: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "riga %d: Tag sconosciuto: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} non può essere vuota\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} non può essere \"/\"\n"
@@ -1391,12 +1358,12 @@ msgstr "%%{buildroot} non può essere \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Sorgenti non validi: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nessuna patch con numero %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nessun sorgente con numero %u\n"
@@ -1406,27 +1373,27 @@ msgstr "Nessun sorgente con numero %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Errore nel parsing di %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "riga %d: Argomento errato su %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "riga %d: Opzione di %%setup errata %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Numero patch non valido %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "riga %d: secondo %%prep\n"
@@ -1512,104 +1479,104 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "riga %d: Secondo %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linea %d: script interno non supportato: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "linea %d: argomenti dell'interprete non consentiti nei trigger: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Impossibile aprire %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: argomento necessario per %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 "riga %d: %%if non bilanciato\n"
 "\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "linea %d: macro non chiusa o errata continuazione linea\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Trovato un %%else con nessun %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "linea %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: condizione %%if errata\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s: %d: istruzione %%include malformata\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "la codifica %s non è supportata dal sistema\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Pacchetto %s: codifica %s non valida in %s: %s - %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 "Non è stata trovata alcuna architettura compatibile per la compilazione\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Il pacchetto non possiede alcuna %%description: %s\n"
@@ -1677,98 +1644,94 @@ msgstr "Percorso del modulo mancante alla linea: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Troppi argomenti alla linea: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Elaborazione policies: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Viene ignorata la regex non valida %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Impossibile creare la pipe per %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Impossibile eseguire %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Impossibile biforcare %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Impossibile eseguire %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s fallito: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "impossibile salvare tutti i dati su %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "File classifier vuoto\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Non è configurato alcun attributo dei file\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) fallita: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load fallita: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Identificazione file \"%s\" fallita: modalità %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Ricerca di %s in corso: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Impossibile trovare %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Impossibile regolarizzare l'hostname: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1804,90 +1767,112 @@ msgstr "%s presenta un valore long troppo grande o troppo piccolo, omesso\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s presenta un valore integer troppo grande o troppo piccolo, omesso\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "impossibile ottenere il %s su %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "condiviso"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "esclusivo"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "tipo indice %x non valido su %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "errore(%d) nella lettura dei record \"%s\" dall'indice %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "errore(%d) nella memorizzazione del record \"%s\" in %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "errore(%d) nella rimozione del record \"%s\" da %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "errore(%d) nell'impostazione del record #%d dell'intestazione\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "errore(%d) nell'eliminazione del record dell'intestazione #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "errore(%d) nell'allocazione di una nuova istanza del pacchetto\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Impossibile aprire il file spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s è un Delta RPM e non può essere installato direttamente\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Payload non supportato (%s) nel pacchetto %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "il pacchetto %s è già stato aggiunto, salto %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "il pacchetto %s è stato già aggiunto, sostituzione con %s in corso\n"
@@ -1904,7 +1889,7 @@ msgstr "(non è un numero)"
 msgid "(not a string)"
 msgstr "(non è una stringa)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(tipo non valido)"
 
@@ -1917,146 +1902,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(non base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(tipo xml non valido)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(non è una firma OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Formato data %u non corretto"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normale"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "sostituito"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "non installato"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "condivisa su rete"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "colore errato"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "mancanti"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(sconosciuto)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s salvato come %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s creato come %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: rimozione fallita: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "directory"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "file"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2100,43 +2085,52 @@ msgstr "] inaspettata"
 msgid "unexpected }"
 msgstr "} inaspettata"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? previsto nell'espressione"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ previsto dopo ? nell'espressione"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} previsto nell'espressione"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": previsto dopo l'espressione secondaria ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ previsto dopo : nell'espressione"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| previsto alla fine dell'espressione"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iteratore di array usato con array di dimensioni differenti"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "riga %d: %s è deprecato: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "gli argomenti per --prefix devono iniziare con /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2685,25 +2679,25 @@ msgstr "non verificare le dipendenze del pacchetto"
 msgid "don't execute verify script(s)"
 msgstr "non eseguire gli script di verifica"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Funzionalità rpmlib mancanti per %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "pacchetto sorgente atteso, trovato binario\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "il pacchetto sorgente non contiene alcun file .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "estrazione archivio fallita%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " sul file "
 
@@ -2754,137 +2748,137 @@ msgid "package has neither file owner or id lists\n"
 msgstr ""
 "il pacchetto non possiede ne un proprietario del file ne un elenco id\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "il gruppo %s non contiene alcun pacchetto\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "nessun pacchetto attiva %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "%s malformato: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "nessun pacchetto corrisponde a %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "nessun pacchetto necessita di %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "nessun pacchetto raccomanda %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "nessun pacchetto suggerisce %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nessun pacchetto fornisce %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "file %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "il file %s non è posseduto da alcun pacchetto\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "numero del pacchetto non valido: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "il record %u non può essere letto\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "il pacchetto %s non è stato installato\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "tag sconosciuto: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: importazione chiave %d fallita.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: chiave pubblica %d non con formato 'armored'.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: lettura importazione fallita(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NON OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2898,116 +2892,116 @@ msgstr "%s: apertura fallita: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Impossibile aprire la directory corrente: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: la directory chroot non è impostata\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Impossibile cambiare directory root: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Impossibile ripristinare directory root: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generazione di %d indici mancanti, prego attendere...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "impossibile aprire l'indice %s usando%s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "non è stato impostato alcun dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: salto"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "errore(%d) nella memorizzazione del record #%d in %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec fallito: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp fallito: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: salto"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: intestazione #%u danneggiata -- viene omessa.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: impossibile leggere intestazione 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "non è stato impostato alcun dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "impossibile creare la cartella %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "l'intestazione #%u nel database non è valida -- viene omessa.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "impossibile aggiungere il record originariamente su %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "ricompilazione database fallita: il database originale rimane in uso\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "sostituzione del vecchio database con il nuovo database fallita!\n"
 
@@ -3354,22 +3348,22 @@ msgstr "impossibile creare il lock %s su %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "attesa del lock %s su %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Impossibile eseguire dlopen di %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Impossibile risolvere il simbolo %s: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Plugin %%__%s_%s non configurato\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Plugin %s non caricato\n"
@@ -3418,14 +3412,15 @@ msgstr ""
 "il pacchetto %s (il quale risulta essere più recente di %s) è già installato"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "l'installazione del pacchetto %s necessita di %<PRIu64>%cB sul filesystem %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "l'installazione del pacchetto %s necessita di %<PRIu64> inode sul filesystem "
 "%s"
@@ -3553,7 +3548,7 @@ msgstr "Funzione exec() non chiamata dopo fork() nello scriptlet lua\n"
 msgid "Unable to restore current directory: %m"
 msgstr "Impossibile tornare alla direcotry corrente: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "supporto agli scriptlet <lua> non disponibile\n"
 
@@ -3596,15 +3591,15 @@ msgstr "scriptlet %s fallita, uscita con stato %d\n"
 msgid "Unknown format"
 msgstr "Formato sconosciuto"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "installa"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "elimina"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3613,96 +3608,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "impossibile aprire il database dei pacchetti in %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' extra nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "'(' mancante nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "')' mancante nell'etichetta del pacchetto: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: lettura chiave pubblica fallita.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transazione"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Header "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3710,19 +3705,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Impossibile ricaricare intestazione della firma.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "saltato"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "fallito"
 
@@ -3763,67 +3758,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "errore di sintassi durante il parsing di ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "errore di sintassi durante il parsing di &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "errore di sintassi durante il parsing di ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "linea %d: %s in: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ previsto dopo ? nell'espressione"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "errore durante il parsing dell'espressione\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "non corrispondente (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- solo sui numeri\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| previsto alla fine dell'espressione"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "errore di sintassi nell'espressione\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "i diversi tipi devono corrispondere\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / non supportato per le stringhe\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- non supportato per le stringhe\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vuoto)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Impossibile aprire tar pipe: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "La macro %%%s presenta delle opzioni incomplete\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "La macro %%%s presenta un corpo incompleto\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "La macro %%%s presenta contenuto vuoto\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "La Macro %%%s richiede whitespace prima del corpo\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Impossibile espandere la macro %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Macro %%%s definita ma non usata nello scope\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opzione %c sconosciuta in %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "impossibile caricare il file di macro %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3831,17 +3914,27 @@ msgstr ""
 "Troppo livelli di ricorsione nell'espansione della macro. Si tratta "
 "probabilmente di una macro definita ricorsivamente.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c non terminato: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Un %% è seguito da una macro non parsabile\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "] inaspettata"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "] inaspettata"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d attivo %d vuoto\n"
@@ -3885,27 +3978,27 @@ msgstr "avvertimento: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintassi non valida nella scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintassi non valida nello script lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "script lua fallito: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintassi non valida nel file lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "hook lua fallito: %s\n"
@@ -3915,17 +4008,17 @@ msgstr "hook lua fallito: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "allocazione memoria (%u byte) ha ritornato NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID chiave %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -4014,44 +4107,44 @@ msgstr "gpg non è riuscito a salvare la firma\n"
 msgid "unable to read the signature\n"
 msgstr "impossibile leggere la firma\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature fallita: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead fallita: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Impossibile firmare pacchetti RPM v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s contiene la stessa identica signature, lo salto\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature fallito: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp fallito\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead fallito: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "sostituzione di %s fallita: %s\n"
@@ -4081,23 +4174,20 @@ msgstr "%s: lettura manifesto fallita: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "non verificare firma header+payload"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Esecuzione di %s fallita (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! solo sui numeri\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Errore nell'esecuzione della scriptlet %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& e || non supportati per le stringhe\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "riga: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Errore nella lettura del file %s in %%files: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: linea: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Impossibile aprire il file %s: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Nessun tag \"Source:\" nello spec file\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "riga %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: Trovato un %%endif con nessun %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "impossibile caricare il file di macro %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Japanese (http://www.transifex.com/rpm-team/rpm/language/"
 "ja/)\n"
@@ -117,10 +117,9 @@ msgid "build source package only from <specfile>"
 msgstr "<specfile> を元に、ソースパッケージのみ作成"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "<specfile> を元に、ソースパッケージのみ作成"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -160,11 +159,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "<specfile> を元に、ソースパッケージのみ作成"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -202,10 +200,9 @@ msgid "build source package only from <tarball>"
 msgstr "<tarball> を元に、ソースパッケージのみを作成"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "<tarball> を元に、ソースパッケージのみを作成"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -283,7 +280,7 @@ msgstr "ターゲットプラットフォームを強制指定"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "[ <specfile> | <tarball> | <source package> ] とのビルドオプション:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "すべてのモード・コマンドで共通のオプション:"
@@ -342,33 +339,38 @@ msgstr "ターゲット %s 用にビルド中\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) の引数は / から始まらなければなりません。"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "データベースを初期化します。"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "インストールされたパッケージヘッダーから、データベースのインデックスを再構築"
 "します。"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "データベースの検証を行います。"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "データベースを初期化します。"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "データベース オプション:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "一つのメジャーモードのみを指定して下さい"
 
@@ -392,7 +394,7 @@ msgstr "RPMキーリングからキーを一覧表示する。"
 msgid "Keyring options:"
 msgstr "キーリングのオプション:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "引数が指定されていません。"
 
@@ -564,38 +566,43 @@ msgid "delete package signatures"
 msgstr "パッケージの署名を削除する"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "ヘッダーとペイロード署名を検証しません。"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "署名オプション:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "マクロファイル内で \"%%_gpg_name\" を設定しなければなりません。\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -627,40 +634,49 @@ msgstr "以下の問い合わせ書式を使用します。"
 msgid "Spec options:"
 msgstr "specのオプション:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "構文解析する引数がありません"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "ホスト名を正式なものにできません: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "一時ファイルを開けません: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "ストリームを開けません: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "実行中(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "%s の不正な終了ステータス (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "ビルド依存性の失敗:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -669,55 +685,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM ビルドのエラー:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "構文解析中の文法エラー ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "構文解析中の文法エラー &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "構文解析中の文法エラー ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "式中で構文解析エラー\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "( が一致しません\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- は数のみ使用可能です\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! は数にのみ使用可能です\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "型は一致していなければなりません\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / は文字列には使えません\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- は文字列には使えません\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& と || は文字列には使えません\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "式中で文法エラー\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -815,172 +782,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "シンボリックリンクが BuildRoot を指しています: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "ディレクトリーがありません: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "ファイルが見つかりません: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "ポリシーファイルの読み込みに失敗しました。: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: 不明なタグ (%d) を読み込めませんでした。\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: 公開鍵の読み込みに失敗しました。\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: ASCII 形式の公開鍵ではありません。\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: エンコードに失敗\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "ディレクトリーの作成に失敗しました"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "ファイルは先頭に \"/\" が必要です: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev グロブは許可されません: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "%%files のファイル %s を開けません: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "%%files ファイル %s の読み込み中にエラー: %m\n"
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "空のファイル分類子\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "不正な _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "ファイルが見つかりません (by glob): %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "他の形式で特別な %s を混ぜることはできません: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "１ 行に複数のファイル: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不正なファイル: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "パッケージに含まれないファイルの検査中: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -989,113 +961,108 @@ msgstr ""
 "インストール済み(ただしパッケージに含まれない)ファイルが見つかりました:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "ファイルの処理中: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "バイナリのアーキテクチャー (%d) がパッケージのアーキテクチャー (%d) と一致し"
 "ません。\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch パッケージ内にアーキテクチャ依存のバイナリー\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "ファイル %s にアーカイブの作成を失敗しました: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "アーカイブの作成に失敗しました: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "%s ファイルを開けませんでした: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "不明なペイロード圧縮: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s のオープンに失敗: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "パッケージの書き込みに失敗: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "書き込み完了: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "「%s」を実行しています:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」の実行に失敗しました。\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "パッケージ \"%s\" のチェックに失敗しました。\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s を作成できません: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "パッケージ %s の出力ファイル名を生成できませんでした: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d 行目: 2番目の %s\n"
@@ -1140,18 +1107,18 @@ msgstr "%%changelog 中に説明がありません\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d 行目: %%description の構文解析エラー: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d 行目: 不正なオプション %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1207,154 +1174,154 @@ msgstr "%d 行目: 不正な %s 番号: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d は複数回数指定しています\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "アーキテクチャは除外されています: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "アーキテクチャは含まれていません: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS は除外されています: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS は含まれていません: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s フィールドがパッケージ中に必要です: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "パッケージ中に %s エントリが重複しています: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "アイコン %s を開けません: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "アイコン %s を読むことができません: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "不明なアイコンタイプ: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "%d 行目: タグはトークンを 1つしかとりません: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d 行目: 不完全な形のタグ: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d 行目: 空のタグ: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d 行目: Prefix は \"/\" で終わってはいけません: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d 行目: Docdir は '/' で始まらなければなりません: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "%d 行目: Epoch フィールドは数字でなければなりません: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d 行目: 不正な修飾子 %s : %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d 行目: 不正な BuildArchtecture フォーマット: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "%d 行目: noarch サブ パッケージでのみサポート: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "内部エラー: にせのタグ %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "%d 行目: %s は非推奨: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不正なパッケージの指定: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d 行目: 不明なタグ: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} を空にすることができません\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} を \"\" にすることができません\n"
@@ -1364,12 +1331,12 @@ msgstr "%%{buildroot} を \"\" にすることができません\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不正なソース: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "パッチ番号 %u はありません\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "ソース番号 %u はありません\n"
@@ -1379,27 +1346,27 @@ msgstr "ソース番号 %u はありません\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup の構文解析エラー: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d 行目: %%setup への不正な引数: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d 行目: 不正な %%setup オプション %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無効なパッケージ番号 %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d 行目: ふたつ目の %%prep\n"
@@ -1485,101 +1452,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "%d 行目: 2番目の %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "%d 行目: 未サポートの内部スクリプト: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "%d 行目: インタープリター引数はトリガーにおいて許可されません: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s を開けません: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: %s に対して期待される引数\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "%d 行目: %%if が閉じていません\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "%d 行目: 終了していないマクロまたは行の不正な継続\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%if がないのに %%else があります\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "%d 行目: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: 不正な %%if 条件\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: 不正な形式の %%include 文\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "作成(build)可能な互換アーキテクチャはありません\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "パッケージには %%description がありません: %s\n"
@@ -1649,98 +1616,94 @@ msgstr "行にモジュールパスが見つかりません: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "オプションが多すぎます: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "ポリシーの処理中: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "不正な正規表現 %s を無視します\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "%s のためのパイプ作成ができません: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "%s を実行できませんでした: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s のフォークに失敗しました: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "%s を実行できませんでした: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s は失敗しました。 %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "%s へ全データの書き込みに失敗しました: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "空のファイル分類子\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "構成すべきファイル属性がありません。\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) に失敗しました: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load に失敗しました: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "ファイル \"%s\" の承認に失敗しました: モード %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "%s を検索しています: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s の検索に失敗しました:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "ホスト名を正式なものにできません: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "スペックファイル %s の問い合わせに失敗しました。解析できません。\n"
@@ -1775,90 +1738,112 @@ msgstr "%s には大き/小さ過ぎるlong値があります。スキップし�
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s には大き/小さ過ぎる整数値があります。スキップします\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "%sロックを獲得できません (%s/%s)\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "共有"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "不正なインデックス形式 %x が %s/%s にあります\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "エラー(%d) \"%s\" レコードの %s インデックスから取得中: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "エラー(%d) - レコード \"%s\" を %s に格納時\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "エラー(%d) - レコード \"%s\" を %s から削除時\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "エラー(%d) - ヘッダー #%d レコードの追加時\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "エラー(%d) - ヘッダー #%d レコードの削除時\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "エラー(%d) - 新しいパッケージインスタンスの割り当て時\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "spec ファイル %s を開けません: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s はデルタ RPM で、直接インストールできません。\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "パッケージ %s 内にサポートしていないペイロード (%s) です。\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "パッケージ %s は既に追加されています。%s を飛ばします。\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "パッケージ %s は既に追加されています。 %s と置換します。\n"
@@ -1875,7 +1860,7 @@ msgstr "(数字ではありません)"
 msgid "(not a string)"
 msgstr "(文字列でない)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(不正なタイプ)"
 
@@ -1888,146 +1873,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(base64 ではありません)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(不正な XML タイプ)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(OpenPGP 署名ではありません)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "無効な日付 %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "通常"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "置換"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "未インストール"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "ネット共有"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "間違った色"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "見つかりません"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(不明)  "
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s は %s として保存されました。\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s は %s として作成されました。\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: 削除に失敗しました: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "ディレクトリー"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "ファイル"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2071,43 +2056,52 @@ msgstr "予期せぬ ]"
 msgid "unexpected }"
 msgstr "予期せぬ }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "式中で ? が期待されます。"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "式中で ? の後に { が期待されます。"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "式中に } が期待されます。"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "? サブ式の後に : が期待されます。"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "式中で : の後に { が期待されます。"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "式の終わりに | が期待されます。"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "配列の繰り返し指定が、サイズが異なる配列の間で使用されています"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "%d 行目: %s は非推奨: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "--prefix の引数は / から始まらなければなりません。"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2651,25 +2645,25 @@ msgstr "パッケージの依存関係を検証しません。"
 msgid "don't execute verify script(s)"
 msgstr "検証スクリプトを実行しません。"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "%s の rpmlib 機能が見つかりません:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "ソースパッケージが期待されますが、これはバイナリパッケージです\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "ソースパッケージに .spec ファイルがありません\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "アーカイブの伸長に失敗%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ": ファイル "
 
@@ -2719,137 +2713,137 @@ msgstr "パッケージはファイル所有者/グループ一覧を持って�
 msgid "package has neither file owner or id lists\n"
 msgstr "パッケージはファイル所有者も id リストも持っていません\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "グループ %s に属するパッケージは存在しません。\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "%s をトリガーするパッケージが存在しません。\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "不正な %s の指定: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "%s に一致するパッケージは存在しません: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "%s を必要とするパッケージは存在しません。\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s を提供するパッケージは存在しません。\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ファイル %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "ファイル %s はどのパッケージにも属していません。\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無効なパッケージ番号: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "レコード %u は読み込めませんでした\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "パッケージ %s はインストールされていません。\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "不明なタグ: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: キー %d のインポートに失敗しました。\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: キー %d は ASCII 形式の公開鍵ではありません。\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: インポート読み込みに失敗しました(%d)。\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "OK ではありません。"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2863,117 +2857,117 @@ msgstr "%s: オープンに失敗しました: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "カレントディレクトリーを開けません: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: chroot ディレクトリーが設定されていません。\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "ルート ディレクトリーの変更に失敗しました: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "ルート ディレクトリーの復元に失敗しました: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "失われたインデックス %d を生成しています、お待ちください...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "dbpath が設定されていません\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: スキップします。"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "エラー(%d) - レコード #%d を %s に格納時\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: 正規表現に失敗しました: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp に失敗しました: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: スキップします。"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 "rpmdb: 破損したヘッダーインスタンス #%u を取得しました。スキップします。\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ヘッダーを読むことができません (0x%x)\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "dbpath が設定されていません。"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "ディレクトリー %s の作成に失敗しました: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "データベース中のヘッダー #%u は不正です -- スキップします。\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "元々 %u にあったレコードを追加できません。\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "データベースの再構築に失敗: オリジナルのデータベースは残っています。\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "古いデータベースを新しいデータベースで置き換えるのに失敗!\n"
 
@@ -3313,22 +3307,22 @@ msgstr "%s ロックを（%s 上に）作成できません。(%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "%s ロックを待っています。(%s 上)\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "%s のdlopenに失敗しました。%s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "シンボル %s の解決に失敗: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "%s プラグインは読み込まれていません。\n"
@@ -3375,15 +3369,16 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "パッケージ %s (%s より新しいもの) は既にインストールされています。"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "パッケージ %s のインストールには %<PRIu64>%cB の領域が %s ファイルシステム上"
 "に必要です。"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "パッケージ %s のインストールには %<PRIu64> の inode が %s ファイルシステム上"
 "に必要です。"
@@ -3510,7 +3505,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr "カレントディレクトリを戻せません: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> スクリプトは組み込みでサポートしていません\n"
 
@@ -3553,15 +3548,15 @@ msgstr "%s スクリプトの実行に失敗しました。終了ステータス
 msgid "Unknown format"
 msgstr "不明な書式"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "インストール"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "削除"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3570,96 +3565,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "%s にある Package データベースを開けません。\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "パッケージラベル中に余分な「(」があります: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "パッケージラベル中に「(」がありません: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "パッケージラベル中に「)」がありません: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: 公開鍵の読み込みに失敗しました。\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "トランザクション"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "ヘッダー "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3667,19 +3662,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "署名ヘッダーの再読み込みができません。\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "スキップした"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "失敗"
 
@@ -3720,67 +3715,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "構文解析中の文法エラー ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "構文解析中の文法エラー &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "構文解析中の文法エラー ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "式中で ? の後に { が期待されます。"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "式中で構文解析エラー\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "( が一致しません\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- は数のみ使用可能です\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "式の終わりに | が期待されます。"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "式中で文法エラー\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "型は一致していなければなりません\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / は文字列には使えません\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- は文字列には使えません\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(空)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "tar パイプのオープンに失敗しました: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "マクロ %%%s はオプションが終端されていません。\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "マクロ %%%s はボディが終端していません。\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "マクロ %%%s のボディは空です。\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "マクロ %%%s の展開に失敗しました。\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "不明なオプション %c (%s(%s)中に)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3788,17 +3871,27 @@ msgstr ""
 "マクロ展開の再帰呼び出しが深すぎます。これは再帰的マクロ定義が原因で発生して"
 "いる可能性があります。\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "終端されていない %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% の後ろに構文解析できないマクロが続いています。\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "予期せぬ ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "予期せぬ ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 有効 %d 空 %d\n"
@@ -3842,27 +3935,27 @@ msgstr "警告: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "lua スクリプトで不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "lua スクリプトで不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua スクリプトに失敗しました: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua ファイルに不正な文法がありました: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua のフックに失敗しました: %s\n"
@@ -3872,17 +3965,17 @@ msgstr "lua のフックに失敗しました: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "メモリ割り当て (%u バイト) が NULL を返しました。\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s、鍵 ID %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(なし)"
 
@@ -3971,44 +4064,44 @@ msgstr "gpg が署名を書き込むのに失敗しました。\n"
 msgid "unable to read the signature\n"
 msgstr "署名を読み込めませんでした。\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature に失敗しました: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM v3 パッケージを署名できません\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s はすでに同一の署名を含みます、スキップしています\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp に失敗しました。\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead に失敗しました: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "%s の置換に失敗: %s\n"
@@ -4038,23 +4131,16 @@ msgstr "%s: manifest の読み込みに失敗: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "ヘッダーとペイロード署名を検証しません。"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "%s の実行に失敗 (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! は数にのみ使用可能です\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "スクリプトレット %s (%s) の実行エラー\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& と || は文字列には使えません\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "%s行目: \n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "%%files ファイル %s の読み込み中にエラー: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: 行: %s\n"
-
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "spec ファイルに「Source:」タグがありません\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "%d 行目: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%if がないのに %%endif があります\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "%s ファイルを開けませんでした: %s\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Korean (http://www.transifex.com/rpm-team/rpm/language/ko/)\n"
 "Language: ko\n"
@@ -111,10 +111,9 @@ msgid "build source package only from <specfile>"
 msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -155,11 +154,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "<spec파일>로 소스 패키지 만을 제작합니다"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -197,10 +195,9 @@ msgid "build source package only from <tarball>"
 msgstr "<tar파일>로 소스 패키지 만을 제작합니다"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "<tar파일>로 소스 패키지 만을 제작합니다"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -278,7 +275,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "다음과 함께 사용하는 제작 옵션 [ <spec파일> | <tar파일> | <소스 패키지> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -337,33 +334,38 @@ msgstr "%s(을)를 제작하고 있습니다\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 옵션의 인수는 반드시 '/' 로 시작해야 합니다"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "데이터베이스를 초기화 합니다"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "설치된 패키지 헤더에서 상반된 목록(inverted lists)의 데이터베이스를 재구축 합"
 "니다"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "데이터베이스 파일을 검사합니다"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "데이터베이스를 초기화 합니다"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "데이터베이스 옵션:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "하나의 주(major) 모드만 지정할 수 있습니다"
 
@@ -387,7 +389,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -554,38 +556,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "서명 옵션:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "매크로 파일 안에 반드시 \"%%_gpg_name\"을 설정해야 합니다\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -617,40 +623,49 @@ msgstr "다음의 질의 형식을 사용하십시요"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "호스트명을 정규화(canonicalize) 할 수 없음: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "실행 중(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "%s의 잘못된 종료 상황 (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -659,55 +674,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM 제작 오류:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "'==' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "'&&' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "'||' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "표현식에서 오류가 발생했습니다\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "'(' 가 일치하지 않습니다\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "'-' 는 숫자에만 사용합니다\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "'!' 는 숫자에만 사용합니다\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "유형은 반드시 일치해야 합니다\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "'* /' 는 문자열에서 사용할 수 없습니다\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "'-' 는 문자열에서 사용할 수 없습니다\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "'&&' 와 '||' 는 문자열에서 사용할 수 없습니다\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "표현식에서 구문 오류가 발생했습니다\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -803,283 +769,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "BuildRoot에 심볼릭링크함: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "파일을 찾을 수 없음: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: 읽는데 실패했습니다: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "파일은 \"/\" 로 시작해야함: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "%s(을)를 열 수 없음: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "%s(을)를 여는데 실패함: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "glob으로 파일을 찾을 수 없음: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "잘못된 파일: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "패키지를 작성할 수 없음: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "작성: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s(을)를 생성할 수 없음: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "%s 패키지의 출력 파일명을 생성할 수 없음: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d 번째 행: 두번째 %s\n"
@@ -1124,18 +1090,18 @@ msgstr "%%changelog에 내용(description)이 없습니다\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d 번째 행: %%description에서 오류가 발생했습니다: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d 번째 행: %s(은)는 잘못된 옵션입니다: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1191,154 +1157,154 @@ msgstr "%d 번째 행: %s(은)는 잘못된 숫자입니다: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "아키텍쳐가 제외됨: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "아키텍쳐가 포함되어 있지 않음: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "운영체제가 제외됨: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "운영체제가 포함되어 있지 않음: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "패키지에 반드시 %s 항목(field)을 포함해야함: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "패키지에 %s 항목(entry)이 중복되어 있음: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "%s 아이콘을 열 수 없음: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "%s 아이콘을 읽을 수 없음: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "알 수 없는 아이콘 유형: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "%d 번째 행: 태그에 하나의 토큰만 있습니다: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d 번째 행: 올바르지 못한 태그입니다: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d 번째 행: 태그가 비어있습니다: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d 번째 행: Prefixes는 절대 \"/\" 로 끝나서는 안됩니다: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d 번째 행: Docdir은 반드시 '/' 로 시작해야 합니다: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d 번째 행: 잘못된 %s: 수식자(qualifier): %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d 번째 행: 잘못된 BuildArchitecture 형식입니다: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "내부 오류: 보거스(Bogus) 태그 %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "잘못된 패키지 지정: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d 번째 행: 알 수 없는 태그입니다: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1348,12 +1314,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "잘못된 소스: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1363,27 +1329,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup에서 오류 발생: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d 번째 행: %%setup에 잘못된 인수가 있습니다: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d 번째 행: %%setup에 잘못된 %s 옵션: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d 번째 행: 두번째 %%prep\n"
@@ -1468,101 +1434,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "%d 번째 행: 두번째 %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s(을)를 열 수 없음: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%else가 %%if 없이 사용되었습니다\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "%d 번째 행: 잘못된 %s: 수식자(qualifier): %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%d 번째 행: %%setup에 잘못된 %s 옵션: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "패키지 제작에 호환하는 아키텍쳐를 찾을 수 없습니다\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "패키지에 %%description이 없음: %s\n"
@@ -1628,98 +1594,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "%s(을)를 실행할 수 없음: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s(을)를 fork 할 수 없음: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "%s(을)를 실행할 수 없음: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s(을)를 찾는데 실패함:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "호스트명을 정규화(canonicalize) 할 수 없음: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1755,90 +1717,112 @@ msgstr "%s(은)는 너무 크거나 너무 적은 정수(long) 값입니다, 생
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s(은)는 너무 크거나 너무 적은 정수(int) 값입니다, 생략합니다\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "%2$s/%3$s의 잠금된(lock) %1$s(을)를 얻을 수 없습니다\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "공유됨"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "폐쇄적(exclusive)"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "새로운 패키지를 배치하는 도중 오류(%d)가 발생했습니다\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "%s spec 파일을 열 수 없음: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1855,7 +1839,7 @@ msgstr "(숫자가 아닙니다)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(부적합한 타입)"
 
@@ -1868,146 +1852,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(base64가 아닙니다)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s(이)가 %s(으)로 저장되었습니다\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s(이)가 %s(으)로 생성되었습니다\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2051,43 +2035,52 @@ msgstr "불필요한 ']' 가 있습니다"
 msgid "unexpected }"
 msgstr "불필요한 '}' 가 있습니다"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "표현식에 '?' 가 와야합니다"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "표현식의 '?' 뒤에 '{' 가 와야합니다"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "표현식에 '}' 가 와야합니다"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "'?' 하부표현식(subexpression) 뒤에 ':' 이 와야합니다"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "표현식의 ':' 뒤에 '{' 가 와야합니다"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "표현식의 끝부분에 '|' 가 와야합니다"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "--prefix 옵션의 인수는 반드시 '/' 로 시작해야 합니다"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2636,25 +2629,25 @@ msgstr "패키지의 의존성을 검사하지 않습니다"
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "소스 패키지가 필요하며, 바이너리가 검색되었습니다\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "소스 패키지에 .spec 파일이 포함되어 있지 않습니다\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "아카이브를 푸는데 실패함%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " 다음 파일의 "
 
@@ -2704,137 +2697,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr "패키지에 파일 소유자 또는 id 목록이 없습니다\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "%s 그룹은 어떤 패키지에도 포함되어 있지 않습니다\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "%s(을)를 생성하는(trigger) 패키지가 없습니다\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "%s(이)가 잘못됨: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "%s(와)과 일치하는 패키지가 없음: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "%s(을)를 필요로 하는 패키지가 없습니다\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s(을)를 제공하는 패키지가 없습니다\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "%s 파일: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "%s 파일은 어떤 패키지에도 들어있지 않습니다\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "부적합한 패키지 번호: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "%s 패키지가 설치되어 있지 않습니다\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "올바르지 않음"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "확인"
 
@@ -2848,117 +2841,117 @@ msgstr "%s: 여는데 실패했습니다: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "db경로가 설정되어 있지 않습니다\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: 0x%x의 헤더를 읽을 수 없습니다\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "db경로가 설정되어 있지 않습니다"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "%u에 처음부터 레코드를 추가할 수 없습니다\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "데이터베이스를 재구축하는데 실패함: 원본 데이터베이스는 그대로 유지됩니다\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "이전 데이터베이스를 새로운 데이터베이스로 교체하는데 실패했습니다!\n"
 
@@ -3295,22 +3288,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3356,12 +3349,13 @@ msgstr "%s 패키지 (%s 보다 최신의 패키지)는 이미 설치되어 있�
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3486,7 +3480,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3529,15 +3523,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3546,96 +3540,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "%s 안의 패키지 데이터베이스를 열 수 없습니다\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3643,19 +3637,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "서명(signature) 헤더를 다시 읽어올 수 없습니다.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3696,83 +3690,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "'==' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "'&&' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "'||' 을 처리(parsing)하는 도중 구문 오류가 발생했습니다\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "표현식의 '?' 뒤에 '{' 가 와야합니다"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "표현식에서 오류가 발생했습니다\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "'(' 가 일치하지 않습니다\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "'-' 는 숫자에만 사용합니다\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "표현식의 끝부분에 '|' 가 와야합니다"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "표현식에서 구문 오류가 발생했습니다\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "유형은 반드시 일치해야 합니다\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "'* /' 는 문자열에서 사용할 수 없습니다\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "'-' 는 문자열에서 사용할 수 없습니다\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(비어있음)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "tar 파이프를 여는데 실패함: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "매크로 %%%s에 종료되지 않은 옵션이 있습니다\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "매크로 %%%s에 종료되지 않은 내용(body)이 있습니다\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "매크로 %%%s에 비어있는 내용(body)이 있습니다\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "매크로 %%%s(을)를 확장(expand)하는데 실패했습니다\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "%2$s(%3$s)에 알 수 없는 옵션 %1$c(이)가 있습니다\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c(이)가 종료되지 않음: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "'%%' 다음에 처리할 수 없는(unparseable) 매크로가 있습니다\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "불필요한 ']' 가 있습니다"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "불필요한 ']' 가 있습니다"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d 활성 %d 비어있음\n"
@@ -3816,27 +3908,27 @@ msgstr "경고: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3846,17 +3938,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "메모리 할당 값 (%u 바이트)이 NULL을 반환하였습니다.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3945,44 +4037,44 @@ msgstr "gpg 서명을 작성하는데 실패했습니다\n"
 msgid "unable to read the signature\n"
 msgstr "서명을 읽을 수 없습니다\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead이 실패했습니다: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4012,14 +4104,8 @@ msgstr "%s: 읽는데 실패했습니다: %s\n"
 msgid "don't verify header+payload signature"
 msgstr ""
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "%s의 실행에 실패함 (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "'!' 는 숫자에만 사용합니다\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "행: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "%d 번째 행: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif가 %%if 없이 사용되었습니다\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "'&&' 와 '||' 는 문자열에서 사용할 수 없습니다\n"

--- a/po/ms.po
+++ b/po/ms.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Malay (http://www.transifex.com/rpm-team/rpm/language/ms/)\n"
 "Language: ms\n"
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -332,31 +332,36 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "memulakan pengkalan data"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "sahkan fail pengkalan data"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "memulakan pengkalan data"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -380,7 +385,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -545,38 +550,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -608,93 +617,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -791,283 +760,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: gagal membaca manifest: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Tidak dapat melaksana %s: %s\n"
 
 #: build/files.c:2258
+#, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1112,18 +1081,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1179,154 +1148,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1336,12 +1305,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1351,27 +1320,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1456,101 +1425,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1616,98 +1585,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1742,90 +1707,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "terkongsi"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Tidak dapat membuka %s untuk dibaca: %m.\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1842,7 +1829,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1855,146 +1842,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2038,35 +2025,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? dijangka dalam ungkapan"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "| dijangka dalam ungkapan"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "| dijangka selepas ungkapan ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| dijangka pada penghujung ungkapan"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2612,25 +2608,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2680,137 +2676,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2824,116 +2820,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Tidak dapat untuk menukar direktori root: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec gagal: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp gagal: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "gagal untuk mencipta direktori %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3270,22 +3266,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3331,12 +3327,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3460,7 +3457,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3503,15 +3500,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3520,96 +3517,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "'(' tambahan dalam label pakej: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Pengepala"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3617,19 +3614,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3670,83 +3667,171 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "? dijangka dalam ungkapan"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "? dijangka dalam ungkapan"
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| dijangka pada penghujung ungkapan"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "? dijangka dalam ungkapan"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(kosong)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s gagal untuk mengembang\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Pilihan tidak diketahui %c dalam %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktif %d kosong %d\n"
@@ -3790,27 +3875,27 @@ msgstr ""
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "skrip lua gagal: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "pautan lua gagal: %s\n"
@@ -3820,17 +3905,17 @@ msgstr "pautan lua gagal: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3919,44 +4004,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/rpm-team/rpm/"
 "language/nb/)\n"
@@ -113,10 +113,9 @@ msgid "build source package only from <specfile>"
 msgstr ""
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "spør pakke som eier <fil>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -277,7 +276,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -336,31 +335,36 @@ msgstr "Bygger for mål %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "initier database"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "gjenoppbygg database inverterte lister fra installerte pakkers headere"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "initier database"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "kun ett større modi kan spesifiseres"
 
@@ -384,7 +388,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -554,38 +558,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -617,40 +625,49 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Kjører(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Ugyldig sluttstatus fra %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -659,55 +676,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM-feil under bygging:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "syntaksfeil under lesing av ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "syntaksfeil under lesing av &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "syntaksfeil under lesing av ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "feil under lesing av uttrykk\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "ubalansert (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- kun på tall\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! kun på tall\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "typene må være like\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / ikke støttet for strenger\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- ikke støttet for strenger\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& og || ikke støttet for strenger\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "syntaksfeil i uttrykk\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -803,283 +771,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolsk lenke peker til BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Fil ikke funnet: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: lesing av manifest feilet: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Kunne ikke åpne %s: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "feil under åpning av %s: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ugyldig fil %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunne ikke åpne %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunne ikke skrive pakke: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1124,18 +1092,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linje %d: Ugyldig flagg %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1191,154 +1159,154 @@ msgstr "linje %d: Ugyldig %s-nummer: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s-felt må være tilstede i pakken: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Kunne ikke åpne ikon %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Kan ikke lese ikon %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Ukjent ikontype: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linje %d: Tagg tar kun et enkelt tegn: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linje %d: Feilutformet tagg: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linje %d: Tom tagg: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linje %d: Prefiks må ikke slutte på \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linje %d: Docdir må begynne med '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linje %d: Ugyldig %s: kvalifikatorer: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linje %d: Ugyldig BuildArchitecture format: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Intern feil: Ugyldig tag %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Ugyldig pakkespesifikasjon: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linje %d: Ukjent tagg: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1348,12 +1316,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "kunne ikke opprette %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1363,27 +1331,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr "Feil under lesing av %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linje %d: Ugyldig argument til %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linje %d: Ugyldig %%setup flagg %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linje %d: %%prep for andre gang\n"
@@ -1468,101 +1436,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "linje %d: Andre %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Kan ikke åpne %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%else uten %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "linje %d: Ugyldig %s: kvalifikatorer: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "linje %d: Ugyldig %%setup flagg %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Ingen kompatible arkitekturer funnet for bygging\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakken har ingen %%description: %s\n"
@@ -1628,98 +1596,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Kunne ikke kjøre %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "klarte ikke å åpne %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Kunne ikke kjøre %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Klarte ikke å finne %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1754,90 +1718,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Kunne ikke åpne spec fil %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1854,7 +1840,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1867,146 +1853,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s lagret som %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s opprettet som %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2050,43 +2036,52 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "argumenter til --prefix må begynne med en /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2628,25 +2623,25 @@ msgstr "ikke verifiser pakkeavhengigheter"
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "kildepakke forventet, binær funnet\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "kildepakke inneholder ikke en .spec-fil\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2696,137 +2691,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr "pakken har verken fileier eller id-lister\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "gruppe %s inneholder ingen pakker\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "ingen pakke utløser %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "ingen pakke krever %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ingen pakke gir %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s eies ikke av noen pakke\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "ugyldig pakkenummer: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakke %s er ikke installert\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "IKKE OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2840,116 +2835,116 @@ msgstr "%s: åpne feilet: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3286,22 +3281,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3347,12 +3342,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3476,7 +3472,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3519,15 +3515,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3536,96 +3532,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "kan ikke åpne pakkedatabase i %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3633,19 +3629,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3686,83 +3682,180 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "syntaksfeil under lesing av ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "syntaksfeil under lesing av &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "syntaksfeil under lesing av ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "syntaksfeil i uttrykk\n"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "feil under lesing av uttrykk\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "ubalansert (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- kun på tall\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "uventet spørringskilde"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "syntaksfeil i uttrykk\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "typene må være like\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / ikke støttet for strenger\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- ikke støttet for strenger\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Kunne ikke åpne tar-rør: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "ventet spørringsformat"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3806,27 +3899,27 @@ msgstr "advarsel: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3836,17 +3929,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3935,44 +4028,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature feilet: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead feilet: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4002,14 +4095,8 @@ msgstr "%s: lesing av manifest feilet: %s\n"
 msgid "don't verify header+payload signature"
 msgstr ""
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Kjøring av %s feilet (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! kun på tall\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "Installerer %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "linje %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif uten %%if\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& og || ikke støttet for strenger\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/rpm-team/rpm/language/nl/)\n"
 "Language: nl\n"
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -332,31 +332,35 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Database opties:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -380,7 +384,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -545,38 +549,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -608,93 +616,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -791,283 +759,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, c-format
+msgid "Can't read content of file: %s\n"
+msgstr ""
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
+#: build/files.c:2233
 #, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
+msgid "Could not open %s file %s: %m\n"
 msgstr ""
 
 #: build/files.c:2258
 #, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
+#, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1112,18 +1080,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1179,154 +1147,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1336,12 +1304,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1351,27 +1319,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1456,101 +1424,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s: regel: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "%s: regel: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1616,98 +1584,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1742,90 +1706,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr ""
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1842,7 +1828,7 @@ msgstr "(geen getal)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1855,146 +1841,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(geen OpenPGP handtekening)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2038,35 +2024,44 @@ msgstr "onverwachte ]"
 msgid "unexpected }"
 msgstr "onverwachte }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? verwacht in expressie"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ verwacht na ? in expressie"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} verwacht in expressie"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ verwacht na : in expressie"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2612,25 +2607,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2680,137 +2675,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "bestand %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NIET OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2824,116 +2819,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3270,22 +3265,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3331,12 +3326,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3460,7 +3456,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3503,15 +3499,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3520,96 +3516,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "ontbrekende '(' in pakketlabel: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "ontbrekende ')' in pakketlabel: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3617,19 +3613,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3670,83 +3666,173 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ verwacht na ? in expressie"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "? verwacht in expressie"
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "? verwacht in expressie"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "? verwacht in expressie"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(leeg)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Onbekende optie %c in %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "onverwachte ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "onverwachte ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== actief %d leeg %d\n"
@@ -3790,27 +3876,27 @@ msgstr "waarschuwing: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3820,17 +3906,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3919,44 +4005,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3985,9 +4071,3 @@ msgstr ""
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "line: %s\n"
-#~ msgstr "regel: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "regel %d: %s\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2019-01-17 10:09+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2019-06-06 09:42-0400\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish (http://www.transifex.com/rpm-team/rpm/language/pl/)\n"
 "Language: pl\n"
@@ -127,10 +127,11 @@ msgid "build source package only from <specfile>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pliku-spec>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "zbudowanie tylko pakietu źródłowego z <pliku-spec>"
+msgstr ""
+"zbudowanie tylko pakietu źródłowego z <pliku-spec> — obliczenie dynamicznych "
+"wymagań budowania"
 
 #: rpmbuild.c:170
 #, c-format
@@ -174,11 +175,12 @@ msgid "build source package only from <source package>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pakietu-źródłowego>"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "zbudowanie tylko pakietu źródłowego z <pakietu-źródłowego>"
+msgstr ""
+"zbudowanie tylko pakietu źródłowego z <pakietu-źródłowego> — obliczenie "
+"dynamicznych wymagań budowania"
 
 #: rpmbuild.c:195
 #, c-format
@@ -218,10 +220,11 @@ msgid "build source package only from <tarball>"
 msgstr "zbudowanie tylko pakietu źródłowego z <pliku-tar>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "zbudowanie tylko pakietu źródłowego z <pliku-tar>"
+msgstr ""
+"zbudowanie tylko pakietu źródłowego z <pliku-tar> — obliczenie dynamicznych "
+"wymagań budowania"
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -299,7 +302,7 @@ msgstr "zastąpienie platformy docelowej"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opcje budowania z [ <plik-spec> | <plik-tar> | <pakiet-źródłowy> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Wspólne opcje dla wszystkich trybów i plików binarnych RPM:"
@@ -358,33 +361,38 @@ msgstr "Budowanie dla %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "parametry dla --root (-r) muszą zaczynać się od /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "zainicjowanie bazy danych"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "przebudowanie odwrotne listy w bazie danych z nagłówków zainstalowanych "
 "pakietów"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "sprawdzenie plików bazy danych"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "zainicjowanie bazy danych"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "wyeksportowanie bazy danych do listy nagłówków standardowego wyjścia"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "zaimportowanie bazy danych z listy nagłówków standardowego wejścia"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opcje bazy danych:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "może być podany tylko jeden główny tryb pracy"
 
@@ -408,7 +416,7 @@ msgstr "wyświetlenie listy kluczy z bazy kluczy RPM"
 msgid "Keyring options:"
 msgstr "Opcje bazy kluczy:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "nie podano parametrów"
 
@@ -581,31 +589,36 @@ msgid "delete package signatures"
 msgstr "usunięcie podpisów pakietów"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "bez sprawdzania podpisu nagłówka+danych"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr "podpisanie plików pakietów"
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr "użycie <klucza> podpisywania pakietów"
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr "<klucz>"
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr "pytanie o hasło klucza podpisywania pakietów"
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opcje podpisu:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Należy ustawić „%%_gpg_name” w pliku makr\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
@@ -614,7 +627,7 @@ msgstr ""
 "Należy ustawić „%%_file_signing_key” w pliku makr lub w wierszu poleceń za "
 "pomocą --fskpath\n"
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr "--fskpath może być podawane tylko podczas podpisywania plików"
 
@@ -648,40 +661,49 @@ msgstr "użycie następującego formatu zapytania"
 msgid "Spec options:"
 msgstr "Opcje pliku spec:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "nie podano parametrów do przetworzenia"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr "nie można przetworzyć SOURCE_DATE_EPOCH\n"
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Nie można ustalić kanonicznej nazwy komputera: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Nie można otworzyć pliku tymczasowego: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Nie można otworzyć strumienia: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Wykonywanie(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Błędny stan wyjścia z %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Niespełnione zależności budowania:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr "ustawianie %s=%s\n"
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -690,55 +712,6 @@ msgstr ""
 "\n"
 "\n"
 "Błędy budowania pakietu RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "błąd składni podczas przetwarzania ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "błąd składni podczas przetwarzania &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "błąd składni podczas przetwarzania ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "błąd przetwarzania w wyrażeniu\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "niesparowane (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- tylko na liczbach\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! tylko na liczbach\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "typy muszą się zgadzać\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / nie są obsługiwane dla ciągów\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- nie jest obsługiwane dla ciągów\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& i || nie są obsługiwane dla ciągów\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "błąd składni w wyrażeniu\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -827,183 +800,188 @@ msgstr "odczytanie dowiązania symbolicznego %s się nie powiodło: %s\n"
 #: build/files.c:1204
 #, c-format
 msgid "absolute symlink: %s -> %s\n"
-msgstr ""
+msgstr "bezwzględne dowiązanie symboliczne: %s → %s\n"
 
 #: build/files.c:1210
 #, c-format
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Dowiązanie symboliczne wskazuje na BuildRoot: %s → %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Niedozwolony znak „%c” (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Ścieżka jest poza buildroot: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Nie odnaleziono katalogu: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Nie odnaleziono pliku: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Nie jest katalogiem: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Odczytanie pliku polityki się nie powiodło: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nie można wczytać nieznanego znacznika (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: odczytanie klucza publicznego się nie powiodło.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: nie jest opakowanym kluczem publicznym.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: odkodowanie się nie powiodło\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr "dowiązanie symboliczne się nie powiodło"
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr "Podwójny identyfikator budowania, stat %s: %m\n"
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr "Podwójne identyfikatory budowania %s i %s\n"
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr "Nie ustawiono makra _build_id_links, przyjmowanie „compat”\n"
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr "Ustawiono makro _build_id_links na nieznaną wartość „%s”\n"
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr "błąd podczas odczytywania identyfikatora budowania w %s: %s\n"
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr "Brak identyfikatora budowania w %s\n"
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr "Identyfikator budowania odnaleziony w %s jest za mały\n"
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr "Identyfikator budowania odnaleziony w %s jest za duży\n"
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "utworzenie katalogu się nie powiodło"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr "Mieszanie głównych plików ELF i plików debugowania w pakiecie"
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Plik musi zaczynać się od „/”: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Wyrażenie regularne %%dev nie jest dozwolone: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 "Wyrażenie regularne nie odnalazło katalogu: %s. Próbowanie bez wyrażenia "
 "regularnego.\n"
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 "Wyrażenie regularne nie odnalazło pliku: %s. Próbowanie bez wyrażenia "
 "regularnego.\n"
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Nie można otworzyć pliku %s w %%files: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "Pusty plik %s w %%files\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Błąd podczas odczytywania pliku %s w %%files: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Nie odnaleziono pliku przez wyrażenie regularne: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr "Plik specjalny na utworzonej liście plików: %s\n"
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Nie można mieszać specjalnego %s z innymi formami: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Więcej niż jeden plik na wiersz: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr "Tworzenie dowiązań identyfikatorów budowania się nie powiodło\n"
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Błędny plik: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Sprawdzanie niespakietowanych plików: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1012,113 +990,108 @@ msgstr ""
 "Odnaleziono zainstalowane (ale niespakietowane) pliki:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr "%s zostało przydzielone do wielu nazw plików"
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Przetwarzanie plików: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "Architektura plików binarnych (%d) nie zgadza się z architekturą pakietu "
 "(%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Pliki binarne zależne od architektury w pakiecie noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "utworzenie archiwum się nie powiodło na pliku %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "utworzenie archiwum się nie powiodło: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Nie można otworzyć pliku %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nieznana kompresja danych: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Nie można wyszukać w pliku %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr "Odczytanie %jd B w pliku %s się nie powiodło: %s\n"
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr "Nie można utworzyć regionu niezmiennego nagłówka\n"
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr "Nie można zapisać nagłówka do %s: %s\n"
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nie można otworzyć %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nie można zapisać pakietu: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Wykonywanie „%s”:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Wykonanie „%s” się nie powiodło.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Sprawdzenie pakietu „%s” się nie powiodło.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nie można utworzyć %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nie można utworzyć wyjściowej nazwy pliku dla pakietu %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
-msgstr ""
+msgstr "Ukończono zadanie pakietu binarnego, wynik %d, nazwa pliku %s\n"
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d. wiersz: drugie %s\n"
@@ -1163,18 +1136,18 @@ msgstr "brak opisu w %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "%d. wiersz: drugi %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "%d. wiersz: błąd podczas przetwarzania %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "%d. wiersz: błędna opcja %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1230,154 +1203,154 @@ msgstr "%d. wiersz: błędny numer %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d zostało określone wiele razy\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Architektura jest wykluczona: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Architektura nie jest dołączona: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "System operacyjny jest wykluczony: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "System operacyjny nie jest dołączony: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Pole %s musi być obecne w pakiecie: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Powtórzone wpisy %s w pakiecie: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Nie można otworzyć ikony %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Nie można odczytać ikony %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Nieznany typ ikony: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "%d. wiersz: znacznik przyjmuje tylko jeden token: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "%d. wiersz: %s w: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s w: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Niedozwolony znak „%c” (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr "Możliwe nierozwinięte makro"
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Niedozwolona sekwencja „..”"
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "%d. wiersz: błędnie sformowany znacznik: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "%d. wiersz: pusty znacznik: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "%d. wiersz: przedrostki nie mogą kończyć się na „/”: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "%d. wiersz: Docdir musi zaczynać się od „/”: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "%d. wiersz: pole Epoch musi być niepodpisaną liczbą: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "%d. wiersz: błędne określenia %s: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "%d. wiersz: błędny format BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr "%d. wiersz: podwójny wpis BuildArch: %s\n"
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "%d. wiersz: obsługiwane są tylko podpakiety noarch: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Wewnętrzny błąd: fałszywy znacznik %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "%d. wiersz: %s jest przestarzałe: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Błędna specyfikacja pakietu: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr "Odnaleziono binarny pakiet RPM. Oczekiwano pliku spec.\n"
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "%d. wiersz: nieznany znacznik: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} nie może być puste\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} nie może być „/”\n"
@@ -1387,12 +1360,12 @@ msgstr "%%{buildroot} nie może być „/”\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Błędne źródło: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Brak łaty numer %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Brak źródła numer %u\n"
@@ -1402,27 +1375,27 @@ msgstr "Brak źródła numer %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Błąd podczas przetwarzania %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "%d. wiersz: błędny parametr dla %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "%d. wiersz: błędna opcja %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Nieprawidłowy numer łaty %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "%d. wiersz: drugie %%prep\n"
@@ -1509,102 +1482,102 @@ msgstr "%d. wiersz: priorytety są dozwolone tylko w wyzwalaczach plików: %s\n
 msgid "line %d: Second %s\n"
 msgstr "%d. wiersz: drugie %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "%d. wiersz: wewnętrzny skrypt jest nieobsługiwany: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr "%d. wiersz: warunek wyzwalacza pliku musi zaczynać się od „/”: %s"
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 "%d. wiersz: parametry interpretatora nie są dozwolone w wyzwalaczach: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
-msgstr ""
+msgstr "dodatkowe tokeny na końcu dyrektywy %s w %d. wierszu:  %s\n"
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr "Makro rozszerzone w komentarzu w %d. wierszu: %s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nie można otworzyć %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: oczekiwano parametru dla %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "%d. wiersz: niezamknięte %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "%d. wiersz: niezamknięte makro lub błędna kontynuacja wiersza\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: napotkano %%else bez %%if\n"
+msgstr "%s: %d. wiersz: %s bez %%if\n"
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "%d. wiersz: %s: %s\n"
+msgstr "%s: %d. wiersz: %s po %s\n"
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: błędny warunek %%if\n"
+msgstr "%s:%d: błędny warunek %s: %s\n"
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: błędnie sformatowany zwrot %%include\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "kodowanie %s nie jest obsługiwane przez system\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Pakiet %s: nieprawidłowe kodowanie %s w %s: %s — %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr "%d. wiersz: %%end nie przyjmuje żadnych parametrów: %s\n"
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr "%d. wiersz: nieoczekiwane %%end, nie ma sekcji do zamknięcia: %s\n"
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr "%d. wiersz nie należy do żadnej sekcji: %s\n"
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Nie odnaleziono zgodnych architektur do zbudowania\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Pakiet nie ma %%description: %s\n"
@@ -1672,98 +1645,94 @@ msgstr "Brak ścieżki do modułu w wierszu: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Za dużo parametrów w wierszu: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Przetwarzanie polityk: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorowanie nieprawidłowego wyrażenia regularnego %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nie można utworzyć potoku dla %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Nie można wykonać %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nie można rozdzielić %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Nie można wykonać %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s się nie powiodło: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "zapisanie wszystkich danych do %s się nie powiodło: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Pusty klasyfikator pliku\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Brak skonfigurowanych atrybutów plików\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) się nie powiodło: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load się nie powiodło: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rozpoznanie pliku „%s” się nie powiodło: tryb %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Wyszukiwanie %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Odnalezienie %s się nie powiodło:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr "Używany jest przestarzały zewnętrzny generator zależności.\n"
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr "%d. wiersz: %s: pakiet %s nie istnieje\n"
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr "%d. wiersz: %s: pakiet %s już istnieje\n"
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr "nie można przetworzyć SOURCE_DATE_EPOCH\n"
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Nie można ustalić kanonicznej nazwy komputera: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "odpytanie pliku spec %s się nie powiodło, nie można przetworzyć\n"
@@ -1798,97 +1767,117 @@ msgstr "%s ma za dużą lub za małą wartość long, pominięto\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s ma za dużą lub za małą wartość całkowitą, pominięto\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "nie można otrzymać %s blokady na %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "współdzielonej"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "wyłącznej"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "nieprawidłowy typ indeksu %x w %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "błąd(%d) podczas uzyskiwania wpisów „%s” z indeksu %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "błąd(%d) podczas zapisywania wpisu „%s” do %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "błąd(%d) usuwania wpisu „%s” z %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "błąd(%d) podczas dodawania wpisu %d. nagłówka\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "błąd(%d) podczas usuwania wpisu %d. nagłówka\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "błąd(%d) podczas przydzielania nowej instancji pakietu\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
-"Odnaleziono bazę danych data.mdb LMDB podczas próby użycia mechanizmu %s: "
-"używanie mechanizmu lmdb.\n"
 
-#: lib/backend/dbi.c:75
-#, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
-msgstr ""
-"Odnaleziono bazę danych Packages.db NDB podczas próby użycia mechanizmu %s: "
-"używanie mechanizmu ndb.\n"
-
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/dbi.c:97
+#, fuzzy, c-format
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 "Odnaleziono bazę danych Packages BDB podczas próby użycia mechanizmu %s: "
 "używanie mechanizmu bdb.\n"
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:101
+#, fuzzy
+msgid "Detected outdated index databases\n"
+msgstr "nie można usunąć poprzedniej bazy danych w %s\n"
+
+#: lib/backend/ndb/glue.c:103
+#, fuzzy
+msgid "Rebuilding outdated index databases\n"
+msgstr "nie można usunąć poprzedniej bazy danych w %s\n"
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Nie można otworzyć pliku spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 "%s jest pakietem RPM Delta i nie może zostać bezpośrednio zainstalowany\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nieobsługiwane dane (%s) w pakiecie %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "pakiet %s został już dodany, pomijanie %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "pakiet %s został już dodany, zastępowanie %s\n"
@@ -1905,7 +1894,7 @@ msgstr "(nie jest liczbą)"
 msgid "(not a string)"
 msgstr "(nie jest ciągiem)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(nieprawidłowy typ)"
 
@@ -1918,146 +1907,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(nie jest base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(nieprawidłowy typ XML)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(nie jest podpisem OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Nieprawidłowa data %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "zwykły"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "zastąpiony"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "niezainstalowany"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "udostępniony w sieci"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "błędny kolor"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "brak"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(nieznany)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s zapisano jako %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s utworzono jako %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: usunięcie się nie powiodło: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "katalog"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "plik"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr "znacznik[%d]: BŁĘDNY, znacznik %d typ %d offset %d liczba %d len %d"
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "load hdr: BŁĘDNE"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr "region: brak znaczników"
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "znacznik regionu: BŁĘDNY, znacznik %d typ %d offset %d liczba %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "offset regionu: BŁĘDNY, znacznik %d typ %d offset %d liczba %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "zakończenie regionu: BŁĘDNE, znacznik %d typ %d offset %d liczba %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr "rozmiar regionu %d: BŁĘDNY, ril %d il %d rdl %d dl %d"
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr "region %d: numer znacznika się nie zgadza il %d ril %d dl %d rdl %d\n"
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "rozmiar hdr(%d): BŁĘDNY, odczytanie zwróciło %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "magic hdr: BŁĘDNE"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "znaczniki hdr: BŁĘDNE, liczba znaczników(%d) jest poza zakresem"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "dane hdr: BŁĘDNE, liczba bajtów(%d) jest poza zakresem"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "blob hdr(%zd): BŁĘDNE, odczytanie zwróciło %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "pad sigh(%zd): BŁĘDNE, odczyt %zd B"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr "podpis "
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "rozmiar blob(%d): BŁĘDNY, 8 + 16 * il(%d) + dl(%d)"
@@ -2101,43 +2090,52 @@ msgstr "nieoczekiwane ]"
 msgid "unexpected }"
 msgstr "nieoczekiwane }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "oczekiwano ? w wyrażeniu"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "oczekiwano { po ? w wyrażeniu"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "oczekiwano } w wyrażeniu"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "oczekiwano : po podwyrażeniu ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "oczekiwano { po : w wyrażeniu"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "oczekiwano | na końcu wyrażenia"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iterator tablicy użyty na tablicach o różnych rozmiarach"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "%d. wiersz: %s jest przestarzałe: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr "wczytanie pliku makra %s się nie powiodło\n"
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "parametry dla --prefix muszą zaczynać się od /"
+msgstr "parametry dla --dbpath muszą zaczynać się od „/”\n"
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2269,7 +2267,7 @@ msgstr "debugowanie wejścia/wyjścia rpmio"
 
 #: lib/poptALL.c:273
 msgid "disable user namespace support"
-msgstr ""
+msgstr "wyłączenie obsługi przestrzeni nazw użytkownika"
 
 #: lib/poptALL.c:332
 #, c-format
@@ -2683,25 +2681,25 @@ msgstr "bez sprawdzania zależności pakietu"
 msgid "don't execute verify script(s)"
 msgstr "bez wykonania żadnych skryptów sprawdzania"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Brak funkcji rpmlib dla %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "oczekiwano pakietu źródłowego, odnaleziono binarny\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "pakiet źródłowy nie zawiera pliku .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozpakowanie archiwum się nie powiodło%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " na pliku "
 
@@ -2751,137 +2749,137 @@ msgstr "pakiet nie ma list właścicieli/grup plików\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "pakiet nie ma list właścicieli ani identyfikatorów plików\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "grupa %s nie zawiera żadnych pakietów\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "brak pakietów wyzwalających %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "błędnie sformowane %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "brak pakietów pasujących do %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr "żaden pakiet nie jest w konflikcie z %s\n"
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr "żaden pakiet nie zastępuje %s\n"
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "brak pakietów wymagających %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "brak pakietów zalecających %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "brak pakietów sugerujących %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "brak pakietów uzupełniających %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "brak pakietów ulepszających %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "brak pakietów dostarczających %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "plik %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "plik %s nie należy do żadnego pakietu\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "nieprawidłowy numer pakietu: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "nie można odczytać wpisu %u\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "pakiet %s nie jest zainstalowany\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nieznany znacznik: „%s”\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: zaimportowanie klucza %d się nie powiodło.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: klucz %d nie jest opakowanym kluczem publicznym.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: zaimportowanie read się nie powiodło(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr "„Fread” się nie powiodło: %s"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr "SKRÓTY"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr "skróty"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr "PODPISY"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr "podpisy"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NIE JEST OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2895,118 +2893,118 @@ msgstr "%s: otwarcie się nie powiodło: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Nie można otworzyć bieżącego katalogu: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: nie ustawiono katalogu chroot\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Nie można zmienić katalogu roota: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Nie można przywrócić katalogu roota: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Tworzenie %d brakujących indeksów, proszę czekać…\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "nie można otworzyć indeksu %s za pomocą %s — %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "ścieżka bazy danych nie została ustawiona\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: pomijanie"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "błąd(%d) podczas zapisywania %d. wpisu do %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: pomijanie"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: pobrano uszkodzony %u. nagłówek — pomijanie.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nie można odczytać nagłówka pod 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr "nie można wstawić nowej bazy danych na miejsce\n"
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr "nie można także przywrócić poprzedniej bazy danych z %s\n"
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr "zastąpienie plików w %s plikami z %s pozwoli przywrócić\n"
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr "Nie można pobrać publicznych kluczy z %s\n"
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr "nie można usunąć poprzedniej bazy danych w %s\n"
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "ścieżka bazy danych nie została ustawiona"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "utworzenie katalogu %s się nie powiodło: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "%u. nagłówek w bazie danych jest błędny — pomijanie.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nie można dodać wpisu będącego pierwotnie przy %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "przebudowanie bazy danych się nie powiodło: pierwotna baza danych pozostała "
 "na miejscu\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "zamiana poprzedniej bazy danych na nową się nie powiodła.\n"
 
@@ -3098,9 +3096,8 @@ msgid "support for rich dependencies."
 msgstr "obsługa złożonych zależności."
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "obsługa złożonych zależności."
+msgstr "obsługa dynamicznych wymagań budowania."
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3350,22 +3347,22 @@ msgstr "nie można utworzyć blokady %s na %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "oczekiwanie na blokadę %s na %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Wykonanie dlopen na %s %s się nie powiodło\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Rozwiązanie symbolu %s się nie powiodło: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Wtyczka %%__%s_%s nie jest skonfigurowana\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Wtyczka %s nie jest wczytana\n"
@@ -3410,13 +3407,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "pakiet %s (nowszy niż %s) jest już zainstalowany"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "instalowanie pakietu %s wymaga %<PRIu64>%c B w systemie plików %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr "instalowanie pakietu %s wymaga %<PRIu64> i-węzłów w systemie plików %s"
 
 #: lib/rpmprob.c:159
@@ -3541,7 +3539,7 @@ msgstr "Nie wywołano exec() po fork() w skrypcie Lua\n"
 msgid "Unable to restore current directory: %m"
 msgstr "Nie można przywrócić bieżącego katalogu: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "Obsługa skryptów <lua> nie jest wbudowana\n"
 
@@ -3584,15 +3582,15 @@ msgstr "Skrypt %s się nie powiódł, stan wyjścia %d\n"
 msgid "Unknown format"
 msgstr "Nieznany format"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "instalacja"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "usunięcie"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr "rpmdb"
 
@@ -3601,96 +3599,96 @@ msgstr "rpmdb"
 msgid "cannot open Packages database in %s\n"
 msgstr "nie można otworzyć bazy danych pakietów w %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "dodatkowe „(” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "brak „(” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "brak „)” w etykiecie pakietu: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: odczytanie klucza publicznego się nie powiodło.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr "nieprawidłowy poziom sprawdzania pakietu %s\n"
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transakcji"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr "%s znacznik %u: nieprawidłowy typ %u"
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr "%s znacznik %u: nieprawidłowa liczba %u"
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr "%s znacznik %u: nieprawidłowe dane %p (%u)"
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr "%s znacznik %u: nieprawidłowy rozmiar %u"
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr "%s znacznik %u: nieprawidłowy podpis OpenPGP"
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr "%s znacznik %u: nieprawidłowa liczba szesnastkowa"
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
-#, c-format
-msgid "%s%s %s"
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
+#, fuzzy, c-format
+msgid "%s%s%s %s"
 msgstr "%s%s %s"
 
-#: lib/rpmvs.c:263
+#: lib/rpmvs.c:268
 msgid "digest"
 msgstr "skrót"
 
-#: lib/rpmvs.c:268
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr "%s%s"
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr "podpis"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr "nagłówek"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr "pakiet"
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Nagłówek "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr "Dane pakietu "
 
@@ -3698,19 +3696,19 @@ msgstr "Dane pakietu "
 msgid "Unable to reload signature header.\n"
 msgstr "Nie można ponownie wczytać nagłówka podpisu.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr "brak podpisu"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr "brak skrótu"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "pominięto"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "się nie powiodło"
 
@@ -3752,67 +3750,155 @@ msgid "Failed to register fork handler: %m\n"
 msgstr ""
 "Zarejestrowanie programu obsługującego rozdzielanie się nie powiodło: %m\n"
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "błąd składni podczas przetwarzania ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "błąd składni podczas przetwarzania &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "błąd składni podczas przetwarzania ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "%d. wiersz: %s w: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "oczekiwano { po ? w wyrażeniu"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "błąd przetwarzania w wyrażeniu\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "niesparowane (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- tylko na liczbach\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "oczekiwano | na końcu wyrażenia"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "błąd składni w wyrażeniu\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "typy muszą się zgadzać\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / nie są obsługiwane dla ciągów\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- nie jest obsługiwane dla ciągów\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr "%3d>%*s(puste)\n"
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(puste)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Otwarcie potoku tar się nie powiodło: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr "Makro %%%s ma niedozwoloną nazwę (%s)\n"
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr "Makro %%%s jest wbudowane (%s)\n"
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s ma niezakończone opcje\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s ma niezakończoną treść\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s ma pustą treść\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makro %%%s wymaga spacji przed treścią\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Rozwinięcie makra %%%s się nie powiodło\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Określono makro %%%s, ale nie jest używane w ramach zakresu\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nieznana opcja %c w %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "wczytanie pliku makra %s się nie powiodło"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3820,17 +3906,27 @@ msgstr ""
 "Za dużo poziomów rekurencji w rozwinięciu makra. Prawdopodobnie jest to "
 "spowodowane rekurencyjną deklaracją makra.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Niezakończone %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Makro niemożliwe do przetworzenia po %%\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "nieoczekiwane ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "nieoczekiwane ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktywne %d puste %d\n"
@@ -3874,27 +3970,27 @@ msgstr "ostrzeżenie: "
 msgid "Error writing to log"
 msgstr "Błąd podczas zapisywania do dziennika"
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nieprawidłowa składnia skryptu Lua: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nieprawidłowa składnia skryptu Lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "skrypt Lua się nie powiódł: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nieprawidłowa składnia pliku Lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "hak Lua się nie powiódł: %s\n"
@@ -3904,17 +4000,17 @@ msgstr "hak Lua się nie powiódł: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "przydzielenie pamięci (%u B) zwróciło NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr "Nieobsługiwana wersja klucza: V%d\n"
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, identyfikator klucza %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(brak)"
 
@@ -4003,44 +4099,44 @@ msgstr "zapisanie podpisu przez gpg się nie powiodło\n"
 msgid "unable to read the signature\n"
 msgstr "nie można odczytać podpisu\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr "obsługa podpisywania plików nie jest wbudowana\n"
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature się nie powiodło: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Nie można podpisywać pakietów RPM v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s zawiera już identyczny podpis, pomijanie\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp się nie powiodło\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead się nie powiodło: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "zastąpienie %s się nie powiodło: %s\n"
@@ -4070,26 +4166,36 @@ msgstr "%s: odczytanie manifestu się nie powiodło: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "bez sprawdzania podpisu nagłówka+danych"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Wykonanie %s się nie powiodło (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! tylko na liczbach\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Błąd podczas wykonywania skryptu %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& i || nie są obsługiwane dla ciągów\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "wiersz: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Błąd podczas odczytywania pliku %s w %%files: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: wiersz: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Nie można otworzyć pliku %s: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Brak znacznika „Source:” w pliku spec\n"
+#, c-format
+#~ msgid ""
+#~ "Found LMDB data.mdb database while attempting %s backend: using lmdb "
+#~ "backend.\n"
+#~ msgstr ""
+#~ "Odnaleziono bazę danych data.mdb LMDB podczas próby użycia mechanizmu %s: "
+#~ "używanie mechanizmu lmdb.\n"
 
-#~ msgid "line %d: %s\n"
-#~ msgstr "%d. wiersz: %s\n"
+#, c-format
+#~ msgid ""
+#~ "Found NDB Packages.db database while attempting %s backend: using ndb "
+#~ "backend.\n"
+#~ msgstr ""
+#~ "Odnaleziono bazę danych Packages.db NDB podczas próby użycia mechanizmu "
+#~ "%s: używanie mechanizmu ndb.\n"
 
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: napotkano %%endif bez %%if\n"
-
-#~ msgid "file %s: %d invalid macro definitions\n"
-#~ msgstr "plik %s: %d nieprawidłowe definicje makr\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "wczytanie pliku makra %s się nie powiodło"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
 "PO-Revision-Date: 2017-08-10 07:39+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/rpm-team/rpm/language/"
@@ -282,7 +282,7 @@ msgstr "ignorar a plataforma-alvo"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opções de criação com [ <fich spec> | <fich tar> | <pacote fonte> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -341,33 +341,38 @@ msgstr "A construir para o alvo %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "os argumentos do --root (-r) têm de começar por /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inicializar a base de dados"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "reconstruir as listas invertidas da base dados com os cabeçalhos dos pacotes "
 "instalados"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "verificar ficheiros da base de dados"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inicializar a base de dados"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opções da base de dados:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "só pode ser especificado um 'major mode'"
 
@@ -391,7 +396,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -564,38 +569,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opções de assinatura:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Precisa definir o \"%%_gpg_name\" no seu ficheiro de macros\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -627,40 +636,49 @@ msgstr "usar o formato de pesquisa seguinte"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Não consegui canonizar o nome da máquina: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "A executar(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Código de saída inválido do %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -669,55 +687,6 @@ msgstr ""
 "\n"
 "\n"
 "Erros de criação do RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "erro de sintaxe ao analisar o ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "erro de sintaxe ao analisar o &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "erro de sintaxe ao analisar o ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "erro de análise na expressão\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "( não correspondido\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- só em números\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! só em números\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "os tipos têm de corresponder\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / não suportados em cadeias de caracteres\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- não suportado em cadeias de caracteres\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& e || não suportados em cadeias de caracteres\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "erro de sintaxe na expressão\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -813,283 +782,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "A 'symlink' aponta para a BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Ficheiro não encontrado: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: a leitura do manifesto falhou: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "O ficheiro precisa de começar por \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Não consigo aceder ao %s: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "o acesso ao %s falhou: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Ficheiro não encontrado pelo glob: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Ficheiro inválido: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, fuzzy, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr "Não consegui ler o ficheiro spec do %s\n"
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Não consigo aceder ao %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Não consegui gravar o pacote: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Gravei: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "não consigo criar o %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Não consigo gerar o ficheiro de saída para o pacote %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linha %d: segundo %s\n"
@@ -1134,18 +1103,18 @@ msgstr "falta a descrição no %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linha %d: Erro ao analisar a %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linha %d: Opção inválida %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1201,154 +1170,154 @@ msgstr "linha %d: Número %s inválido: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "A arquitectura está excluída: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "A arquitectura não está incluída: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "O SO está excluído: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "O SO não está incluído: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "O campo %s tem de estar presente no pacote: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Entradas %s duplicadas no pacote: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Não consegui abrir o ícone %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Não consegui ler o ícone %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Tipo de ícone desconhecido: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linha %d: Opção só recebe um parâmetro: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "Linha %d: Opção inválida: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linha %d: Opção em branco: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linha %d: Os prefixos não podem acabar em \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linha %d: A docdir tem de começar por '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linha %d: Qualificadores %s: inválidos: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linha %d: Formato da BuildArchitecture inválido: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erro interno: Opção esquisita %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Descrição do pacote inválida: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linha %d: Opção desconhecida: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1358,12 +1327,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Código-fonte inválido: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1373,27 +1342,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erro ao analisar o %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linha %d: Argumento inválido para %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linha %d: Opção inválida do %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linha %d: segundo %%prep\n"
@@ -1478,101 +1447,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "linha %d: Segundo %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Incapaz de aceder ao %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, fuzzy, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr "%s:%d: Descobri um %%else sem um %%if\n"
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, fuzzy, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr "linha %d: Qualificadores %s: inválidos: %s\n"
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, fuzzy, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr "linha %d: Opção inválida do %%setup %s: %s\n"
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Não foram encontradas arquitecturas compatíveis para as quais criar\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "O pacote não tem uma %%description: %s\n"
@@ -1638,98 +1607,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Não consegui executar o %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Não consegui executar à parte o %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Não consegui executar o %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Não consegui encontrar o %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Não consegui canonizar o nome da máquina: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "a pesquisa do ficheiro spec %s falhou, não consigo analisar\n"
@@ -1764,90 +1729,112 @@ msgstr "O %s tem um valor demasiado elevado ou pequeno, foi ignorado\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "O %s tem um valor inteiro demasiado elevado ou pequeno, foi ignorado\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "não consigo trancar o %s no %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "partilhado"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "erro(%d) ao criar uma nova instância do pacote\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Não consegui abrir ficheiro spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1864,7 +1851,7 @@ msgstr "(não é um número)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(tipo inválido)"
 
@@ -1877,146 +1864,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(não é um base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s gravado como %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s criado como %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2060,35 +2047,44 @@ msgstr "] inesperado"
 msgid "unexpected }"
 msgstr "} inesperado"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "esperado um ? na expressão"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "esperado um { a seguir ao ? na expressão"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "esperado um } na expressão"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "esperado um : a seguir à sub-expressão ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "esperado um { a seguir ao : na expressão"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "esperado um | no fim da expressão"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, fuzzy, c-format
 msgid "failed to load macro file %s\n"
 msgstr "Não consegui ler o ficheiro spec do %s\n"
@@ -2645,26 +2641,26 @@ msgstr "não verificar as dependências do pacote"
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 "esperava-se um pacote com código-fonte, foi encontrado um pacote binário\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "o pacote de código-fonte não contem um ficheiro .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "a abertura do pacote falhou%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " no ficheiro "
 
@@ -2714,137 +2710,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr "o pacote nem tem um dono do ficheiro ou as listas de IDs\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "o grupo %s não contém nenhum pacote\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "nenhum pacote activa o %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "malformado %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "nenhum pacote coincide com %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, fuzzy, c-format
 msgid "no package conflicts %s\n"
 msgstr "nenhum pacote oferece o %s\n"
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, fuzzy, c-format
 msgid "no package obsoletes %s\n"
 msgstr "nenhum pacote precisa do %s\n"
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "nenhum pacote precisa do %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nenhum pacote oferece o %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ficheiro %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "o ficheiro %s não pertence a nenhum pacote\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "o pacote %s não está instalado\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NÃO-OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2858,117 +2854,117 @@ msgstr "%s: o acesso falhou: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "não foi definido o dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: não consigo ler o cabeçalho em 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "não foi definido o dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "não consigo adicionar o registo originalmente em %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "falhou a reconstrução da base de dados: a base de dados original mantém-se\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "falhou a substituição da base de dados antiga pela nova!\n"
 
@@ -3307,22 +3303,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3371,12 +3367,13 @@ msgstr "o pacote %s (que é mais recente que o %s) já está instalado"
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3500,7 +3497,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3543,15 +3540,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3560,96 +3557,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "não consigo abrir a base de dados Packages em %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, fuzzy, c-format
 msgid "invalid package verify level %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3657,19 +3654,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Não consegui reler o cabeçalho do assinatura.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3710,83 +3707,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "erro de sintaxe ao analisar o ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "erro de sintaxe ao analisar o &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "erro de sintaxe ao analisar o ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "esperado um { a seguir ao ? na expressão"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "erro de análise na expressão\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "( não correspondido\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- só em números\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "esperado um | no fim da expressão"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "erro de sintaxe na expressão\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "os tipos têm de corresponder\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / não suportados em cadeias de caracteres\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- não suportado em cadeias de caracteres\n"
+
+#: rpmio/macro.c:348
 #, fuzzy, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr "%3d>%*s(vazio)"
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vazio)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Não consegui abrir o 'pipe' para o tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, fuzzy, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr "A macro %%%s tem as opções incompletas\n"
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "A macro %%%s tem as opções incompletas\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "A macro %%%s tem o conteúdo incompleto\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "A macro %%%s tem o conteúdo em branco\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "A macro %%%s não conseguiu ser expandida\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opção desconhecida %c em %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c não terminado: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Segue-se uma macro impossível de analisar ao %%\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "] inesperado"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "] inesperado"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== activo %d vazio %d\n"
@@ -3830,27 +3925,27 @@ msgstr "aviso: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3860,17 +3955,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "a alocação de memória (%u bytes) devolveu NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3959,44 +4054,44 @@ msgstr "o gpg não conseguiu gravar a assinatura\n"
 msgid "unable to read the signature\n"
 msgstr "incapaz de ler a assinatura\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: o rpmWriteSignature falhou: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: o writeLead falhou: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4025,6 +4120,12 @@ msgstr "%s: a leitura do manifesto falhou: %s\n"
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr ""
+
+#~ msgid "! only on numbers\n"
+#~ msgstr "! só em números\n"
+
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& e || não suportados em cadeias de caracteres\n"
 
 #~ msgid "Exec of %s failed (%s): %s\n"
 #~ msgstr "A execução de %s falhou (%s): %s\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/rpm-team/rpm/"
 "language/pt_BR/)\n"
@@ -118,10 +118,9 @@ msgid "build source package only from <specfile>"
 msgstr "construir pacote fonte somente a partir do <specfile>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "construir pacote fonte somente a partir do <specfile>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -163,11 +162,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "construir pacote fonte somente a partir do <specfile>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -210,10 +208,9 @@ msgid "build source package only from <tarball>"
 msgstr "construir pacote fonte somente a partir do <tarball>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "construir pacote fonte somente a partir do <tarball>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -290,7 +287,7 @@ msgstr "substituir plataforma de destino"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "opções de construção com [ <specfile> | <tarball> | <pacote fonte> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Opções comuns para todos os executáveis e modos rpm:"
@@ -349,33 +346,38 @@ msgstr "Construindo para o destino %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "os argumentos para --root (-r) devem começar com uma /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "Inicializar banco de dados"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "reconstruir as listas invertidas do banco de dados a partir dos cabeçalhos "
 "dos pacotes instalados"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "verificar arquivos do banco de dados"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "Inicializar banco de dados"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opções de banco de dados:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "somente um modo principal pode ser especificado"
 
@@ -399,7 +401,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "nenhum argumento foi passado"
 
@@ -581,38 +583,43 @@ msgid "delete package signatures"
 msgstr "remover a assinatura dos pacotes"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "não verificar a assinatura do cabeçalho+carga útil"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opções de assinatura:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Você deve definir o \"%%_gpg_name\" no seu arquivo de macro\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -644,40 +651,49 @@ msgstr "utilizar o seguinte formato de consulta"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Não foi possível canonizar o nome de máquina: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Executando (%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Status de saída de %s inválido (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Falha ao construir dependências:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -686,55 +702,6 @@ msgstr ""
 "\n"
 "\n"
 "Erros na construção do RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "erro de sintaxe ao analisar ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "erro de sintaxe ao analisar &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "erro de sintaxe ao analisar ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "erro de análise na expressão\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "( sem correspondência\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- somente em números\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! somente em números\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "os tipos devem corresponder\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / não são suportados para strings\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- não é suportado para strings\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& e || não são suportados para strings\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "erro de sintaxe na expressão\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -832,172 +799,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Ligação simbólica aponta para BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Arquivo não encontrado: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: falha na leitura do manifesto: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: não foi possível carregar a etiqueta desconhecida (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: falha ao ler a chave pública.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: não é uma chave pública blindada.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: falha ao codificar\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "falha ao criar o diretório"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "O arquivo precisa da \"/\" inicial: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Não foi possível abrir %%files arquivo %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "falha ao abrir %s: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "O arquivo não foi encontrado pelo glob: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Arquivo inválido: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Procurando por arquivos desempacotados: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1006,112 +978,107 @@ msgstr ""
 "Arquivo(s) instalado(s) (mas não empacotado(s)) encontrado(s):\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Processando arquivos: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binários dependentes de arquitetura no pacote noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Compactação de carga útil desconhecida: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Não foi possível gravar o pacote: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Gravou: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Executando \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "A execução de \"%s\" falhou.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Falha na verificação \"%s\" do pacote.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "Não foi possível criar %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 "Não foi possível gerar o nome de arquivo de saída para o pacote %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "linha %d: segundo %s\n"
@@ -1156,18 +1123,18 @@ msgstr "nenhuma descrição no %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "linha %d: Erro ao analisar %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "linha %d: Opção inválida %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1223,154 +1190,154 @@ msgstr "linha %d: Número %s inválido: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d definido várias vezes\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "A arquitetura está excluída: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "A arquitetura não está excluída: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "O SO está excluído: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "O SO não está incluído: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "o campo %s deve estar presente no pacote: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Entrada %s duplicada no pacote: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Não foi possível abrir o ícone %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Não foi possível ler o ícone %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Tipo de ícone desconhecido: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "linha %d: A etiqueta toma apenas um token: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "linha %d: Etiqueta mal formada: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "linha %d: Etiqueta vazia: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "linha %d: Os prefixos não podem terminar com \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "linha %d: O docdir deve começar com \"/\": %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "linha %d: campo Epoch deve ser um número sem sinal: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "linha %d: %s inválido: qualificadores: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "linha %d: formato BuildArchitecture inválido: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "linha %d: Somente subpacotes noarch são suportados: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Erro interno: tag %d falsa\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "linha %d: %s é obsoleto: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Especificação do pacote inválida: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "linha %d: Etiqueta desconhecida: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} não pode ser vazio\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} não pode ser \"/\"\n"
@@ -1380,12 +1347,12 @@ msgstr "%%{buildroot} não pode ser \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Fonte inválida: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nenhum número de patch %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nenhum número de fonte %u\n"
@@ -1395,27 +1362,27 @@ msgstr "Nenhum número de fonte %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Erro ao analisar %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "linha %d: Argumento inválido para %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "linha %d: Opção inválida %s de %%setup: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "número da correção %s inválido: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "linha %d: segundo %%prep\n"
@@ -1500,101 +1467,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "linha %d: Segundo %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "linha %d: script interno não suportado: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Não foi possível abrir %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Há um %%else sem um %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "linha %d: %s inválido: qualificadores: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "linha %d: Opção inválida %s de %%setup: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Nenhuma arquitetura compatível encontrada para a construção\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "O pacote não tem %%description: %s\n"
@@ -1660,98 +1627,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorar regex inválida %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Não foi possível criar um pipe para %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Não foi possível executar %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Não foi possível bifurcar %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Não foi possível executar %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Os atributos do arquivo não foram configurados\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) falhou: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load falhou: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Falha no reconhecimento do arquivo \"%s\": modo %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Localizando %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Falha ao localizar %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Não foi possível canonizar o nome de máquina: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "a consulta ao specfile %s falhou, não foi possível analisá-lo\n"
@@ -1786,90 +1749,112 @@ msgstr "%s tem valor inteiro longo muito grande ou muito pequeno, ignorado\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s tem um valor inteiro muito grande ou muito pequeno, ignorado\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "não foi possível obter o bloqueio %s em %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "compartilhado"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "erro (%d) ao armazenar o registro \"%s\" em %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "erro (%d) ao remover o registro \"%s\" a partir de %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "erro(%d) ao adicionar o registro de cabeçalho #%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "erro(%d) ao remover o registro de cabeçalho #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "erro (%d) ao alocar nova instância do pacote\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Não foi possível abrir o arquivo spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s é um Delta RPM e não pode ser instalado diretamente\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Carga útil (%s) não suportada no pacote %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "o pacote %s já foi adicionado, ignorando %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "o pacote %s já foi adicionado, substituindo por %s\n"
@@ -1886,7 +1871,7 @@ msgstr "(não é um número)"
 msgid "(not a string)"
 msgstr "(não é uma sequência)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(tipo inválido)"
 
@@ -1899,146 +1884,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(não é base 64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(tipo xml inválido)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(não é uma assinatura OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "substituído"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "não instalado"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "compartilhado pela rede"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "cor errada"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "faltando"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(desconhecido)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s salvo como %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s criado como %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2082,43 +2067,52 @@ msgstr "] não esperado"
 msgid "unexpected }"
 msgstr "} não esperado"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? esperado na expressão"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ esperado após ? na expressão"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} esperado na expressão"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": esperado após a subexpressão ?"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ esperado após : na expressão"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| esperado no fim da expressão"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iterador da matriz utilizado com diferentes tamanhos de matrizes"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "linha %d: %s é obsoleto: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "argumentos para --prefix devem começar com uma /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2661,25 +2655,25 @@ msgstr "não verificar as dependências do pacote"
 msgid "don't execute verify script(s)"
 msgstr "não executar script(s) de verificação"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Faltando recursos do rpmlib para %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "um pacote fonte era esperado, mas um binário foi encontrado\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "o pacote fonte não contém um arquivo .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "a descompactação do arquivo falhou %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " no arquivo "
 
@@ -2729,137 +2723,137 @@ msgstr "o pacote não tem listas de proprietários/grupos\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "o pacote não tem listas de proprietários nem de ids\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "o grupo %s não contém nenhum pacote\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "nenhum disparador de pacote %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "%s malformado: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "nenhum pacote corresponde com %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "nenhum pacote requer %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nenhum pacote fornece %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "arquivo %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "o arquivo %s não pertence a nenhum pacote\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "número de pacote inválido: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "o registro %u não pôde ser lido\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "o pacote %s não está instalado\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "etiqueta desconhecida: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: a importação da chave %d falhou.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: %d não é uma chave pública blindada.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: leitura de importação falhou (%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "Não está OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2873,118 +2867,118 @@ msgstr "%s: falha ao abrir: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: diretório chroot não definido\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Não foi possível alterar o diretório raiz: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Não foi possível restaurar o diretório raiz: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "nenhum dbpath foi definido\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: ignorando"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "erro (%d) ao armazenar o registro #%d em %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: o regexec falhou: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: o regcomp falhou: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: ignorando"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: cabeçalho danificado #%u recuperado -- ignorando.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: não foi possível ler o cabeçalho em 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "nenhum dbpath foi definido"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "falha ao criar o diretório %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "o cabeçalho #%u do banco de dados é inválido -- ignorando.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "não é possível adicionar o registro originalmente em %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "falha ao reconstruir o banco de dados: o banco de dados original permanece "
 "no lugar\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "falha ao substituir o banco de dados velho pela novo!\n"
 
@@ -3329,22 +3323,22 @@ msgstr "não foi possível criar o bloqueio de transação %s em %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "esperando pelo bloqueio de transação %s em %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Falha ao resolver o símbolo %s: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3389,14 +3383,15 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "o pacote %s (que é mais recente que o %s) já está instalado"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 "a instalação do pacote %s precisa de %<PRIu64>%cB no sistema de arquivos %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "a instalação do pacote %s precisa de %<PRIu64> inodes no sistema de arquivos "
 "%s"
@@ -3522,7 +3517,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "suporte a scriptlet <lua> não embutido\n"
 
@@ -3565,15 +3560,15 @@ msgstr "o scriptlet %s falhou, status de saída %d\n"
 msgid "Unknown format"
 msgstr "Formato desconhecido"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "instalar"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "apagar"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3582,96 +3577,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "não foi possível abrir o banco de dados de pacotes em %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "\"(\" extra no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "\"(\" faltando no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "\")\" faltando no rótulo do pacote: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: falha na leitura da chave pública.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transação"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Cabeçalho "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3679,19 +3674,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Não foi possível recarregar o cabeçalho da assinatura.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "ignorado"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "falhou"
 
@@ -3732,83 +3727,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "erro de sintaxe ao analisar ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "erro de sintaxe ao analisar &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "erro de sintaxe ao analisar ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ esperado após ? na expressão"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "erro de análise na expressão\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "( sem correspondência\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- somente em números\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| esperado no fim da expressão"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "erro de sintaxe na expressão\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "os tipos devem corresponder\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / não são suportados para strings\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- não é suportado para strings\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(vazio)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Não foi possível abrir o pipe do tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "O macro %%%s tem opções incompletas\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "O macro %%%s tem um corpo incompleto\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "O macro %%%s tem um corpo vazio\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "O macro %%%s falhou ao expandir\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Opção desconhecida %c em %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c incompleto: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Um %% é seguido por um macro não analisável\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "] não esperado"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "] não esperado"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d ativo %d vazio\n"
@@ -3852,27 +3945,27 @@ msgstr "aviso: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "sintaxe inválida no scriptlet lua: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "sintaxe inválida no script lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "falha no script lua: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "sintaxe inválida no arquivo lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "falha na conexão lua: %s\n"
@@ -3882,17 +3975,17 @@ msgstr "falha na conexão lua: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "a alocação de memória (%u bytes) retornou NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID da chave %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(nada)"
 
@@ -3981,44 +4074,44 @@ msgstr "o gpg falhou ao gravar a assinatura\n"
 msgid "unable to read the signature\n"
 msgstr "não foi possível ler a assinatura\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature falhou: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature falhou: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "o rpmMkTemp falhou\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead falhou: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4048,20 +4141,8 @@ msgstr "%s: falha na leitura do manifesto: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "não verificar a assinatura do cabeçalho+carga útil"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "A execução de %s falhou (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! somente em números\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "linha: %s\n"
-
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: linha: %s\n"
-
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Nenhuma etiqueta \"Source:\" no arquivo .spec\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "linha %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: Há um %%endif sem um %%if\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& e || não são suportados para strings\n"

--- a/po/rpm.pot
+++ b/po/rpm.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -271,7 +271,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -330,31 +330,35 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -378,7 +382,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -543,38 +547,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -606,93 +614,53 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -789,283 +757,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, c-format
+msgid "Can't read content of file: %s\n"
+msgstr ""
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
+#: build/files.c:2233
 #, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
+msgid "Could not open %s file %s: %m\n"
 msgstr ""
 
 #: build/files.c:2258
 #, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
+#, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1110,18 +1078,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1177,154 +1145,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1334,12 +1302,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1349,27 +1317,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1454,101 +1422,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1614,98 +1582,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1740,90 +1704,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr ""
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1840,7 +1826,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1853,146 +1839,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2036,35 +2022,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2610,25 +2605,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2678,137 +2673,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr ""
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr ""
 
@@ -2822,116 +2817,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3268,22 +3263,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3329,12 +3324,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3458,7 +3454,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3501,15 +3497,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3518,96 +3514,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3615,19 +3611,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3668,83 +3664,167 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+msgid "unexpected end of expression"
+msgstr ""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3788,27 +3868,27 @@ msgstr ""
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3818,17 +3898,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3917,44 +3997,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Russian (http://www.transifex.com/rpm-team/rpm/language/ru/)\n"
 "Language: ru\n"
@@ -120,10 +120,9 @@ msgid "build source package only from <specfile>"
 msgstr "собрать исходный пакет по <файлу спецификации>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "собрать исходный пакет по <файлу спецификации>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -165,11 +164,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "собрать исходный пакет по <файлу спецификации>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -210,10 +208,9 @@ msgid "build source package only from <tarball>"
 msgstr "собрать исходный пакет из <архив tar>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "собрать исходный пакет из <архив tar>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -291,7 +288,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "Параметры сборки с [ <файл спецификации> | <тар архив> | <исходный пакет> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Общие параметры для всех режимов и компонентов rpm:"
@@ -350,33 +347,38 @@ msgstr "Сборка для платформы %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументы для --root (-r) должны начинаться с /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "инициализировать базу данных"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "переиндексировать базу инвертированных списков из установленных заголовков "
 "пакетов"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "проверить файлы базы данных"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "инициализировать базу данных"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Параметры базы данных"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "может быть указан только один из основных режимов"
 
@@ -400,7 +402,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "не заданы аргументы"
 
@@ -574,38 +576,43 @@ msgid "delete package signatures"
 msgstr "удалить подписи пакета"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "не проверять подпись заголовока и содержимого"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Параметры подписи:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Вы должны установить \"%%_gpg_name\" в вашем макрофайле\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -637,40 +644,49 @@ msgstr "используйте следующий формат запроса"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Невозможно канонизировать имя компьютера: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Выполняется(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Неверный код возврата из %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Неудовлетворенные зависимости сборки:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -679,55 +695,6 @@ msgstr ""
 "\n"
 "\n"
 "Ошибки сборки пакетов:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "синтаксическая ошибка при анализе ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "синтаксическая ошибка при анализе &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "синтаксическая ошибка при анализе ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "ошибка анализа выражения\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "незакрытая (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- только для чисел\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! только для чисел\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "типы должны совпадать\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / не поддерживается для строк\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- не поддерживается для строк\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& и || не поддерживаются для строк\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "синтаксическая ошибка в выражении\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -823,172 +790,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Символическая ссылка указывает на BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Недопустимый символ '%c' (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Файл не найден: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: ошибка чтения списка файлов: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: это не открытый ключ.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "не удалось создать каталог"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Файл должен начинаться с \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Невозможно открыть %s: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "невозможно открыть %s: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Файл не найден: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Неверный файл %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Проверка на неупакованный(е) файл(ы): %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -997,111 +969,106 @@ msgstr ""
 "Обнаружен(ы) установленный(е) (но не упакованный(е)) файл(ы):\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Двоичные данные с архитектурой в пакете noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Невозможно открыть %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Невозможно записать пакет: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записан: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Выполнение \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Выполнение \"%s\" не удалось.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "невозможно создать %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Невозможно создать имя файла для пакета %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "строка %d: %s повторно\n"
@@ -1146,18 +1113,18 @@ msgstr "нет описания в %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "строка %d: %%changelog повторно\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "строка %d: Ошибка анализа %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "строка %d: Неверный параметр %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1213,154 +1180,154 @@ msgstr "строка %d: Неверное число %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Архитектура исключена: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Архитектура не включена: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "ОС исключена: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "ОС не включена: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Поле %s обязано присутствовать в пакете: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Повторяющиеся записи %s в пакете: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Невозможно открыть пиктограмму %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Невозможно прочитать пиктограмму %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Неизвестный тип пиктограммы: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "строка %d: Ярлык требует только один аргумент: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "строка %d: %s в: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s в: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Недопустимый символ '%c' (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Недопустимая последовательность \"..\""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "строка %d: Неверный тэг: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "строка %d: Пустой тэг: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "строка %d: Префикс не может заканчиваться на \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "строка %d: Docdir должен начинаться с '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "строка %d: Неверное число %s: определяет: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "строка %d: Неверный формат BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Внутренняя ошибка: Неизвестный ярлык %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Неверная спецификация пакета: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "строка %d: Неизвестный тэг: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не может быть пустой\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не может быть \"/\"\n"
@@ -1370,12 +1337,12 @@ msgstr "%%{buildroot} не может быть \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Неверный исходник: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Нет заплаты номер %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Нет исходника номер %u\n"
@@ -1385,27 +1352,27 @@ msgstr "Нет исходника номер %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Ошибка анализа %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "строка %d: Неверный аргумент для %%setup %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "строка %d: Неверный параметр %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "строка %d: второй %%prep\n"
@@ -1490,101 +1457,101 @@ msgstr "строка %d: Приоритеты разрешены только д
 msgid "line %d: Second %s\n"
 msgstr "строка %d: Второе %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Невозможно открыть %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Для %s требуется аргумент\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Найден %%else без %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "строка %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: плохое %%if условие\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "кодировка %s не поддерживается системой\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Не найдены совместимые архитектуры для сборки.\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Пакет не имеет %%description: %s\n"
@@ -1650,98 +1617,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Невозможно выполнить %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Сбой ветвления %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Невозможно выполнить %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s не удалось: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "не удалось записать все данные в %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Идет поиск  %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Невозможно найти %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Невозможно канонизировать имя компьютера: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "запрос файла спецификации %s не удался, невозможно разобрать файл\n"
@@ -1777,90 +1740,112 @@ msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 "%s имеет слишком малую или слишком большую величину integer, пропущено\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "невозможно получить блокировку %s на %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "разделяемый"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "исключительный"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "ошибка(%d) сохранения записи \"%s\" в %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "ошибка(%d) удаления записи %s из %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "ошибка(%d) резервирования памяти для образа нового пакета\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Ошибка открытия файла спецификации %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s является Delta RPM и не может быть установлен напрямую\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакет %s был уже добавлен, пропускаем %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакет %s уже был добавлен, заменяется %s\n"
@@ -1877,7 +1862,7 @@ msgstr "(не число)"
 msgid "(not a string)"
 msgstr "(не строка)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(неправильный тип)"
 
@@ -1890,146 +1875,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(не base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(неверный тип xml)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(не подпись формата OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Неверная дата %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "нормальный"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "перемещен"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "не установлен"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(неизвестный)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s сохранен как %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s создан как %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2073,43 +2058,52 @@ msgstr "неожиданная \"]\""
 msgid "unexpected }"
 msgstr "неожиданная \"}\""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "в выражении ожидалось \"?\""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "в выражении после \"?\" ожидалось \"{\""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "в выражении ожидалось \"}\""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "в выражении после \"?\" ожидалось \":\""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "в выражении после \":\" ожидалось \"{\""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "в конце выражения ожидался \"|\""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "аргументы для --prefix должны начинаться с /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2653,25 +2647,25 @@ msgstr "не проверять зависимости пакета"
 msgid "don't execute verify script(s)"
 msgstr "не исполнять сценарий(и) проверки"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "обнаружен двоичный пакет вместо ожидаемого исходного\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "исходный пакет не содержит файла спецификации\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "распаковка архива не удалась%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " на файле "
 
@@ -2721,137 +2715,137 @@ msgstr "пакет не содержит списков владельцев/г�
 msgid "package has neither file owner or id lists\n"
 msgstr "пакет не содержит списков ни хозяев файлов, ни их ID\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "группа %s не содержит никаких пакетов\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "ни один из пакетов не взводит триггер %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "ошибка формата %s: %s.\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "ни один пакет не подходит к %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "ни один из пакетов не требует %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ни один из пакетов не предоставляет %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "файл %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "файл %s не принадлежит ни одному из пакетов\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "неверный номер пакета: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "запись %u не может быть прочитана\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакет %s не установлен\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "НЕ ОК"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "ОК"
 
@@ -2865,117 +2859,117 @@ msgstr "%s: ошибка открытия: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "параметер dbpath не установлен\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "ошибка (%d) сохранения записи #%d в %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: получен поврежденный заголовок #%u -- пропускается.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: невозможно прочесть заголовок в 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "параметер dbpath не установлен"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "не удалось создать каталог %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заголовок номер %u в базе данных неверный -- пропускается.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "невозможно добавить запись (первоначально в %u)\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "перестроение базы данных не удалось, старая база данных остается на месте\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "невозможно заменить старую базу данных на новую!\n"
 
@@ -3312,22 +3306,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3374,12 +3368,13 @@ msgstr "пакет %s (который новее, чем %s) уже устано
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3503,7 +3498,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3546,15 +3541,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr "Неизвестный формат"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "установить"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "стереть"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3563,96 +3558,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "не могу открыть базу данных Packages в %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "транзакция"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Заголовок "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3660,19 +3655,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Невозможно перезагрузить заголовок подписи.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "пропущено"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "не удалось"
 
@@ -3713,83 +3708,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "синтаксическая ошибка при анализе ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "синтаксическая ошибка при анализе &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "синтаксическая ошибка при анализе ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "строка %d: %s в: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "в выражении после \"?\" ожидалось \"{\""
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "ошибка анализа выражения\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "незакрытая (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- только для чисел\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "в конце выражения ожидался \"|\""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "синтаксическая ошибка в выражении\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "типы должны совпадать\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / не поддерживается для строк\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- не поддерживается для строк\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(пусто)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Ошибка открытия канала tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Незакрытые параметры в макросе %%%s\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Незакрытый макрос %%%s\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Макрос %%%s пуст\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Невозможно раскрыть макрос %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Неизвестный параметр %c в %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Незакрытая %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "непонятный макрос после %%\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "неожиданная \"]\""
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "неожиданная \"]\""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "====================== активных %d пустых %d\n"
@@ -3833,27 +3926,27 @@ msgstr "предупреждение: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3863,17 +3956,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "memory alloc (%u bytes) returned NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3962,44 +4055,44 @@ msgstr "ошибка gpg при записи подписи\n"
 msgid "unable to read the signature\n"
 msgstr "невозможно прочесть подпись\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: ошибка rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: ошибка writeLead: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4029,14 +4122,8 @@ msgstr "%s: ошибка чтения списка файлов: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "не проверять подпись заголовока и содержимого"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Выполнить %s не удалось (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! только для чисел\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "строка: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "строка %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: Найден %%endif без %%if\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& и || не поддерживаются для строк\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:50+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:50-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Slovak (http://www.transifex.com/rpm-team/rpm/language/sk/)\n"
 "Language: sk\n"
@@ -117,10 +117,9 @@ msgid "build source package only from <specfile>"
 msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -162,11 +161,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "vytvorenie zdrojového balíčka z <spec_subor>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -207,10 +205,9 @@ msgid "build source package only from <tarball>"
 msgstr "vytvorenie iba zdrojového balíčka z <tar_subor>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "vytvorenie iba zdrojového balíčka z <tar_subor>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -288,7 +285,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "Zostavovacie možnosti s [ <spec_subor> | <tar_subor> | <zdrojovy balicek> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Spoočné možnosti pre všetky režimy rpm a spustiteľné súbory:"
@@ -347,31 +344,36 @@ msgstr "Zostavuje sa pre cieľ %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenty pre --root (-r) musia začínať znakom /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inicializuje sa databáza"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "znovu zostaviť obrátené zoznamy inštalovaných hlavičiek balíčka"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "skontrolovať databázové súbory"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inicializuje sa databáza"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "exportuj databázu na stdout ako postupnosť hlavičiek"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "importuj databázu z stdin postupnosti hlavičiek"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Možnosti databázy:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "môže byť použitý iba jeden hlavný režim"
 
@@ -395,7 +397,7 @@ msgstr "zobraziť kľúče z kľúčového zväzku RPM"
 msgid "Keyring options:"
 msgstr "Možnosti zväzku kľúčov:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "nezadané žiadne parametre"
 
@@ -568,38 +570,43 @@ msgid "delete package signatures"
 msgstr "vymazať podpis balíčka"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "neoverovať podpis hlavičky a payloadu"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Možnosti podpisu:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Je potrebné nastaviť \"%%_gpg_name\" v makro súbore\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -631,40 +638,49 @@ msgstr "použiť nasledovný formát otázky"
 msgid "Spec options:"
 msgstr "Spec možnosti:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "žiadne argumenty pre parsovanie"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Nie je možné kanonizovať názov počítača: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Nie je možné otvoriť dočasný súbor: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Nie je možné otvoriť prúd: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Vykonávanie(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Chybný návratový kód z %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Chybné závislosti pri zostavovaní:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -673,55 +689,6 @@ msgstr ""
 "\n"
 "\n"
 "Chyby zostavenia RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "chyba syntaxe pri spracovaní ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "chyba syntaxe pri spracovaní &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "chyba syntaxe pri spracovaní ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "chyba spracovania vo výraze\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "nedoplnená (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- len na číslach\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! len na číslach\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "typy musia súhlasiť\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / nie sú podporované pre reťazce\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- nie je podporované pre reťazce\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& a || nie sú podporované pre reťazce\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "chyba syntaxe vo výraze\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -817,172 +784,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolický link ukazuje na BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Cesta sa nachádza mimo buildroot: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Priečinok nenájdený: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Súbor nenájdený: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Toto nie je adresár: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Chyba čítania súboru politiky: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: nie je možné načítať neznámu značku (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: čítanie verejného kľúča zlyhalo.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: nie je obrnený verejný kľúč.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: zlyhalo kódovanie\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "vytvorenie priečinka zlyhalo"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Súbor potrebuje úvodný \"/\": %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob nie je povolený: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Nie je možné otvoriť %%files súbor %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Chyba čítania %%files súboru %s: %m\n"
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "Klasifikátor prázdneho súboru\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Súbor nenájdený globom: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Viac než jeden súbor na riadku: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Zlý súbor: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Kontrolujú sa nezabalené súbory: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -991,111 +963,106 @@ msgstr ""
 "Nájdené nainštalované (ale nezabalené) súbory:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Spracovávajú sa súbory: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binárky závislé na architektúre v bezarchitektúrnom balíčku\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "vytvorenie archívu zlyhalo na súbore %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "vytvorenie archívu zlyhalo: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Nie je možné otvoriť súbor %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Neznáma kompresia payloadu: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Nie je možné otvoriť %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Nie je možné zapísať balíček: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapísané: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Spúšťa sa \"%s\":\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Spustenie \"%s\" zlyhalo.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Kontrola balíčka \"%s\" zlyhala.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "nie je možné vytvoriť %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Nie je možné vytvoriť meno výstupného súboru pre balík %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "riadok %d: druhý %s\n"
@@ -1140,18 +1107,18 @@ msgstr "žiadny popis v %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "riadok %d: Chyba pri parsovaní %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "riadok %d: zlá možnosť %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1207,154 +1174,154 @@ msgstr "riadok %d: Chybné %s číslo: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d definované viac krát\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Architektúra je vyradená: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Architektúra nie je zahrnutá: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS je vyradený: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS nie je zahrnutý: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Položka %s musí byť v balíčku prítomná: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Duplikovaná položka %s v balíčku: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Nie je možné otvoriť ikonu %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Nie je možné prečítať ikonu %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Neznámy typ ikony: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "riadok %d: Značka má len jeden token: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "riadok %d: Poškodená značka: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "riadok %d: Prázdna značka: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "riadok %d: Prefixy nemôžu končiť \"/\": %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "riadok %d: Docdir musí začínať '/': %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "riadok %d: Súbor epochy musí byť nepodpísané číslo: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "riadok %d: Zlé určenie %s: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "riadok %d: Zlý formát BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "riadok %d: Podporované sú iba subbalíčky typu noarch: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interná chyba: Chybná značka %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "riadok %d: %s je zastaralý: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Zlá špecifikácia balíčka: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "riadok %d: neznáma značka: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} nemôže byť prázdne\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} nemôže byť \"/\"\n"
@@ -1364,12 +1331,12 @@ msgstr "%%{buildroot} nemôže byť \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Zlý zdroj: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Bez čísla záplaty %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Bez čísla zdroja %u\n"
@@ -1379,27 +1346,27 @@ msgstr "Bez čísla zdroja %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Chyba pri parsovaní %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "riadok %d: Zlý parameter v %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "riadok %d: Zlá možnosť v %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neplatné číslo záplaty %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "riadok %d: druhý %%prep\n"
@@ -1484,101 +1451,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "riadok %d: Druhý %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "riadok %d: nepodporovaný interný skript: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "riadok %d: argumenty interpretera nie sú v triggeroch povolené: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Nie je možné otvoriť %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Očakávaný argument pre %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "riadok %d: neuzatvorené makro alebo zlá náväznosť riadka\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%else bez počiatočného %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "riadok %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: zlá kondícia %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Nenájdené žiadne kompatibilné architektúry pre zostavenie\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Balíček neobsahuje %%description: %s\n"
@@ -1645,98 +1612,94 @@ msgstr "Chýba cesta modulu v riadku: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Príliž veľa argumentov v riadku: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Vykonávaná politika: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorovanie neplatného regexu %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Nie je možné vytvoriť rúru pre %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Nie je možné spustiť %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Nie je možné vykonať fork %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Nie je možné spustiť %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s zlyhalo: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "nie je možné zapísať všetky dáta do %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Klasifikátor prázdneho súboru\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Nenastavené žiadne atribúty\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) zlyhalo: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load zlyhal: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Rozpoznávanie súboru \"%s\" zlyhalo: režim %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Hľadá sa  %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Zlyhalo vyhľadávanie %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Nie je možné kanonizovať názov počítača: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "otázka na spec-súbor %s zlyhala, nie je možné analyzovať\n"
@@ -1771,90 +1734,112 @@ msgstr "%s má príliš veľkú alebo príliš malú long hodnotu, preskakuje sa
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s má príliš veľkú alebo príliš malú int hodnotu, preskakuje sa\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "nie je možné získaž zámok %s na %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "zdieľaný"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "výhradný"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "neplatný typ indexu %x v %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "chyba(%d) získaných \"%s\" záznamov z %s indexu: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "chyba(%d) pri ukladaní záznamu \"%s\" do %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "chyba(%d) v odstraňovaní záznamu \"%s\" z %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "chyba(%d) pridania hlavičky #%d záznamu\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "chyba(%d) odstránenia hlavičky #%d záznamu\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "chyba(%d) pri alokácii novej inštancii balíčka\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Nie je možné otvoriť spec súbor %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s je Delta RPM a nemôže byž priamo inštalovaný\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodporovaný payload (%s) v balíčku %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "balíček %s už bol pridaný, %s sa preskakuje\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "balíček %s už bol pridaný, nahradzuje sa s %s\n"
@@ -1871,7 +1856,7 @@ msgstr "(nie je číslo)"
 msgid "(not a string)"
 msgstr "(nie je reťazec)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(neplatný typ)"
 
@@ -1884,146 +1869,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(nie je base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(neplatný typ xml)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(nie je OpenPGP podpis)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normálny"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "nahradený"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "nenainštalovaný"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "zdieľaný sieťou"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "zlá farba"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "chýbajúci"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(neznámy)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s uložený ako %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s vytvorený ako %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2067,43 +2052,52 @@ msgstr "neočakávané ]"
 msgid "unexpected }"
 msgstr "neočakávané }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? očakávané vo výraze"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ očakávané po ? vo výraze"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} očakávané vo výraze"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": očakávané po ? podvýraze"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ očakávané po : vo výraze"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| očakávené na konci výrazu"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "iterátor poľa použitý s poľami inej veľkosti"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "riadok %d: %s je zastaralý: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "argumenty pre --prefix musia začínať znakom /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2647,25 +2641,25 @@ msgstr "nekontrolovať závislosti balíčka"
 msgid "don't execute verify script(s)"
 msgstr "nespúšťať kontrolné skripty"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Chýbajúce funkcie rpmlib pre %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "očakáva sa balíček so zdrojovým kódom, nájdený bol binárny\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "balíček so zdrojovými kódmi neobsahuje .spec súbor\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "rozbaľovanie archívu zlyhalo %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " pre súbor "
 
@@ -2715,137 +2709,137 @@ msgstr "balíček nemá vlastníka súboru ani zoznamy skupín\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "balíček nemá vlastníka súboru alebo zoznamy ID\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "skupina %s neobsahuje žiadne balíky\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "žiadny z balíkov nespúšťa %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "poškodený %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "žiadny z balíčkov sa nezhoduje s %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "žiadny z balíkov nevyžaduje %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "žiadny z balíkov neposkytuje %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "súbor %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "súbor %s nie je vlastnený žiadnym balíkom\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "chybné číslo balíku: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "záznam %u nie je možné čítať\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "balík %s nie je nainštalovaný\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "neznáma značka: \"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: kľúč %d import zlyhal.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: kľúč %d nie je verejný obrnený kľúč.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importné čítanie zlyhalo(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NIE JE V PORIADKU"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "V PORIADKU"
 
@@ -2859,116 +2853,116 @@ msgstr "%s: otvorenie zlyhalo: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Nie je možné otvoriť aktuálny priečinok: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: nie je nastavený chroot priečinka\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Nie je možné zmeniť koreňový adresár: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Nie je možné obnoviť koreňový adresár: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Generuje sa %d chýbajúcich indexov, prosím čakajte...\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "nenastavená dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preskakuje sa"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "chyba(%d) ukladania záznamu #%d do %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec zlyhal: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp zlyhal: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preskakuje sa"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: poškodená hlavička #%u získaná -- preskakuje sa.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: nie je možné čítať hlavičku na 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "nebola nastavená žiadna dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "zlyhanie pri vytváraní priečinka %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "hlavička #%u v databázy je zlá -- preskakuje sa.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "nie je možné pridať záznam pôvodne na %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "zlyhalo znovuzostavenie databázy: pôvodná databáza zostáva na mieste\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "nepodarilo sa nahradiť starú databázu novou!\n"
 
@@ -3305,22 +3299,22 @@ msgstr "nie je možné vytvoriť %s zámok na %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "čaká sa na %s zámok na %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Zlyhalo dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Zlyhalo vyriešenie symbolu %s: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Zásuvný modul %s nenačítaný\n"
@@ -3365,13 +3359,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "balíček %s (ktorý je novší než %s) je už nainštalovaný"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "inštalovaný balíček %s vyžaduje %<PRIu64>%cB v súborovom systéme %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "inštalovaný balíček %s vyžaduje %<PRIu64> inody na súborovom systéme %s"
 
@@ -3496,7 +3491,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr "Nie je možné obnoviť aktuálny priečinok: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "nie je zabudovaná podpora pre skriptlety <lua>\n"
 
@@ -3539,15 +3534,15 @@ msgstr "%s skriplet zlyhal, návratový kód: %d\n"
 msgid "Unknown format"
 msgstr "Neznámy formát"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "inštalovať"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "zmazať"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3556,96 +3551,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "nie je možné otvoriť databázu balíčkov v %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "nadbytočná '(' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "chýbajúca '(' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "chýbajúca ')' v popise balíčka: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: čítanie verejného kľúča zlyhalo.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transakcia"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Hlavička"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3653,19 +3648,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Nie je možné znova načítať hlavičku podpisu.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "preskočené"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "zlyhané"
 
@@ -3706,67 +3701,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "chyba syntaxe pri spracovaní ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "chyba syntaxe pri spracovaní &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "chyba syntaxe pri spracovaní ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ očakávané po ? vo výraze"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "chyba spracovania vo výraze\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "nedoplnená (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- len na číslach\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| očakávené na konci výrazu"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "chyba syntaxe vo výraze\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "typy musia súhlasiť\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / nie sú podporované pre reťazce\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- nie je podporované pre reťazce\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prázdne)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Nie je možné otvoriť rúru pre tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s má neukončené parametre\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s má neukončené telo\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s má prázdné telo\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Zlyhalo vyhodnotenie makra %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Neznáma možnosť %c v %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3774,17 +3857,27 @@ msgstr ""
 "Príliž veľa úrovní rekurzie v rozbaľovaní makra. Zrejme je to spôsobené "
 "vyhlásením rekurzívneho makra.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neukončené %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Po %% nasleduje nespracovateľné makro\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "neočakávané ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "neočakávané ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktívnych %d prázdnych %d\n"
@@ -3828,27 +3921,27 @@ msgstr "varovanie: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "neplatná syntax v lua skriptlete: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nesprávna syntax v lua skripte: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skript zlyhal: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "neplatná syntax v súbore lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "obslúženie lua zlyhalo: %s\n"
@@ -3858,17 +3951,17 @@ msgstr "obslúženie lua zlyhalo: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokácia pamäti (%u bajtov) vrátila NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ID kľúča %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(žiadne)"
 
@@ -3957,44 +4050,44 @@ msgstr "gpg zlyhal pri zápise podpisu\n"
 msgid "unable to read the signature\n"
 msgstr "nie je možné prečítať podpis\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature zlyhalo: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s už obsahuje rovnaký podpis, preskakuje sa\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp zlyhal\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead zlyhalo: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "nahradenie %s zlyhalo: %s\n"
@@ -4024,23 +4117,16 @@ msgstr "%s: čítanie zoznamu zlyhalo: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "neoverovať podpis hlavičky a payloadu"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Spustenie %s zlyhalo (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! len na číslach\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Chyba spustenia skriptletu %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& a || nie sú podporované pre reťazce\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "riadok: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Chyba čítania %%files súboru %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: riadok: %s\n"
-
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Bez značky \"Source:\" v spec súbore\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "riadok %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%endif bez počiatočného %%if\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Nie je možné otvoriť súbor %s: %s\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Slovenian (http://www.transifex.com/rpm-team/rpm/language/"
 "sl/)\n"
@@ -275,7 +275,7 @@ msgstr "brez upoštevanja strojnega okolja ciljnega sistema"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -334,31 +334,35 @@ msgstr "Izgradnja za ciljni sistem %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenti izbire --root (-r) se morajo začeti z /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr ""
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr ""
 
-#: rpmdb.c:28
-msgid "export database to stdout header list"
+#: rpmdb.c:29
+msgid "salvage database"
 msgstr ""
 
 #: rpmdb.c:31
+msgid "export database to stdout header list"
+msgstr ""
+
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr ""
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "izbran sme biti le en glavni način"
 
@@ -382,7 +386,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -547,38 +551,42 @@ msgid "delete package signatures"
 msgstr ""
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr ""
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -610,93 +618,53 @@ msgstr "uporabi naslednjo obliko poizvedbe"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Iskanje kanoničnega imena gostitelja je bilo neuspešno: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Izvajanje(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
 "RPM build errors:\n"
-msgstr ""
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
 msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
@@ -793,283 +761,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr ""
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "odpiranje %s je bilo neuspešno: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "Ni možno odpreti %s: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "odpiranje %s je bilo neuspešno: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr ""
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ni možno odpreti %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ni možno ustvariti %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Neuspešno ustvarjanje izhodne datoteke za paket %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1114,18 +1082,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1181,154 +1149,154 @@ msgstr "vrstica %d: Napačno število %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1338,12 +1306,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1353,27 +1321,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1458,101 +1426,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ni možno odpreti %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "vrstica %d: Napačno število %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1618,98 +1586,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Iskanje kanoničnega imena gostitelja je bilo neuspešno: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "poizvedba po datoteki spec. %s je bila neuspešna, razčlemba ni možna\n"
@@ -1746,90 +1710,112 @@ msgstr ""
 "%s ima preveliko ali premajhno vrednost malega (small) celega\n"
 "števila, prezrto\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "skupno"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "izključujoče"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Datoteke s specifikacijami %s ni možno odpreti: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1846,7 +1832,7 @@ msgstr "(ni število)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1859,146 +1845,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2042,43 +2028,52 @@ msgstr "nepričakovan ]"
 msgid "unexpected }"
 msgstr "nepričakovan }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "v izrazu je pričakovan ?"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "v izrazu je za { pričakovan ?"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "v izrazu je pričakovan }"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "za podizrazom ? je pričakovano :"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "v izrazu je za : pričakovan {"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "na koncu izraza je pričakovan |"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "argumenti izbire --prefix se morajo začeti z /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2622,25 +2617,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " za datoteko "
 
@@ -2690,137 +2685,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "skupina %s ne vsebuje nobenega paketa\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "noben paket ne proži %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "noben paket ne potrebuje %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "noben paket ne nudi %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "datoteka %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "datoteka %s ni del nobenega paketa\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neveljavna številka paketa: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s ni nameščen\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NI DOBRO"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "V REDU"
 
@@ -2834,116 +2829,116 @@ msgstr "%s: odpiranje je bilo neuspešno: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "dbpath ni nastavljena"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "zamenjava stare podatkovne zbirke z novo je bila neuspešna!\n"
 
@@ -3280,22 +3275,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3341,12 +3336,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3470,7 +3466,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3513,15 +3509,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3530,96 +3526,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3627,19 +3623,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3680,83 +3676,173 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "v izrazu je za { pričakovan ?"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "v izrazu je pričakovan ?"
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "na koncu izraza je pričakovan |"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "v izrazu je pričakovan ?"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prazni)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "nepričakovan ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "nepričakovan ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivni %d prazni %d\n"
@@ -3800,27 +3886,27 @@ msgstr "opozorilo: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3830,17 +3916,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokacija pomnilnika (%u bajtov) vrnjeno NIČ.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3929,44 +4015,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature je bilo neuspešno: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead je bil neuspešen: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
 "PO-Revision-Date: 2017-08-10 07:39+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Serbian (http://www.transifex.com/rpm-team/rpm/language/sr/)\n"
@@ -278,7 +278,7 @@ msgstr "премости циљну платформу"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Опције прављења уз [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Заједничке опције за све rpm режиме и извршне програме:"
@@ -337,32 +337,37 @@ msgstr "Правим за циљ %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументи за --root (-r) морају почети знаком /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "иницијализуј базу података"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "поново направи обрнуте спискове базе података из заглавља инсталираних пакета"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "провера датотека базе података"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "иницијализуј базу података"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Опције базе података:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "само један главни режим сме бити наведен"
 
@@ -386,7 +391,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "нема задатих аргумената"
 
@@ -558,38 +563,43 @@ msgid "delete package signatures"
 msgstr "обриши потписе пакета"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "немој проверавати потпис заглавља+товара"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Опције потписа:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Морате поставити „%%_gpg_name“ у макро датотеци\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -621,40 +631,49 @@ msgstr "користи следећи облик упита"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Није могуће утврдити назив домаћина: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Извршавам(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Лош статус излаза из %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Неуспело прављење зависности:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -663,55 +682,6 @@ msgstr ""
 "\n"
 "\n"
 "Грешке RPM прављења:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "синтаксна грешка при рашчлањивању ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "синтаксна грешка при рашчлањивању &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "синтаксна грешка при рашчлањивању ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "грешка рашчлањивања у изразу\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "неупарена (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- само код бројева\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! само код бројева\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "врсте се морају поклапати\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / није подржано за стрингове\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- није подржано за стрингове\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& и || нису подржани за стрингове\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "синтаксна грешка у изразу\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -807,172 +777,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symlink тачке за BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Датотека није пронађена: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: неуспело читање манифеста: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: не могу да учитам непознату ознаку (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: неуспело читање јавног кључа.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: јавни кључ није ојачан.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "неуспело креирање директоријума"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Испред датотеке је потребно да стоји „/“: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Не могу да отворим %%files датотеку %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "отварање %s није успело: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Датотека није пронађена поклапањем: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Лоша датотека: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Проверавам за незапаковане датотеке: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -981,111 +956,106 @@ msgstr ""
 "Пронађене су инсталиране (али незапаковане) датотеке:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Бинарне датотеке зависне од архитектуре у noarch пакету\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Непозната компресија товара: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, fuzzy, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr "Неуспело читање датотеке спецификације из %s\n"
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Не могу да отворим %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Не могу да запишем пакет: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записано: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Извршавам „%s“:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Извршавање „%s“ није успело.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Неуспела провера пакета „%s“.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "не могу да направим %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Не могу да направим име излазне датотеке за пакет %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "ред %d: други %s\n"
@@ -1130,18 +1100,18 @@ msgstr "нема описа у %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "ред %d: Грешка при тумачењу %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "ред %d: Лоша опција %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1197,154 +1167,154 @@ msgstr "ред %d: Лош %s број: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d дефинисано више пута\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Архитектура је изостављена: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Архитектура није уврштена: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS је изостављен: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS није уврштен: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s поље мора бити присутно у пакету: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Удвојене %s ставке у пакету: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Не могу да отворим икону %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Не могу да прочитам икону %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Непозната врста иконе: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "ред %d: Ознака прихвата само један жетон: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "ред %d: Лоше обликована ознака: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "ред %d: Празна ознака: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "ред %d: Префикси се не смеју завршавати са „/“: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "ред %d: Docdir мора почети са „/“: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "ред %d: Поље епохе мора бити број без предзнака: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "ред %d: Лоши %s: квалификатори: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "ред %d: Лош облик за BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "ред %d: Само noarch подпакети су подржани: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Интерна грешка: Лажна ознака %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Лоша спецификација пакета: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "ред %d: Непозната ознака: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не може бити празно\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не може бити „/“\n"
@@ -1354,12 +1324,12 @@ msgstr "%%{buildroot} не може бити „/“\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Лош извор: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Нема закрпе број %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Нема извора број %u\n"
@@ -1369,27 +1339,27 @@ msgstr "Нема извора број %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Грешка у тумачењу %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "ред %d: Лош аргумент за %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "ред %d: Лоша %%setup опција %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Неисправан број закрпе %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "ред %d: други %%prep\n"
@@ -1474,101 +1444,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "ред %d: Други %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "ред %d: неподржана интерна скрипта: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Не могу да отворим %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, fuzzy, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr "%s:%d: Добио %%else без %%if\n"
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, fuzzy, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr "ред %d: Лоши %s: квалификатори: %s\n"
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, fuzzy, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr "ред %d: Лоша %%setup опција %s: %s\n"
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Нису пронађене усаглашене архитектуре за прављење\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Пакет нема %%description: %s\n"
@@ -1634,98 +1604,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Не могу да направим цев за %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Не могу да извршим %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Не могу да одвојим %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Не могу да извршим %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) није успело: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load није успело: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Препознавање датотеке „%s“ није успело: режим %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Проналазак %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Неуспело тражење %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Није могуће утврдити назив домаћина: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "упит на датотеком спецификације %s није успео, не могу да протумачим\n"
@@ -1760,90 +1726,112 @@ msgstr "%s има превелику или премалу long вредност
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s има превелику или премалу целобројну вредност, прескочено\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "не могу да добијем %s катанац на %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "дељено"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "ексклузивно"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "грешка(%d) при складиштењу слога „%s“ у %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "грешка(%d) при уклањању слога „%s“ из %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "грешка(%d) при заузимању новог примерка пакета\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Не могу да отворим датотеку спецификације %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s је Делта RPM и не може се директно инсталирати\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Неподржан терет (%s) у пакету %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакет %s је већ додат, прескачем %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакет %s је већ додат, замењујем са %s\n"
@@ -1860,7 +1848,7 @@ msgstr "(није број)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(неисправна врста)"
 
@@ -1873,146 +1861,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(није base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(неисправна xml врста)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(није OpenPGP потпис)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s сачувано као %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s направљено као %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2056,35 +2044,44 @@ msgstr "неочекиван ]"
 msgid "unexpected }"
 msgstr "неочекиван }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? очекиван у изразу"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ очекивано после ? у изразу"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} очекиван у изразу"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": очекиван након ? подизраза"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ очекивано после : у изразу"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| очекиван на крају израза"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "показивач низа коришћен са низовима различитих величина"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, fuzzy, c-format
 msgid "failed to load macro file %s\n"
 msgstr "Неуспело читање датотеке спецификације из %s\n"
@@ -2640,25 +2637,25 @@ msgstr "немој проверавати зависности пакета"
 msgid "don't execute verify script(s)"
 msgstr "немој извршити скрипту(е) провере"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "очекиван је изворни пакет, пронађен је бинарни\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "изворни пакет не садржи .spec датотеку\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "распакивање архиве није успело %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " на датотеци "
 
@@ -2708,137 +2705,137 @@ msgstr "пакет нема спискове власника/групе дат�
 msgid "package has neither file owner or id lists\n"
 msgstr "пакет нема спискове нити власника ни id датотека\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "група %s не садржи ниједан пакет\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "ниједан пакет не активира %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "лоше обликован %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "ниједан пакет не одговара %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, fuzzy, c-format
 msgid "no package conflicts %s\n"
 msgstr "ниједан пакет не пружа %s\n"
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, fuzzy, c-format
 msgid "no package obsoletes %s\n"
 msgstr "ниједан пакет не захтева %s\n"
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "ниједан пакет не захтева %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "ниједан пакет не пружа %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "датотека %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "датотека %s не припада ниједном пакету\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "неисправан број пакета: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакет %s није инсталиран\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "непозната ознака: „%s“\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: увозно читање није успело(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "НИЈЕ УРЕДУ"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "УРЕДУ"
 
@@ -2852,118 +2849,118 @@ msgstr "%s: отварање није успело: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Не могу да променим коренски директоријум: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "није постављен dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: прескачем"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "грешка(%d) при записивању слога #%d у %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec није успео: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp није успео: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: прескачем"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: оштећено заглавље #%u враћено -- прескачем.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: не могу да прочитам заглавље на 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "није постављен dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "неуспело креирање директоријума %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заглавље #%u у бази податак је лоше -- прескачем.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "не могу да додам слог првобитно на %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "неуспело поновно прављење базе података: основна база података је остала на "
 "месту\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "неуспела замена старе базе података са новом базом података!\n"
 
@@ -3304,22 +3301,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3364,13 +3361,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "пакет %s (који је новији од %s) је већ инсталиран"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "пакет %s који се инсталира захтева %<PRIu64>%cБ на %s систему датотека"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "пакет %s који се инсталира захтева %<PRIu64> и-чворова на %s систему датотека"
 
@@ -3495,7 +3493,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "није уграђена подршка <lua> скриптица\n"
 
@@ -3538,15 +3536,15 @@ msgstr "%s скриптица није успела, излазни статус
 msgid "Unknown format"
 msgstr "Непознат облик"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3555,96 +3553,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "не могу да отворим Packages базу података у %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "сувишна „(“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "недостаје „(“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "недостаје „)“ у ознаци пакета: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: неуспело читање јавног кључа.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, fuzzy, c-format
 msgid "invalid package verify level %s\n"
 msgstr "неисправан број пакета: %s\n"
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Заглавље "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3652,20 +3650,20 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Не могу да поново учитам заглавље потписа.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 #, fuzzy
 msgid "no signature"
 msgstr "(није OpenPGP потпис)"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3706,83 +3704,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "синтаксна грешка при рашчлањивању ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "синтаксна грешка при рашчлањивању &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "синтаксна грешка при рашчлањивању ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ очекивано после ? у изразу"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "грешка рашчлањивања у изразу\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "неупарена (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- само код бројева\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| очекиван на крају израза"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "синтаксна грешка у изразу\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "врсте се морају поклапати\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / није подржано за стрингове\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- није подржано за стрингове\n"
+
+#: rpmio/macro.c:348
 #, fuzzy, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr "%3d>%*s(празно)"
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(празно)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Неуспело отварање tar цеви: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, fuzzy, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr "Макро %%%s има незавршене опције\n"
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Макро %%%s има незавршене опције\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Макро %%%s има незавршено тело\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Макро %%%s има празно тело\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Макро %%%s није могао да се прошири\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Непозната опција %c у %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Неограничено %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% је праћена са макроом кога није могуће рашчланити\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "неочекиван ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "неочекиван ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== активно %d празно %d\n"
@@ -3826,27 +3922,27 @@ msgstr "упозорење: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "неправилна синтакса у lua скриптици: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "неправилна синтакса у lua скрипти: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua скрипта није успела: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "неправилна синтакса у lua датотеци: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua удица није успела: %s\n"
@@ -3856,17 +3952,17 @@ msgstr "lua удица није успела: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "алокација меморије (%u бајта) је вратила НАЛ.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3955,44 +4051,44 @@ msgstr "gpg није успео да запише потпис\n"
 msgid "unable to read the signature\n"
 msgstr "не могу да прочитам потпис\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature није успело: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature није успело: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp није успело\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead није успело: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4021,6 +4117,12 @@ msgstr "%s: неуспело читање манифеста: %s\n"
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr "немој проверавати потпис заглавља+товара"
+
+#~ msgid "! only on numbers\n"
+#~ msgstr "! само код бројева\n"
+
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& и || нису подржани за стрингове\n"
 
 #~ msgid "Exec of %s failed (%s): %s\n"
 #~ msgstr "Извршавање %s није успело (%s): %s\n"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: RPM\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
 "PO-Revision-Date: 2017-08-10 07:39+0000\n"
 "Last-Translator: pmatilai <pmatilai@laiskiainen.org>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/rpm-team/rpm/"
@@ -279,7 +279,7 @@ msgstr "premosti ciljnu platformu"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Opcije pravljenja uz [ <specfile> | <tarball> | <source package> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Zajedničke opcije za sve rpm režime i izvršne programe:"
@@ -338,33 +338,38 @@ msgstr "Pravim za cilj %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argumenti za --root (-r) moraju početi znakom /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "inicijalizuj bazu podataka"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "ponovo napravi obrnute spiskove baze podataka iz zaglavlja instaliranih "
 "paketa"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "provera datoteka baze podataka"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "inicijalizuj bazu podataka"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Opcije baze podataka:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "samo jedan glavni režim sme biti naveden"
 
@@ -388,7 +393,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr ""
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "nema zadatih argumenata"
 
@@ -560,38 +565,43 @@ msgid "delete package signatures"
 msgstr "obriši potpise paketa"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "nemoj proveravati potpis zaglavlja+tovara"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Opcije potpisa:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Morate postaviti „%%_gpg_name“ u makro datoteci\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -623,40 +633,49 @@ msgstr "koristi sledeći oblik upita"
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Nije moguće utvrditi naziv domaćina: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Izvršavam(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Loš status izlaza iz %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Neuspelo pravljenje zavisnosti:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -665,55 +684,6 @@ msgstr ""
 "\n"
 "\n"
 "Greške RPM pravljenja:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "sintaksna greška pri raščlanjivanju ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "sintaksna greška pri raščlanjivanju &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "sintaksna greška pri raščlanjivanju ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "greška raščlanjivanja u izrazu\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "neuparena (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- samo kod brojeva\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! samo kod brojeva\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "vrste se moraju poklapati\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / nije podržano za stringove\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- nije podržano za stringove\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& i || nisu podržani za stringove\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "sintaksna greška u izrazu\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -809,172 +779,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symlink tačke za BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Datoteka nije pronađena: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "%s: neuspelo čitanje manifesta: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: ne mogu da učitam nepoznatu oznaku (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: neuspelo čitanje javnog ključa.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: javni ključ nije ojačan.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "neuspelo kreiranje direktorijuma"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Ispred datoteke je potrebno da stoji „/“: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Ne mogu da otvorim %%files datoteku %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
-
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "otvaranje %s nije uspelo: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Datoteka nije pronađena poklapanjem: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Loša datoteka: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Proveravam za nezapakovane datoteke: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -983,111 +958,106 @@ msgstr ""
 "Pronađene su instalirane (ali nezapakovane) datoteke:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Binarne datoteke zavisne od arhitekture u noarch paketu\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Nepoznata kompresija tovara: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, fuzzy, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr "Neuspelo čitanje datoteke specifikacije iz %s\n"
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Ne mogu da otvorim %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Ne mogu da zapišem paket: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Zapisano: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Izvršavam „%s“:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Izvršavanje „%s“ nije uspelo.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Neuspela provera paketa „%s“.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "ne mogu da napravim %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Ne mogu da napravim ime izlazne datoteke za paket %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "red %d: drugi %s\n"
@@ -1132,18 +1102,18 @@ msgstr "nema opisa u %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "red %d: Greška pri tumačenju %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "red %d: Loša opcija %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1199,154 +1169,154 @@ msgstr "red %d: Loš %s broj: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d definisano više puta\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Arhitektura je izostavljena: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Arhitektura nije uvrštena: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS je izostavljen: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS nije uvršten: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s polje mora biti prisutno u paketu: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Udvojene %s stavke u paketu: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Ne mogu da otvorim ikonu %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Ne mogu da pročitam ikonu %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Nepoznata vrsta ikone: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "red %d: Oznaka prihvata samo jedan žeton: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "red %d: Loše oblikovana oznaka: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "red %d: Prazna oznaka: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "red %d: Prefiksi se ne smeju završavati sa „/“: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "red %d: Docdir mora početi sa „/“: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "red %d: Polje epohe mora biti broj bez predznaka: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "red %d: Loši %s: kvalifikatori: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "red %d: Loš oblik za BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "red %d: Samo noarch podpaketi su podržani: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Interna greška: Lažna oznaka %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Loša specifikacija paketa: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "red %d: Nepoznata oznaka: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} ne može biti prazno\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} ne može biti „/“\n"
@@ -1356,12 +1326,12 @@ msgstr "%%{buildroot} ne može biti „/“\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Loš izvor: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Nema zakrpe broj %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Nema izvora broj %u\n"
@@ -1371,27 +1341,27 @@ msgstr "Nema izvora broj %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Greška u tumačenju %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "red %d: Loš argument za %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "red %d: Loša %%setup opcija %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Neispravan broj zakrpe %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "red %d: drugi %%prep\n"
@@ -1476,101 +1446,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "red %d: Drugi %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "red %d: nepodržana interna skripta: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Ne mogu da otvorim %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, fuzzy, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr "%s:%d: Dobio %%else bez %%if\n"
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, fuzzy, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr "red %d: Loši %s: kvalifikatori: %s\n"
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, fuzzy, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr "red %d: Loša %%setup opcija %s: %s\n"
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Nisu pronađene usaglašene arhitekture za pravljenje\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket nema %%description: %s\n"
@@ -1636,98 +1606,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Ne mogu da napravim cev za %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Ne mogu da izvršim %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Ne mogu da odvojim %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Ne mogu da izvršim %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) nije uspelo: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load nije uspelo: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Prepoznavanje datoteke „%s“ nije uspelo: režim %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Pronalazak %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Neuspelo traženje %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Nije moguće utvrditi naziv domaćina: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "upit na datotekom specifikacije %s nije uspeo, ne mogu da protumačim\n"
@@ -1762,90 +1728,112 @@ msgstr "%s ima preveliku ili premalu long vrednost, preskočeno\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s ima preveliku ili premalu celobrojnu vrednost, preskočeno\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "ne mogu da dobijem %s katanac na %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "deljeno"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "ekskluzivno"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "greška(%d) pri skladištenju sloga „%s“ u %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "greška(%d) pri uklanjanju sloga „%s“ iz %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "greška(%d) pri zauzimanju novog primerka paketa\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Ne mogu da otvorim datoteku specifikacije %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s je Delta RPM i ne može se direktno instalirati\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Nepodržan teret (%s) u paketu %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paket %s je već dodat, preskačem %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paket %s je već dodat, zamenjujem sa %s\n"
@@ -1862,7 +1850,7 @@ msgstr "(nije broj)"
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(neispravna vrsta)"
 
@@ -1875,146 +1863,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(nije base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(neispravna xml vrsta)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(nije OpenPGP potpis)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sačuvano kao %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s napravljeno kao %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2058,35 +2046,44 @@ msgstr "neočekivan ]"
 msgid "unexpected }"
 msgstr "neočekivan }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? očekivan u izrazu"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ očekivano posle ? u izrazu"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} očekivan u izrazu"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": očekivan nakon ? podizraza"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ očekivano posle : u izrazu"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| očekivan na kraju izraza"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "pokazivač niza korišćen sa nizovima različitih veličina"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, fuzzy, c-format
 msgid "failed to load macro file %s\n"
 msgstr "Neuspelo čitanje datoteke specifikacije iz %s\n"
@@ -2643,25 +2640,25 @@ msgstr "nemoj proveravati zavisnosti paketa"
 msgid "don't execute verify script(s)"
 msgstr "nemoj izvršiti skriptu(e) provere"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "očekivan je izvorni paket, pronađen je binarni\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "izvorni paket ne sadrži .spec datoteku\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "raspakivanje arhive nije uspelo %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " na datoteci "
 
@@ -2711,137 +2708,137 @@ msgstr "paket nema spiskove vlasnika/grupe datoteka\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "paket nema spiskove niti vlasnika ni id datoteka\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "grupa %s ne sadrži nijedan paket\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "nijedan paket ne aktivira %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "loše oblikovan %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "nijedan paket ne odgovara %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, fuzzy, c-format
 msgid "no package conflicts %s\n"
 msgstr "nijedan paket ne pruža %s\n"
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, fuzzy, c-format
 msgid "no package obsoletes %s\n"
 msgstr "nijedan paket ne zahteva %s\n"
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "nijedan paket ne zahteva %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "nijedan paket ne pruža %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "datoteka %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "datoteka %s ne pripada nijednom paketu\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "neispravan broj paketa: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s nije instaliran\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "nepoznata oznaka: „%s“\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: uvozno čitanje nije uspelo(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "NIJE UREDU"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "UREDU"
 
@@ -2855,118 +2852,118 @@ msgstr "%s: otvaranje nije uspelo: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Ne mogu da promenim korenski direktorijum: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "nije postavljen dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: preskačem"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "greška(%d) pri zapisivanju sloga #%d u %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec nije uspeo: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp nije uspeo: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: preskačem"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: oštećeno zaglavlje #%u vraćeno -- preskačem.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: ne mogu da pročitam zaglavlje na 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "nije postavljen dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "neuspelo kreiranje direktorijuma %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "zaglavlje #%u u bazi podatak je loše -- preskačem.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "ne mogu da dodam slog prvobitno na %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "neuspelo ponovno pravljenje baze podataka: osnovna baza podataka je ostala "
 "na mestu\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "neuspela zamena stare baze podataka sa novom bazom podataka!\n"
 
@@ -3307,22 +3304,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3367,13 +3364,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "paket %s (koji je noviji od %s) je već instaliran"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "paket %s koji se instalira zahteva %<PRIu64>%cB na %s sistemu datoteka"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "paket %s koji se instalira zahteva %<PRIu64> i-čvorova na %s sistemu datoteka"
 
@@ -3498,7 +3496,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "nije ugrađena podrška <lua> skriptica\n"
 
@@ -3541,15 +3539,15 @@ msgstr "%s skriptica nije uspela, izlazni status %d\n"
 msgid "Unknown format"
 msgstr "Nepoznat oblik"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3558,96 +3556,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "ne mogu da otvorim Packages bazu podataka u %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "suvišna „(“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "nedostaje „(“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "nedostaje „)“ u oznaci paketa: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: neuspelo čitanje javnog ključa.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, fuzzy, c-format
 msgid "invalid package verify level %s\n"
 msgstr "neispravan broj paketa: %s\n"
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Zaglavlje "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3655,20 +3653,20 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Ne mogu da ponovo učitam zaglavlje potpisa.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 #, fuzzy
 msgid "no signature"
 msgstr "(nije OpenPGP potpis)"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3709,83 +3707,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "sintaksna greška pri raščlanjivanju ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "sintaksna greška pri raščlanjivanju &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "sintaksna greška pri raščlanjivanju ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ očekivano posle ? u izrazu"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "greška raščlanjivanja u izrazu\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "neuparena (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- samo kod brojeva\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| očekivan na kraju izraza"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "sintaksna greška u izrazu\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "vrste se moraju poklapati\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / nije podržano za stringove\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- nije podržano za stringove\n"
+
+#: rpmio/macro.c:348
 #, fuzzy, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr "%3d>%*s(prazno)"
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(prazno)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Neuspelo otvaranje tar cevi: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, fuzzy, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr "Makro %%%s ima nezavršene opcije\n"
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makro %%%s ima nezavršene opcije\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makro %%%s ima nezavršeno telo\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makro %%%s ima prazno telo\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s nije mogao da se proširi\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Nepoznata opcija %c u %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Neograničeno %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "%% je praćena sa makroom koga nije moguće raščlaniti\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "neočekivan ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "neočekivan ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktivno %d prazno %d\n"
@@ -3829,27 +3925,27 @@ msgstr "upozorenje: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "nepravilna sintaksa u lua skriptici: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "nepravilna sintaksa u lua skripti: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua skripta nije uspela: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "nepravilna sintaksa u lua datoteci: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua udica nije uspela: %s\n"
@@ -3859,17 +3955,17 @@ msgstr "lua udica nije uspela: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "alokacija memorije (%u bajta) je vratila NAL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3958,44 +4054,44 @@ msgstr "gpg nije uspeo da zapiše potpis\n"
 msgid "unable to read the signature\n"
 msgstr "ne mogu da pročitam potpis\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature nije uspelo: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp nije uspelo\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead nije uspelo: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4024,6 +4120,12 @@ msgstr "%s: neuspelo čitanje manifesta: %s\n"
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr "nemoj proveravati potpis zaglavlja+tovara"
+
+#~ msgid "! only on numbers\n"
+#~ msgstr "! samo kod brojeva\n"
+
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& i || nisu podržani za stringove\n"
 
 #~ msgid "Exec of %s failed (%s): %s\n"
 #~ msgstr "Izvršavanje %s nije uspelo (%s): %s\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-11-26 04:02+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-11-26 04:02-0500\n"
 "Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
 "Language-Team: Swedish (http://www.transifex.com/rpm-team/rpm/language/sv/)\n"
 "Language: sv\n"
@@ -116,10 +116,9 @@ msgid "build source package only from <specfile>"
 msgstr "bygg endast källpaket från <specfil>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "bygg endast källpaket från <specfil>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -161,11 +160,10 @@ msgid "build source package only from <source package>"
 msgstr "bygg endast källpaket från <källpaket>"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "bygg endast källpaket från <källpaket>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -206,10 +204,9 @@ msgid "build source package only from <tarball>"
 msgstr "bygg endast källpaket från <tar-arkiv>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "bygg endast källpaket från <tar-arkiv>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -286,7 +283,7 @@ msgstr "åsidosätt målplattform"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Byggflaggor med [ <specfil> | <tar-arkiv> | <källpaket> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Gemensamma flaggor för alla rpm-lägen och binärer:"
@@ -345,31 +342,36 @@ msgstr "Bygger för målet %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "argument till --root (-r) måste börja med /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "initiera databas"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "bygg om databasens inverterade listor från installerade pakets huvuden"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "verifiera databasfiler"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "initiera databas"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "exportera databasen till standard ut huvudlista"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "importera databasen från standard in huvudlista"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Databasflaggor:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "enbart ett huvudläge kan anges"
 
@@ -393,7 +395,7 @@ msgstr "lista nycklar från RPM-nyckelringen"
 msgid "Keyring options:"
 msgstr "Nyckelringsflaggor:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "inga argument angivna"
 
@@ -565,31 +567,36 @@ msgid "delete package signatures"
 msgstr "tag bort paketsignaturer"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "verifiera inte huvud+lastsignatur"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr "signera paketfiler"
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr "använd signeringsnyckeln <nyckel>"
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr "<nyckel>"
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr "fråga efter lösenords för filsigneringsnyckeln"
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Signaturflaggor:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Du måste sätta ”%%_gpg_name” i din makrofil\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
@@ -598,7 +605,7 @@ msgstr ""
 "Du måste sätta ”%%_file_signing_key” i din makrofil eller på kommandoraden "
 "med --fskpath\n"
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr "--fskpath kan endast anges när filer signeras"
 
@@ -630,40 +637,49 @@ msgstr "använd följande frågeformat"
 msgid "Spec options:"
 msgstr "Spec-flaggor:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "inga parametrar angivna för tolkning"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr "kan inte tolka SOURCE_DATE_EPOCH\n"
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Kunde inte kanonisera värdnamn: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Kan inte öppna temporär fil: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Kan inte öppna ström: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Kör(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Dålig slutstatus från %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Ouppfyllda byggberoenden:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr "sätter %s=%s\n"
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -672,55 +688,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM-byggfel:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "syntaxfel vid tolkning av ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "syntaxfel vid tolkning av &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "syntaxfel vid tolkning av ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "tolkningsfel i uttryck\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "ensam (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- endast i tal\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! endast på tal\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "typer måste passa ihop\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / stöds inte för strängar\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- stöds inte för strängar\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& och || stöds inte för strängar\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "syntaxfel i uttryck\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -816,173 +783,178 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Symbolisk länk pekar på BuildRoot: %s → %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Otillåtet tecken ”%c” (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Sökvägen är utanför buildroot: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Katalogen hittades inte: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Filen hittades inte: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Inte en katalog: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Misslyckades med att läsa policyfil: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: kan inte läsa okänd tagg (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: läsning av publik nyckel misslyckades.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: inte en publik nyckel med skal.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: misslyckades att koda\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr "misslyckad symlänk"
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr "Dubblerat bygg-id, stat %s: %m\n"
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr "Dubblerade bygg-id:n %s och %s\n"
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr "makrot _build_id_links är inte satt, antar ”compat”\n"
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr "makrot _build_id_links är satt till det okända värdet ”%s”\n"
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr "fel när bygg-id lästes i %s: %s\n"
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr "Bygg-id saknas i %s\n"
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr "Bygg-id hittat i %s är för litet\n"
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr "Bygg-id hittat i %s är för stort\n"
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "misslyckades att skapa katalog"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr "Blandning av huvud-ELF och felsökningsfiler i paketet"
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Filen behöver inledande ”/”: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev-matchning inte tillåten: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 "Hittade ingen katalog vid matchningen: %s.  Försöker utan att matcha.\n"
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "Hittade ingen fil vid matchningen: %s.  Försöker utan att matcha.\n"
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Kunde inte öppna %%files-fil %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "Tom %%files-fil %s\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Fel vid läsning av %%files-fil %s: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "ogiltigt _docdir_fmt: %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Hittade ingen fil vid matchningen: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr "Specialfil i genererad fillista: %s\n"
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Kan inte blanda special %s med andra former: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Mer än en fil på en rad: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr "Att generera bygg-id-länkar misslyckades\n"
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Felaktig fil: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Letar efter opackade fil(er): %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -991,111 +963,106 @@ msgstr ""
 "Installerade (men opaketerade) filer funna:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr "%s mappades till flera filnamn"
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Bearbetar filer: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "Binärers arkitektur (%d) matchar inte paketarkitekturen (%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Arkitekturberoende binärfiler i noarch-paket\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "misslyckades skapa arkiv vid filen %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "misslyckades skapa arkiv: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Kunde inte öppna %s-fil: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Okänd lastkomprimering: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Kunde inte söka i filen %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr "Kan inte skapa oföränderlig huvudregion\n"
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr "Kan inte skriva ett huvud till %s: %s\n"
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Kunde inte öppna %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Kunde inte skriva paket: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Skrev: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Kör ”%s”:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Körning av ”%s” misslyckades.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Paketkontroll ”%s” misslyckades.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "kan inte skapa %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Kunde inte generera utfilnamn för paketet %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "rad %d: andra %s\n"
@@ -1140,18 +1107,18 @@ msgstr "ingen beskrivning i %%changelog\n"
 msgid "line %d: second %%changelog\n"
 msgstr "rad %d: andra %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "rad %d: Fel i tolkning av %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "rad %d: otillåten flagga %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1207,154 +1174,154 @@ msgstr "rad %d: Felaktigt %s-tal: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d definierat flera gånger\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Arkitekturen är utesluten: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Arkitekturen är inte medtagen: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS är uteslutet: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS är inte medtaget: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s-fält måste finnas med i paketet: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Dubbla %s-poster i paketet: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Kan inte öppna ikon %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Kan inte läsa ikon %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Okänd ikontyp: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "rad %d: Taggen tar endast ett värde: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "rad %d: %s i: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s i: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Otillåtet tecken ”%c” (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr "Möjligt oexpanderat makro"
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Otillåten sekvens ”..”"
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "rad %d: Felaktig tagg: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "rad %d: Tom tagg: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "rad %d: Prefix får inte sluta med ”/”: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "rad %d: Docdir måste börja med ”/”: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "rad %d: Epoch-fält måste vara ett teckenlöst tal: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "rad %d: Felaktigt %s: bestämningar: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "rad %d: Felaktigt BuildArchitecture-format: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr "rad %d: dubblerad BuildArch-post: %s\n"
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "rad %d: Endast noarch-underpaket stöds: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Internt fel: felaktig tagg %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "rad %d: %s är föråldrad: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Felaktig paketangivelse %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr "Binärt rpm-paket hittat.  Spec-fil förväntades!\n"
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "rad %d: Okänd tagg: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} fick inte vara tom\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} kan inte vara ”/”\n"
@@ -1364,12 +1331,12 @@ msgstr "%%{buildroot} kan inte vara ”/”\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Dålig källa: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Inget patch-nummer %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Inget källkodsnummer %u\n"
@@ -1379,27 +1346,27 @@ msgstr "Inget källkodsnummer %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Fel i tolkning av %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "rad %d: Felaktigt argument till %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "rad %d: Felaktig %%setup-flagga %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Felaktigt patch-nummer %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "rad %d: andra %%prep\n"
@@ -1484,101 +1451,101 @@ msgstr "rad %d: prioriteter är endast tillåta för filutlösare: %s\n"
 msgid "line %d: Second %s\n"
 msgstr "rad %d: En andra %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "rad %d: ej stött internt skript: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr "rad %d: filtriggervillkor måste börja med ”/”: %s"
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "rad %d: argument till tolken tillåts inte i utlösare: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr "Makro expanderat i kommentar på rad %d: %s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Kan inte öppna %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Argument förväntades för %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "rad %d: Oavslutat %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "rad %d: oavslutat makro eller felaktig fortsättning på rad\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Fick ett %%else utan något %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "rad %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: felaktigt %%if-villkor\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: felformaterad %%include-sats\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "kodningen %s stödjs inte av systemet\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Paketet %s: felaktig %s-kodning i %s: %s — %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr "rad %d: %%end tar inte några argument: %s\n"
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr "rad %d: %%end förväntades inte här, ingen sektion att avsluta: %s\n"
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr "rad %d tillhör inte någon sektion: %s\n"
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Hittade inga kompatibla arkitekturer att bygga\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paketet har ingen %%description: %s\n"
@@ -1645,98 +1612,94 @@ msgstr "Saknad modulväg på rad: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "För många argument på rad: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Bearbetning policyer: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ignorerar ogiltigt reguttr %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Kunde inte öppna rör för %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Kunde inte köra %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Kunde inte grena (fork) %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Kunde inte köra %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s misslyckades: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "misslyckades med att skriva all data till %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Tom filklassificerare\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Inga filattribut konfigurerade\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) misslyckades: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load misslyckades: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Igenkänning av filen ”%s” misslyckades: läge %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Letar efter %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Misslyckades med att hitta %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr "Föråldrad extern beroendegenerator används!\n"
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr "rad %d: %s: paket %s finns inte\n"
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr "rad %d: %s: paket %s finns redan\n"
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr "kan inte tolka SOURCE_DATE_EPOCH\n"
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Kunde inte kanonisera värdnamn: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "fråga av specfil %s misslyckades, kan inte tolka\n"
@@ -1771,90 +1734,114 @@ msgstr "%s har för stort eller för litet ”long”-värde, hoppar över\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s har för stort eller för litet heltalsvärde, hoppar över\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "kan inte få %s lås på %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "delat"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "uteslutande"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "ogiltig indextyp %x på %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "fel(%d) när ”%s”-poster hämtades från %s-indexet: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "fel(%d) när post ”%s” sparades i %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "fel(%d) när post ”%s” togs bort från %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "fel(%d) vid tillägg av post för huvud nr. %d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "fel(%d) tar bort post för huvud nr. %d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "fel(%d) vid allokering av ny paketinstans\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
+#: lib/backend/ndb/glue.c:101
+#, fuzzy
+msgid "Detected outdated index databases\n"
+msgstr "kunde inte radera den gamla databasen på %s\n"
+
+#: lib/backend/ndb/glue.c:103
+#, fuzzy
+msgid "Rebuilding outdated index databases\n"
+msgstr "kunde inte radera den gamla databasen på %s\n"
+
+#: lib/backend/ndb/rpmidx.c:204
 #, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Kan inte öppna specfilen %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s är en delta-RPM och kan inte installeras direkt\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Ej stödd last (%s) i paket %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "paket %s var redan tillagt, hoppar över %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "paket %s är redan tillagt, ersätter med %s\n"
@@ -1871,7 +1858,7 @@ msgstr "(inte ett tal)"
 msgid "(not a string)"
 msgstr "(inte en sträng)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(felaktig typ)"
 
@@ -1884,146 +1871,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(inte base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(felaktig xml-typ)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(inte en OpenPGP-signatur)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ogiltig tidpunkt %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "ersatt"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "inte installerad"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "nätdelad"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "fel färg"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "saknas"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(okänd)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s sparades som %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s skapades som %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: borttagande misslyckades: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "katalog"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "fil"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr "tagg[%d]: FEL, tagg %d typ %d position %d antal %d längd %d"
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "hvdlast: FEL"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr "region: inga taggar"
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "regiontagg: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "regionposition: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "regionavslutning: FEL, tagg %d typ %d position %d antal %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr "region %d storlek: FEL, ril %d il %d rdl %d dl %d"
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "hvdstorlek(%d): FEL, läsning returnerade %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "hvdmagi: FEL"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "hvdtaggar: FEL, antal taggar(%d) utanför intervall"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "hvddata: FEL, antal byte(%d) utanför intervall"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "hvdklick(%zd): FEL, läsning returnerade %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "sighutfyllnad(%zd): FEL, läste %zd byte"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr "signatur "
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "klickstorlek(%d): FEL, 8 + 16 * il(%d) + dl(%d)"
@@ -2067,43 +2054,52 @@ msgstr "oväntad ]"
 msgid "unexpected }"
 msgstr "oväntad }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? förväntades i uttryck"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ förväntades efter ? i uttryck"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} förväntades i uttryck"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": förväntades efter ? i deluttryck"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ förväntades efter : i uttryck"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| förväntades vid slutet på uttryck"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "vektoriterator använd med vektor av annan storlek"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "rad %d: %s är föråldrad: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "argument till --prefix måste börja med /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2647,25 +2643,25 @@ msgstr "verifiera inte paketberoenden"
 msgid "don't execute verify script(s)"
 msgstr "utför inte verifieringsskript"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Saknade rpmlib-funktioner för %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "källpaket förväntades, fann binärpaket\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "källpaket innehåller ingen .spec-fil\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "uppackning av arkiv misslyckades%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " vid fil "
 
@@ -2715,137 +2711,137 @@ msgstr "paketet har inte filägare-/-grupplistor\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "paketet har varken filägare eller id-listor\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "grupp %s innehåller inga paket\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "inga paketutlösare %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "felformaterad %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "inga paket matchar %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "inget paket behöver %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "inget paket rekommenderar %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "inget paket föreslår %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "inget paket kompletterar %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "inget paket förbättrar %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "inget paket tillhandahåller %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "fil %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "filen %s tillhör inget paket\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "felaktigt paketnummer: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "post %u kunde inte läsas\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "paket %s är inte installerat\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "okänd tagg: ”%s”\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: import av nyckeln %d misslyckades.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: nyckeln %d är inte en bepansrad publik nyckel.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: importläsning misslyckades(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr "Fread misslyckades: %s"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr "KONTROLLSUMMOR"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr "kontrollsummor"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr "SIGNATURER"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr "signaturer"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "EJ OK"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2859,116 +2855,116 @@ msgstr "%s: open misslyckades: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Det går inte öppna aktuell katalog: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: chroot-katalog inte satt\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Kunde inte ändra rotkatalog: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Det går inte att återställa root-katalogen: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Genererar %d saknade index, vänta …\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "kan inte öppna %s-indexet med %s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "ingen dbpath har satts\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: hoppar över"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "fel(%d) när post nr. %d sparades i %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec misslyckades: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp misslyckades: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: hoppar över"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: skadat huvud nr. %u hämtat -- hoppar över.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: kan inte läsa huvud vid 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr "kunde inte flytta den nya databasen på plats\n"
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr "kunde inte heller återställa den gamla databasen från %s\n"
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr "byt ut filer i %s med filer från %s för att återställa\n"
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr "Kunde inte hämta publika nycklar från %s\n"
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr "kunde inte radera den gamla databasen på %s\n"
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "ingen dbpath har satts"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "misslyckades att skapa katalogen %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "huvud nr. %u i databasen är felaktigt -- hoppar över.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "kan inte lägga till post ursprungligen vid %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "kunde inte bygga om databasen: orginaldatabasen finns kvar\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "kunde inte ersätta gammal databas med ny databas!\n"
 
@@ -3057,9 +3053,8 @@ msgid "support for rich dependencies."
 msgstr "stöd för rika beroenden"
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "stöd för rika beroenden"
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3307,22 +3302,22 @@ msgstr "det går inte att skapa %s-lås på %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "väntar på %s-lås på %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Misslyckades med att göra dlopen på %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Misslyckades med att lösa upp symbolen %s: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Insticksmodulen %%__%s_%s är inte konfigurerad\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Insticksmodulen %s är inte inläst\n"
@@ -3367,13 +3362,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "paket %s (som är nyare än %s) är redan installerat"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "installation av paket %s kräver %<PRIu64> %cB på filsystemet %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr "installation av paket %s kräver %<PRIu64> inoder på filsystem %s"
 
 #: lib/rpmprob.c:159
@@ -3497,7 +3493,7 @@ msgstr "Ingen exec() anropad efter fork() i lua-skript\n"
 msgid "Unable to restore current directory: %m"
 msgstr "Det går inte att återställa aktuell katalog: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua>-skriptstöd är inte inbyggt\n"
 
@@ -3540,15 +3536,15 @@ msgstr "%s-skript misslyckades, slutstatus %d\n"
 msgid "Unknown format"
 msgstr "Okänt format"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "installera"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "radera"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3557,96 +3553,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "kan inte öppna paketdatabas i %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "överflödigt ”(” i paketetikett: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "”(” saknas i etikett: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "”)” saknas i paketetikett: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: misslyckades att läsa publik nyckel.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "transaktion"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr "%stagg %u: felaktig typ %u"
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr "%s: tagg %u: felaktigt antal %u"
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr "%stagg %u: felaktig data %p (%u)"
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr "%stagg %u: felaktig storlek %u"
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr "%stagg %u: felaktig OpenPGP-signatur"
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr "%s: tagg %u: felakigt hextal"
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
-#, c-format
-msgid "%s%s %s"
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
+#, fuzzy, c-format
+msgid "%s%s%s %s"
 msgstr "%s%s %s"
 
-#: lib/rpmvs.c:263
+#: lib/rpmvs.c:268
 msgid "digest"
 msgstr "kontrollsumma"
 
-#: lib/rpmvs.c:268
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr "%s%s"
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr "signatur"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr "huvud"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr "paket"
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Huvud "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr "Last "
 
@@ -3654,19 +3650,19 @@ msgstr "Last "
 msgid "Unable to reload signature header.\n"
 msgstr "Kan inte läsa om signaturhuvud.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "hoppade över"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "misslyckades"
 
@@ -3707,67 +3703,155 @@ msgstr "Misslyckades med att initiera NSS-biblioteket\n"
 msgid "Failed to register fork handler: %m\n"
 msgstr "Misslyckades med att registrera greningshanteraren: %m\n"
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "syntaxfel vid tolkning av ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "syntaxfel vid tolkning av &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "syntaxfel vid tolkning av ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "rad %d: %s i: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ förväntades efter ? i uttryck"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "tolkningsfel i uttryck\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "ensam (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- endast i tal\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| förväntades vid slutet på uttryck"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "syntaxfel i uttryck\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "typer måste passa ihop\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / stöds inte för strängar\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- stöds inte för strängar\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(tom)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Kunde inte öppna ”tar”-rör: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr "Makrot %%%s har ett otillåtet namn (%s)\n"
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Makrot %%%s har oavslutade flaggor\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Makrot %%%s har oavslutad kropp\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Makrot %%%s har tom kropp\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Makrot %%%s måste ha blanksteg före kroppen\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Makro %%%s misslyckades att expandera\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Makrot %%%s definierat men inte använt i sin räckvidd\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Okänd flagga %c i %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "misslyckades med att läsa in makrofilen %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3775,17 +3859,27 @@ msgstr ""
 "Alltför många nivåer av rekursion i en makroexpansion.  Det beror sannolikt "
 "på en rekursiv makrodeklaration.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Oavslutad %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Ett %% följs av ett makro som inte kan tolkas\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "oväntad ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "oväntad ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== aktiva %d tomma %d\n"
@@ -3829,27 +3923,27 @@ msgstr "varning: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "felaktig syntax i lua-skript: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "felaktig syntax i lua-skript: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua-skript misslyckades: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "felaktig syntax i lua-fil: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua-hake misslyckades: %s\n"
@@ -3859,17 +3953,17 @@ msgstr "lua-hake misslyckades: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "minnesallokering (%u byte) returnerade NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr "Ej stödd version av nyckeln: V%d\n"
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, nyckel-ID %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(ingen)"
 
@@ -3958,44 +4052,44 @@ msgstr "gpg kunde inte skriva signatur\n"
 msgid "unable to read the signature\n"
 msgstr "kan inte läsa signaturen\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr "Stöd för filsignering är inte inbyggt\n"
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature misslyckades: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead misslyckades: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Kan inte signera RPM-v3-paket\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s innehåller redan en identisk signatur, hoppar över\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature misslyckades: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp misslyckades\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead misslyckades: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "misslyckades med att ersätta %s: %s\n"
@@ -4025,23 +4119,20 @@ msgstr "%s: läsning av paketlista misslyckades: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "verifiera inte huvud+lastsignatur"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Körning (exec) av %s misslyckades (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! endast på tal\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Fel vid körning av skript %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& och || stöds inte för strängar\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "rad: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Fel vid läsning av %%files-fil %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: rad: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Kunde inte öppna %s-fil: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Ingen ”Source:”-tagg i spec-filen\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "rad %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: Fick ett %%endif utan något %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "misslyckades med att läsa in makrofilen %s"

--- a/po/te.po
+++ b/po/te.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Telugu (http://www.transifex.com/rpm-team/rpm/language/te/)\n"
 "Language: te\n"
@@ -275,7 +275,7 @@ msgstr ""
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr ""
@@ -334,31 +334,36 @@ msgstr ""
 msgid "arguments to --root (-r) must begin with a /"
 msgstr ""
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "డేటాబేసును ఆరంభించు"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "డేటాబేసు ఫైళ్ళను సరిచూడు"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "డేటాబేసును ఆరంభించు"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "డేటాబేసు ఐచ్ఛికాలు:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr ""
 
@@ -382,7 +387,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr "కీరింగ్ ఐచ్ఛికాలు:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -547,38 +552,42 @@ msgid "delete package signatures"
 msgstr "ప్యాకేజీ సంతకాలను తొలగించు"
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "సంతకం ఐచ్ఛికాలు:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr ""
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -610,40 +619,49 @@ msgstr ""
 msgid "Spec options:"
 msgstr ""
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr ""
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr ""
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr ""
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -652,55 +670,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM నిర్మాణ దోషాలు:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr ""
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr ""
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr ""
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr ""
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr ""
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr ""
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr ""
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr ""
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr ""
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr ""
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -796,283 +765,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr ""
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "ఫైలు కనపడలేదు: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr ""
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, c-format
+msgid "Can't read content of file: %s\n"
+msgstr ""
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr ""
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr ""
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr ""
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
+#: build/files.c:2233
 #, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
+msgid "Could not open %s file %s: %m\n"
 msgstr ""
 
 #: build/files.c:2258
 #, c-format
+msgid "Empty %s file %s\n"
+msgstr ""
+
+#: build/files.c:2303
+#, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr ""
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "చెడ్డ ఫైలు: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr ""
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr ""
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr ""
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr ""
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr ""
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr ""
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr ""
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr ""
@@ -1117,18 +1086,18 @@ msgstr ""
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr ""
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1184,154 +1153,154 @@ msgstr ""
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr ""
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1341,12 +1310,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "చెడ్డ వనరు: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1356,27 +1325,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr ""
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr ""
@@ -1461,101 +1430,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr ""
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr ""
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
+#: build/parseSpec.c:482
 #, c-format
 msgid "%s: line %d: %s with no %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:467
+#: build/parseSpec.c:485
 #, c-format
 msgid "%s: line %d: %s after %s\n"
 msgstr ""
 
-#: build/parseSpec.c:494
+#: build/parseSpec.c:512
 #, c-format
 msgid "%s:%d: bad %s condition: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr ""
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr ""
@@ -1621,98 +1590,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr ""
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr ""
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr ""
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr ""
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1747,90 +1712,112 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr ""
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr ""
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr ""
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr ""
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr ""
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1847,7 +1834,7 @@ msgstr ""
 msgid "(not a string)"
 msgstr ""
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr ""
 
@@ -1860,146 +1847,146 @@ msgstr ""
 msgid "%a %b %d %Y"
 msgstr ""
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr ""
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr ""
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr ""
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr ""
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr ""
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr ""
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr ""
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr ""
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr ""
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr ""
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr ""
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2043,35 +2030,44 @@ msgstr ""
 msgid "unexpected }"
 msgstr ""
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr ""
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr ""
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
@@ -2617,25 +2613,25 @@ msgstr ""
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr ""
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr ""
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr ""
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr ""
 
@@ -2685,137 +2681,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr ""
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr ""
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr ""
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr ""
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr ""
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "ఫైల్ %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr ""
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr ""
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr ""
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr ""
 
@@ -2829,116 +2825,116 @@ msgstr ""
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr ""
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr ""
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr ""
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr ""
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr ""
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr ""
 
@@ -3275,22 +3271,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3336,12 +3332,13 @@ msgstr ""
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3465,7 +3462,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3508,15 +3505,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr ""
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr ""
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr ""
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3525,96 +3522,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr ""
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr ""
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3622,19 +3619,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr ""
 
@@ -3675,83 +3672,167 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+msgid "syntax error while parsing =="
+msgstr ""
+
+#: rpmio/expression.c:333
+msgid "syntax error while parsing &&"
+msgstr ""
+
+#: rpmio/expression.c:342
+msgid "syntax error while parsing ||"
+msgstr ""
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+msgid "unterminated string in expression"
+msgstr ""
+
+#: rpmio/expression.c:409
+msgid "parse error in expression"
+msgstr ""
+
+#: rpmio/expression.c:447
+msgid "unmatched ("
+msgstr ""
+
+#: rpmio/expression.c:470
+msgid "- only on numbers"
+msgstr ""
+
+#: rpmio/expression.c:489
+msgid "unexpected end of expression"
+msgstr ""
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+msgid "syntax error in expression"
+msgstr ""
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+msgid "types must match"
+msgstr ""
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+msgid "* and / not supported for strings"
+msgstr ""
+
+#: rpmio/expression.c:608
+msgid "- not supported for strings"
+msgstr ""
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr ""
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr ""
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr ""
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr ""
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr ""
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
+msgid "no such macro: '%s'\n"
 msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr ""
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr ""
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+msgid "argument expected"
+msgstr ""
+
+#: rpmio/macro.c:1488
+msgid "unexpected argument"
+msgstr ""
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr ""
@@ -3795,27 +3876,27 @@ msgstr ""
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3825,17 +3906,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3924,44 +4005,44 @@ msgstr ""
 msgid "unable to read the signature\n"
 msgstr ""
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr ""
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -3990,6 +4071,3 @@ msgstr ""
 #: tools/rpmgraph.c:219
 msgid "don't verify header+payload signature"
 msgstr ""
-
-#~ msgid "line: %s\n"
-#~ msgstr "వరుస: %s\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/rpm-team/rpm/language/tr/)\n"
 "Language: tr\n"
@@ -120,10 +120,9 @@ msgid "build source package only from <specfile>"
 msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -165,11 +164,10 @@ msgid "build source package only from <source package>"
 msgstr ""
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "kaynak paketi sadece <specDosyası>ndan oluşturur"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -212,10 +210,9 @@ msgid "build source package only from <tarball>"
 msgstr "kaynak paketi sadece <tarpaketi>nden oluşturur"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "kaynak paketi sadece <tarpaketi>nden oluşturur"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -293,7 +290,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "[ <specDosyası> | <tarPaketi> | <kaynakPaketi> ] ile paketleme seçenekleri:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Tüm rpm kipleri ve yürütülebilir dosyaları için ortak seçenekler:"
@@ -352,31 +349,36 @@ msgstr "%s için derleniyor\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) ile verilenler '/' ile başlamalı"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "veritabanını başlangıç durumuna getirir"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "kurulu paket başlıklarından veritabanı listelerini yeniden oluşturur"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "veritabanı dosyaralını doğrular"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "veritabanını başlangıç durumuna getirir"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr ""
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr ""
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Veritabanı seçenekleri:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "sadece bir ana kip belirtilebilir"
 
@@ -400,7 +402,7 @@ msgstr ""
 msgid "Keyring options:"
 msgstr "Anahtarlık seçenekleri:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr ""
 
@@ -572,38 +574,42 @@ msgid "delete package signatures"
 msgstr "paket imzalarını sil"
 
 #: rpmsign.c:37
+msgid "create rpm v3 header+payload signatures"
+msgstr ""
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "İmza seçenekleri:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Makro dosyanızda \"%%_pgp_name\" tanımlanmış olmalı\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -635,40 +641,49 @@ msgstr "izleyen sorgulama biçimini kullanır"
 msgid "Spec options:"
 msgstr "Belirtim seçenekleri:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr ""
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Böyle bir makina yok: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr ""
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr ""
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "%s icra ediliyor: %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "%s çıkışında hata (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr ""
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -677,55 +692,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM derleme hataları:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "== çözümlenirken sözdizimi hatası bulundu\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "&& çözümlenirken sözdizimi hatası bulundu\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "|| çözümlenirken sözdizimi hatası bulundu\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "ifadede çözümleme hatası\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "uyumsuz (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- sadece sayılarda\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! sadece sayılarda\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "türler eşleşmeli\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / dizgelerde desteklenmez\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- dizgelerde desteklenmez\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& ve || dizgelerde desteklenmez\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "ifadede sözdizimi hatası\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -821,283 +787,283 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Sembolik bağ BuildRoot gösteriyor: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr ""
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr ""
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr ""
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Dosya bulunamadı: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Dizin değil: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "dosyaların sahipleri doğrulanmaz"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr ""
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: genel anahtar okuması başarısız oldu.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr ""
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: kodlama başarısız oldu\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr ""
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Dosya \"/\" ile içermeli: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr ""
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
-msgstr ""
-
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
-msgstr ""
-
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr ""
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
+msgstr "%s açılamadı: %s\n"
 
 #: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
+msgstr "%s açılamadı: %s\n"
+
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr ""
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Dosya glob tarafından bulunamadı: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr ""
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr ""
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Dosya hatalı: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr ""
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
 "%s"
 msgstr ""
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Dosyalar işleniyor: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr ""
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr ""
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr ""
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr ""
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "paket yazılamadı: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Yazıldı: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "\"%s\" yürütülüyor:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "\"%s\"in yürütülmesi başarısız oldu.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr ""
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "%s dosyası oluşturulamıyor: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "%s paket dosyası için çıktı dosya adı üretilemedi: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "%d satır: %s saniye\n"
@@ -1142,18 +1108,18 @@ msgstr "%%changelog içinde açıklama yok\n"
 msgid "line %d: second %%changelog\n"
 msgstr ""
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "satır %d: %%description ayrıştırılırken hata: %s \n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "satır %d: %s seçeneği hatalı: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1209,154 +1175,154 @@ msgstr "satır %d: Hatalı %s numarası: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr ""
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Mimari dışlandı: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Mimari içerilmedi: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "OS dışlandı: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "OS içerilmedi: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Pakette %s alan mevcut olmalı: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Pakette %s girdi tekrarlanmış: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "%s kısayol simgesi açılamadı: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "%s kısayol simgesi okunamadı: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "bilinmeyen kısayol simgesi türü: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "satır %d: Etiket sadece tek dizgecik alır: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr ""
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr ""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "satır %d: Etiket bozuk: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "satır %d: Etiket boş: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "satır %d: Önekler \"/\" ile bitemez: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "satır %d: Docdir '/' ile başlamalı: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "satır %d: %s hatalı: niteleyiciler: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "satır %d: BuildArchitecture biçimi hatalı: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "İçsel hata: %d etiketi sahte\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Paket özellikleri hatalı: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "satır %d: Bilinmeyen etiket: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr ""
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr ""
@@ -1366,12 +1332,12 @@ msgstr ""
 msgid "Bad source: %s: %s\n"
 msgstr "Kaynak hatalı: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr ""
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr ""
@@ -1381,27 +1347,27 @@ msgstr ""
 msgid "Error parsing %%setup: %s\n"
 msgstr "%%setup çözümlenirken hata: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "satır %d: %%setup argumanı hatalı: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "satır %d: %%setup seçeneği %s hatalı: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Geçersiz yama numarası %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "satır %d: %%prep saniye\n"
@@ -1486,101 +1452,101 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "satır %d: %s saniye\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "satır %d: desteklenmeyen içsel betik: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "%s açılamadı: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr ""
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr ""
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: %%if'siz bir  %%else alındı\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "satır %d: %s hatalı: niteleyiciler: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "satır %d: %%setup seçeneği %s hatalı: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr ""
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr ""
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Kurgulamak için uyumlu mimari yok\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Paket %%description içermiyor: %s\n"
@@ -1646,98 +1612,94 @@ msgstr ""
 msgid "Too many arguments in line: %s\n"
 msgstr ""
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr ""
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr ""
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "%s icra edilemedi: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "%s ayrılamadı: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "%s icra edilemedi: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr ""
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr ""
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr ""
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr ""
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "%s bulunamadı:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Böyle bir makina yok: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s spec dosyasının sorgulanması başarısız, çözümlenemiyor\n"
@@ -1772,90 +1734,112 @@ msgstr "%s ya çok büyük ya da çok küçük 'long' değer içeriyor, atlandı
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s ya çok büyük ya da çok küçük 'integer' değer içeriyor, atlandı\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "%s kilit  %s/%s'den alınamadı\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "paylaşımlı"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "bağdaşık"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr ""
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "yeni paket örneğini tutma hatası(%d)\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "%s spec dosyası açılamadı: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr ""
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr ""
@@ -1872,7 +1856,7 @@ msgstr "(bir sayı değil)"
 msgid "(not a string)"
 msgstr "(dizge değil)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(geçersiz tür)"
 
@@ -1885,146 +1869,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(base64 değil)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(geçersiz xml türü)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(OpenPGP imzası değil)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr ""
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "normal"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr ""
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "kurulmamış"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr ""
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "yanlış renk"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "eksik"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(bilinmiyor)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s %s olarak kaydedildi\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s %s olarak oluşturuldu\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr ""
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "dizin"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "dosya"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr ""
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr ""
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr ""
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr ""
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr ""
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr ""
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr ""
@@ -2068,43 +2052,52 @@ msgstr "beklenmeyen ]"
 msgid "unexpected }"
 msgstr "beklenmeyen }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "ifade içerisinde ? gerekli"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "ifade içerisinde ? dan sonra { gerekli"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "ifade içinde } gerekli"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "? alt ifadesinden sonra : gerekli"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "ifade içersinde : den sonra { gerekli"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "ifadenin sonunda | gerekli"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr ""
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr ""
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "--prefix ile belirtilenler '/' ile başlamalı"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2646,25 +2639,25 @@ msgstr "paket bağımlılıkları doğrulanmaz"
 msgid "don't execute verify script(s)"
 msgstr ""
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr ""
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "kaynak paketi gerekirken çalıştırılabilir paketi bulundu\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "kaynak paketi .spec dosyası içermiyor\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "arşiv paketi açılırken başarısız%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " dosyada "
 
@@ -2714,137 +2707,137 @@ msgstr ""
 msgid "package has neither file owner or id lists\n"
 msgstr "paket ne dosya sahibi ne de kimlik listesi içeriyor\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "%s grubu hiç paket içermiyor\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "%s tetikleyen paket yok\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr ""
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr ""
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "%s gerektiren paket yok\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr ""
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr ""
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr ""
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr ""
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "%s sağlayan paket yok\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "dosya %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "%s dosyası, hiç bir pakete ait değil\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "geçersiz paket numarası: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr ""
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "%s paketi kurulu değil\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr ""
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "TAMAM DEĞİL"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "Tamam"
 
@@ -2858,118 +2851,118 @@ msgstr "%s: açılamadı: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: chroot dizini belirlenmemiş\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr ""
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr ""
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "belirtilmiş bir dbpath değeri yok\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr ""
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: 0x%x de başlık okunamadı\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "belirtilmiş bir dbpath yok"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "kayıt özgün olarak %u e eklenemedi\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "veritabanı yeniden oluşturulamadı: mevcut veritabanı değişmeden\n"
 "yerinde bırakıldı\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "eski veritabanının yenisiyle değiştirilirmesi başarısız!\n"
 
@@ -3306,22 +3299,22 @@ msgstr ""
 msgid "waiting for %s lock on %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr ""
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr ""
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr ""
@@ -3367,12 +3360,13 @@ msgstr "%s paketi zaten yüklü (%s sürümünden daha yeni)"
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3496,7 +3490,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr ""
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 
@@ -3539,15 +3533,15 @@ msgstr ""
 msgid "Unknown format"
 msgstr "Bilinmeyen biçim"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "kur"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "sil"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3556,96 +3550,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "%s de Paket veritabanı açılamadı\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr ""
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr ""
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr ""
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Başlık"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3653,19 +3647,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "İmza başlığı yeniden yüklenemedi.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "atlandı"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "başarısız oldu"
 
@@ -3706,83 +3700,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "== çözümlenirken sözdizimi hatası bulundu\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "&& çözümlenirken sözdizimi hatası bulundu\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "|| çözümlenirken sözdizimi hatası bulundu\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, c-format
+msgid "expanded string: %s\n"
+msgstr ""
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "ifade içerisinde ? dan sonra { gerekli"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "ifadede çözümleme hatası\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "uyumsuz (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- sadece sayılarda\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "ifadenin sonunda | gerekli"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "ifadede sözdizimi hatası\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "türler eşleşmeli\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / dizgelerde desteklenmez\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- dizgelerde desteklenmez\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(boş)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "tar veriyolu açılamadı: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "%%%s makrosunu seçenekleri sonlandırılmamış\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "%%%s makrosunun gövdesi sonlandırılmamış\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "%%%s makrosu boş\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr ""
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "%%%s makrosu genişletmede başarısız\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "%c seçeneği %s(%s) de anlaşılamadı\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "makro dosyası %s'in yüklenmesi başarısız oldu"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr ""
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c sonlandırılmamış: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Bir ayrıştırılamayan makro tarafından bir %% izlendi\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "beklenmeyen ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "beklenmeyen ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== %d etkin %d boş\n"
@@ -3826,27 +3918,27 @@ msgstr "uyarı: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr ""
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr ""
@@ -3856,17 +3948,17 @@ msgstr ""
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "bellek ayrılırken (%u bayt) NULL döndü.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr ""
 
@@ -3955,44 +4047,44 @@ msgstr "imzanın yazılması sırasında gpg hata verdi\n"
 msgid "unable to read the signature\n"
 msgstr "imza okunamadı\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr ""
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr ""
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "RPM v3 paketleri imzalanamıyor\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr ""
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: rpmWriteSignature başarısız: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr ""
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: writeLead başarısız: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr ""
@@ -4022,17 +4114,12 @@ msgstr ""
 msgid "don't verify header+payload signature"
 msgstr ""
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "%s 'in icrası başarısız (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! sadece sayılarda\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "satır: %s\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& ve || dizgelerde desteklenmez\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: satır: %s\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "satır %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: %%if'siz bir %%endif alındı\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "makro dosyası %s'in yüklenmesi başarısız oldu"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/rpm-team/rpm/language/"
 "uk/)\n"
@@ -119,10 +119,9 @@ msgid "build source package only from <specfile>"
 msgstr "зібрати за <файлом специфікації> лише пакунок з кодами"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "зібрати за <файлом специфікації> лише пакунок з кодами"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -171,12 +170,10 @@ msgstr ""
 "зібрати за <пакунком з початковими кодами> лише пакунок з початковими кодами"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
 msgstr ""
-"зібрати за <пакунком з початковими кодами> лише пакунок з початковими кодами"
 
 #: rpmbuild.c:195
 #, c-format
@@ -218,10 +215,9 @@ msgid "build source package only from <tarball>"
 msgstr "зібрати за <архівом tar> лише пакунок з кодами"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "зібрати за <архівом tar> лише пакунок з кодами"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -300,7 +296,7 @@ msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr ""
 "Параметри збирання з [ <файл spec> | <архів tar> | <пакунок з кодами> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Загальні параметри для всіх режимів та виконуваних файлів rpm:"
@@ -359,33 +355,38 @@ msgstr "Збирання для %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "аргументи параметра --root (-r) мають починатися символом /"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "ініціалізувати базу даних"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "перебудувати зворотні списки бази даних на основі заголовків встановлених "
 "пакунків"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "перевірити файли бази даних"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "ініціалізувати базу даних"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "експортувати базу даних до списку заголовків stdout"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "імпортувати базу даних зі списку заголовків stdin"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Параметри бази даних:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "можна визначати лише один основний режим"
 
@@ -409,7 +410,7 @@ msgstr "показати список ключів зі сховища ключ�
 msgid "Keyring options:"
 msgstr "Параметри сховища ключів:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "не вказано жодних параметрів"
 
@@ -588,38 +589,43 @@ msgid "delete package signatures"
 msgstr "вилучити підписи пакунка"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "не перевіряти підпис заголовка та вмісту"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Параметри підписування:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Вам слід встановити значення \"%%_gpg_name\" у вашому файлі макросу\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -651,40 +657,49 @@ msgstr "використовувати вказаний нижче формат 
 msgid "Spec options:"
 msgstr "Параметри spec:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "не вказано аргументів обробки"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Не вдалося привести до канонічної форми назву вузла: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Не вдалося відкрити файл тимчасових даних: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Не вдалося відкрити потік даних: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Виконання(%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Отримано стан виходу з помилкою від %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Не вдалося зібрати залежності:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -693,55 +708,6 @@ msgstr ""
 "\n"
 "\n"
 "Помилки збирання RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "синтаксична помилка під час обробки ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "синтаксична помилка під час обробки &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "синтаксична помилка під час обробки ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "помилка обробки у виразі\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "незакрита дужка (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- лише для чисел\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! лише для чисел\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "типи мають збігатися\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / не підтримується для рядків\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- не підтримується для рядків\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& і || не підтримуються для рядків\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "синтаксична помилка у виразі\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -839,172 +805,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Символічне посилання вказує на BuildRoot: %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "Некоректний символ «%c» (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Шлях поза межами кореневої теки збирання: %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Не знайдено каталогу: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Файл не знайдено: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Не є каталогом: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Не вдалося прочитати файл правил: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: не вдалося завантажити невідомий теґ (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: невдала спроба читання відкритого ключа.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: не є захищеним відкритим ключем.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: не вдалося закодувати\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "не вдалося створити каталог"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Назва файла має починатися з «/»: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "Не можна використовувати glob %%dev: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Не вдалося відкрити файл %%files %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "Порожній файл %%files %s\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Помилка під час спроби читання файла %%files %s: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "некоректний формат каталогу документації %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "У glob файла не виявлено: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Не можна змішувати спеціальний %s з іншими формами: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Декілька файлів у одному рядку: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Помилковий файл: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Пошук незапакованих файлів: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1013,113 +984,108 @@ msgstr ""
 "Виявлено встановлені (але не запаковані) файли:\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Обробка файлів: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr ""
 "Архітектура виконуваних файлів (%d) не збігається з архітектурою пакунка "
 "(%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Виявлено залежні від архітектури бінарні файли у пакунку noarch\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "спроба створення архіву зазнала невдачі на файлі %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "спроба створення архіву зазнала невдачі: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Не вдалося відкрити файл %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Невідомий спосіб стиснення вмісту: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Не вдалося виконати позиціювання у файлі %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Не вдалося відкрити %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Не вдалося записати пакунок: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Записано: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Виконання «%s»:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Спроба виконання «%s» зазнала невдачі.\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Спроба перевірки пакунка «%s» зазнала невдачі.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "не вдалося створити %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Не вдалося створити назву файла виведених даних для пакунка %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "рядок %d: друге %s\n"
@@ -1164,18 +1130,18 @@ msgstr "у %%changelog не вказано опису\n"
 msgid "line %d: second %%changelog\n"
 msgstr "рядок %d: другий запис %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "рядок %d: помилка під час обробки %%description: %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "рядок %d: помилковий параметр %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1231,154 +1197,154 @@ msgstr "рядок %d: помилкова кількість %s: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d визначено декілька разів\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Виключено архітектуру: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Не включено архітектуру: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "Виключено ОС: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "Не включено ОС: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "У пакунку має бути поле %s: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Дублювання записів %s у пакунку: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Не вдалося відкрити піктограму %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Не вдалося прочитати піктограму %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Невідомий тип піктограми: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "рядок %d: у тезі має бути лише один елемент: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "рядок %d: %s у %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s у %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "Некоректний символ «%c» (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "Заборонена послідовність «..»"
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "рядок %d: помилковий теґ: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "рядок %d: порожній теґ: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "рядок %d: префікси не повинні завершуватися на «/»: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "рядок %d: запис Docdir має починатися з «/»: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "рядок %d: у полі Epoch має бути вказано ціле невід’ємне число: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "рядок %d: помилкове значення %s: специфікатори: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "рядок %d: помилковий формат BuildArchitecture: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "рядок %d: передбачено підтримку лише підпакунків типу noarch: %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Внутрішня помилка: зайвий теґ %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "рядок %d: %s вважається застарілим: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Помилкова специфікація пакунка: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "рядок %d: невідомий теґ: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} не може бути порожнім\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} не може приймати значення «/»\n"
@@ -1388,12 +1354,12 @@ msgstr "%%{buildroot} не може приймати значення «/»\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Помилкове джерело: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Латки з номером %u не існує\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Джерела з номером %u не існує\n"
@@ -1403,27 +1369,27 @@ msgstr "Джерела з номером %u не існує\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Помилка під час обробки %%setup: %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "рядок %d: помилковий аргумент %%setup: %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "рядок %d: помилковий параметр %%setup %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Некоректний номер латки %s: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "рядок %d: друге %%prep\n"
@@ -1511,103 +1477,103 @@ msgstr ""
 msgid "line %d: Second %s\n"
 msgstr "рядок %d: друге %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "рядок %d: непідтримуваний вбудований скрипт: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr ""
 "рядок %d: у перемикачах не можна використовувати аргументи інтерпретатора: "
 "%s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr "Макрос розгорнуто у коментарі у рядку %d: %s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Не вдалося відкрити %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: мало бути вказано аргумент для %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "рядок %d: незавершена команда %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "рядок %d: незавершений макрос або помилкове продовження рядка\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: вказано %%else без %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "рядок %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: помилкова умова %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: помилкове форматування інструкції %%include\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "у системі не передбачено підтримки кодування %s\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Пакунок %s: некоректне кодування %s у %s: %s - %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Не знайдено сумісних архітектур для збирання\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "У пакунка немає поля %%description: %s\n"
@@ -1675,98 +1641,94 @@ msgstr "Не вказано шлях до модуля у рядку: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Забагато аргументів у рядку: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Обробка правил: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Ігноруємо некоректний формальний вираз %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Не вдалося створити канал для %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Не вдалося виконати %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Не вдалося розгалуження %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Не вдалося виконати %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "Помилка %s: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "Не вдалося записати всі дані до %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Порожній класифікатор файла\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Не вказано атрибутів файла\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "помилка magic_open(0x%x): %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "помилка magic_load: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Спроба розпізнавання файла «%s» зазнала невдачі: режим %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Пошук %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Не вдалося знайти %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Не вдалося привести до канонічної форми назву вузла: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr ""
@@ -1804,91 +1766,113 @@ msgstr ""
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s має занадто велике або занадто мале ціле значення, пропущено\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "не вдалося отримати блокування %s на %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "спільний"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "ексклюзивний"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "некоректний тип покажчика %x у %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "помилка(%d) отримання записів «%s» з покажчика %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "помилка (%d) під час спроби збереження запису «%s» до %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "помилка (%d) під час спроби вилучення запису «%s» з %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "помилка (%d) під час додавання запису заголовка №%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "помилка (%d) під час вилучення запису заголовка №%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "помилка (%d) розподілу нового екземпляра пакунка\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Не вдалося відкрити файл spec %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr ""
 "%s належить до типу Delta RPM, його не можна встановлювати безпосередньо\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Непідтримуваний вміст (%s) у пакунку %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "пакунок %s вже було додано, пропускаємо %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "пакунок %s вже було додано, замінюємо на %s\n"
@@ -1905,7 +1889,7 @@ msgstr "(не є числом)"
 msgid "(not a string)"
 msgstr "(не є рядком)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(некоректний тип)"
 
@@ -1918,146 +1902,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(не є base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(некоректний тип xml)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(не є підписом OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Некоректна дата %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "звичайний"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "замінено"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "не встановлено"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "мережевий"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "помилковий колір"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "немає"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(невідомо)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s збережено як %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s створено як %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: спроба вилучення зазнала невдачі: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "каталог"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "файл"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "завантаження заголовка: ПОМИЛКА"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "мітка області: BAD, мітка %d тип %d відступ %d кількість %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "зміщення ділянки: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "залишок ділянки: ПОМИЛКА, теґ %d тип %d зміщення %d к-ть %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "розмір заголовка(%d): ПОМИЛКА, read повернуто %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "magic заголовка: ПОМИЛКА"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "теґи заголовка: ПОМИЛКА, кількість теґів(%d) перевищує максимальну"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "дані заголовка: ПОМИЛКА, кількість байтів(%d) перевищує максимальну"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "бінарний елемент заголовка(%zd): ПОМИЛКА, read повернуто %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "pad sigh (%zd): ПОМИЛКА, прочитано %zd байтів"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "розмір бінарного об’єкта (%d): ПОМИЛКА, 8 + 16 * il(%d) + dl(%d)"
@@ -2101,43 +2085,52 @@ msgstr "неочікувана ]"
 msgid "unexpected }"
 msgstr "неочікувана }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "не вистачає ? у виразі"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "у виразі після ? слід вказати {"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "у виразі не вистачає }"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": після ? не вистачає підвиразу"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "у виразі після : слід вказати {"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "вираз має завершуватися символом |"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "ітератор масиву використано з двома масивами різної розмірності"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "рядок %d: %s вважається застарілим: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "аргументи параметра --prefix мають починатися символом /"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2685,25 +2678,25 @@ msgstr "не перевіряти залежності пакунків"
 msgid "don't execute verify script(s)"
 msgstr "не виконувати скриптів перевірки"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Для %s можливості rpmlib є недостатніми:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "слід було вказати пакунок з кодами, вказано бінарний пакунок\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "у пакунку з кодами не міститься файла .spec\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "спроба розпакування архіву завершилася невдало%s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " на файлі "
 
@@ -2754,137 +2747,137 @@ msgid "package has neither file owner or id lists\n"
 msgstr ""
 "у пакунку немає ні списку власників файлів, ні списку ідентифікаторів\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "у групі %s не міститься жодного пакунка\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "жоден з пакунків не перемикає %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "помилковий формат %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "жодне з пакунків не відповідає ключу %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "жоден з пакунків не потребує %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "жоден із пакунків не рекомендує %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "жоден із пакунків не пропонує %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "жоден із пакунків не доповнює %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "жоден із пакунків не розширює можливості %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "жоден з пакунків не надає %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "файл %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "файл %s не належить до жодного з пакунків\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "некоректний номер пакунка: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "не вдалося прочитати запис %u\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "пакунок %s не встановлено\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "невідомий теґ: «%s»\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: спроба імпортування ключа %d завершилася невдало.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: ключ %d не є захищеним відкритим ключем.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: помилка читання під час імпортування(%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "ПОМИЛКА"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "Гаразд"
 
@@ -2898,118 +2891,118 @@ msgstr "%s: помилка відкриття: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Не вдалося відкрити поточний каталог: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: не встановлено каталогу chroot\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Не вдалося змінити кореневий каталог: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Не вдалося відновити кореневий каталог: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Створення %d пропущених покажчиків, будь ласка, зачекайте…\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "не вдалося відкрити покажчик %s за допомогою %s — %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "не було встановлено шляху dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: пропущено"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "помилка (%d) збереження запису №%d до %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: помилка regexec: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: помилка regcomp: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: пропущено"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: отримано пошкоджений заголовок №%u — пропущено.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: не вдалося прочитати заголовок за адресою 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "не було встановлено шляху dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "не вдалося створити каталог %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "заголовок №%u у базі даних є помилковим — пропущено.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "не вдалося додати запис з початковим розташуванням у %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "не вдалося перебудувати базу даних: початкова база даних залишається на "
 "місці\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "не вдалося замінити стару базу даних новою!\n"
 
@@ -3104,9 +3097,8 @@ msgid "support for rich dependencies."
 msgstr "підтримка розширених залежностей."
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "підтримка розширених залежностей."
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3353,22 +3345,22 @@ msgstr "не вдалося створити блокування %s для %s (
 msgid "waiting for %s lock on %s\n"
 msgstr "очікування на блокування %s на %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Не вдалося виконати dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Спроба визначення символу %s завершилася невдало: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Додаток %%__%s_%s не налаштовано\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Модуль %s не завантажено\n"
@@ -3413,13 +3405,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "пакунок %s (який є новішим за %s) вже встановлено"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "встановлення пакунка %s потребує %<PRIu64>%cБ у файловій системі %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 "встановлення пакунка %s потребує %<PRIu64> inod-ів у файловій системі %s"
 
@@ -3544,7 +3537,7 @@ msgstr "У скрипті Lua не викликано exec() після fork()\n
 msgid "Unable to restore current directory: %m"
 msgstr "Не вдалося відновити поточний каталог: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr ""
 "підтримку допоміжних скриптів мовою <lua> не було передбачено під час "
@@ -3589,15 +3582,15 @@ msgstr "помилка допоміжного скрипту %s, стан вих
 msgid "Unknown format"
 msgstr "Невідомий формат"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "встановити"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "вилучити"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3606,96 +3599,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "не вдалося відкрити базу даних Packages у %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "зайвий символ «(» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "не вистачає «(» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "не вистачає «)» у мітці пакунка: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: спроба читання відкритого ключа завершилася невдало.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "операція"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Заголовок "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3703,19 +3696,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Не вдалося перезавантажити заголовок підпису.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "пропущено"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "невдача"
 
@@ -3756,67 +3749,155 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "синтаксична помилка під час обробки ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "синтаксична помилка під час обробки &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "синтаксична помилка під час обробки ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "рядок %d: %s у %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "у виразі після ? слід вказати {"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "помилка обробки у виразі\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "незакрита дужка (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- лише для чисел\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "вираз має завершуватися символом |"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "синтаксична помилка у виразі\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "типи мають збігатися\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / не підтримується для рядків\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- не підтримується для рядків\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(порожньо)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Не вдалося відкрити канал tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Запис параметрів макросу %%%s не завершено\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Запис макросу %%%s не завершено\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Тіло макросу %%%s є порожнім\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "У макросі %%%s мало бути використано пробіл перед текстом макросу\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Не вдалося розгорнути макрос %%%s\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "Макрос %%%s визначено, але не використано у області видимості\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Невідомий параметр %c у %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "не вдалося завантажити файл макросу %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3824,17 +3905,27 @@ msgstr ""
 "Забагато рівнів вкладеності у макросі. Ймовірно, це викликано рекурсивним "
 "оголошенням макросу.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "Не закрито %c: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "За %% вказано непридатний до обробки макрос\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "неочікувана ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "неочікувана ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "=================== активних %d порожніх %d\n"
@@ -3878,27 +3969,27 @@ msgstr "попередження: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "некоректний синтаксис у допоміжному скрипті lua: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "некоректний синтаксис у скрипті lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "помилка скрипту lua: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "некоректний синтаксис у файлі lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "помилка виклику lua: %s\n"
@@ -3909,17 +4000,17 @@ msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr ""
 "у відповідь на спробу отримання області пам’яті (%u байтів) повернуто NULL.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, ід. ключа %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(нічого)"
 
@@ -4008,44 +4099,44 @@ msgstr "gpg не вдалося записати підпис\n"
 msgid "unable to read the signature\n"
 msgstr "не вдалося прочитати підпис\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: помилка rpmReadSignature: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: помилка headerRead: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Підписування пакунків RPM версії 3 неможливе\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s вже містить ідентичний підпис, пропускаємо\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: помилка rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "помилка rpmMkTemp\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: помилка writeLead: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "спроба заміни %s зазнала невдачі: %s\n"
@@ -4075,23 +4166,20 @@ msgstr "%s: помилка читання маніфесту: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "не перевіряти підпис заголовка та вмісту"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Не вдалося виконати %s (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! лише для чисел\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Помилка під час спроби виконання допоміжного скрипту %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& і || не підтримуються для рядків\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "рядок: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Помилка під час спроби читання файла %%files %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: рядок: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Не вдалося відкрити файл %s: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "У файлі spec немає теґу \"Source:\"\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "рядок %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d: вказано %%endif без %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "не вдалося завантажити файл макросу %s"

--- a/po/vi.po
+++ b/po/vi.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2017-10-13 05:51+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2017-10-13 05:51-0400\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/rpm-team/rpm/language/"
 "vi/)\n"
@@ -122,10 +122,9 @@ msgid "build source package only from <specfile>"
 msgstr "xây dựng chỉ gói nguồn từ <tập_tin_đặc_tả>"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "xây dựng chỉ gói nguồn từ <tập_tin_đặc_tả>"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -171,11 +170,10 @@ msgid "build source package only from <source package>"
 msgstr "chỉ xây dựng gói nguồn từ <gói nguồn>"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "chỉ xây dựng gói nguồn từ <gói nguồn>"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -219,10 +217,9 @@ msgid "build source package only from <tarball>"
 msgstr "xây dựng chỉ gói nguồn từ <kho_tar>"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "xây dựng chỉ gói nguồn từ <kho_tar>"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -299,7 +296,7 @@ msgstr "có quyền cao hơn nền tảng đích"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "Tùy chọn xây dựng với [ <tập_tin_đặc_tả> | <kho_tar> | <gói nguồn> ]:"
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "Các tùy chọn chung với mọi chế độ và tập tin thực hiện được kiểu rpm:"
@@ -358,33 +355,38 @@ msgstr "Đang xây dựng cho nền tảng đích %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "đối số của “--root” (-r) phải bắt đầu với dấu sổ chéo “/”"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "khởi tạo cơ sở dữ liệu"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr ""
 "xây dựng lại các danh sách nghịch chuyển cơ sở dữ liệu từ các phần đầu gói "
 "được cài đặt"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "thẩm tra các tập tin cơ sở dữ liệu"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "khởi tạo cơ sở dữ liệu"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "xuất cơ sở dữ liệu ra danh sách phần đầu đầu ra tiêu chuẩn"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "nhập cơ sở dữ liệu từ danh sách phần đầu đầu vào tiêu chuẩn"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "Tùy chọn cơ sở dữ liệu:"
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "chỉ có thể đưa ra một chế độ chính"
 
@@ -408,7 +410,7 @@ msgstr "liệt kê các khóa từ chùm chìa khóa RPM"
 msgid "Keyring options:"
 msgstr "Tùy chọn chùm chìa khóa:"
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "chưa đưa ra đối số"
 
@@ -604,38 +606,43 @@ msgid "delete package signatures"
 msgstr "xóa chữ ký của gói"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "không nên thẩm tra chữ ký phần_đầu+trọng_tải"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr ""
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr ""
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr ""
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr ""
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "Tùy chọn chữ ký:"
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "Bạn phải đặt \"%%_gpg_name\" trong tập tin vĩ lệnh\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr ""
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr ""
 
@@ -667,40 +674,49 @@ msgstr "dùng định dạng truy vấn theo đây"
 msgid "Spec options:"
 msgstr "Tùy chọn đặc tả:"
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "chưa đưa ra đối số để phân tích"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "Không thể làm hợp quy tắc tên máy: %s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "Không thể mở tập tin tạm: %s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "Không thể mở luồng dữ liệu: %s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "Đang thực hiện (%s): %s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "Trạng thái thoát sai từ %s (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "Gặp lỗi khi xây dựng các thành phần phụ thuộc:\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr ""
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -709,55 +725,6 @@ msgstr ""
 "\n"
 "\n"
 "Lỗi xây dựng RPM:\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "gặp lỗi cú pháp khi phân tích ==\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "gặp lỗi cú pháp khi phân tích &&\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "gặp lỗi cú pháp khi phân tích ||\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "gặp lỗi phân tích trong biểu thức\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "có dấu ngoặc mở “(” lẻ đôi\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- chỉ với con số\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! chỉ với con số\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "các kiểu phải tương ứng\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / không được hỗ trợ cho chuỗi\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- không được hỗ trợ cho chuỗi\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& và || không được hỗ trợ cho chuỗi\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "gặp lỗi cú pháp trong biểu thức\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -853,172 +820,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "Liên kết mềm chỉ tới BuildRoot (gốc xây dựng): %s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "ký tự không hợp lệ “%c” (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "Đường dẫn nằm ngoài buildroot (gốc xây dựng): %s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "Không tìm thấy thư mục: %s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "Không tìm thấy tập tin: %s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "Không phải là một thư mục: %s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "Gặp lỗi khi đọc tập tin chính sách: %s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s: không thể nạp thẻ bất thường (%d).\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s: gặp lỗi khi đọc khóa công.\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: không phải là khóa công dạng văn bản.\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s: gặp lỗi khi giải mã\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr ""
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "gặp lỗi khi tạo thư mục"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "Tập tin cần có dấu sổ chéo “/” đi trước: %s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "không cho phép %%dev glob: %s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "Không thể mở tập tin %%files %s: %m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "Tập tin %%files trống rỗng %s\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "Gặp lỗi khi đang đọc tập tin %%files %s: %m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "_docdir_fmt không hợp lệ %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "Glob (chức năng mở rộng mẫu khi tìm kiếm) không tìm thấy tập tin: %s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "Không thể trộn lẫn %s đặc biệt với dạng khác: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "Nhiều hơn một tập tin mỗi dòng: %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "Tập tin sai: %s: %s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "Đang kiểm tra có tập tin chưa đóng gói: %s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -1027,111 +999,106 @@ msgstr ""
 "Tìm thấy tập tin đã cài đặt (nhưng chưa đóng gói):\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "Đang xử lý tập tin: %s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "Kiến trúc nhị phân (%d) không khớp với kiến trúc gói (%d).\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "Nhị phân phụ thuộc kiến trúc trong gói không phụ thuộc kiến trúc\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "tiến trình tạo kho nén bị lỗi với tập tin %s: %s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "tiến trình tạo kho nén bị lỗi: %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "Không thể mở tập tin %s: %s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "Không thể nén phần trọng tải: %s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "Không thể di chuyển vị trí đọc trong tập tin %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Không thể mở %s: %s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "Không thể ghi gói: %s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "Đã ghi: %s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "Thực hiện %s:\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "Việc thực hiện %s bị lỗi\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "Gặp lỗi khi kiểm tra “%s”.\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "không thể tạo %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "Không thể tạo tên tập tin kết xuất cho gói %s: %s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "dòng %d: %s thứ hai\n"
@@ -1176,18 +1143,18 @@ msgstr "không có mô tả trong bản ghi thay đổi (%%changelog)\n"
 msgid "line %d: second %%changelog\n"
 msgstr "dòng %d: %%changelog thứ hai\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "dòng %d: Gặp lỗi khi phân tích mô tả (%%description): %s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "dòng %d: Tùy chọn sai %s: %s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1243,155 +1210,155 @@ msgstr "dòng %d: Số %s sai: %s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d được xác định nhiều lần\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "Kiến trúc bị loại trừ: %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "Kiến trúc không được bao gồm: %s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "Hệ điều hành bị loại trừ: %s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "Hệ điều hành không được bao gồm: %s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "Trường %s phải nằm trong gói: %s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "Mục nhập %s trùng trong gói: %s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "Không thể mở biểu tượng %s: %s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "Không thể đọc biểu tượng %s: %s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Không hỗ trợ kiểu biểu tượng: %s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "dòng %d: Thẻ chấp nhận chỉ một hiệu bài: %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "dòng %d: %s trong: %s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s trong: %s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "ký tự không hợp lệ “%c” (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "chuỗi không hợp lệ \"..\""
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "dòng %d: Thẻ dạng sai: %s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "dòng %d: Thẻ rỗng: %s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "dòng %d: Tiền tố không nên kết thúc với dấu sổ chéo “/”: %s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr ""
 "dòng %d: Docdir (thư mục tài liệu) phải bắt đầu với dấu sổ chéo “/”: %s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "dòng %d: trường Epoch (Kỷ nguyên) phải là con số không dấu: %s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "dòng %d: %s sai: điều kiện: %s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "dòng %d: định dạng BuildArchitecture (kiến trúc xây dựng) sai: %s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "dòng %d: Chỉ hỗ trợ gói phụ kiểu “noarch” (không có kiến trúc): %s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "Lỗi nội bộ: Thẻ giả %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "dòng %d: không tán thành %s: %s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "Đặc tả gói sai: %s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "dòng %d: Không rõ thẻ: %s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} không thể là rỗng\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} không thể là \"/\"\n"
@@ -1401,12 +1368,12 @@ msgstr "%%{buildroot} không thể là \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "Nguồn sai: %s: %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "Không có miếng và số %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "Không có số nguồn %u\n"
@@ -1416,27 +1383,27 @@ msgstr "Không có số nguồn %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "Lỗi phân tích thiết lập (%%setup): %s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "dòng %d: Đối số sai tới thiết lập (%%setup): %s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "dòng %d: Tùy chọn thiết lập (%%setup) sai %s: %s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "Miếng và sô %s không hợp lệ: %s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "dòng %d: chuẩn bị (%%prep) thứ hai\n"
@@ -1524,101 +1491,101 @@ msgstr "dòng %d: Ưu tiên chỉ cho phép với các bẫy tập tin: %s\n"
 msgid "line %d: Second %s\n"
 msgstr "dòng %d: %s thứ hai\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "dòng %d: văn lệnh nội bộ không được hỗ trợ: %s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "dòng %d: phiên dịch tham số không được phép trong bẫy: %s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr "Vĩ lệnh được khai triển trong phần ghi chú trên dòng %d: %s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "Không thể mở %s: %s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d: Cần đối số cho %s\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "dòng %d: Chưa đóng %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "dòng %d: chưa đóng vĩ lệnh hoặc dòng kéo dài sai\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d: Có một toán tử %%else (nếu không) mà không có %%if (nếu)\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "dòng %d: %s: %s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d: điều kiện %%if sai\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d: câu lệnh bao gồm (%%include) sai dạng\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "bảng mã %s không được hệ thống hỗ trợ\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "Gói %s: bảng mã %s không hợp lệ trong %s: %s - %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "Không tìm thấy kiến trúc tương thích để xây dựng\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "Gói không có mô tả (%%description): %s\n"
@@ -1686,98 +1653,94 @@ msgstr "Thiếu đường dẫn mô-đun trong dòng: %s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "Quá nhiều đối số trong dòng: %s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "Thực hiện các chính sách: %s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "Bỏ qua biểu thức chính quy không hợp lệ %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "Không thể tạo ống dẫn cho %s: %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "Không thể thực hiện %s: %s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "Không thể tạo tiến trình con %s: %s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "Không thể thực hiện %s: %s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s bị lỗi: %x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "gặp lỗi khi toàn bộ dữ liệu vào %s: %s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "Phân loại tập tin trống rỗng\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "Chưa có các thuộc tính tập tin được cấu hình\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) bị lỗi: %s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load gặp lỗi: %s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "Gặp lỗi khi chấp nhận tập tin \"%s\": chế độ %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "Đang tìm  %s: %s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "Gặp lỗi khi tìm %s:\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "Không thể làm hợp quy tắc tên máy: %s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "lỗi truy vấn tập tin đặc tả %s nên không phân tích được\n"
@@ -1812,90 +1775,112 @@ msgstr "%s có giá trị dài quá lớn hoặc quá nhỏ nên bỏ qua\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s có giá trị nguyên quá lớn hoặc quá nhỏ nên bỏ qua\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "không thể lấy khóa %s ở %s/%s\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "chung"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "độc quyền"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "kiểu bảng mục mục không hợp lệ %x trên %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "gặp lỗi (%d) khi lấy bản ghi \"%s\" từ chỉ mục %s: %s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "gặp lỗi (%d) khi ghi bản ghi %s vào %s\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "Gặp lỗi (%d) khi gỡ bỏ bản ghi “%s” ra khỏi %s\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "lỗi (%d) khi thêm bản ghi phần đầu #%d\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "lỗi (%d) khi gỡ bỏ bản ghi phần đầu #%d\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "lỗi (%d) phân bỏ minh dụ gói mới\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "Không thể mở tập tin đặc tả %s: %s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s là một Delta RPM và không thể được cài đặt trực tiếp\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "Không hỗ trợ phần tải (%s) trong gói %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "gói %s đã được thêm vào nên bỏ qua %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "gói %s đã được thêm vào nên thay thế bằng %s\n"
@@ -1912,7 +1897,7 @@ msgstr "(không phải con số)"
 msgid "(not a string)"
 msgstr "(không phải chuỗi)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(kiểu không hợp lệ)"
 
@@ -1925,146 +1910,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %d %b %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(không phải base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(kiểu XML không hợp lệ)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(không phải chữ ký OpenPGP)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "Ngày không hợp lệ %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "thông thường"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "đã thay thế"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "chưa cài đặt"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "chia sẻ qua mạng"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "màu sai"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "thiếu"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(không hiểu)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s được lưu dạng %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s được tạo dạng %s\n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s: gặp lỗi khi gỡ bỏ: %s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "thư mục"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "tập tin"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "tải hdr: SAI"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "thẻ vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "bù vùng: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "vùng theo đuôi: SAI, thẻ %d kiểu %d bù %d số lượng %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "kích cỡ hdr (%d): SAI, hàm đọc đã trả về %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "ma thuật hdr: SAI"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "thẻ hdr: SAI, tổng số thẻ (%d) ở ngoài phạm vi"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "dữ liệu hdr: SAI, tổng số byte (%d) ở ngoài phạm vi"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "hdr blob(%zd): SAI, việc đọc trả về %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "đệm sigh(%zd): SAI, đọc %zd byte"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "kích cỡ blob (%d): SAI, 8 + 16 * il(%d) + dl(%d)"
@@ -2108,43 +2093,52 @@ msgstr "gặp dấu ngoặc vuông đóng “]” bất thường"
 msgid "unexpected }"
 msgstr "gặp dấu ngoặc móc đóng “}” bất thường"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "cần dấu hỏi “?” trong biểu thức"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "cần dấu ngoặc móc mở “{” sau dấu hỏi “?” trong biểu thức"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "cần dấu ngoặc móc đóng “}” trong biểu thức"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr "cần dấu hai chấm “:” theo sau biểu thức phụ dấu hỏi “?”"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "cần dấu ngoặc móc mở “{” sau dấu hai chấm “:” trong biểu thức"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "cần ký hiệu ống dẫn “|” ở kết thúc của biểu thức"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "đồ lặp lại mảng được sử dụng với các mảng có kích cỡ khác nhau"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "dòng %d: không tán thành %s: %s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "đối số cho “--prefix” (tiền tố) phải bắt đầu với dấu sổ chéo “/”"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2690,25 +2684,25 @@ msgstr "không thẩm tra các quan hệ phụ thuộc của gói"
 msgid "don't execute verify script(s)"
 msgstr "không chạy văn lệnh thẩm tra"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "Thiếu tính năng rpmlib cho %s:\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "cần gói nguồn còn tìm thấy gói nhị phân\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "gói nguồn không chứa tập tin đặc tả\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "lỗi giải nén kho %s%s: %s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr " ở tập tin"
 
@@ -2758,137 +2752,137 @@ msgstr "gói không có danh sách nhóm/chủ tập tin\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "gói không có người sở hữu tập tin cũng không có danh sách mã số\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "nhóm %s không chứa gói\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "không có bộ gây nên gói %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "dạng sai %s: %s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "không có gói tương ứng với %s: %s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "không có gói cần thiết %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "không có gói nào khuyến nghị %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "không gói nào gợi ý %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "không có gói nào cung  %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "không có gói nào tăng cường %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "không có gói cung cấp %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "tập tin %s: %s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "tập tin %s không được bất kỳ gói sở hưu\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "số thứ tự gói không hợp lệ: %s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "không thể đọc mục ghi %u\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "chưa cài đặt gói %s\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "không hiểu thẻ: “%s”\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s: gặp lỗi khi nhập khóa %d.\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s: khóa %d không phải là khóa công dạng văn bản.\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s: lỗi đọc khi nhập (%d).\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "KHÔNG_ĐƯỢC"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "OK"
 
@@ -2902,118 +2896,118 @@ msgstr "%s: gặp lỗi khi mở: %s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "Không thể mở thư mục làm việc hiện thời: %m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s: thư mục đổi gốc chưa đặt\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "Không thể chuyển đổi thư mục gốc: %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "Không thể phục hồi thư mục gốc: %m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "Đang tạo %d thiếu mục lục, vui lòng chờ…\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "không thể mở bảng mục lục %s dùng %s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "chưa đặt đường dẫn cơ sở dữ liệu (dbpath)\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader: bỏ qua"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "gặp lỗi (%d) khi lưu bản ghi #%d vào %s\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec (thực hiện biểu thức chính quy) bị lỗi: %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp bị lỗi: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator: bỏ qua"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb: nhận được phần đầu bị hỏng #%u -- bỏ qua.\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s: không thể đọc phần đầu ở 0x%x\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "chưa đặt đường dẫn cơ sở dữ liệu (dbpath)"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "gặp lỗi khi tạo thư mục %s: %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "phần đầu #%u trong cơ sở dữ liệu là sai -- bỏ qua.\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "không thể thêm bản ghi nguyên gốc tại %u\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr ""
 "gặp lỗi khi xây dựng lại cơ sở dữ liệu: cơ sỏ dữ liệu nguyên gốc được giữ "
 "lại để thay thế\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "gặp lỗi khi thay thế cơ sở dữ liệu cũ bằng cái mới!\n"
 
@@ -3108,9 +3102,8 @@ msgid "support for rich dependencies."
 msgstr "hỗ trợ cho các phần phục thuộc dồi dào"
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "hỗ trợ cho các phần phục thuộc dồi dào"
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3357,22 +3350,22 @@ msgstr "không thể tạo khóa %s trên %s (%s)\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "đang đợi %s khóa %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "Gặp lỗi khi dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "Gặp lỗi khi phân giải ký hiệu %s: %s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "Chưa cấu hình phần bổ xung %%__%s_%s\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "Phần bổ xung %s chưa được tải\n"
@@ -3417,13 +3410,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "gói %s (mới hơn %s) đã được cài đặt"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "việc cài đặt %s cần %<PRIu64>%cB trên hệ thống tập tin %s"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr "việc cài đặt %s cần %<PRIu64> nút trên hệ thống tập tin %s"
 
 #: lib/rpmprob.c:159
@@ -3547,7 +3541,7 @@ msgstr "Không có lệnh gọi exec() sau fork() trong lua scriptlet\n"
 msgid "Unable to restore current directory: %m"
 msgstr "Không thể phục hồi thư mục hiện tại: %m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "chưa hỗ trợ <lua> scriptlet dựng sẵn\n"
 
@@ -3590,15 +3584,15 @@ msgstr "%s scriptlet gặp lỗi, trạng thái thoát %d\n"
 msgid "Unknown format"
 msgstr "Không hiểu định dạng"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "cài đặt"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "tẩy"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3607,96 +3601,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "không thể mở cơ sở dữ liệu Gói trong %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "thừa “(” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "thiếu “(” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "thiếu “)” trong nhãn gói: %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s: gặp lỗi khi đọc khóa công khai.\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "giao dịch"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "Phần đầu"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3704,19 +3698,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "Không thể nạp lại phần đầu chữ ký.\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "bị bỏ qua"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "gặp lỗi"
 
@@ -3757,68 +3751,156 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "gặp lỗi cú pháp khi phân tích ==\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "gặp lỗi cú pháp khi phân tích &&\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "gặp lỗi cú pháp khi phân tích ||\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "dòng %d: %s trong: %s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "cần dấu ngoặc móc mở “{” sau dấu hỏi “?” trong biểu thức"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "gặp lỗi phân tích trong biểu thức\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "có dấu ngoặc mở “(” lẻ đôi\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- chỉ với con số\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "cần ký hiệu ống dẫn “|” ở kết thúc của biểu thức"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "gặp lỗi cú pháp trong biểu thức\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "các kiểu phải tương ứng\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / không được hỗ trợ cho chuỗi\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- không được hỗ trợ cho chuỗi\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s (trống)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "Gặp lỗi khi mở đường ống tar: %m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "Vĩ lệnh %%%s có tùy chọn chưa chấm dứt\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "Vĩ lệnh %%%s có thân chưa chấm dứt\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "Vĩ lệnh %%%s có thân rỗng\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "Vĩ lệnh %%%s cần có dấu cách trước phần thân\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "Vĩ lệnh %%%s không mở rộng được\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr ""
 "Vĩ lệnh %%%s được định nghĩa nhưng lại không được dùng trong phạm vi của nó\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "Không hiểu tùy chọn %c trong %s(%s)\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "gặp lỗi khi tải tập tin vĩ lệnh %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
@@ -3826,17 +3908,27 @@ msgstr ""
 "Quá nhiều mức đệ quy trong khai triển vĩ lệnh. Nó giống như là có nguyên "
 "nhân bởi khai báo vĩ lệnh đệ quy.\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "%c chưa chấm dứt: %s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "Một dấu %% đi trước một vĩ lệnh không thể phân tích được\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "gặp dấu ngoặc vuông đóng “]” bất thường"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "gặp dấu ngoặc vuông đóng “]” bất thường"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== hoạt động %d trống %d\n"
@@ -3880,27 +3972,27 @@ msgstr "cảnh báo: "
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "có lỗi cú pháp trong lua scriptlet: %s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "cú pháp không hợp lệ trong văn lệnh lua: %s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "gặp lỗi khi thực thi văn lệnh lua: %s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "cú pháp không hợp lệ trong tập tin Lua: %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Lỗi kích hoạt khả năng Lua: %s\n"
@@ -3910,17 +4002,17 @@ msgstr "Lỗi kích hoạt khả năng Lua: %s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "cấp phát bộ nhớ (%u byte) trở về VÔ GIÁ TRỊ.\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, Mã số khóa %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(không có)"
 
@@ -4011,44 +4103,44 @@ msgstr "gpg không ghi được chữ ký\n"
 msgid "unable to read the signature\n"
 msgstr "không thể đọc chữ ký\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s: rpmReadSignature gặp lỗi: %s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: gặp lỗi khi headerRead: %s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "Không thể ký gói RPM v3\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s đã sẵn chứa chữ ký định danh nên bỏ qua\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s: gặp lỗi khi rpmWriteSignature: %s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "gặp lỗi khi rpmMkTemp\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s: Gặp lỗi khi writeLead: %s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "gặp lỗi khi thay thế %s: %s\n"
@@ -4078,24 +4170,20 @@ msgstr "%s: gặp lỗi khi đọc manifest: %s\n"
 msgid "don't verify header+payload signature"
 msgstr "không nên thẩm tra chữ ký phần_đầu+trọng_tải"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "Gặp lỗi khi thực thi %s (%s): %s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! chỉ với con số\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "Gặp lỗi khi thực thi scriptlet %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& và || không được hỗ trợ cho chuỗi\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "dòng: %s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "Gặp lỗi khi đang đọc tập tin %%files %s: %m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: dòng: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "Không thể mở tập tin %s: %s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "Không có thẻ \"Source:\" trong tập tin đặc tả\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "dòng %d: %s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr ""
-#~ "%s:%d: Có một toán tử %%endif (kết thúc nếu) mà không có %%if (nếu)\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "gặp lỗi khi tải tập tin vĩ lệnh %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2018-11-08 09:09+0000\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2018-11-08 09:09-0500\n"
 "Last-Translator: Taiki Akita <taiki_akita@163.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/rpm-team/rpm/"
 "language/zh_CN/)\n"
@@ -131,10 +131,9 @@ msgid "build source package only from <specfile>"
 msgstr "依据 <specfile> 构建源代码软件包"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "依据 <specfile> 构建源代码软件包"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -174,11 +173,10 @@ msgid "build source package only from <source package>"
 msgstr "仅从 <source package> 中构建源代码 RPM 包"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "仅从 <source package> 中构建源代码 RPM 包"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -216,10 +214,9 @@ msgid "build source package only from <tarball>"
 msgstr "依据 <tarball> 构建源代码软件包"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "依据 <tarball> 构建源代码软件包"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -296,7 +293,7 @@ msgstr "重载目标平台"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "适用于 [ <specfile> | <tarball> | <source package> ] 的构建选项："
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "所有 rpm 模式和可执行文件的通用选项："
@@ -355,31 +352,36 @@ msgstr "为目标%s构建\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的参数必须以 / 开头"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "初始化数据库"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "从已安装软件包包头重建数据库反向列表"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "校验数据库文件"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "初始化数据库"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "将数据库导出到标准输出头列表"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "从标准输入头列表导入数据库"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "数据库选项："
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "仅能指定一个主模式"
 
@@ -403,7 +405,7 @@ msgstr "列出RPM密钥环中的密钥"
 msgid "Keyring options:"
 msgstr "密钥环选项："
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "没有指定参数"
 
@@ -568,38 +570,43 @@ msgid "delete package signatures"
 msgstr "删除软件包签名"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "不验证报头+净负荷签名"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr "签署一个或多个包文件"
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr "使用 <key> 作为签名密钥"
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr "<key>"
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr "当需要输入签名密钥的密码时显示提示"
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "签名选项："
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "你必须在你的宏文件中设置 \"%%_gpg_name\" \n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr "您必须在宏文件中或通过 --fskpath 参数设置 \"%%_file_signing_key\"\n"
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr "--fskpath 参数只能在签名时使用"
 
@@ -631,40 +638,49 @@ msgstr "使用这种格式打印信息"
 msgid "Spec options:"
 msgstr "Spec 选项："
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "没有给出参数用于分析"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr ""
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "无法正规化主机名：%s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "无法打开临时文件：%s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "无法打开流：%s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "正在执行(%s)：%s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "%s (%s) 退出状态不好\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "构建依赖失败：\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr "设置 %s=%s\n"
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -673,55 +689,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM 构建错误：\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "== 语法解析错误\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "&& 语法解析错误\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "解析 || 时有语法错误\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "表达式解析错误\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "不匹配的 (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- 只用于数字\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! 只用于数字\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "类型必须匹配\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "* / 不支持字符串\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "- 不支持字符串\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "&& 和 || 不支持字符串\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "表达式语法错误\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -817,172 +784,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "符号链接指向了 BuildRoot：%s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "无效字符 '%c' (0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "路径在 buildroot 之外：%s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "没有找到目录：%s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "没有找到文件：%s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "此路径不是一个目录：%s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "无法读取策略文件：%s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：无法加载未知标签(%d)。\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公钥读取失败。\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s: 不是带装甲的(armored)公钥。\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：编码失败\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr "无法创建符号连接"
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr ""
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr ""
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr ""
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr ""
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr ""
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr ""
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr ""
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr ""
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "创建目录失败"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr ""
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "文件需要 \"/\" 开头：%s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob 不被允许：%s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr ""
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "无法打开 %%files 文件 %s：%m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "空 %%file 文件 %s\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "读取 %%files 文件 %s 失败：%m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "无法通过通配符查找文件：%s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr ""
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "特殊 %s 与其他形式不能混合使用: %s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一行中有多个文件： %s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr ""
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "损坏的文件：%s：%s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "检查未打包文件：%s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -991,111 +963,106 @@ msgstr ""
 "发现已安装(但未打包的)文件：\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr ""
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "处理文件：%s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二进制架构 (%d) 和软件包构架 (%d)不匹配。\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 软件包中有架构相关的二进制文件\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "对此文件创建归档失败 %s：%s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "创建归档失败： %s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "不能打开文件 %s：%s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "未知的净负荷压缩：%s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "无法 seek 文件 %s：%s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr ""
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr ""
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "无法打开 %s：%s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "无法写入软件包：%s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已写至：%s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在执行 \"%s\"：\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr " \"%s\" 执行失败。\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "软件包检查 \"%s\" 失败。\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "无法创建 %s: %s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "无法为软件包 %s 生成输出文件名：%s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "行 %d：第二个 %s\n"
@@ -1140,18 +1107,18 @@ msgstr "%%changelog 中没有描述\n"
 msgid "line %d: second %%changelog\n"
 msgstr "行 %d: 第二个 %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "行 %d：解析 %%description 时发生错误：%s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "行 %d：错误的选项 %s：%s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1207,154 +1174,154 @@ msgstr "行 %d：错误的 %s 数字：%s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d 定义了许多次\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "系统结构被排除了： %s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "不包含体系统结构：%s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "被排除的操作系統：%s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "操作系统未包含：%s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s 字段必须在软件包中存在：%s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "%s 條目在软件包中重复：%s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "无法打开图标 %s：%s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "无法读取图标 %s：%s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "未知的图标格式：%s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "行 %d：标签只需要一个令牌： %s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "行 %d：%s 位于：%s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s 位于：%s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "无效字符 '%c' (0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr ""
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "非法序列“..”"
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "行 %d：有缺陷的标签：%s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "行 %d：空的标签：%s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "行 %d：前缀不能以 “/” 结尾：%s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "行 %d：Docdir 必须以 “/\" 開頭：%s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "行 %d：Epoch 标签必须是无符号数：%s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "行 %d：错误的 %s：限定符：%s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "行 %d：错误的 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr ""
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "行 %d：只能支持noarch的子包：%s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "内部错误：虚假标签 %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "行 %d： %s 不建议使用：%s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "有问题的软件包规范：%s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr ""
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "行 %d：未知标签：%s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不能为空\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不能为 \"/\"\n"
@@ -1364,12 +1331,12 @@ msgstr "%%{buildroot} 不能为 \"/\"\n"
 msgid "Bad source: %s: %s\n"
 msgstr "问题来源： %s： %s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "没有 %u 补丁\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "没有 %u 源码\n"
@@ -1379,27 +1346,27 @@ msgstr "没有 %u 源码\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "解析 %%setup 时发生错误：%s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "行 %d：%%setup 中存在坏的参数：%s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "行 %d：错误的 %%setup 选项 %s：%s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s：%s：%s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "无效的补丁编号 %s：%s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "行 %d：第二个 %%prep\n"
@@ -1484,101 +1451,101 @@ msgstr "行 %d：仅文件触发器中允许使用优先级：%s\n"
 msgid "line %d: Second %s\n"
 msgstr "列 %d：第二个 %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "行 %d：不支持的内部脚本：%s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr ""
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "行 %d：触发器中不允许使用解释器参数：%s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
 msgstr "展开行 %d 注释中的宏：%s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "不能打开 %s：%s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s：%d：%s 需要参数\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "行 %d：未结束的 %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr "行 %d：宏未闭合，或换行文本出错\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s：%d：有一个 %%else 没有对应的 %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "行 %d：%s：%s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s：%d：%%if 条件句有误\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s：%d：%%include 语句格式错误\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr "系统不支持编码 %s\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "软件包 %s：无效的 %s 编码于 %s：%s - %s\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr ""
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "没有找到可供构建的兼容构架\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "软件包没有 %%description：%s\n"
@@ -1644,98 +1611,94 @@ msgstr "缺少的模块路径存在于： %s \n"
 msgid "Too many arguments in line: %s\n"
 msgstr "此行存在过多参数：%s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "处理策略：%s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略无效的正则表达式 %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "无法为 %s建立管道： %m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "无法执行%s：%s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "无法抽取分支 %s：%s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "无法执行%s：%s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失败：%x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "无法写入所有的数据到 %s：%s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "空文件分类\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "没有配置文件属性\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失败：%s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失败：%s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "文件 \"%s\" 辨识失败：模式 %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在查找 %s：%s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "查找 %s 失败：\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr ""
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr ""
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr ""
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr ""
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "无法正规化主机名：%s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "查询 spec 文件 %s 失败，无法解析\n"
@@ -1770,92 +1733,114 @@ msgstr "%s 有过大或者是过小的 long 数值，忽略\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s 有过大或者是过小的整数值，忽略\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "无法取得 %s 位于 %s/%s 的锁定\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "已共享"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "无效的索引类型 %x 于 %s/%s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr ""
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr ""
 "添加表头 #%d 记录时出错 (%d)\n"
 "\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "移除表头 #%d 记录时出错 (%d)\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "在分配新软件包进程时出错 (%d)\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
-#, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+#: lib/backend/ndb/glue.c:101
+msgid "Detected outdated index databases\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/glue.c:103
+msgid "Rebuilding outdated index databases\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmidx.c:204
+#, c-format
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "无法打开 spec 文件 %s：%s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 是一个 Delta RPM 并且无法直接被安装。\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr ""
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "软件包 %s 已被加入，跳过 %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "软件包 %s 已被加入，以 %s 替换\n"
@@ -1872,7 +1857,7 @@ msgstr "(不是数字)"
 msgid "(not a string)"
 msgstr "(不是字符串)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(无效类型)"
 
@@ -1885,146 +1870,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%a %b %d %Y"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(非base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(无效的xml 类型)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(不是OpenPGP 签名)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "无效日期%u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "正常"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "已被替换"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "未安装"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "网络共享"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "错误颜色"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "丢失"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(未知)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已另存为 %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立为 %s \n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s：移除失败：%s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "目录"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "文件"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr ""
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "头部载入：不当"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr ""
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "区域标签：不当，标记 %d 类型 %d 偏移 %d 计数 %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "区域偏移：不当，标记 %d 类型 %d 偏移 %d 计数 %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "区域结尾：不当，标记 %d 类型 %d 偏移 %d 计数 %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr ""
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "头部大小(%d)：不当，读取返回 %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "头部幻数：不当"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "头部标记：不当，标记(%d)的号码超出范围"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "头部数据：不当，字节(%d)的号码超出范围"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "头部 blob(%zd)：不当，读取返回 %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "sigh 填充(%zd)：不当，读取 %zd 字节"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr ""
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "blob 大小(%d)：不当，8 + 16 * il(%d) + dl(%d)"
@@ -2068,43 +2053,52 @@ msgstr "未预期的 ]"
 msgid "unexpected }"
 msgstr "未预期的 }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? 预期于表达式中"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr ""
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} 预期在表达式中"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ""
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr ""
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| 预期于表达式结尾"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "使用不同大小数组的数组的迭代器"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "行 %d： %s 不建议使用：%s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "--prefix 参数必须用 / 开始"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2644,25 +2638,25 @@ msgstr "不验证包依赖"
 msgid "don't execute verify script(s)"
 msgstr "不执行验证脚本"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr " %s 缺失rpmlib的特性\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "期望源代码包，但找到二进制包\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "源代码包中没有找到 .spec 文件\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解压压缩文件 %s%s 失败：%s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr "  在文件"
 
@@ -2712,137 +2706,137 @@ msgstr "软件包中没有文件的所有者/群组列表\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "软件包中也不没有文件的所有者或者是 id 列表\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "没有找到属于 %s 组的软件包\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "没有软件包触发器 %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "格式不对 %s：%s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "没有软件包和 %s 匹配：%s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "没有软件包需要 %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "没有推荐安装 %s 的软件包\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "没有建议安装 %s 的软件包\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "没有提供 %s 的软件包\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "没有用于增强 %s 的软件包\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "没有软件包提供 %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "文件 %s：%s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "文件 %s 不属于任何软件包\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "无效的软件包编号：%s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "记录 %u 不能读取\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "未安装软件包 %s \n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "未知标签：\"%s\"\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s：导入密钥 %d 失败。\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：公钥 %d  不受到保护。\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：导入读取时失败(%d)。\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr ""
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr ""
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr ""
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "不正确"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "确定"
 
@@ -2856,116 +2850,116 @@ msgstr "%s：打开失败：%s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "无法打开当前目录：%m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s：没有设置 chroot 目录\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "无法更改根目录： %m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "无法恢复根目录：%m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr ""
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr ""
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "没有设置 dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳过"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s: regexec 函数执行失败： %s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s: regcomp 函数执行失败: %s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳过"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：获取到损坏表头 #%u -- 跳过此项。\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：无法读取位于 0x%x 的表头\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr ""
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr ""
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr ""
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "没有设置 dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "無法建立 %s 目录： %s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr ""
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "无法加入原本位于 %u 的记录\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建数据库失败：原始数据库仍保持原状\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "用新的数据库取代旧的数据库失败！\n"
 
@@ -3054,9 +3048,8 @@ msgid "support for rich dependencies."
 msgstr "富依赖关系支持"
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "富依赖关系支持"
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3303,22 +3296,22 @@ msgstr "无法创建 %s 锁定于 %s (%s) \n"
 msgid "waiting for %s lock on %s\n"
 msgstr "正在等候 %s 锁定 %s\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "dlopen 失败 %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "解析符号 %s 失败：%s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "插件 %%__%s_%s 未配置\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "%s 插件未载入\n"
@@ -3364,12 +3357,13 @@ msgstr "软件包 %s (比 %s 还要新) 已经安装"
 
 #: lib/rpmprob.c:145
 #, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:155
 #, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr ""
 
 #: lib/rpmprob.c:159
@@ -3493,7 +3487,7 @@ msgstr ""
 msgid "Unable to restore current directory: %m"
 msgstr "无法恢复当前目录：%m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 脚本支持未内建\n"
 
@@ -3536,15 +3530,15 @@ msgstr "%s 脚本执行失败，退出状态码为 %d\n"
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "安裝"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "删除"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3553,96 +3547,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "无法从 %s 打开软件包数据库\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的“（”存在于软件包标签中：%s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "丢失“（”在软件包标签 %s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "丢失“）”在软件包标签 %s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "读出公钥失败：%s\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "事务"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr ""
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr ""
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr ""
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr ""
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr ""
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr ""
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
 #, c-format
-msgid "%s%s %s"
-msgstr ""
-
-#: lib/rpmvs.c:263
-msgid "digest"
+msgid "%s%s%s %s"
 msgstr ""
 
 #: lib/rpmvs.c:268
+msgid "digest"
+msgstr ""
+
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr ""
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr ""
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr ""
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "头"
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr ""
 
@@ -3650,19 +3644,19 @@ msgstr ""
 msgid "Unable to reload signature header.\n"
 msgstr "无法重载签名头。\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "已跳过"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "已失败"
 
@@ -3703,83 +3697,181 @@ msgstr ""
 msgid "Failed to register fork handler: %m\n"
 msgstr ""
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "== 语法解析错误\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "&& 语法解析错误\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "解析 || 时有语法错误\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "行 %d：%s 位于：%s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "表达式语法错误\n"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "表达式解析错误\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "不匹配的 (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- 只用于数字\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| 预期于表达式结尾"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "表达式语法错误\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "类型必须匹配\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "* / 不支持字符串\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "- 不支持字符串\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "打开 tar 管道失败：%m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "宏 %%%s 具有未结束的选项\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "宏 %%%s 主体未结束\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "宏 %%%s 中存在空内容\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "宏 %%%s 在结构之前需要空格\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "宏 %%%s 展开失败\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "宏 %%%s 已经定义但是没有使用\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中存在未知的选项 %1$c\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "载入宏文件 %s 失败"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "宏扩展中存在太多层的递归。这有可能是由宏的递归声明引起的。\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未结束的 %c：%s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在一个不可解析的宏之之后跟着 %%\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "未预期的 ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "未预期的 ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3823,27 +3915,27 @@ msgstr "警告："
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "lua 脚本中存在无效的语法：%s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "Lua 脚本中存在无效的语法：%s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 脚本执行失败：%s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua文件中存在无效的语法 %s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "lua hook 执行失败：%s\n"
@@ -3853,17 +3945,17 @@ msgstr "lua hook 执行失败：%s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "内在分配 (%u 字节) 返回 NULL。\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr ""
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s, 密钥 ID %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(无)"
 
@@ -3952,44 +4044,44 @@ msgstr "写入签名时 gpg 验证失败\n"
 msgid "unable to read the signature\n"
 msgstr "无法读取签名\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr ""
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 函数执行失败：%s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s：headerRead 函数执行失败：%s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "无法对 RPM v3 版本的软件包签名\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已经包含了相同的签名，跳过\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失败：%s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp 失败\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失败：%s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "替换 %s 失败：%s\n"
@@ -4019,23 +4111,20 @@ msgstr "%s：读取 manifest 文件失败：%s\n"
 msgid "don't verify header+payload signature"
 msgstr "不验证报头+净负荷签名"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "执行 %s 失败(%s)：%s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! 只用于数字\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "执行脚本 %s (%s)失败\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "&& 和 || 不支持字符串\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "行：%s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "读取 %%files 文件 %s 失败：%m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: 行: %s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "不能打开文件 %s：%s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "spec 文件内没有 \"Source:\" 标签\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "行 %d：%s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s：%d：有一个 %%endif 没有对应的 %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "载入宏文件 %s 失败"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,13 +7,15 @@
 # You-Cheng Hsieh <yochenhsieh@gmail.com>, 2012-2013
 # Panu Matilainen <pmatilai@redhat.com>, 2017. #zanata
 # byStarTW <pan93412@gmail.com>, 2018. #zanata
+# byStarTW <pan93412@gmail.com>, 2019. #zanata
+# zerng07 <pswo10680@gmail.com>, 2020. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: rpm-maint@lists.rpm.org\n"
-"POT-Creation-Date: 2019-06-05 14:48+0300\n"
-"PO-Revision-Date: 2018-04-23 12:38+0000\n"
-"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"POT-Creation-Date: 2020-03-23 13:45+0200\n"
+"PO-Revision-Date: 2020-02-10 03:44-0500\n"
+"Last-Translator: zerng07 <pswo10680@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/rpm-team/rpm/"
 "language/zh_TW/)\n"
 "Language: zh_TW\n"
@@ -72,7 +74,7 @@ msgstr "無法重新開啟酬載：%s\n"
 #: rpm2cpio.c:79
 #, c-format
 msgid "files over 4GB not supported by cpio, use rpm2archive instead\n"
-msgstr ""
+msgstr "超過 4GB 的檔案不受 cpio 支援，請改用 rpm2archive\n"
 
 #: rpmbuild.c:120
 #, c-format
@@ -115,10 +117,9 @@ msgid "build source package only from <specfile>"
 msgstr "根據 <specfile> 只建置源碼軟體包"
 
 #: rpmbuild.c:166
-#, fuzzy
 msgid ""
 "build source package only from <specfile> - calculate dynamic build requires"
-msgstr "根據 <specfile> 只建置源碼軟體包"
+msgstr ""
 
 #: rpmbuild.c:170
 #, c-format
@@ -158,11 +159,10 @@ msgid "build source package only from <source package>"
 msgstr "只從 <source package> 編譯來源軟體包"
 
 #: rpmbuild.c:191
-#, fuzzy
 msgid ""
 "build source package only from <source package> - calculate dynamic build "
 "requires"
-msgstr "只從 <source package> 編譯來源軟體包"
+msgstr ""
 
 #: rpmbuild.c:195
 #, c-format
@@ -200,10 +200,9 @@ msgid "build source package only from <tarball>"
 msgstr "從 <tarball> 中只建置源碼軟體包"
 
 #: rpmbuild.c:216
-#, fuzzy
 msgid ""
 "build source package only from <tarball> - calculate dynamic build requires"
-msgstr "從 <tarball> 中只建置源碼軟體包"
+msgstr ""
 
 #: rpmbuild.c:219
 msgid "build binary package from <source package>"
@@ -280,7 +279,7 @@ msgstr "無視目標平臺"
 msgid "Build options with [ <specfile> | <tarball> | <source package> ]:"
 msgstr "組建選項中使用 [ <specfile> | <tarball> | <source package> ]："
 
-#: rpmbuild.c:282 rpmdb.c:40 rpmkeys.c:38 rpm.c:53 rpmsign.c:51 rpmspec.c:46
+#: rpmbuild.c:282 rpmdb.c:43 rpmkeys.c:38 rpm.c:53 rpmsign.c:55 rpmspec.c:46
 #: tools/rpmdeps.c:43 tools/rpmgraph.c:221
 msgid "Common options for all rpm modes and executables:"
 msgstr "用於所有 rpm 模式和可執行檔案的共同選項："
@@ -339,31 +338,36 @@ msgstr "建置目標 %s\n"
 msgid "arguments to --root (-r) must begin with a /"
 msgstr "--root (-r) 的引數必須以「/」開頭"
 
-#: rpmdb.c:21
+#: rpmdb.c:22
 msgid "initialize database"
 msgstr "初始化資料庫"
 
-#: rpmdb.c:23
+#: rpmdb.c:24
 msgid "rebuild database inverted lists from installed package headers"
 msgstr "從安裝的軟體包表頭重建資料庫的反相清單"
 
-#: rpmdb.c:26
+#: rpmdb.c:27
 msgid "verify database files"
 msgstr "驗證資料庫檔案"
 
-#: rpmdb.c:28
+#: rpmdb.c:29
+#, fuzzy
+msgid "salvage database"
+msgstr "初始化資料庫"
+
+#: rpmdb.c:31
 msgid "export database to stdout header list"
 msgstr "匯出資料庫至標準輸出標頭列表"
 
-#: rpmdb.c:31
+#: rpmdb.c:34
 msgid "import database from stdin header list"
 msgstr "從標準輸入標頭列表匯入資料庫"
 
-#: rpmdb.c:38
+#: rpmdb.c:41
 msgid "Database options:"
 msgstr "資料庫選項："
 
-#: rpmdb.c:126 rpmkeys.c:83 rpm.c:118 rpmsign.c:187
+#: rpmdb.c:132 rpmkeys.c:83 rpm.c:118 rpmsign.c:191
 msgid "only one major mode may be specified"
 msgstr "只能指定一個主要工作模式"
 
@@ -387,7 +391,7 @@ msgstr "列出 RPM 鑰匙圈的金鑰"
 msgid "Keyring options:"
 msgstr "鑰匙圈選項："
 
-#: rpmkeys.c:64 rpmsign.c:162
+#: rpmkeys.c:64 rpmsign.c:166
 msgid "no arguments given"
 msgstr "沒有指定引數"
 
@@ -552,38 +556,43 @@ msgid "delete package signatures"
 msgstr "刪除軟體包簽署"
 
 #: rpmsign.c:37
+#, fuzzy
+msgid "create rpm v3 header+payload signatures"
+msgstr "不驗證表頭+酬載簽署"
+
+#: rpmsign.c:41
 msgid "sign package(s) files"
 msgstr "簽名軟體包檔案"
 
-#: rpmsign.c:39
+#: rpmsign.c:43
 msgid "use file signing key <key>"
 msgstr "使用檔案簽名金鑰 <key>"
 
-#: rpmsign.c:40
+#: rpmsign.c:44
 msgid "<key>"
 msgstr "<key>"
 
-#: rpmsign.c:42
+#: rpmsign.c:46
 msgid "prompt for file signing key password"
 msgstr "提示檔案簽名金鑰的密碼"
 
-#: rpmsign.c:49
+#: rpmsign.c:53
 msgid "Signature options:"
 msgstr "簽署選項："
 
-#: rpmsign.c:101
+#: rpmsign.c:105
 #, c-format
 msgid "You must set \"%%_gpg_name\" in your macro file\n"
 msgstr "您必須在您的巨集檔案中設定「%%_gpg_name」\n"
 
-#: rpmsign.c:114
+#: rpmsign.c:118
 #, c-format
 msgid ""
 "You must set \"%%_file_signing_key\" in your macro file or on the command "
 "line with --fskpath\n"
 msgstr "你必須在巨集或指令行上透過 --fskpath 設定 \"%%_file_signing_key\"\n"
 
-#: rpmsign.c:167
+#: rpmsign.c:171
 msgid "--fskpath may only be specified when signing files"
 msgstr "--fskpath 只能在簽名檔案時指定"
 
@@ -615,40 +624,49 @@ msgstr "使用以下的查詢格式"
 msgid "Spec options:"
 msgstr "規格選項："
 
-#: rpmspec.c:84
+#: rpmspec.c:85
 msgid "no arguments given for parse"
 msgstr "沒有可供解析的參數"
 
-#: build/build.c:119
+#: build/build.c:33
+msgid "unable to parse SOURCE_DATE_EPOCH\n"
+msgstr "無法解析 SOURCE_DATE_EPOCH\n"
+
+#: build/build.c:59
+#, c-format
+msgid "Could not canonicalize hostname: %s\n"
+msgstr "無法標準化主機名稱：%s\n"
+
+#: build/build.c:164
 #, c-format
 msgid "Unable to open temp file: %s\n"
 msgstr "無法開啟暫存檔案：%s\n"
 
-#: build/build.c:124
+#: build/build.c:169
 #, c-format
 msgid "Unable to open stream: %s\n"
 msgstr "無法開啟串流：%s\n"
 
-#: build/build.c:157
+#: build/build.c:202
 #, c-format
 msgid "Executing(%s): %s\n"
 msgstr "正在執行(%s)：%s\n"
 
-#: build/build.c:160
+#: build/build.c:205
 #, c-format
 msgid "Bad exit status from %s (%s)\n"
 msgstr "來自 %s 不良的離開狀態 (%s)\n"
 
-#: build/build.c:234
+#: build/build.c:272
 msgid "Failed build dependencies:\n"
 msgstr "相依性建置失敗：\n"
 
-#: build/build.c:262
+#: build/build.c:303
 #, c-format
 msgid "setting %s=%s\n"
 msgstr "%s = %s 設定中\n"
 
-#: build/build.c:383
+#: build/build.c:429
 msgid ""
 "\n"
 "\n"
@@ -657,55 +675,6 @@ msgstr ""
 "\n"
 "\n"
 "RPM 建置錯誤：\n"
-
-#: build/expression.c:215
-msgid "syntax error while parsing ==\n"
-msgstr "解析 == 時有語法錯誤\n"
-
-#: build/expression.c:245
-msgid "syntax error while parsing &&\n"
-msgstr "解析 && 時有語法錯誤\n"
-
-#: build/expression.c:254
-msgid "syntax error while parsing ||\n"
-msgstr "解析 || 時有語法錯誤\n"
-
-#: build/expression.c:304
-msgid "parse error in expression\n"
-msgstr "表述式解析錯誤\n"
-
-#: build/expression.c:340
-msgid "unmatched (\n"
-msgstr "不符合的 (\n"
-
-#: build/expression.c:372
-msgid "- only on numbers\n"
-msgstr "- 只能用於數字\n"
-
-#: build/expression.c:388
-msgid "! only on numbers\n"
-msgstr "! 只能用於數字\n"
-
-#: build/expression.c:434 build/expression.c:487 build/expression.c:550
-#: build/expression.c:647
-msgid "types must match\n"
-msgstr "類型必須符合\n"
-
-#: build/expression.c:447
-msgid "* / not suported for strings\n"
-msgstr "字串不支援 *、/\n"
-
-#: build/expression.c:503
-msgid "- not suported for strings\n"
-msgstr "字串不支援 -\n"
-
-#: build/expression.c:660
-msgid "&& and || not suported for strings\n"
-msgstr "字串不支援 && 和 ||\n"
-
-#: build/expression.c:695
-msgid "syntax error in expression\n"
-msgstr "表述式中有語法錯誤\n"
 
 #: build/files.c:343 build/files.c:524 build/files.c:743
 #, c-format
@@ -801,172 +770,177 @@ msgstr ""
 msgid "Symlink points to BuildRoot: %s -> %s\n"
 msgstr "指向 BuildRoot 的符號連結：%s -> %s\n"
 
-#: build/files.c:1352
+#: build/files.c:1331
+#, fuzzy, c-format
+msgid "Illegal character (0x%x) in filename: %s\n"
+msgstr "非法字符「%c」(0x%x)"
+
+#: build/files.c:1368
 #, c-format
 msgid "Path is outside buildroot: %s\n"
 msgstr "位置超出了 buildroot：%s\n"
 
-#: build/files.c:1392
+#: build/files.c:1412
 #, c-format
 msgid "Directory not found: %s\n"
 msgstr "目錄不存在：%s\n"
 
-#: build/files.c:1393 lib/rpminstall.c:459
+#: build/files.c:1413 lib/rpminstall.c:459
 #, c-format
 msgid "File not found: %s\n"
 msgstr "找不到檔案：%s\n"
 
-#: build/files.c:1405
+#: build/files.c:1434
 #, c-format
 msgid "Not a directory: %s\n"
 msgstr "不是一個目錄：%s\n"
 
-#: build/files.c:1598
+#: build/files.c:1588
+#, fuzzy, c-format
+msgid "Can't read content of file: %s\n"
+msgstr "無法讀取策略檔案：%s\n"
+
+#: build/files.c:1629
 #, c-format
 msgid "%s: can't load unknown tag (%d).\n"
 msgstr "%s：無法呼叫不明的標籤 (%d)。\n"
 
-#: build/files.c:1604
+#: build/files.c:1635
 #, c-format
 msgid "%s: public key read failed.\n"
 msgstr "%s：公鑰讀入失敗。\n"
 
-#: build/files.c:1608
+#: build/files.c:1639
 #, c-format
 msgid "%s: not an armored public key.\n"
 msgstr "%s：不是一個受保護的公鑰。\n"
 
-#: build/files.c:1617
+#: build/files.c:1648
 #, c-format
 msgid "%s: failed to encode\n"
 msgstr "%s：編碼失敗\n"
 
-#: build/files.c:1663
+#: build/files.c:1694
 msgid "failed symlink"
 msgstr "錯誤的軟連結"
 
-#: build/files.c:1719 build/files.c:1722
+#: build/files.c:1750 build/files.c:1753
 #, c-format
 msgid "Duplicate build-id, stat %s: %m\n"
 msgstr "重複的 build-id，狀態 %s：%m\n"
 
-#: build/files.c:1729
+#: build/files.c:1760
 #, c-format
 msgid "Duplicate build-ids %s and %s\n"
 msgstr "重複的 build-id %s 與 %s\n"
 
-#: build/files.c:1783
+#: build/files.c:1814
 msgid "_build_id_links macro not set, assuming 'compat'\n"
 msgstr "_build_id_links 巨集尚未設定，假設為「compat」\n"
 
-#: build/files.c:1796
+#: build/files.c:1827
 #, c-format
 msgid "_build_id_links macro set to unknown value '%s'\n"
 msgstr "_build_id_links 巨集設定了一個未知的值「%s」\n"
 
-#: build/files.c:1885
+#: build/files.c:1916
 #, c-format
 msgid "error reading build-id in %s: %s\n"
 msgstr "無法讀取 build-id 於 %s：%s\n"
 
-#: build/files.c:1889
+#: build/files.c:1920
 #, c-format
 msgid "Missing build-id in %s\n"
 msgstr "%s 遺失 build-id\n"
 
-#: build/files.c:1894
+#: build/files.c:1925
 #, c-format
 msgid "build-id found in %s too small\n"
 msgstr "%s 中找到的 build-id 太小\n"
 
-#: build/files.c:1895
+#: build/files.c:1926
 #, c-format
 msgid "build-id found in %s too large\n"
 msgstr "%s 中找到的 build-id 太大\n"
 
-#: build/files.c:1910 rpmio/rpmfileutil.c:443
+#: build/files.c:1941 rpmio/rpmfileutil.c:443
 msgid "failed to create directory"
 msgstr "無法建立目錄"
 
-#: build/files.c:1928
+#: build/files.c:1959
 msgid "Mixing main ELF and debug files in package"
 msgstr "在軟體包內混合主要 ELF 與偵錯檔案"
 
-#: build/files.c:2129
+#: build/files.c:2160
 #, c-format
 msgid "File needs leading \"/\": %s\n"
 msgstr "檔案需要以「/」開頭：%s\n"
 
-#: build/files.c:2153
+#: build/files.c:2184
 #, c-format
 msgid "%%dev glob not permitted: %s\n"
 msgstr "%%dev glob 尚未允許：%s\n"
 
-#: build/files.c:2165
+#: build/files.c:2196
 #, c-format
 msgid "Directory not found by glob: %s. Trying without globbing.\n"
 msgstr "無法透過 glob 找到資料夾：%s。嘗試以非 glob 方式搜尋。\n"
 
-#: build/files.c:2167
+#: build/files.c:2198
 #, c-format
 msgid "File not found by glob: %s. Trying without globbing.\n"
 msgstr "無法透過 glob 找到檔案：%s。嘗試以非 glob 方式搜尋。\n"
 
-#: build/files.c:2203
-#, c-format
-msgid "Could not open %%files file %s: %m\n"
+#: build/files.c:2233
+#, fuzzy, c-format
+msgid "Could not open %s file %s: %m\n"
 msgstr "無法開啟 %%files 檔案 %s：%m\n"
 
-#: build/files.c:2226
-#, c-format
-msgid "Empty %%files file %s\n"
+#: build/files.c:2258
+#, fuzzy, c-format
+msgid "Empty %s file %s\n"
 msgstr "空的 %%files 檔案 %s\n"
 
-#: build/files.c:2232
-#, c-format
-msgid "Error reading %%files file %s: %m\n"
-msgstr "讀取 %%files 檔案 %s 失敗：%m\n"
-
-#: build/files.c:2258
+#: build/files.c:2303
 #, c-format
 msgid "illegal _docdir_fmt %s: %s\n"
 msgstr "illegal _docdir_fmt %s: %s\n"
 
-#: build/files.c:2380 lib/rpminstall.c:461
+#: build/files.c:2424 lib/rpminstall.c:461
 #, c-format
 msgid "File not found by glob: %s\n"
 msgstr "透過 glob 解析找不到檔案：%s\n"
 
-#: build/files.c:2467
+#: build/files.c:2511
 #, c-format
 msgid "Special file in generated file list: %s\n"
 msgstr "特殊檔案於生成的檔案列表：%s\n"
 
-#: build/files.c:2491
+#: build/files.c:2535
 #, c-format
 msgid "Can't mix special %s with other forms: %s\n"
 msgstr "無法將特殊 %s 與其他形式混合：%s\n"
 
-#: build/files.c:2507
+#: build/files.c:2551
 #, c-format
 msgid "More than one file on a line: %s\n"
 msgstr "一列上超過一個檔案：%s\n"
 
-#: build/files.c:2576
+#: build/files.c:2620
 msgid "Generating build-id links failed\n"
 msgstr "生成 build-id 連結時失敗\n"
 
-#: build/files.c:2693
+#: build/files.c:2737
 #, c-format
 msgid "Bad file: %s: %s\n"
 msgstr "不良檔案：%s：%s\n"
 
-#: build/files.c:2761
+#: build/files.c:2805
 #, c-format
 msgid "Checking for unpackaged file(s): %s\n"
 msgstr "正在檢查未打包的檔案：%s\n"
 
-#: build/files.c:2774
+#: build/files.c:2818
 #, c-format
 msgid ""
 "Installed (but unpackaged) file(s) found:\n"
@@ -975,111 +949,106 @@ msgstr ""
 "找到已安裝 (但未打包) 的檔案：\n"
 "%s"
 
-#: build/files.c:2889
+#: build/files.c:2933
 #, c-format
 msgid "%s was mapped to multiple filenames"
 msgstr "%s 被映射至多檔案名稱"
 
-#: build/files.c:3138
+#: build/files.c:3182
 #, c-format
 msgid "Processing files: %s\n"
 msgstr "正在處理檔案：%s\n"
 
-#: build/files.c:3160
+#: build/files.c:3204
 #, c-format
 msgid "Binaries arch (%d) not matching the package arch (%d).\n"
 msgstr "二進位檔案架構 (%d) 無法符合軟體包架構 (%d)。\n"
 
-#: build/files.c:3166
+#: build/files.c:3210
 msgid "Arch dependent binaries in noarch package\n"
 msgstr "noarch 軟體包中有架構依賴二進位檔\n"
 
-#: build/pack.c:89
+#: build/pack.c:93
 #, c-format
 msgid "create archive failed on file %s: %s\n"
 msgstr "在 %s 檔案建立封存檔案時失敗：%s\n"
 
-#: build/pack.c:92
+#: build/pack.c:96
 #, c-format
 msgid "create archive failed: %s\n"
 msgstr "建立封存檔案失敗：%s\n"
 
-#: build/pack.c:120
-#, c-format
-msgid "Could not open %s file: %s\n"
-msgstr "無法開啟 %s 檔案：%s\n"
-
-#: build/pack.c:339
+#: build/pack.c:320
 #, c-format
 msgid "Unknown payload compression: %s\n"
 msgstr "未知的有效載荷壓縮：%s\n"
 
-#: build/pack.c:393 sign/rpmgensig.c:286 sign/rpmgensig.c:632
-#: sign/rpmgensig.c:667
+#: build/pack.c:374 sign/rpmgensig.c:286 sign/rpmgensig.c:642
+#: sign/rpmgensig.c:677
 #, c-format
 msgid "Could not seek in file %s: %s\n"
 msgstr "檔案無法尋找於檔案 %s: %s\n"
 
-#: build/pack.c:419
+#: build/pack.c:400
 #, c-format
 msgid "Failed to read %jd bytes in file %s: %s\n"
 msgstr ""
 
-#: build/pack.c:433
+#: build/pack.c:414
 msgid "Unable to create immutable header region\n"
 msgstr "無法建立不可修改的標頭區段\n"
 
-#: build/pack.c:438
+#: build/pack.c:419
 #, c-format
 msgid "Unable to write header to %s: %s\n"
 msgstr "無法寫入標頭至 %s：%s\n"
 
-#: build/pack.c:506
+#: build/pack.c:489
 #, c-format
 msgid "Could not open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/pack.c:513
+#: build/pack.c:496
 #, c-format
 msgid "Unable to write package: %s\n"
 msgstr "無法寫入軟體包：%s\n"
 
-#: build/pack.c:597
+#: build/pack.c:583
 #, c-format
 msgid "Wrote: %s\n"
 msgstr "已寫入：%s\n"
 
-#: build/pack.c:616
+#: build/pack.c:602
 #, c-format
 msgid "Executing \"%s\":\n"
 msgstr "正在執行「%s」：\n"
 
-#: build/pack.c:619
+#: build/pack.c:605
 #, c-format
 msgid "Execution of \"%s\" failed.\n"
 msgstr "「%s」執行失敗。\n"
 
-#: build/pack.c:623
+#: build/pack.c:609
 #, c-format
 msgid "Package check \"%s\" failed.\n"
 msgstr "軟體包檢查「%s」失敗。\n"
 
-#: build/pack.c:667
+#: build/pack.c:653
 #, c-format
 msgid "cannot create %s: %s\n"
 msgstr "無法建立 %s：%s\n"
 
-#: build/pack.c:686
+#: build/pack.c:672
 #, c-format
 msgid "Could not generate output filename for package %s: %s\n"
 msgstr "無法產生軟體包 %s 的檔案名稱輸出：%s\n"
 
-#: build/pack.c:755
+#: build/pack.c:742
 #, c-format
 msgid "Finished binary package job, result %d, filename %s\n"
 msgstr ""
 
-#: build/parseSimpleScript.c:17 build/parsePreamble.c:745
+#: build/parseSimpleScript.c:17 build/parsePreamble.c:746
 #, c-format
 msgid "line %d: second %s\n"
 msgstr "列 %d：第二個 %s\n"
@@ -1087,7 +1056,7 @@ msgstr "列 %d：第二個 %s\n"
 #: build/parseChangelog.c:183
 #, c-format
 msgid "bogus date in %%changelog: %s\n"
-msgstr "布格日期 (bogus date) 於 %%changelog：%s\n"
+msgstr "%%changelog 中有造假的日期：%s\n"
 
 #: build/parseChangelog.c:216
 #, c-format
@@ -1124,18 +1093,18 @@ msgstr "%%changelog 中沒有描述\n"
 msgid "line %d: second %%changelog\n"
 msgstr "第 %d 列：第二個 %%changelog\n"
 
-#: build/parseDescription.c:32
+#: build/parseDescription.c:33
 #, c-format
 msgid "line %d: Error parsing %%description: %s\n"
 msgstr "列 %d：解析 %%description 時發生錯誤：%s\n"
 
-#: build/parseDescription.c:45 build/parseFiles.c:46 build/parsePolicies.c:45
+#: build/parseDescription.c:46 build/parseFiles.c:46 build/parsePolicies.c:45
 #: build/parseScript.c:320
 #, c-format
 msgid "line %d: Bad option %s: %s\n"
 msgstr "列 %d：不良選項 %s：%s\n"
 
-#: build/parseDescription.c:56 build/parseFiles.c:57 build/parsePolicies.c:55
+#: build/parseDescription.c:57 build/parseFiles.c:57 build/parsePolicies.c:55
 #: build/parseScript.c:331
 #, c-format
 msgid "line %d: Too many names: %s\n"
@@ -1191,154 +1160,154 @@ msgstr "列 %d：不良的 %s 數字：%s\n"
 msgid "%s %d defined multiple times\n"
 msgstr "%s %d 被定義許多次\n"
 
-#: build/parsePreamble.c:473
+#: build/parsePreamble.c:474
 #, c-format
 msgid "Architecture is excluded: %s\n"
 msgstr "被排除的架構：%s\n"
 
-#: build/parsePreamble.c:478
+#: build/parsePreamble.c:479
 #, c-format
 msgid "Architecture is not included: %s\n"
 msgstr "未包含的架構：%s\n"
 
-#: build/parsePreamble.c:483
+#: build/parsePreamble.c:484
 #, c-format
 msgid "OS is excluded: %s\n"
 msgstr "被排除的作業系統：%s\n"
 
-#: build/parsePreamble.c:488
+#: build/parsePreamble.c:489
 #, c-format
 msgid "OS is not included: %s\n"
 msgstr "未包含的作業系統：%s\n"
 
-#: build/parsePreamble.c:514
+#: build/parsePreamble.c:515
 #, c-format
 msgid "%s field must be present in package: %s\n"
 msgstr "%s 欄位必須出現於軟體包中：%s\n"
 
-#: build/parsePreamble.c:537
+#: build/parsePreamble.c:538
 #, c-format
 msgid "Duplicate %s entries in package: %s\n"
 msgstr "軟體包中有重複的 %s 條目：%s\n"
 
-#: build/parsePreamble.c:608
+#: build/parsePreamble.c:609
 #, c-format
 msgid "Unable to open icon %s: %s\n"
 msgstr "無法開啟圖示 %s：%s\n"
 
-#: build/parsePreamble.c:624
+#: build/parsePreamble.c:625
 #, c-format
 msgid "Unable to read icon %s: %s\n"
 msgstr "無法讀取圖示 %s：%s\n"
 
-#: build/parsePreamble.c:634
+#: build/parsePreamble.c:635
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "不明的圖示類型：%s\n"
 
-#: build/parsePreamble.c:648
+#: build/parsePreamble.c:649
 #, c-format
 msgid "line %d: Tag takes single token only: %s\n"
 msgstr "列 %d：標籤只需單一符記：%s\n"
 
-#: build/parsePreamble.c:656
+#: build/parsePreamble.c:657
 #, c-format
 msgid "line %d: %s in: %s\n"
 msgstr "第 %d 行：%s 在：%s\n"
 
-#: build/parsePreamble.c:658
+#: build/parsePreamble.c:659
 #, c-format
 msgid "%s in: %s\n"
 msgstr "%s 在：%s\n"
 
-#: build/parsePreamble.c:677
+#: build/parsePreamble.c:678
 #, c-format
 msgid "Illegal char '%c' (0x%x)"
 msgstr "非法字符「%c」(0x%x)"
 
-#: build/parsePreamble.c:683
+#: build/parsePreamble.c:684
 msgid "Possible unexpanded macro"
 msgstr "可能未展開的巨集"
 
-#: build/parsePreamble.c:689
+#: build/parsePreamble.c:690
 msgid "Illegal sequence \"..\""
 msgstr "非法序列「..」"
 
-#: build/parsePreamble.c:777
+#: build/parsePreamble.c:778
 #, c-format
 msgid "line %d: Malformed tag: %s\n"
 msgstr "列 %d：格式不良的標籤：%s\n"
 
-#: build/parsePreamble.c:785
+#: build/parsePreamble.c:786
 #, c-format
 msgid "line %d: Empty tag: %s\n"
 msgstr "列 %d：空的標籤：%s\n"
 
-#: build/parsePreamble.c:846
+#: build/parsePreamble.c:847
 #, c-format
 msgid "line %d: Prefixes must not end with \"/\": %s\n"
 msgstr "列 %d：前綴不能以「/」結尾：%s\n"
 
-#: build/parsePreamble.c:858
+#: build/parsePreamble.c:859
 #, c-format
 msgid "line %d: Docdir must begin with '/': %s\n"
 msgstr "列 %d：Docdir 必須以「/」開頭：%s\n"
 
-#: build/parsePreamble.c:870
+#: build/parsePreamble.c:871
 #, c-format
 msgid "line %d: Epoch field must be an unsigned number: %s\n"
 msgstr "第 %d 行：Epoch 欄位必須為一個無號整數：%s\n"
 
-#: build/parsePreamble.c:906
+#: build/parsePreamble.c:908
 #, c-format
 msgid "line %d: Bad %s: qualifiers: %s\n"
 msgstr "列 %d：不良 %s：修飾詞：%s\n"
 
-#: build/parsePreamble.c:940
+#: build/parsePreamble.c:942
 #, c-format
 msgid "line %d: Bad BuildArchitecture format: %s\n"
 msgstr "列 %d：不良 BuildArchitecture 格式：%s\n"
 
-#: build/parsePreamble.c:947
+#: build/parsePreamble.c:949
 #, c-format
 msgid "line %d: Duplicate BuildArch entry: %s\n"
 msgstr "第 %d 行：重複的 BuildArch 項目：%s\n"
 
-#: build/parsePreamble.c:957
+#: build/parsePreamble.c:959
 #, c-format
 msgid "line %d: Only noarch subpackages are supported: %s\n"
 msgstr "第 %d 行：只有通用 noarch 子軟體包支援：%s\n"
 
-#: build/parsePreamble.c:972
+#: build/parsePreamble.c:974
 #, c-format
 msgid "Internal error: Bogus tag %d\n"
 msgstr "內部錯誤：假造的標籤 %d\n"
 
-#: build/parsePreamble.c:1070
+#: build/parsePreamble.c:1072
 #, c-format
 msgid "line %d: %s is deprecated: %s\n"
 msgstr "第 %d 行：%s 重複：%s\n"
 
-#: build/parsePreamble.c:1131
+#: build/parsePreamble.c:1133
 #, c-format
 msgid "Bad package specification: %s\n"
 msgstr "不良軟體包規格：%s\n"
 
-#: build/parsePreamble.c:1176
+#: build/parsePreamble.c:1178
 msgid "Binary rpm package found. Expected spec file!\n"
 msgstr "找到二進位 rpm 軟體包。沒有期望的 spec 檔案！\n"
 
-#: build/parsePreamble.c:1179
+#: build/parsePreamble.c:1181
 #, c-format
 msgid "line %d: Unknown tag: %s\n"
 msgstr "列 %d：未知標籤：%s\n"
 
-#: build/parsePreamble.c:1214
+#: build/parsePreamble.c:1216
 #, c-format
 msgid "%%{buildroot} couldn't be empty\n"
 msgstr "%%{buildroot} 不能為空白\n"
 
-#: build/parsePreamble.c:1218
+#: build/parsePreamble.c:1220
 #, c-format
 msgid "%%{buildroot} can not be \"/\"\n"
 msgstr "%%{buildroot} 不能為「/」\n"
@@ -1348,12 +1317,12 @@ msgstr "%%{buildroot} 不能為「/」\n"
 msgid "Bad source: %s: %s\n"
 msgstr "不良源碼：%s：%s\n"
 
-#: build/parsePrep.c:67
+#: build/parsePrep.c:68
 #, c-format
 msgid "No patch number %u\n"
 msgstr "沒有修補編號 %u\n"
 
-#: build/parsePrep.c:135
+#: build/parsePrep.c:137
 #, c-format
 msgid "No source number %u\n"
 msgstr "沒有源碼編號 %u\n"
@@ -1363,27 +1332,27 @@ msgstr "沒有源碼編號 %u\n"
 msgid "Error parsing %%setup: %s\n"
 msgstr "解析 %%setup 時發生錯誤：%s\n"
 
-#: build/parsePrep.c:270
+#: build/parsePrep.c:275
 #, c-format
 msgid "line %d: Bad arg to %%setup: %s\n"
 msgstr "列 %d：%%setup 中出現不良引數：%s\n"
 
-#: build/parsePrep.c:285
+#: build/parsePrep.c:291
 #, c-format
 msgid "line %d: Bad %%setup option %s: %s\n"
 msgstr "列 %d：不良 %%setup 選項 %s：%s\n"
 
-#: build/parsePrep.c:455
+#: build/parsePrep.c:454
 #, c-format
 msgid "%s: %s: %s\n"
 msgstr "%s: %s: %s\n"
 
-#: build/parsePrep.c:468
+#: build/parsePrep.c:467
 #, c-format
 msgid "Invalid patch number %s: %s\n"
 msgstr "無效的修補編號 %s：%s\n"
 
-#: build/parsePrep.c:495
+#: build/parsePrep.c:497
 #, c-format
 msgid "line %d: second %%prep\n"
 msgstr "列 %d：第二個 %%prep\n"
@@ -1468,105 +1437,105 @@ msgstr "第 %d 列：優先級只允許在檔案觸發器上：%s\n"
 msgid "line %d: Second %s\n"
 msgstr "列 %d：第二個 %s\n"
 
-#: build/parseScript.c:371
+#: build/parseScript.c:374
 #, c-format
 msgid "line %d: unsupported internal script: %s\n"
 msgstr "列 %d：不支援的內部指令小稿：%s\n"
 
-#: build/parseScript.c:389
+#: build/parseScript.c:392
 #, c-format
 msgid "line %d: file trigger condition must begin with '/': %s"
 msgstr "第 %d 列：檔案觸發器條件必須以「/」為開頭：%s"
 
-#: build/parseScript.c:395
+#: build/parseScript.c:398
 #, c-format
 msgid "line %d: interpreter arguments not allowed in triggers: %s\n"
 msgstr "第 %d 列：「翻譯員」參數不允許在觸發器內：%s\n"
 
-#: build/parseSpec.c:230
+#: build/parseSpec.c:232
 #, c-format
 msgid "extra tokens at the end of %s directive in line %d:  %s\n"
 msgstr ""
 
-#: build/parseSpec.c:264
+#: build/parseSpec.c:266
 #, c-format
 msgid "Macro expanded in comment on line %d: %s\n"
-msgstr "變數在第 %d 列的留言中擴展：%s\n"
+msgstr "變數在第 %d 列的註解中擴展：%s\n"
 
-#: build/parseSpec.c:369
+#: build/parseSpec.c:390
 #, c-format
 msgid "Unable to open %s: %s\n"
 msgstr "無法開啟 %s：%s\n"
 
-#: build/parseSpec.c:403
+#: build/parseSpec.c:424
 #, c-format
 msgid "%s:%d: Argument expected for %s\n"
 msgstr "%s:%d：為 %s 的預料中參數\n"
 
-#: build/parseSpec.c:428
+#: build/parseSpec.c:449
 #, c-format
 msgid "line %d: Unclosed %%if\n"
 msgstr "第 %d 行：未關閉的 %%if\n"
 
-#: build/parseSpec.c:433
+#: build/parseSpec.c:454
 #, c-format
 msgid "line %d: unclosed macro or bad line continuation\n"
 msgstr ""
 "第 %d 行：未關閉的巨集、或是錯誤的變數被繼續。\n"
 "\n"
 
-#: build/parseSpec.c:464
-#, fuzzy, c-format
+#: build/parseSpec.c:482
+#, c-format
 msgid "%s: line %d: %s with no %%if\n"
-msgstr "%s:%d：有個 %%else 沒有對應 %%if\n"
+msgstr ""
 
-#: build/parseSpec.c:467
-#, fuzzy, c-format
+#: build/parseSpec.c:485
+#, c-format
 msgid "%s: line %d: %s after %s\n"
-msgstr "第 %d 行：%s：%s\n"
+msgstr ""
 
-#: build/parseSpec.c:494
-#, fuzzy, c-format
+#: build/parseSpec.c:512
+#, c-format
 msgid "%s:%d: bad %s condition: %s\n"
-msgstr "%s:%d：錯誤的 %%if 條件\n"
+msgstr ""
 
-#: build/parseSpec.c:522
+#: build/parseSpec.c:540
 #, c-format
 msgid "%s:%d: malformed %%include statement\n"
 msgstr "%s:%d：異常的 %%include 聲明\n"
 
-#: build/parseSpec.c:750
+#: build/parseSpec.c:779
 #, c-format
 msgid "encoding %s not supported by system\n"
 msgstr ""
 "系統不支援編碼 %s\n"
 "\n"
 
-#: build/parseSpec.c:779
+#: build/parseSpec.c:808
 #, c-format
 msgid "Package %s: invalid %s encoding in %s: %s - %s\n"
 msgstr "%s 軟體包：於 %s: %s - %s 中無效的 %s 編碼\n"
 
-#: build/parseSpec.c:815
+#: build/parseSpec.c:844
 #, c-format
 msgid "line %d: %%end doesn't take any arguments: %s\n"
 msgstr "第 %d 行：%%end 沒有任何參數：%s\n"
 
-#: build/parseSpec.c:822
+#: build/parseSpec.c:851
 #, c-format
 msgid "line %d: %%end not expected here, no section to close: %s\n"
 msgstr "第 %d 行：非期望的 %%end，沒有區段供關閉：%s\n"
 
-#: build/parseSpec.c:838
+#: build/parseSpec.c:867
 #, c-format
 msgid "line %d doesn't belong to any section: %s\n"
 msgstr "第 %d 行並不屬於任何區段：%s\n"
 
-#: build/parseSpec.c:999
+#: build/parseSpec.c:1028
 msgid "No compatible architectures found for build\n"
 msgstr "找不到可供建置的相容架構\n"
 
-#: build/parseSpec.c:1039
+#: build/parseSpec.c:1083
 #, c-format
 msgid "Package has no %%description: %s\n"
 msgstr "軟體包沒有 %%description：%s\n"
@@ -1634,98 +1603,94 @@ msgstr "遺失模組路徑於行：%s\n"
 msgid "Too many arguments in line: %s\n"
 msgstr "太多參數於行：%s\n"
 
-#: build/policies.c:307
+#: build/policies.c:311
 #, c-format
 msgid "Processing policies: %s\n"
 msgstr "處理策略中：%s\n"
 
-#: build/rpmfc.c:179
+#: build/rpmfc.c:183
 #, c-format
 msgid "Ignoring invalid regex %s\n"
 msgstr "忽略無效的正規表達式 %s\n"
 
-#: build/rpmfc.c:273
+#: build/rpmfc.c:216
+#, c-format
+msgid "%s: mime and magic supplied, only mime will be used\n"
+msgstr ""
+
+#: build/rpmfc.c:287
 #, c-format
 msgid "Couldn't create pipe for %s: %m\n"
 msgstr "無法為 %s 建立導管：%m\n"
 
-#: build/rpmfc.c:296
-#, c-format
-msgid "Couldn't exec %s: %s\n"
-msgstr "無法執行 %s：%s\n"
-
-#: build/rpmfc.c:301 lib/rpmscript.c:322
+#: build/rpmfc.c:293 lib/rpmscript.c:322
 #, c-format
 msgid "Couldn't fork %s: %s\n"
 msgstr "無法分支 %s：%s\n"
 
-#: build/rpmfc.c:385
+#: build/rpmfc.c:321
+#, c-format
+msgid "Couldn't exec %s: %s\n"
+msgstr "無法執行 %s：%s\n"
+
+#: build/rpmfc.c:407
 #, c-format
 msgid "%s failed: %x\n"
 msgstr "%s 失敗：%x\n"
 
-#: build/rpmfc.c:389
+#: build/rpmfc.c:411
 #, c-format
 msgid "failed to write all data to %s: %s\n"
 msgstr "無法寫入所有資料至 %s：%s\n"
 
-#: build/rpmfc.c:1070
+#: build/rpmfc.c:1165
 msgid "Empty file classifier\n"
 msgstr "空的檔案分類\n"
 
-#: build/rpmfc.c:1079
+#: build/rpmfc.c:1174
 msgid "No file attributes configured\n"
 msgstr "無設定檔案特性\n"
 
-#: build/rpmfc.c:1103
+#: build/rpmfc.c:1200
 #, c-format
 msgid "magic_open(0x%x) failed: %s\n"
 msgstr "magic_open(0x%x) 失敗：%s\n"
 
-#: build/rpmfc.c:1109
+#: build/rpmfc.c:1206 build/rpmfc.c:1210
 #, c-format
 msgid "magic_load failed: %s\n"
 msgstr "magic_load 失敗：%s\n"
 
-#: build/rpmfc.c:1152
+#: build/rpmfc.c:1257 build/rpmfc.c:1276
 #, c-format
 msgid "Recognition of file \"%s\" failed: mode %06o %s\n"
 msgstr "檔案「%s」辨識失敗：模式 %06o %s\n"
 
-#: build/rpmfc.c:1353
+#: build/rpmfc.c:1480
 #, c-format
 msgid "Finding  %s: %s\n"
 msgstr "正在尋找 %s：%s\n"
 
-#: build/rpmfc.c:1362 build/rpmfc.c:1371
+#: build/rpmfc.c:1489 build/rpmfc.c:1498
 #, c-format
 msgid "Failed to find %s:\n"
 msgstr "找不到 %s：\n"
 
-#: build/rpmfc.c:1410
+#: build/rpmfc.c:1537
 msgid "Deprecated external dependency generator is used!\n"
 msgstr "不推薦使用外部的相依性生成器！\n"
 
-#: build/spec.c:90
+#: build/spec.c:88
 #, c-format
 msgid "line %d: %s: package %s does not exist\n"
 msgstr "第 %d 行：%s：軟體包 %s 不存在\n"
 
-#: build/spec.c:93
+#: build/spec.c:91
 #, c-format
 msgid "line %d: %s: package %s already exists\n"
 msgstr "第 %d 行：%s：軟體包 %s 已存在\n"
 
-#: build/spec.c:214
-msgid "unable to parse SOURCE_DATE_EPOCH\n"
-msgstr "無法解析 SOURCE_DATE_EPOCH\n"
-
-#: build/spec.c:240
-#, c-format
-msgid "Could not canonicalize hostname: %s\n"
-msgstr "無法標準化主機名稱：%s\n"
-
-#: build/spec.c:520
+#: build/spec.c:471
 #, c-format
 msgid "query of specfile %s failed, can't parse\n"
 msgstr "%s 規格檔查詢失敗，無法剖析\n"
@@ -1760,90 +1725,114 @@ msgstr "%s 有過大或過小的 long 數值，略過\n"
 msgid "%s has too large or too small integer value, skipped\n"
 msgstr "%s 有過大或過小的整數值，略過\n"
 
-#: lib/backend/db3.c:808
+#: lib/backend/db3.c:804
 #, c-format
 msgid "cannot get %s lock on %s/%s\n"
 msgstr "無法取得 %s 於 %s/%s 的鎖定\n"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "shared"
 msgstr "已共享"
 
-#: lib/backend/db3.c:810
+#: lib/backend/db3.c:806
 msgid "exclusive"
 msgstr "排他"
 
-#: lib/backend/db3.c:892
+#: lib/backend/db3.c:888
 #, c-format
 msgid "invalid index type %x on %s/%s\n"
 msgstr "無效的索引類型 %x 於 %s / %s\n"
 
-#: lib/backend/db3.c:1068
+#: lib/backend/db3.c:1066
 #, c-format
 msgid "error(%d) getting \"%s\" records from %s index: %s\n"
 msgstr "錯誤 (%d) 取得「%s」紀錄自 %s 索引：%s\n"
 
-#: lib/backend/db3.c:1098
+#: lib/backend/db3.c:1096
 #, c-format
 msgid "error(%d) storing record \"%s\" into %s\n"
 msgstr "儲存記錄「%2$s」到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1106
+#: lib/backend/db3.c:1104
 #, c-format
 msgid "error(%d) removing record \"%s\" from %s\n"
 msgstr "從 %3$s 移除記錄「%2$s」時發生錯誤(%1$d)\n"
 
-#: lib/backend/db3.c:1208
+#: lib/backend/db3.c:1216
 #, c-format
 msgid "error(%d) adding header #%d record\n"
 msgstr "錯誤 (%d) 增加標頭 #%d 紀錄\n"
 
-#: lib/backend/db3.c:1217
+#: lib/backend/db3.c:1225
 #, c-format
 msgid "error(%d) removing header #%d record\n"
 msgstr "錯誤 (%d) 移除標頭 #%d 紀錄\n"
 
-#: lib/backend/db3.c:1272
+#: lib/backend/db3.c:1280
 #, c-format
 msgid "error(%d) allocating new package instance\n"
 msgstr "分配新軟體包實體時發生錯誤(%d)\n"
 
-#: lib/backend/dbi.c:66
+#: lib/backend/dbi.c:93
 #, c-format
-msgid ""
-"Found LMDB data.mdb database while attempting %s backend: using lmdb "
-"backend.\n"
+msgid "Converting database from %s to %s backend\n"
 msgstr ""
 
-#: lib/backend/dbi.c:75
+#: lib/backend/dbi.c:97
 #, c-format
-msgid ""
-"Found NDB Packages.db database while attempting %s backend: using ndb "
-"backend.\n"
+msgid "Found %s %s database while attempting %s backend: using %s backend.\n"
 msgstr ""
 
-#: lib/backend/dbi.c:84
+#: lib/backend/ndb/glue.c:101
+#, fuzzy
+msgid "Detected outdated index databases\n"
+msgstr "無法在 %s 移除舊的資料庫\n"
+
+#: lib/backend/ndb/glue.c:103
+#, fuzzy
+msgid "Rebuilding outdated index databases\n"
+msgstr "無法在 %s 移除舊的資料庫\n"
+
+#: lib/backend/ndb/rpmidx.c:204
 #, c-format
-msgid ""
-"Found BDB Packages database while attempting %s backend: using bdb backend.\n"
+msgid "rpmidx: Version mismatch. Expected version: %u. Found version: %u\n"
 msgstr ""
 
-#: lib/depends.c:93
+#: lib/backend/ndb/rpmpkg.c:125
+#, c-format
+msgid "rpmpkg: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmpkg.c:499
+msgid "rpmpkg: detected non-zero blob, trying auto repair\n"
+msgstr ""
+
+#: lib/backend/ndb/rpmxdb.c:237
+#, c-format
+msgid "rpmxdb: Version mismatch. Expected version: %u. Found version: %u\n"
+msgstr ""
+
+#: lib/backend/sqlite.c:154
+#, fuzzy, c-format
+msgid "Unable to open sqlite database %s: %s\n"
+msgstr "無法開啟 %s 規格檔：%s\n"
+
+#: lib/depends.c:87
 #, c-format
 msgid "%s is a Delta RPM and cannot be directly installed\n"
 msgstr "%s 為增量 RPM 且不能直接安裝\n"
 
-#: lib/depends.c:97
+#: lib/depends.c:91
 #, c-format
 msgid "Unsupported payload (%s) in package %s\n"
 msgstr "不支援的有效負荷 (%s) 於套件 %s\n"
 
-#: lib/depends.c:378
+#: lib/depends.c:362
 #, c-format
 msgid "package %s was already added, skipping %s\n"
 msgstr "軟體包 %s 已被加入，跳過 %s\n"
 
-#: lib/depends.c:379
+#: lib/depends.c:363
 #, c-format
 msgid "package %s was already added, replacing with %s\n"
 msgstr "軟體包 %s 已被加入，以 %s 替換\n"
@@ -1860,7 +1849,7 @@ msgstr "(不是數字)"
 msgid "(not a string)"
 msgstr "(不是字串)"
 
-#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:267
+#: lib/formats.c:47 lib/formats.c:151 lib/formats.c:269
 msgid "(invalid type)"
 msgstr "(無效型態)"
 
@@ -1873,146 +1862,146 @@ msgstr "%c"
 msgid "%a %b %d %Y"
 msgstr "%Y %b %d %a"
 
-#: lib/formats.c:253
+#: lib/formats.c:255
 msgid "(not base64)"
 msgstr "(不是 base64)"
 
-#: lib/formats.c:313
+#: lib/formats.c:315
 msgid "(invalid xml type)"
 msgstr "(無效 xml 類型)"
 
-#: lib/formats.c:358
+#: lib/formats.c:360
 msgid "(not an OpenPGP signature)"
 msgstr "(不是個 OpenPGP 簽署)"
 
-#: lib/formats.c:369
+#: lib/formats.c:371
 #, c-format
 msgid "Invalid date %u"
 msgstr "無效的日期 %u"
 
-#: lib/formats.c:417
+#: lib/formats.c:419
 msgid "normal"
 msgstr "一般"
 
-#: lib/formats.c:420 lib/verify.c:325
+#: lib/formats.c:422 lib/verify.c:325
 msgid "replaced"
 msgstr "已替換"
 
-#: lib/formats.c:423 lib/verify.c:319
+#: lib/formats.c:425 lib/verify.c:319
 msgid "not installed"
 msgstr "未安裝"
 
-#: lib/formats.c:426 lib/verify.c:321
+#: lib/formats.c:428 lib/verify.c:321
 msgid "net shared"
 msgstr "已網路分享"
 
-#: lib/formats.c:429 lib/verify.c:323
+#: lib/formats.c:431 lib/verify.c:323
 msgid "wrong color"
 msgstr "錯誤色彩"
 
-#: lib/formats.c:432
+#: lib/formats.c:434
 msgid "missing"
 msgstr "遺失"
 
-#: lib/formats.c:435
+#: lib/formats.c:437
 msgid "(unknown)"
 msgstr "(未知)"
 
-#: lib/fsm.c:749
+#: lib/fsm.c:725
 #, c-format
 msgid "%s saved as %s\n"
 msgstr "%s 已被另存為 %s\n"
 
-#: lib/fsm.c:802
+#: lib/fsm.c:778
 #, c-format
 msgid "%s created as %s\n"
 msgstr "%s 已建立為 %s \n"
 
-#: lib/fsm.c:1093
+#: lib/fsm.c:1069
 #, c-format
 msgid "%s %s: remove failed: %s\n"
 msgstr "%s %s：移除失敗：%s\n"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "directory"
 msgstr "目錄"
 
-#: lib/fsm.c:1094
+#: lib/fsm.c:1070
 msgid "file"
 msgstr "檔案"
 
-#: lib/header.c:310
+#: lib/header.c:301
 #, c-format
 msgid "tag[%d]: BAD, tag %d type %d offset %d count %d len %d"
 msgstr "標籤 [%d]：壞的，標籤 %d 類型 %d  偏差 %d 數值 %d 長度 %d"
 
-#: lib/header.c:977
+#: lib/header.c:971
 msgid "hdr load: BAD"
 msgstr "hdr_load：壞的"
 
-#: lib/header.c:1799
+#: lib/header.c:1793
 msgid "region: no tags"
 msgstr "區域：沒有標籤"
 
-#: lib/header.c:1821
+#: lib/header.c:1815
 #, c-format
 msgid "region tag: BAD, tag %d type %d offset %d count %d"
 msgstr "區域標籤：壞的，標籤 %d 類型 %d  偏差 %d 數值 %d"
 
-#: lib/header.c:1829
+#: lib/header.c:1823
 #, c-format
 msgid "region offset: BAD, tag %d type %d offset %d count %d"
 msgstr "區域偏差：壞的，標籤 %d 類型 %d  偏差 %d 數值 %d"
 
-#: lib/header.c:1851
+#: lib/header.c:1845
 #, c-format
 msgid "region trailer: BAD, tag %d type %d offset %d count %d"
 msgstr "區域 trailer：壞的，標籤 %d 類型 %d  偏差 %d 數值 %d"
 
-#: lib/header.c:1860
+#: lib/header.c:1854
 #, c-format
 msgid "region %d size: BAD, ril %d il %d rdl %d dl %d"
 msgstr "區域 %d 大小：壞的， ril %d il %d rdl %d dl %d"
 
-#: lib/header.c:1868
+#: lib/header.c:1862
 #, c-format
 msgid "region %d: tag number mismatch il %d ril %d dl %d rdl %d\n"
 msgstr ""
 
-#: lib/header.c:1918
+#: lib/header.c:1912
 #, c-format
 msgid "hdr size(%d): BAD, read returned %d"
 msgstr "hdr_size (%d)：壞的，讀取時回傳 %d"
 
-#: lib/header.c:1922
+#: lib/header.c:1916
 msgid "hdr magic: BAD"
 msgstr "hdr_magic：壞的"
 
-#: lib/header.c:1927
+#: lib/header.c:1921
 #, c-format
 msgid "hdr tags: BAD, no. of tags(%d) out of range"
 msgstr "hdr_tags：壞的，標籤 (%d) 的編號超出範圍"
 
-#: lib/header.c:1932
+#: lib/header.c:1926
 #, c-format
 msgid "hdr data: BAD, no. of bytes(%d) out of range"
 msgstr "hdr_data：壞的，標籤 (%d) 的編號超出範圍"
 
-#: lib/header.c:1942
+#: lib/header.c:1936
 #, c-format
 msgid "hdr blob(%zd): BAD, read returned %d"
 msgstr "hdr_blob(%zd)：壞的，讀取時回傳 %d"
 
-#: lib/header.c:1951
+#: lib/header.c:1945
 #, c-format
 msgid "sigh pad(%zd): BAD, read %zd bytes"
 msgstr "sigh_pad(%zd)：壞的，讀取 %zd 位元組"
 
-#: lib/header.c:1964
+#: lib/header.c:1958
 msgid "signature "
 msgstr "簽名"
 
-#: lib/header.c:1991
+#: lib/header.c:1985
 #, c-format
 msgid "blob size(%d): BAD, 8 + 16 * il(%d) + dl(%d)"
 msgstr "blob 大小 (%d)：差的，8 + 16 * il(%d) + dl(%d)"
@@ -2056,43 +2045,52 @@ msgstr "未預期的 ]"
 msgid "unexpected }"
 msgstr "未預期的 }"
 
-#: lib/headerfmt.c:511
+#: lib/headerfmt.c:473
+msgid "escaped char expected after \\"
+msgstr ""
+
+#: lib/headerfmt.c:515
 msgid "? expected in expression"
 msgstr "? 預期於表述式中"
 
-#: lib/headerfmt.c:518
+#: lib/headerfmt.c:522
 msgid "{ expected after ? in expression"
 msgstr "{ 預期於表述式中的 ? 之後"
 
-#: lib/headerfmt.c:530 lib/headerfmt.c:570
+#: lib/headerfmt.c:534 lib/headerfmt.c:574
 msgid "} expected in expression"
 msgstr "} 預期於表述式中"
 
-#: lib/headerfmt.c:538
+#: lib/headerfmt.c:542
 msgid ": expected following ? subexpression"
 msgstr ": 預期跟著 ? 子表述式"
 
-#: lib/headerfmt.c:556
+#: lib/headerfmt.c:560
 msgid "{ expected after : in expression"
 msgstr "{ 預期於表述式中 : 之後"
 
-#: lib/headerfmt.c:578
+#: lib/headerfmt.c:582
 msgid "| expected at end of expression"
 msgstr "| 預期於表述式的結尾"
 
-#: lib/headerfmt.c:753
+#: lib/headerfmt.c:757
 msgid "array iterator used with different sized arrays"
 msgstr "用於不同大小陣列的陣列迭代器"
 
-#: lib/poptALL.c:144
+#: lib/package.c:315
+#, fuzzy, c-format
+msgid "RPM v3 packages are deprecated: %s\n"
+msgstr "第 %d 行：%s 重複：%s\n"
+
+#: lib/poptALL.c:144 rpmio/macro.c:1282
 #, c-format
 msgid "failed to load macro file %s\n"
 msgstr ""
 
 #: lib/poptALL.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "arguments to --dbpath must begin with '/'\n"
-msgstr "--prefix 的引數必須以「/」開頭"
+msgstr ""
 
 #: lib/poptALL.c:172
 #, c-format
@@ -2632,25 +2630,25 @@ msgstr "不校驗軟體包的相依關係"
 msgid "don't execute verify script(s)"
 msgstr "不執行校驗指令小稿"
 
-#: lib/psm.c:146
+#: lib/psm.c:148
 #, c-format
 msgid "Missing rpmlib features for %s:\n"
 msgstr "遺失為 %s 的 rpmlib 功能：\n"
 
-#: lib/psm.c:183
+#: lib/psm.c:185
 msgid "source package expected, binary found\n"
 msgstr "預期是源碼軟體包，但卻找到二進位軟體包\n"
 
-#: lib/psm.c:194
+#: lib/psm.c:196
 msgid "source package contains no .spec file\n"
 msgstr "源碼軟體包內未包含 .spec 檔案\n"
 
-#: lib/psm.c:608
+#: lib/psm.c:610
 #, c-format
 msgid "unpacking of archive failed%s%s: %s\n"
 msgstr "解包封存檔失敗 %s%s：%s\n"
 
-#: lib/psm.c:609
+#: lib/psm.c:611
 msgid " on file "
 msgstr "  於檔案 "
 
@@ -2700,137 +2698,137 @@ msgstr "軟體包內沒有檔案擁有者/群組記錄\n"
 msgid "package has neither file owner or id lists\n"
 msgstr "軟體包內沒有檔案擁有者及 ID 清單\n"
 
-#: lib/query.c:313
+#: lib/query.c:326
 #, c-format
 msgid "group %s does not contain any packages\n"
 msgstr "群組 %s 內不包含任何軟體包\n"
 
-#: lib/query.c:320
+#: lib/query.c:333
 #, c-format
 msgid "no package triggers %s\n"
 msgstr "沒有軟體包會觸發 %s\n"
 
-#: lib/query.c:331 lib/query.c:350 lib/query.c:366
+#: lib/query.c:344 lib/query.c:363 lib/query.c:379
 #, c-format
 msgid "malformed %s: %s\n"
 msgstr "格式不良的 %s：%s\n"
 
-#: lib/query.c:341 lib/query.c:356 lib/query.c:371
+#: lib/query.c:354 lib/query.c:369 lib/query.c:384
 #, c-format
 msgid "no package matches %s: %s\n"
 msgstr "沒有軟體包符合 %s：%s\n"
 
-#: lib/query.c:379
+#: lib/query.c:392
 #, c-format
 msgid "no package conflicts %s\n"
 msgstr ""
 
-#: lib/query.c:386
+#: lib/query.c:399
 #, c-format
 msgid "no package obsoletes %s\n"
 msgstr ""
 
-#: lib/query.c:393
+#: lib/query.c:406
 #, c-format
 msgid "no package requires %s\n"
 msgstr "沒有軟體包需要 %s\n"
 
-#: lib/query.c:400
+#: lib/query.c:413
 #, c-format
 msgid "no package recommends %s\n"
 msgstr "沒有任何軟體包推薦 %s\n"
 
-#: lib/query.c:407
+#: lib/query.c:420
 #, c-format
 msgid "no package suggests %s\n"
 msgstr "沒有任何軟體包建議 %s\n"
 
-#: lib/query.c:414
+#: lib/query.c:427
 #, c-format
 msgid "no package supplements %s\n"
 msgstr "沒有軟體包補充 %s\n"
 
-#: lib/query.c:421
+#: lib/query.c:434
 #, c-format
 msgid "no package enhances %s\n"
 msgstr "沒有軟體包增強 %s\n"
 
-#: lib/query.c:429
+#: lib/query.c:442
 #, c-format
 msgid "no package provides %s\n"
 msgstr "沒有軟體包提供 %s\n"
 
-#: lib/query.c:461
+#: lib/query.c:474
 #, c-format
 msgid "file %s: %s\n"
 msgstr "檔案 %s：%s\n"
 
-#: lib/query.c:464
+#: lib/query.c:477
 #, c-format
 msgid "file %s is not owned by any package\n"
 msgstr "檔案 %s 不被任何軟體包擁有\n"
 
-#: lib/query.c:475
+#: lib/query.c:488
 #, c-format
 msgid "invalid package number: %s\n"
 msgstr "無效的軟體包編號：%s\n"
 
-#: lib/query.c:482
+#: lib/query.c:495
 #, c-format
 msgid "record %u could not be read\n"
 msgstr "%u 記錄無法讀取\n"
 
-#: lib/query.c:496 lib/rpminstall.c:701
+#: lib/query.c:504 lib/rpminstall.c:701
 #, c-format
 msgid "package %s is not installed\n"
 msgstr "軟體包 %s 尚未安裝\n"
 
-#: lib/query.c:530
+#: lib/query.c:535
 #, c-format
 msgid "unknown tag: \"%s\"\n"
 msgstr "未知的標籤：「%s」\n"
 
-#: lib/rpmchecksig.c:50 lib/rpmchecksig.c:58
+#: lib/rpmchecksig.c:48 lib/rpmchecksig.c:56
 #, c-format
 msgid "%s: key %d import failed.\n"
 msgstr "%s：密鑰 %d 匯入失敗。\n"
 
-#: lib/rpmchecksig.c:66
+#: lib/rpmchecksig.c:64
 #, c-format
 msgid "%s: key %d not an armored public key.\n"
 msgstr "%s：密鑰 %d 非 armor 狀態的公鑰。\n"
 
-#: lib/rpmchecksig.c:111
+#: lib/rpmchecksig.c:109
 #, c-format
 msgid "%s: import read failed(%d).\n"
 msgstr "%s：匯入時讀取失敗(%d)。\n"
 
-#: lib/rpmchecksig.c:131
+#: lib/rpmchecksig.c:129
 #, c-format
 msgid "Fread failed: %s"
 msgstr "fread 失敗：%s"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "DIGESTS"
 msgstr "DIGESTS"
 
-#: lib/rpmchecksig.c:247
+#: lib/rpmchecksig.c:246
 msgid "digests"
 msgstr "digests"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "SIGNATURES"
 msgstr "簽名"
 
-#: lib/rpmchecksig.c:251
+#: lib/rpmchecksig.c:250
 msgid "signatures"
 msgstr "簽名"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "NOT OK"
 msgstr "不正確"
 
-#: lib/rpmchecksig.c:253
+#: lib/rpmchecksig.c:252
 msgid "OK"
 msgstr "正確"
 
@@ -2844,116 +2842,116 @@ msgstr "%s：開啟失敗：%s\n"
 msgid "Unable to open current directory: %m\n"
 msgstr "無法開啟目前的目錄：%m\n"
 
-#: lib/rpmchroot.c:116 lib/rpmchroot.c:144
+#: lib/rpmchroot.c:116 lib/rpmchroot.c:145
 #, c-format
 msgid "%s: chroot directory not set\n"
 msgstr "%s：chroot 目錄未設定\n"
 
-#: lib/rpmchroot.c:130
+#: lib/rpmchroot.c:131
 #, c-format
 msgid "Unable to change root directory: %m\n"
 msgstr "無法修改根目錄：%m\n"
 
-#: lib/rpmchroot.c:155
+#: lib/rpmchroot.c:157
 #, c-format
 msgid "Unable to restore root directory: %m\n"
 msgstr "無法恢復根目錄：%m\n"
 
-#: lib/rpmdb.c:72
+#: lib/rpmdb.c:65
 #, c-format
 msgid "Generating %d missing index(es), please wait...\n"
 msgstr "生成 %d 個遺失的索引，請等待…\n"
 
-#: lib/rpmdb.c:167 lib/rpmdb.c:213
+#: lib/rpmdb.c:160 lib/rpmdb.c:206
 #, c-format
 msgid "cannot open %s index using %s - %s (%d)\n"
 msgstr "無法開啟 %s 個索引，透過 %s - %s (%d)\n"
 
-#: lib/rpmdb.c:462
+#: lib/rpmdb.c:460
 msgid "no dbpath has been set\n"
 msgstr "尚未設定 dbpath\n"
 
-#: lib/rpmdb.c:974
+#: lib/rpmdb.c:971
 msgid "miFreeHeader: skipping"
 msgstr "miFreeHeader：跳過"
 
-#: lib/rpmdb.c:990
+#: lib/rpmdb.c:987
 #, c-format
 msgid "error(%d) storing record #%d into %s\n"
 msgstr "儲存記錄 #%2$d 到 %3$s 時發生錯誤(%1$d)\n"
 
-#: lib/rpmdb.c:1102
+#: lib/rpmdb.c:1099
 #, c-format
 msgid "%s: regexec failed: %s\n"
 msgstr "%s：regexec 失敗：%s\n"
 
-#: lib/rpmdb.c:1283
+#: lib/rpmdb.c:1280
 #, c-format
 msgid "%s: regcomp failed: %s\n"
 msgstr "%s：regcomp 失敗：%s\n"
 
-#: lib/rpmdb.c:1446
+#: lib/rpmdb.c:1443
 msgid "rpmdbNextIterator: skipping"
 msgstr "rpmdbNextIterator：跳過"
 
-#: lib/rpmdb.c:1533
+#: lib/rpmdb.c:1530
 #, c-format
 msgid "rpmdb: damaged header #%u retrieved -- skipping.\n"
 msgstr "rpmdb：已擷取損壞的表頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2063
+#: lib/rpmdb.c:2065
 #, c-format
 msgid "%s: cannot read header at 0x%x\n"
 msgstr "%s：無法讀取位於 0x%x 的表頭\n"
 
-#: lib/rpmdb.c:2414
+#: lib/rpmdb.c:2408
 msgid "could not move new database in place\n"
 msgstr "無法移動新的資料庫\n"
 
-#: lib/rpmdb.c:2417
+#: lib/rpmdb.c:2411
 #, c-format
 msgid "could also not restore old database from %s\n"
 msgstr "同樣無法從 %s 還原舊的軟體庫\n"
 
-#: lib/rpmdb.c:2419 lib/rpmdb.c:2606
+#: lib/rpmdb.c:2413 lib/rpmdb.c:2599
 #, c-format
 msgid "replace files in %s with files from %s to recover\n"
 msgstr "將 %s 的檔案替換成來自 %s 的檔案以進行恢復\n"
 
-#: lib/rpmdb.c:2428
+#: lib/rpmdb.c:2422
 #, c-format
 msgid "Could not get public keys from %s\n"
 msgstr "無法從 %s 取得公鑰\n"
 
-#: lib/rpmdb.c:2435
+#: lib/rpmdb.c:2429
 #, c-format
 msgid "could not delete old database at %s\n"
 msgstr "無法在 %s 移除舊的資料庫\n"
 
-#: lib/rpmdb.c:2505
+#: lib/rpmdb.c:2500
 msgid "no dbpath has been set"
 msgstr "尚未設定 dbpath"
 
-#: lib/rpmdb.c:2523
+#: lib/rpmdb.c:2518
 #, c-format
 msgid "failed to create directory %s: %s\n"
 msgstr "無法建立目錄 %s：%s\n"
 
-#: lib/rpmdb.c:2560
+#: lib/rpmdb.c:2553
 #, c-format
 msgid "header #%u in the database is bad -- skipping.\n"
 msgstr "在資料庫中有不良的表頭 #%u -- 跳過。\n"
 
-#: lib/rpmdb.c:2575
+#: lib/rpmdb.c:2568
 #, c-format
 msgid "cannot add record originally at %u\n"
 msgstr "無法加入原本位於 %u 的記錄\n"
 
-#: lib/rpmdb.c:2591
+#: lib/rpmdb.c:2584
 msgid "failed to rebuild database: original database remains in place\n"
 msgstr "重建資料庫時失敗：原來的資料庫保持原狀\n"
 
-#: lib/rpmdb.c:2604
+#: lib/rpmdb.c:2597
 msgid "failed to replace old database with new database!\n"
 msgstr "以新的資料庫取代舊的資料庫時失敗！\n"
 
@@ -3042,9 +3040,8 @@ msgid "support for rich dependencies."
 msgstr "支援富相依性"
 
 #: lib/rpmds.c:1254
-#, fuzzy
 msgid "support for dynamic buildrequires."
-msgstr "支援富相依性"
+msgstr ""
 
 #: lib/rpmds.c:1258
 msgid "package payload can be compressed using zstd."
@@ -3291,22 +3288,22 @@ msgstr "無法建立 %s 鎖於 %s (%s) 上\n"
 msgid "waiting for %s lock on %s\n"
 msgstr "等待 %s 鎖於 %s 上\n"
 
-#: lib/rpmplugins.c:65
+#: lib/rpmplugins.c:67
 #, c-format
 msgid "Failed to dlopen %s %s\n"
 msgstr "無法 dlopen %s %s\n"
 
-#: lib/rpmplugins.c:73
+#: lib/rpmplugins.c:77
 #, c-format
 msgid "Failed to resolve symbol %s: %s\n"
 msgstr "無法接收符號 %s：%s\n"
 
-#: lib/rpmplugins.c:155
+#: lib/rpmplugins.c:159
 #, c-format
 msgid "Plugin %%__%s_%s not configured\n"
 msgstr "附加元件 %%__%s_%s 尚未設定\n"
 
-#: lib/rpmplugins.c:200
+#: lib/rpmplugins.c:204
 #, c-format
 msgid "Plugin %s not loaded\n"
 msgstr "%s 插件未載入\n"
@@ -3351,13 +3348,14 @@ msgid "package %s (which is newer than %s) is already installed"
 msgstr "軟體包 %s (比 %s 還新) 已經安裝"
 
 #: lib/rpmprob.c:145
-#, c-format
-msgid "installing package %s needs %<PRIu64>%cB on the %s filesystem"
+#, fuzzy, c-format
+msgid ""
+"installing package %s needs %<PRIu64>%cB more space on the %s filesystem"
 msgstr "安裝軟體包 %s 需要 %<PRIu64>%cB 於 %s 檔案系統上"
 
 #: lib/rpmprob.c:155
-#, c-format
-msgid "installing package %s needs %<PRIu64> inodes on the %s filesystem"
+#, fuzzy, c-format
+msgid "installing package %s needs %<PRIu64> more inodes on the %s filesystem"
 msgstr "安裝軟體包 %s 需要 %<PRIu64> inode 於 %s 檔案系統上"
 
 #: lib/rpmprob.c:159
@@ -3481,7 +3479,7 @@ msgstr "Lua 指令小稿 沒有任何 exec() 在 fork() 之後呼叫\n"
 msgid "Unable to restore current directory: %m"
 msgstr "無法恢復目前的目錄：%m"
 
-#: lib/rpmscript.c:162 rpmio/macro.c:1020
+#: lib/rpmscript.c:162 rpmio/macro.c:1079
 msgid "<lua> scriptlet support not built in\n"
 msgstr "<lua> 指令小稿 不支援內建\n"
 
@@ -3524,15 +3522,15 @@ msgstr "%s 指令小稿 失敗，離開狀態碼 %d\n"
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: lib/rpmte.c:755
+#: lib/rpmte.c:757
 msgid "install"
 msgstr "安裝"
 
-#: lib/rpmte.c:756
+#: lib/rpmte.c:758
 msgid "erase"
 msgstr "抹除"
 
-#: lib/rpmte.c:757
+#: lib/rpmte.c:759
 msgid "rpmdb"
 msgstr ""
 
@@ -3541,96 +3539,96 @@ msgstr ""
 msgid "cannot open Packages database in %s\n"
 msgstr "無法開啟軟體包資料庫 %s\n"
 
-#: lib/rpmts.c:199
+#: lib/rpmts.c:203
 #, c-format
 msgid "extra '(' in package label: %s\n"
 msgstr "額外的「(」存在於軟體包標籤中：%s\n"
 
-#: lib/rpmts.c:217
+#: lib/rpmts.c:221
 #, c-format
 msgid "missing '(' in package label: %s\n"
 msgstr "軟體包標籤遺漏「(」：%s\n"
 
-#: lib/rpmts.c:225
+#: lib/rpmts.c:229
 #, c-format
 msgid "missing ')' in package label: %s\n"
 msgstr "軟體包標籤遺漏「)」：%s\n"
 
-#: lib/rpmts.c:284
+#: lib/rpmts.c:288
 #, c-format
 msgid "%s: reading of public key failed.\n"
 msgstr "%s：讀取公鑰失敗。\n"
 
-#: lib/rpmts.c:1072
+#: lib/rpmts.c:1076
 #, c-format
 msgid "invalid package verify level %s\n"
 msgstr ""
 
-#: lib/rpmts.c:1229
+#: lib/rpmts.c:1233
 msgid "transaction"
 msgstr "處理事項"
 
-#: lib/rpmvs.c:150
+#: lib/rpmvs.c:154
 #, c-format
 msgid "%s tag %u: invalid type %u"
 msgstr "%s 標籤 %u：無效的類型 %u"
 
-#: lib/rpmvs.c:156
+#: lib/rpmvs.c:160
 #, c-format
 msgid "%s: tag %u: invalid count %u"
 msgstr "%s 標籤 %u：無效的數字 %u"
 
-#: lib/rpmvs.c:176
+#: lib/rpmvs.c:180
 #, c-format
 msgid "%s tag %u: invalid data %p (%u)"
 msgstr "%s 標籤 %u：無效的資料 %p (%u)"
 
-#: lib/rpmvs.c:186
+#: lib/rpmvs.c:190
 #, c-format
 msgid "%s tag %u: invalid size %u"
 msgstr "%s 標籤 %u：無效的大小 %u"
 
-#: lib/rpmvs.c:193
+#: lib/rpmvs.c:197
 #, c-format
 msgid "%s tag %u: invalid OpenPGP signature"
 msgstr "%s 標籤 %u：無效的 OpenGPG 簽名"
 
-#: lib/rpmvs.c:205
+#: lib/rpmvs.c:209
 #, c-format
 msgid "%s: tag %u: invalid hex"
 msgstr "%s 標籤 %u：無效的十六進位碼"
 
-#: lib/rpmvs.c:260 lib/rpmvs.c:272
-#, c-format
-msgid "%s%s %s"
+#: lib/rpmvs.c:264 lib/rpmvs.c:277
+#, fuzzy, c-format
+msgid "%s%s%s %s"
 msgstr "%s%s %s"
 
-#: lib/rpmvs.c:263
+#: lib/rpmvs.c:268
 msgid "digest"
 msgstr "digest"
 
-#: lib/rpmvs.c:268
+#: lib/rpmvs.c:273
 #, c-format
 msgid "%s%s"
 msgstr "%s%s"
 
-#: lib/rpmvs.c:275
+#: lib/rpmvs.c:281
 msgid "signature"
 msgstr "簽名"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "header"
 msgstr "標頭"
 
-#: lib/rpmvs.c:302
+#: lib/rpmvs.c:308
 msgid "package"
 msgstr "軟體包"
 
-#: lib/rpmvs.c:508
+#: lib/rpmvs.c:532
 msgid "Header "
 msgstr "表頭 "
 
-#: lib/rpmvs.c:509
+#: lib/rpmvs.c:533
 msgid "Payload "
 msgstr "有效載荷"
 
@@ -3638,19 +3636,19 @@ msgstr "有效載荷"
 msgid "Unable to reload signature header.\n"
 msgstr "無法重新載入簽署表頭。\n"
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no signature"
 msgstr ""
 
-#: lib/transaction.c:1220
+#: lib/transaction.c:1272
 msgid "no digest"
 msgstr ""
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "skipped"
 msgstr "已跳過"
 
-#: lib/transaction.c:1540
+#: lib/transaction.c:1624
 msgid "failed"
 msgstr "已失敗"
 
@@ -3691,83 +3689,181 @@ msgstr "無法初始化 NSS 的函式庫\n"
 msgid "Failed to register fork handler: %m\n"
 msgstr "無法註冊 fork 處理器：%m\n"
 
-#: rpmio/macro.c:334
+#: rpmio/expression.c:303
+#, fuzzy
+msgid "syntax error while parsing =="
+msgstr "解析 == 時有語法錯誤\n"
+
+#: rpmio/expression.c:333
+#, fuzzy
+msgid "syntax error while parsing &&"
+msgstr "解析 && 時有語法錯誤\n"
+
+#: rpmio/expression.c:342
+#, fuzzy
+msgid "syntax error while parsing ||"
+msgstr "解析 || 時有語法錯誤\n"
+
+#: rpmio/expression.c:370
+msgid "macro expansion returned a bare word, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:372
+msgid "macro expansion did not return an integer"
+msgstr ""
+
+#: rpmio/expression.c:373
+#, fuzzy, c-format
+msgid "expanded string: %s\n"
+msgstr "第 %d 行：%s 在：%s\n"
+
+#: rpmio/expression.c:383
+msgid "bare words are no longer supported, please use \"...\""
+msgstr ""
+
+#: rpmio/expression.c:398
+#, fuzzy
+msgid "unterminated string in expression"
+msgstr "{ 預期於表述式中的 ? 之後"
+
+#: rpmio/expression.c:409
+#, fuzzy
+msgid "parse error in expression"
+msgstr "表述式解析錯誤\n"
+
+#: rpmio/expression.c:447
+#, fuzzy
+msgid "unmatched ("
+msgstr "不符合的 (\n"
+
+#: rpmio/expression.c:470
+#, fuzzy
+msgid "- only on numbers"
+msgstr "- 只能用於數字\n"
+
+#: rpmio/expression.c:489
+#, fuzzy
+msgid "unexpected end of expression"
+msgstr "| 預期於表述式的結尾"
+
+#: rpmio/expression.c:493 rpmio/expression.c:798 rpmio/expression.c:852
+#: rpmio/expression.c:889
+#, fuzzy
+msgid "syntax error in expression"
+msgstr "表述式中有語法錯誤\n"
+
+#: rpmio/expression.c:534 rpmio/expression.c:593 rpmio/expression.c:654
+#: rpmio/expression.c:754 rpmio/expression.c:813
+#, fuzzy
+msgid "types must match"
+msgstr "類型必須符合\n"
+
+#: rpmio/expression.c:544
+msgid "division by zero"
+msgstr ""
+
+#: rpmio/expression.c:552
+#, fuzzy
+msgid "* and / not supported for strings"
+msgstr "字串不支援 *、/\n"
+
+#: rpmio/expression.c:608
+#, fuzzy
+msgid "- not supported for strings"
+msgstr "字串不支援 -\n"
+
+#: rpmio/macro.c:348
 #, c-format
 msgid "%3d>%*s(empty)\n"
 msgstr ""
 
-#: rpmio/macro.c:364
+#: rpmio/macro.c:378
 #, c-format
 msgid "%3d<%*s(empty)\n"
 msgstr "%3d<%*s(清空)\n"
 
-#: rpmio/macro.c:588
+#: rpmio/macro.c:496
+#, fuzzy, c-format
+msgid "Failed to open shell expansion pipe for command: %s: %m \n"
+msgstr "無法開啟 tar 導管：%m\n"
+
+#: rpmio/macro.c:634
 #, c-format
 msgid "Macro %%%s has illegal name (%s)\n"
 msgstr "巨集 %%%s 擁有非法名稱（%s）\n"
 
-#: rpmio/macro.c:593
+#: rpmio/macro.c:639
 #, c-format
 msgid "Macro %%%s is a built-in (%s)\n"
 msgstr ""
 
-#: rpmio/macro.c:638
+#: rpmio/macro.c:683
 #, c-format
 msgid "Macro %%%s has unterminated opts\n"
 msgstr "巨集 %%%s 具有未終結的選項\n"
 
-#: rpmio/macro.c:649 rpmio/macro.c:686
+#: rpmio/macro.c:694 rpmio/macro.c:733
 #, c-format
 msgid "Macro %%%s has unterminated body\n"
 msgstr "巨集 %%%s 具有未終結的主體\n"
 
-#: rpmio/macro.c:706
+#: rpmio/macro.c:753
 #, c-format
 msgid "Macro %%%s has empty body\n"
 msgstr "巨集 %%%s 具有空的主體\n"
 
-#: rpmio/macro.c:711
+#: rpmio/macro.c:758
 #, c-format
 msgid "Macro %%%s needs whitespace before body\n"
 msgstr "巨集 %%%s 需要在內容以前有一個空白\n"
 
-#: rpmio/macro.c:715
+#: rpmio/macro.c:762
 #, c-format
 msgid "Macro %%%s failed to expand\n"
 msgstr "巨集 %%%s 展開時失敗\n"
 
-#: rpmio/macro.c:802
+#: rpmio/macro.c:848
 #, c-format
 msgid "Macro %%%s defined but not used within scope\n"
 msgstr "巨集 %%%s 被定義但未使用於 scope 中\n"
 
-#: rpmio/macro.c:926
+#: rpmio/macro.c:968
 #, c-format
 msgid "Unknown option %c in %s(%s)\n"
 msgstr "在 %2$s(%3$s) 中有未知的選項 %1$c\n"
 
-#: rpmio/macro.c:1181
+#: rpmio/macro.c:1027
 #, c-format
-msgid "failed to load macro file %s"
-msgstr "無法載入巨集檔案 %s"
+msgid "no such macro: '%s'\n"
+msgstr ""
 
-#: rpmio/macro.c:1261
+#: rpmio/macro.c:1390
 msgid ""
 "Too many levels of recursion in macro expansion. It is likely caused by "
 "recursive macro declaration.\n"
 msgstr "巨集附加元件中太多遞迴階級。這可能是因為遞迴巨集聲明而造成。\n"
 
-#: rpmio/macro.c:1320 rpmio/macro.c:1335
+#: rpmio/macro.c:1420
 #, c-format
 msgid "Unterminated %c: %s\n"
 msgstr "未終結的 %c：%s\n"
 
-#: rpmio/macro.c:1366
+#: rpmio/macro.c:1475
 #, c-format
 msgid "A %% is followed by an unparseable macro\n"
 msgstr "在無法解析的巨集之後跟著一個 %%\n"
 
-#: rpmio/macro.c:1694
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "argument expected"
+msgstr "未預期的 ]"
+
+#: rpmio/macro.c:1488
+#, fuzzy
+msgid "unexpected argument"
+msgstr "未預期的 ]"
+
+#: rpmio/macro.c:1797
 #, c-format
 msgid "======================== active %d empty %d\n"
 msgstr "======================== 作用中 %d 清空 %d\n"
@@ -3811,27 +3907,27 @@ msgstr "警告："
 msgid "Error writing to log"
 msgstr ""
 
-#: rpmio/rpmlua.c:575
+#: rpmio/rpmlua.c:576
 #, c-format
 msgid "invalid syntax in lua scriptlet: %s\n"
 msgstr "Lua 指令小稿 包含無效的語法：%s\n"
 
-#: rpmio/rpmlua.c:593
+#: rpmio/rpmlua.c:594
 #, c-format
 msgid "invalid syntax in lua script: %s\n"
 msgstr "Lua 指令小稿包含無效的語法：%s\n"
 
-#: rpmio/rpmlua.c:598 rpmio/rpmlua.c:617
+#: rpmio/rpmlua.c:599 rpmio/rpmlua.c:618
 #, c-format
 msgid "lua script failed: %s\n"
 msgstr "lua 指令小稿失敗：%s\n"
 
-#: rpmio/rpmlua.c:612
+#: rpmio/rpmlua.c:613
 #, c-format
 msgid "invalid syntax in lua file: %s\n"
 msgstr "lua 檔案內有無效語法：%s\n"
 
-#: rpmio/rpmlua.c:809
+#: rpmio/rpmlua.c:810
 #, c-format
 msgid "lua hook failed: %s\n"
 msgstr "Lua 鉤子 (hook) 失敗：%s\n"
@@ -3841,17 +3937,17 @@ msgstr "Lua 鉤子 (hook) 失敗：%s\n"
 msgid "memory alloc (%u bytes) returned NULL.\n"
 msgstr "記憶體配置 (%u 位元組) 回傳 NULL。\n"
 
-#: rpmio/rpmpgp.c:664 rpmio/rpmpgp.c:752 rpmio/rpmpgp.c:826
+#: rpmio/rpmpgp.c:667 rpmio/rpmpgp.c:755 rpmio/rpmpgp.c:829
 #, c-format
 msgid "Unsupported version of key: V%d\n"
 msgstr "不支援的密鑰版本：V%d\n"
 
-#: rpmio/rpmpgp.c:1127
+#: rpmio/rpmpgp.c:1130
 #, c-format
 msgid "V%d %s/%s %s, key ID %s"
 msgstr "V%d %s/%s %s，密鑰識別碼 %s"
 
-#: rpmio/rpmpgp.c:1135
+#: rpmio/rpmpgp.c:1138
 msgid "(none)"
 msgstr "(無)"
 
@@ -3940,44 +4036,44 @@ msgstr "寫入簽署時 gpg 失敗\n"
 msgid "unable to read the signature\n"
 msgstr "無法讀取簽名\n"
 
-#: sign/rpmgensig.c:488
+#: sign/rpmgensig.c:491
 msgid "file signing support not built in\n"
 msgstr "檔案簽名不支援內建\n"
 
-#: sign/rpmgensig.c:562
+#: sign/rpmgensig.c:565
 #, c-format
 msgid "%s: rpmReadSignature failed: %s"
 msgstr "%s：rpmReadSignature 失敗：%s"
 
-#: sign/rpmgensig.c:569
+#: sign/rpmgensig.c:572
 #, c-format
 msgid "%s: headerRead failed: %s\n"
 msgstr "%s: headerRead 失敗：%s\n"
 
-#: sign/rpmgensig.c:574
+#: sign/rpmgensig.c:577
 msgid "Cannot sign RPM v3 packages\n"
 msgstr "無法簽名 RPM v3 軟體包\n"
 
-#: sign/rpmgensig.c:603
+#: sign/rpmgensig.c:613
 #, c-format
 msgid "%s already contains identical signature, skipping\n"
 msgstr "%s 已經包含了相同的簽名，略過\n"
 
-#: sign/rpmgensig.c:638 sign/rpmgensig.c:661
+#: sign/rpmgensig.c:648 sign/rpmgensig.c:671
 #, c-format
 msgid "%s: rpmWriteSignature failed: %s\n"
 msgstr "%s：rpmWriteSignature 失敗：%s\n"
 
-#: sign/rpmgensig.c:648
+#: sign/rpmgensig.c:658
 msgid "rpmMkTemp failed\n"
 msgstr "rpmMkTemp 失敗\n"
 
-#: sign/rpmgensig.c:655
+#: sign/rpmgensig.c:665
 #, c-format
 msgid "%s: writeLead failed: %s\n"
 msgstr "%s：writeLead 失敗：%s\n"
 
-#: sign/rpmgensig.c:680
+#: sign/rpmgensig.c:690
 #, c-format
 msgid "replacing %s failed: %s\n"
 msgstr "替換 %s 失敗：%s\n"
@@ -4007,23 +4103,20 @@ msgstr "%s：讀取清單失敗：%s\n"
 msgid "don't verify header+payload signature"
 msgstr "不驗證表頭+酬載簽署"
 
-#~ msgid "Exec of %s failed (%s): %s\n"
-#~ msgstr "執行 %s 失敗 (%s)：%s\n"
+#~ msgid "! only on numbers\n"
+#~ msgstr "! 只能用於數字\n"
 
-#~ msgid "Error executing scriptlet %s (%s)\n"
-#~ msgstr "執行指令小稿 時錯誤 %s (%s)\n"
+#~ msgid "&& and || not suported for strings\n"
+#~ msgstr "字串不支援 && 和 ||\n"
 
-#~ msgid "line: %s\n"
-#~ msgstr "列：%s\n"
+#, c-format
+#~ msgid "Error reading %%files file %s: %m\n"
+#~ msgstr "讀取 %%files 檔案 %s 失敗：%m\n"
 
-#~ msgid "%s: line: %s\n"
-#~ msgstr "%s: 列：%s\n"
+#, c-format
+#~ msgid "Could not open %s file: %s\n"
+#~ msgstr "無法開啟 %s 檔案：%s\n"
 
-#~ msgid "No \"Source:\" tag in the spec file\n"
-#~ msgstr "規格檔內無「Source:」標籤\n"
-
-#~ msgid "line %d: %s\n"
-#~ msgstr "列 %d：%s\n"
-
-#~ msgid "%s:%d: Got a %%endif with no %%if\n"
-#~ msgstr "%s:%d：有個 %%endif 沒有對應 %%if\n"
+#, c-format
+#~ msgid "failed to load macro file %s"
+#~ msgstr "無法載入巨集檔案 %s"

--- a/rpm.am
+++ b/rpm.am
@@ -7,4 +7,4 @@ rpmlibexecdir = $(prefix)/lib/rpm
 rpmconfigdir = $(prefix)/lib/rpm
 
 # Libtool version (current-revision-age) for all our libraries
-rpm_version_info = 9:0:0
+rpm_version_info = 10:0:1


### PR DESCRIPTION
Update libtool version info for 4.16.0 - only added APIs, none removed.
Regenerate translations.