### PR TITLE
Fix regression causing segfault on database autodetection

### DIFF
--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -52,7 +52,7 @@ dbiIndex dbiNew(rpmdb rdb, rpmDbiTagVal rpmtag)
 static int tryBackend(const char *dbhome, const struct rpmdbOps_s *be)
 {
     int rc = 0;
-    if (be->path) {
+    if (be && be->path) {
 	char *path = rstrscat(NULL, dbhome, "/", be->path, NULL);
 	rc = (access(path, F_OK) == 0);
 	free(path);


### PR DESCRIPTION
If configuration points to non-existent backend, tryBackend() will
segfault on the first call. Duh. Regression introduced in commit
3eb0eed3806b41efdf86f0433d0b5d7d6c953561.