### PR TITLE
fix testsuite on Mageia

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1051,7 +1051,7 @@ ls ./usr/src/debug/ | cut -f1,2 -d\.
 # Check that the source path has been rewritten in the .debug file.
 # Drop the final arch prefix to make the test arch-independent.
 readelf --debug-dump=info ./usr/lib/debug/usr/local/bin/hello2*.debug \
-  | grep comp_dir | sed -e 's/\t$//' | cut -f5- -d/ | cut -f1,2 -d\.
+  | grep comp_dir | egrep -v 'glibc.*/csu$' | sed -e 's/\t$//' | cut -f5- -d/ | cut -f1,2 -d\.
 ],
 [0],
 [hello2-1.0-1
@@ -1088,7 +1088,7 @@ ls ./usr/src/debug/
 
 # Check that the source path has been rewritten in the .debug file.
 readelf --debug-dump=info ./usr/lib/debug/usr/local/bin/hello2*.debug \
-  | grep comp_dir | sed -e 's/\t$//' | cut -f5- -d/
+  | grep comp_dir | egrep -v 'glibc.*/csu$' | sed -e 's/\t$//' | cut -f5- -d/
 ],
 [0],
 [hello-1.0


### PR DESCRIPTION
it consistently fails b/c readelf returns more stuff:

$ readelf --debug-dump=info ./usr/lib/debug/usr/local/bin/hello2*.debug | grep comp_dir
    <24>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <43>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <86>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <a5>   DW_AT_comp_dir    : (indirect string, offset: 0x0): /usr/src/debug/hello-1.0
    <3ff>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <5dd>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu

$ readelf --debug-dump=info ./usr/lib/debug/usr/local/bin/hello2*.debug    | grep csu
    <24>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <43>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <86>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <3ff>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu
    <4df>   DW_AT_name        : (indirect string, offset: 0x391): __libc_csu_fini
    <4f9>   DW_AT_name        : (indirect string, offset: 0x474): __libc_csu_init
    <5dd>   DW_AT_comp_dir    : (indirect string, offset: 0x52a): /home/iurt/rpmbuild/BUILD/glibc-2.31/csu

I don't know why it works on Fedora but let's filter glibc's csu and voila