### PR TITLE
Flush 1998 vintage dirent.h and fcntl.h compatibility mess from system.h

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <regex.h>
+#include <fcntl.h>
 #if WITH_CAP
 #include <sys/capability.h>
 #endif

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -5,6 +5,7 @@
 #include <sys/select.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <fcntl.h>
 #include <magic.h>
 #include <regex.h>
 #ifdef HAVE_LIBELF

--- a/configure.ac
+++ b/configure.ac
@@ -625,7 +625,7 @@ CFLAGS=$old_CFLAGS
 AC_STRUCT_DIRENT_D_TYPE
 
 AC_CHECK_HEADERS(limits.h)
-AC_CHECK_HEADERS(fcntl.h getopt.h)
+AC_CHECK_HEADERS(getopt.h)
 
 AC_CHECK_HEADERS(sys/utsname.h)
 

--- a/lib/backend/db3.c
+++ b/lib/backend/db3.c
@@ -11,6 +11,7 @@ static int _debug = 1;	/* XXX if < 0 debugging, > 0 unusual error returns */
 #include <popt.h>
 #include <db.h>
 #include <signal.h>
+#include <fcntl.h>
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmmacro.h>

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <fcntl.h>
 
 #include "lib/rpmdb_internal.h"
 #include <rpm/rpmstring.h>

--- a/lib/backend/ndb/rpmpkg.c
+++ b/lib/backend/ndb/rpmpkg.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <libgen.h>
+#include <dirent.h>
 
 #include "rpmpkg.h"
 

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -16,6 +16,7 @@
 #include <sys/mman.h>
 #include <endian.h>
 #include <libgen.h>
+#include <dirent.h>
 
 #include "rpmxdb.h"
 

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -1,6 +1,7 @@
 #include "system.h"
 
 #include <sqlite3.h>
+#include <fcntl.h>
 
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>

--- a/lib/cpio.c
+++ b/lib/cpio.c
@@ -17,6 +17,7 @@
 #include <sys/types.h> /* already included from system.h */
 #endif
 #include <string.h>
+#include <fcntl.h>
 
 #include <rpm/rpmio.h>
 #include <rpm/rpmlog.h>

--- a/lib/rpmchroot.c
+++ b/lib/rpmchroot.c
@@ -1,6 +1,7 @@
 #include "system.h"
 #include <sched.h>
 #include <stdlib.h>
+#include <fcntl.h>
 #include <rpm/rpmstring.h>
 #include <rpm/rpmlog.h>
 #include "lib/rpmchroot.h"

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -7,6 +7,7 @@
 #include <sys/file.h>
 #include <utime.h>
 #include <errno.h>
+#include <dirent.h>
 
 #ifndef	DYING	/* XXX already in "system.h" */
 #include <fnmatch.h>

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -12,6 +12,7 @@
 #include <rpm/rpmmacro.h>	/* XXX rpmCleanPath */
 #include <rpm/rpmds.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #include "lib/rpmfi_internal.h"
 #include "lib/rpmte_internal.h"	/* relocations */

--- a/lib/rpmlock.c
+++ b/lib/rpmlock.c
@@ -2,6 +2,7 @@
 #include "system.h"
 
 #include <errno.h>
+#include <fcntl.h>
 
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -3,6 +3,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #include <rpm/rpmfileutil.h>
 #include <rpm/rpmmacro.h>

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -6,6 +6,7 @@
 
 #include <inttypes.h>
 #include <libgen.h>
+#include <fcntl.h>
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmlib.h>			/* rpmReadPackage etc */

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -8,6 +8,7 @@
 #include <libgen.h>
 #include <errno.h>
 #include <sys/statvfs.h>
+#include <fcntl.h>
 
 /* duplicated from cpio.c */
 #if MAJOR_IN_MKDEV

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -6,6 +6,7 @@
 #include "system.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #if WITH_CAP
 #include <sys/capability.h>
 #endif

--- a/misc/fts.c
+++ b/misc/fts.c
@@ -66,6 +66,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #endif
 
 #include "system.h"
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <dirent.h>

--- a/misc/fts.c
+++ b/misc/fts.c
@@ -68,6 +68,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #include "system.h"
 #include <stdlib.h>
 #include <string.h>
+#include <dirent.h>
 #include <errno.h>
 #include "misc/rpmfts.h"
 #   define __set_errno(val) (*__errno_location ()) = (val)

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <dirent.h>
 #include <pwd.h>
 #include <assert.h>
 #include <sys/stat.h>		/* S_ISDIR */
@@ -74,8 +75,6 @@ typedef struct {
     int (*gl_lstat)(const char *, struct stat *);
     int (*gl_stat)(const char *, struct stat *);
 } glob_t;
-
-#define	NAMLEN(_d)	NLENGTH(_d)
 
 #include <errno.h>
 #ifndef __set_errno
@@ -746,7 +745,7 @@ glob_in_dir(const char *pattern, const char *directory, int flags,
 		    if (fnmatch(pattern, name, fnm_flags) == 0) {
 			struct globlink *new = (struct globlink *)
 			    alloca(sizeof(struct globlink));
-			len = NAMLEN(d);
+			len = strlen(d->d_name);
 			new->name = (char *) xmalloc(len + 1);
 			*((char *) mempcpy(new->name, name, len))
 			    = '\0';

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <dirent.h>
+#include <fcntl.h>
 #if defined(__linux__)
 #include <sys/personality.h>
 #endif

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -6,6 +6,7 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <ctype.h>
+#include <dirent.h>
 #if defined(__linux__)
 #include <sys/personality.h>
 #endif

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -18,6 +18,7 @@
 #include <sys/wait.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #include <rpm/rpmio.h>
 #include <rpm/rpmmacro.h>

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -9,6 +9,7 @@
 #include <sys/wait.h>
 #include <popt.h>
 #include <libgen.h>
+#include <fcntl.h>
 
 #include <rpm/rpmlib.h>			/* RPMSIGTAG & related */
 #include <rpm/rpmmacro.h>

--- a/system.h
+++ b/system.h
@@ -49,23 +49,6 @@ char * stpncpy(char * dest, const char * src, size_t n);
 #include <sys/file.h>
 #endif
 
-#ifdef HAVE_DIRENT_H
-# include <dirent.h>
-# define NLENGTH(direct) (strlen((direct)->d_name))
-#else /* not HAVE_DIRENT_H */
-# define dirent direct
-# define NLENGTH(direct) ((direct)->d_namlen)
-# ifdef HAVE_SYS_NDIR_H
-#  include <sys/ndir.h>
-# endif /* HAVE_SYS_NDIR_H */
-# ifdef HAVE_SYS_DIR_H
-#  include <sys/dir.h>
-# endif /* HAVE_SYS_DIR_H */
-# ifdef HAVE_NDIR_H
-#  include <ndir.h>
-# endif /* HAVE_NDIR_H */
-#endif /* HAVE_DIRENT_H */
-
 #if HAVE_LIMITS_H
 #include <limits.h>
 #endif

--- a/system.h
+++ b/system.h
@@ -43,12 +43,6 @@ char * stpncpy(char * dest, const char * src, size_t n);
 #define	getenv(_s)	__secure_getenv(_s)
 #endif
 
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#else
-#include <sys/file.h>
-#endif
-
 #if HAVE_LIMITS_H
 #include <limits.h>
 #endif


### PR DESCRIPTION
dirent.h and struct dirent are actually standard on this millenium, the
only thing that isn't is d_type member for which we have and retain
a specific test in configure.ac. Include <dirent.h> where needed,
relatively few places do which makes it even a bigger insult to have
this included from system.h.