### PR TITLE
Unset SOURCE_DATE_EPOCH for the test-suite

### DIFF
--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -27,6 +27,8 @@ export HOME
 TZ=UTC
 export TZ
 
+unset SOURCE_DATE_EPOCH
+
 TOPDIR="${RPMTEST}/build"
 
 RPM_XFAIL=${RPM_XFAIL-1}


### PR DESCRIPTION
Fixes the reproducable build test failing in Fedora rpm builds due to
%source_date_epoch_from_changelog being set on the outside, which
leaks the SOURCE_DATE_EPOCH environment into the test-suite and
changes the expectation.