### PR TITLE
Fix regression causing all ELF files classified as OCaml

### DIFF
--- a/fileattrs/ocaml.attr
+++ b/fileattrs/ocaml.attr
@@ -2,3 +2,4 @@
 %__ocaml_requires	%{_rpmconfigdir}/ocamldeps.sh --requires
 %__ocaml_magic		^(ELF|Objective caml|OCaml) .*$
 %__ocaml_path		.(cma|cmi|cmo|cmx|cmxa|cmxs)$
+%__ocaml_flags		magic_and_path


### PR DESCRIPTION
Commit a6fe37c39b39acbcbd014dd1e6d5653ff84254a1 causes OCaml generators
to execute on all ELF files due to missing "magic_and_path" flag.

Fixes: #1173