### PR TITLE
Fix bunch of tests to not depend on external macro configuration

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -124,8 +124,8 @@ AT_SETUP([parametrized macro 2])
 AT_KEYWORDS([macros])
 AT_CHECK([
 runroot rpm \
-    --define '%bar() "Bar %#: %{?1} %{?2}"' \
-    --define '%foo() "Foo %#: %{?1} %{?2}" %bar a' \
+    --define 'bar() "Bar %#: %{?1} %{?2}"' \
+    --define 'foo() "Foo %#: %{?1} %{?2}" %bar a' \
     --eval '%foo 1 2'
 ],
 [0],
@@ -137,7 +137,7 @@ AT_SETUP([parametrized macro 3])
 AT_KEYWORDS([macros])
 AT_CHECK([
 runroot rpm \
-    --define '%foo() 1:%1 2:%2' \
+    --define 'foo() 1:%1 2:%2' \
     --eval '%foo %nil bar'
 ],
 [0],
@@ -149,8 +149,8 @@ AT_SETUP([parametrized macro 4])
 AT_KEYWORDS([macros])
 AT_CHECK([
 runroot rpm \
-    --define '%bar yyy' \
-    --define '%foo() %1' \
+    --define 'bar yyy' \
+    --define 'foo() %1' \
     --eval '%foo %bar' \
     --eval '%foo %%bar'
 ],
@@ -164,7 +164,7 @@ AT_SETUP([parametrized macro 5])
 AT_KEYWORDS([macros])
 AT_CHECK([
 runroot rpm \
-    --define '%foo() %#:%{?1:"%1"}%{?2: "%2"}' \
+    --define 'foo() %#:%{?1:"%1"}%{?2: "%2"}' \
     --define 'bar zzz' \
     --eval '%foo 1' \
     --eval '%foo   2  ' \
@@ -280,7 +280,7 @@ AT_CHECK([
 runroot rpm --eval "%{dirname}"
 runroot rpm --eval "%{dirname:}"
 runroot rpm --eval "%{dirname:dir}"
-runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
+runroot rpm --define 'xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
 runroot rpm --eval "%{getncpus:}"
@@ -566,7 +566,7 @@ AT_KEYWORDS([macros define undefine])
 AT_CHECK([
 # basic %define in nested scoping level
 runroot rpm \
-    --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand:%undefine xxx} %{echo:%xxx}' \
+    --define 'foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand:%undefine xxx} %{echo:%xxx}' \
     --eval .'%foo'.
 ],
 [0],
@@ -581,7 +581,7 @@ AT_KEYWORDS([macros define])
 AT_CHECK([
 # %define macro once in a nested scope
 runroot rpm \
-    --define '%foo() %{expand:%define xxx 1} %{echo:%xxx}' \
+    --define 'foo() %{expand:%define xxx 1} %{echo:%xxx}' \
     --eval .'%foo'. \
     --eval '%xxx'
 ],
@@ -598,7 +598,7 @@ AT_CHECK([
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 # %define macro twice in a nested scope
 runroot rpm \
-    --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %define xxx 2} %{echo:%xxx}' \
+    --define 'foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %define xxx 2} %{echo:%xxx}' \
     --eval .'%foo'. \
     --eval '%xxx'
 ],
@@ -616,7 +616,7 @@ AT_CHECK([
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 # %define in a nested level covered by %global
 runroot rpm \
-    --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %global xxx 2} %{echo:%xxx}' \
+    --define 'foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %global xxx 2} %{echo:%xxx}' \
     --eval .'%foo'. \
     --eval '%xxx' \
     --eval .'%undefine xxx'. \

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -161,13 +161,13 @@ RPMDB_INIT
 rm -rf "${TOPDIR}"
 
 runroot rpmbuild -bb --quiet \
-	--define "%optflags -O2 -g" \
-	--define "%_target_platform noarch-linux" \
-	--define "%_binary_payload w.ufdio" \
-	--define "%_buildhost localhost" \
-	--define "%use_source_date_epoch_as_buildtime 1" \
-	--define "%source_date_epoch_from_changelog 1" \
-	--define "%clamp_mtime_to_source_date_epoch 1" \
+	--define "optflags -O2 -g" \
+	--define "_target_platform noarch-linux" \
+	--define "_binary_payload w.ufdio" \
+	--define "_buildhost localhost" \
+	--define "use_source_date_epoch_as_buildtime 1" \
+	--define "source_date_epoch_from_changelog 1" \
+	--define "clamp_mtime_to_source_date_epoch 1" \
 	/data/SPECS/attrtest.spec 
 for v in SHA256HEADER SHA1HEADER SIGMD5 PAYLOADDIGEST PAYLOADDIGESTALT; do
     runroot rpm -q --qf "${v}: %{${v}}\n" /build/RPMS/noarch/attrtest-1.0-1.noarch.rpm


### PR DESCRIPTION
While --define '%foo 1' is often equal to --define 'foo 1', if %foo
happens to be already defined, the define expands to that value,
completely changing the intent of the --define.

Found due to %source_date_epoch_from_changelog being set in Fedora,
causing %source_date_epoch_from_changelog cli define in our reproducable
builds test to become --define '1 1' inside a spec build, effectively
canceling the effect of the define. What fun!