### PR TITLE
Eliminate extra compilation step from CI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -303,9 +303,9 @@ doc/librpm.doxy: doc/librpm.doxy.in doc/librpm/Doxyheader.h Makefile.am configur
 	  -e "s,[@]VERSION[@],$(VERSION)," \
 	< $(top_srcdir)/doc/librpm.doxy.in > doc/librpm.doxy
 
-doc/librpm/html/index.html: doc/librpm.doxy
+doc/librpm/html: doc/librpm.doxy
 	@DOXYGEN@ doc/librpm.doxy
-noinst_DATA += doc/librpm/html/index.html
+noinst_DATA += doc/librpm/html
 endif
 EXTRA_DIST += doc/librpm.doxy.in doc/librpm/Doxyheader.h
 EXTRA_DIST += doc/librpm/html

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -64,6 +64,5 @@ RUN ./configure \
   --enable-python \
   --enable-silent-rules \
   --enable-werror
-RUN make -j
 
 CMD make -j distcheck; rc=$?; find . -name rpmtests.log|xargs cat; exit $rc


### PR DESCRIPTION
Fix distcheck to work without extra compile step, and drop said extra step.