### PR TITLE
Warn on undefined macro uses in specs

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -204,7 +204,7 @@ int specExpand(rpmSpec spec, int lineno, const char *sbuf,
     snprintf(lnobuf, sizeof(lnobuf), "%d", lineno);
     rpmPushMacroFlags(spec->macros, "__file_lineno", NULL, lnobuf, RMIL_SPEC, RPMMACRO_LITERAL);
 
-    rc = (rpmExpandMacros(spec->macros, sbuf, obuf, 0) < 0);
+    rc = (rpmExpandMacros(spec->macros, sbuf, obuf, RPMMACRO_WUNDEF) < 0);
 
     rpmPopMacro(spec->macros, "__file_lineno");
 

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -421,6 +421,7 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba)
     int buildAmount = ba->buildAmount;
     char * buildRootURL = NULL;
     char * specFile = NULL;
+    char *buildtree = NULL;
     rpmSpec spec = NULL;
     int rc = 1; /* assume failure */
     rpmSpecFlags specFlags = spec_flags;
@@ -436,8 +437,12 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba)
 	buildRootURL = rpmGenPath(NULL, ba->buildRootOverride, NULL);
 
     /* Create build tree if necessary */
-    const char * buildtree = "%{_topdir}:%{_specdir}:%{_sourcedir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}:%{_buildrootdir}";
+    const char * buildpath = "%{_topdir}:%{_specdir}:%{_sourcedir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}:%{_buildrootdir}";
     const char * rootdir = rpmtsRootDir(ts);
+
+    if (rpmExpandMacros(NULL, buildpath, &buildtree, RPMMACRO_WUNDEF) < 0)
+	goto exit;
+
     if (rpmMkdirs(!rstreq(rootdir, "/") ? rootdir : NULL , buildtree)) {
 	goto exit;
     }
@@ -520,6 +525,7 @@ exit:
     free(specFile);
     rpmSpecFree(spec);
     free(buildRootURL);
+    free(buildtree);
     return rc;
 }
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -308,8 +308,7 @@ matchchar(const char * p, char pl, char pr)
     return (const char *)NULL;
 }
 
-static void mbErr(MacroBuf mb, int error, const char *fmt, ...)
-{
+static void mbErr(MacroBuf mb, int error, const char *fmt, ...) {
     char *emsg = NULL;
     int n;
     va_list ap;
@@ -1394,6 +1393,7 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
     }
 
     while (mb->error == 0 && (c = *s) != '\0') {
+	int brace = 0;
 	const struct builtins_s* builtin = NULL;
 	s++;
 	/* Copy text until next macro */
@@ -1445,6 +1445,7 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	    s = se;
 	    continue;
 	case '{':		/* %{...}/%{...:...} substitution */
+	    brace = 1;
 	    f = s+1;	/* skip { */
 	    f = setNegateAndCheck(f, &negate, &chkexist);
 	    for (fe = f; (c = *fe) && !strchr(" :}", c);)
@@ -1536,6 +1537,10 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	    /* XXX hack to permit non-overloaded %foo to be passed */
 	    c = '%';	/* XXX only need to save % */
 	    mbAppend(mb, c);
+	    if (brace && mb->flags & RPMMACRO_WUNDEF) {
+		mbErr(mb, 0, _("undefined macro %.*s in %.*s\n"),
+				(int)fn, f, (int)slen, src);
+	    }
 	    continue;
 	}
 

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -65,6 +65,8 @@ typedef enum rpmMacroFlags_e {
 void	rpmDumpMacroTable	(rpmMacroContext mc,
 					FILE * fp);
 
+#define RPMMACRO_WUNDEF (1 << 0)
+
 /** \ingroup rpmmacro
  * Expand macro into buffer.
  * @param mc		macro context (NULL uses global context).

--- a/tests/data/SPECS/configtest.spec
+++ b/tests/data/SPECS/configtest.spec
@@ -2,6 +2,7 @@
 %define _sysconfdir /etc
 
 %{!?filetype: %global filetype file}
+%{!?filedata: %global filedata somestuff}
 
 Name:		configtest%{?sub:-%{sub}}
 Version:	%{ver}

--- a/tests/data/SPECS/replacetest.spec
+++ b/tests/data/SPECS/replacetest.spec
@@ -1,4 +1,5 @@
 %{!?filetype: %global filetype file}
+%{!?filedata: %global filedata somestuff}
 %{?fixit: %global havepretrans 1}
 %{!?user: %global user root}
 %{!?grp: %global grp root}


### PR DESCRIPTION
Implement a warn-on-undefined macro use flag in the macro engine, use
when parsing specs. We only cover %{...} macros as specs consist of numerous
directives starting with % that are not macros at all.

This uncovers a sheer mountain of dirt, including in our own test-suite. Looking at rawhide specs, the more common themes include
- undefined due to missing buildrequires (which are not checked on plain parse)
- %global abuse, probably due to certain guidelines insisting on %global over %define
- stuff trailing %endif
- suprising number of variants where things like %{name} and %{version} or custom macros are referred long before definition, many of which will have only worked due to sheer luck or such

If anybody wants to look, https://laiskiainen.org/tmp/rawhide-specs-unused-macros-080420.txt is what I got by running this patch on rawhide specs essentially with `rpmspec -q * 2>&1|grep undefined`. The more interesting cases get lost in the missing buildrequires noise unfortunately, but it does give an idea...

Also only an RFC at the moment, I don't like the flag name at all but too battle weary atm to think of anything better.