### PR TITLE
Adjust %__python_path

### DIFF
--- a/fileattrs/python.attr
+++ b/fileattrs/python.attr
@@ -24,5 +24,5 @@
     end
 }
 
-%__python_path ((/lib(64)?/python[[:digit:]]\\.[[:digit:]]+/.*\\.(py[oc]?|so))|(^%{_bindir}/python[[:digit:]]\\.[[:digit:]]+))$
+%__python_path ^((%{_prefix}/lib(64)?/python[[:digit:]]+\\.[[:digit:]]+/.*\\.(py[oc]?|so))|(%{_bindir}/python[[:digit:]]+\\.[[:digit:]]+))$
 %__python_magic [Pp]ython.*(executable|byte-compiled)


### PR DESCRIPTION
 - sync with Fedora
 - only match direct Python sitedir, no /opt/.../lib/python3.7 stuff
 - prep for multiple digits Python major releases (e.g. 12.1)
 - use the value of %_prefix

See also:

https://src.fedoraproject.org/rpms/python-rpm-generators/c/8eef42cbaa6ff0e5c006959fc06ec115ed5ca37b
https://lists.fedoraproject.org/archives/list/packaging@lists.fedoraproject.org/thread/UFKUM5UKCTNGIT3KJVYEI5VXPI23QMBN/
https://github.com/rpm-software-management/rpm/pull/1153#discussion_r407997958