### PR TITLE
ndb: do not mmap the index database read-write all the time

### DIFF
--- a/lib/backend/ndb/rpmidx.h
+++ b/lib/backend/ndb/rpmidx.h
@@ -5,7 +5,7 @@ struct rpmidxdb_s;
 typedef struct rpmidxdb_s *rpmidxdb;
 
 int rpmidxOpen(rpmidxdb *idxdbp, rpmpkgdb pkgdb, const char *filename, int flags, int mode);
-int rpmidxOpenXdb(rpmidxdb *idxdbp, rpmpkgdb pkgdb, rpmxdb xdb, unsigned int xdbtag);
+int rpmidxOpenXdb(rpmidxdb *idxdbp, rpmpkgdb pkgdb, rpmxdb xdb, unsigned int xdbtag, int flags);
 int rpmidxDelXdb(rpmpkgdb pkgdb, rpmxdb xdb, unsigned int xdbtag);
 void rpmidxClose(rpmidxdb idxdbp);
 

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -621,6 +621,8 @@ void rpmxdbClose(rpmxdb xdb)
     }
     if (xdb->slots)
 	free(xdb->slots);
+    if (xdb->mapped)
+	unmapheader(xdb);
     if (xdb->fd >= 0)
 	close(xdb->fd);
     if (xdb->filename)

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -369,6 +369,8 @@ static int rpmxdbReadHeader(rpmxdb xdb)
 			    nslot->mapcallback(xdb, nslot->mapcallbackdata, 0, 0);
 			}
 		    }
+		} else {
+		    nslot->mapped = slot->mapped;
 		}
 	    }
 	}
@@ -624,7 +626,8 @@ static int moveblobto(rpmxdb xdb, struct xdb_slot *oldslot, struct xdb_slot *aft
     didmap = 0;
     oldpagecnt = oldslot->pagecnt;
     if (!oldslot->mapped && oldpagecnt) {
-	oldslot->mapflags = PROT_READ;
+	if (!oldslot->mapcallback)
+	    oldslot->mapflags = PROT_READ;
 	if (mapslot(xdb, oldslot))
 	    return RPMRC_FAIL;
         didmap = 1;

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -392,17 +392,14 @@ static int rpmxdbReadHeader(rpmxdb xdb, int rw)
     return RPMRC_OK;
 }
 
-static int rpmxdbWriteHeader(rpmxdb xdb)
+static void rpmxdbWriteHeader(rpmxdb xdb)
 {
-    if (!xdb->mapped)
-	return RPMRC_FAIL;
     h2lea(XDB_MAGIC, xdb->mapped + XDB_OFFSET_MAGIC);
     h2lea(XDB_VERSION, xdb->mapped + XDB_OFFSET_VERSION);
     h2lea(xdb->generation, xdb->mapped + XDB_OFFSET_GENERATION);
     h2lea(xdb->slotnpages, xdb->mapped + XDB_OFFSET_SLOTNPAGES);
     h2lea(xdb->pagesize, xdb->mapped + XDB_OFFSET_PAGESIZE);
     h2lea(xdb->usergeneration, xdb->mapped + XDB_OFFSET_USERGENERATION);
-    return RPMRC_OK;
 }
 
 static void rpmxdbUpdateSlot(rpmxdb xdb, struct xdb_slot *slot)

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2578,6 +2578,7 @@ int rpmdbRebuild(const char * prefix, rpmts ts,
     }
 
     rpmdbClose(olddb);
+    dbCtrl(newdb, DB_CTRL_INDEXSYNC);
     rpmdbClose(newdb);
 
     if (failed) {


### PR DESCRIPTION
Use read-only mapping for the index databases if the user only requested read-only database access. Also map the xdb database header read-only and only switch to a read-write mapping if an operation is done that needs write access.