### PR TITLE
Handle manually specified debuginfo package more gracefully

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2867,11 +2867,14 @@ static void addPackageDeps(Package from, Package to, enum rpmTag_e tag);
  * main debuginfo package */
 static Package cloneDebuginfoPackage(rpmSpec spec, Package pkg, Package maindbg)
 {
-    const char *name = headerGetString(pkg->header, RPMTAG_NAME);
-    char *dbgname = NULL;
-    Package dbg;
+    Package dbg = NULL;
+    char *dbgname = headerFormat(pkg->header, "%{name}-debuginfo", NULL);
 
-    rasprintf(&dbgname, "%s-%s", name, "debuginfo");
+    if (lookupPackage(spec, dbgname, PART_NAME|PART_QUIET, &dbg) == RPMRC_OK) {
+	rpmlog(RPMLOG_WARNING, _("package %s already exists\n"), dbgname);
+	goto exit;
+    }
+
     dbg = newPackage(dbgname, spec->pool, &spec->packages);
     headerPutString(dbg->header, RPMTAG_NAME, dbgname);
     copyInheritedTags(dbg->header, pkg->header);
@@ -2888,6 +2891,7 @@ static Package cloneDebuginfoPackage(rpmSpec spec, Package pkg, Package maindbg)
     addPackageProvides(dbg);
     dbg->ds = rpmdsThis(dbg->header, RPMTAG_REQUIRENAME, RPMSENSE_EQUAL);
 
+exit:
     _free(dbgname);
     return dbg;
 }


### PR DESCRIPTION
In todays' "look ma what crawled from under the bed" episode, we have
encounter a subpackage whose name is not derived from the main package
name, and a manually specified debuginfo package on that. This particular
combo manages to evade all our checks for duplicate package names, and
in the right phase of the moon actually creates corrupt packages due to
two threads end up writing to the same output file simultaneously. Which
is what happened in https://pagure.io/fedora-infrastructure/issue/8816

Catch the case and use the spec-defined variant (because getting rid
of it would be harder) but issue a warning because most likely this
is not what they really wanted.