### PR TITLE
Bump gettext version to 0.18.2 to get rid of deprecation warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -625,7 +625,7 @@ if test "x$have_sqlite" = "xyes"; then
 fi
 AM_CONDITIONAL([SQLITE], [test "x$have_sqlite" = "xyes"])
 
-AM_GNU_GETTEXT_VERSION([0.16.1])
+AM_GNU_GETTEXT_VERSION([0.18.2])
 AM_GNU_GETTEXT([external])
 AM_ICONV
 


### PR DESCRIPTION
Our beloved gettext 0.16.1 version causes automake to complain about
AM_PROG_MKDIR_P being deprecated although we never directly use such
a macro for anything. This appears to have been fixed in gettext 0.18.2
so bump to that version, having been released in 2012 makes it, um,
mature enough, even for rpm purposes.