### PR TITLE
rpmfc: Do not prepend buildroot to a path for parametric generator

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -533,20 +533,18 @@ static ARGV_t runCall(const char *cmd,
 		     const char *buildRoot, const char *fn)
 {
     ARGV_t output = NULL;
-    char *path = rstrscat(NULL, buildRoot ? buildRoot : "", "/", fn, NULL);
 
     if (_rpmfc_debug)
-	rpmlog(RPMLOG_DEBUG, "Calling %s() on %s\n", cmd, path);
+	rpmlog(RPMLOG_DEBUG, "Calling %s() on %s\n", cmd, fn);
 
     /* Hack to pass in the path as what looks like a macro argument */
-    rpmPushMacroFlags(NULL, "1", NULL, path, 1, RPMMACRO_LITERAL);
+    rpmPushMacroFlags(NULL, "1", NULL, fn, 1, RPMMACRO_LITERAL);
     char *exp = rpmExpand(cmd, NULL);
     rpmPopMacro(NULL, "1");
     if (*exp)
 	argvSplit(&output, exp, "\n\r");
     free(exp);
 
-    free(path);
     return output;
 }
 


### PR DESCRIPTION
'fn' already contains full path to a file, so no need to prepend it once
more. This is actually breaking things.

Before:
D: Calling %{__pythonname_provides %{?__pythonname_provides_opts}}() on /home/brain/rpmbuild/BUILDROOT/hello-1-1.fc33.x86_64//home/brain/rpmbuild/BUILDROOT/hello-1-1.fc33.x86_64/usr/share/applications/org.gnome.Terminal.desktop

After:
D: Calling %{__pythonname_provides %{?__pythonname_provides_opts}}() on /home/brain/rpmbuild/BUILDROOT/hello-1-1.fc33.x86_64/usr/share/applications/org.gnome.Terminal.desktop

Fixes: https://github.com/rpm-software-management/rpm/issues/1162
Signed-off-by: Igor Raits <i.gnatenko.brain@gmail.com>