### PR TITLE
Export CC and CXX in __build_pre

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -815,6 +815,9 @@ package or when debugging this package.\
   export RPM_PACKAGE_NAME RPM_PACKAGE_VERSION RPM_PACKAGE_RELEASE\
   LANG=C\
   export LANG\
+  CC=\"%{__cc}\"\
+  CXX=\"%{__cxx}\"\
+  export CC CXX \
   unset CDPATH DISPLAY ||:\
   %{?buildroot:RPM_BUILD_ROOT=\"%{u2p:%{buildroot}}\"\
   export RPM_BUILD_ROOT}\


### PR DESCRIPTION
This helps ensure that the values of the __cc and __cxx macros are respected
during builds.