### PR TITLE
actually include the new man pages

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,8 +8,9 @@ EXTRA_DIST += $(man_man1_DATA)
 
 man_man8dir = $(mandir)/man8
 man_man8_DATA = rpm.8 rpm-misc.8 rpmbuild.8 rpmdeps.8 rpmgraph.8 rpm2cpio.8
-man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8
-man_man8_DATA += rpm-plugin-systemd-inhibit.8
+man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8 rpm2archive.8
+man_man8_DATA += rpm-plugin-systemd-inhibit.8 rpm-plugin-audit.8 rpm-plugin-ima.8
+man_man8_DATA += rpm-plugin-prioreset.8 rpm-plugin-selinux.8 rpm-plugin-syslog.8
 EXTRA_DIST += $(man_man8_DATA)
 
 man_fr_man8dir = $(mandir)/fr/man8


### PR DESCRIPTION
https://rpm.org/wiki/Releases/4.16.0 says "Add man pages for all plugins and rpm2archive (#1016)"
However RPM 4.16.0 alpha doesn't actually include them…
Ahem

This pull request actually includes the new man pages  the tarball and thus the vendor rpms… :-)
Thanks