### PR TITLE
Deprecate NSS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,7 @@ AM_CONDITIONAL([WITH_BEECRYPT],[test "$with_crypto" = beecrypt])
 WITH_BEECRYPT_INCLUDE=
 WITH_BEECRYPT_LIB=
 if test "$with_crypto" = beecrypt ; then
+  AC_MSG_WARN([Using the beecrypt library with rpm is deprecated and support will be removed in a future release!])
   AC_DEFINE(WITH_BEECRYPT, 1, [Build with beecrypt instead of nss3 support?])
   if test "$with_internal_beecrypt" = yes ; then
     WITH_BEECRYPT_INCLUDE="-I\$(top_srcdir)/beecrypt"

--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,7 @@ AM_CONDITIONAL(LIBDWARF,[test "$WITH_LIBDWARF" = yes])
 # Select crypto library
 AC_ARG_WITH(crypto,
             [AC_HELP_STRING([--with-crypto=CRYPTO_LIB],
-                            [The cryptographic library to use (nss|beecrypt|openssl|libgcrypt). The default is libgcrypt. beecrypt is DEPRECATED.])
+                            [The cryptographic library to use (nss|beecrypt|openssl|libgcrypt). The default is libgcrypt. beecrypt and nss are DEPRECATED.])
                             ],[],
                             [with_crypto=libgcrypt])
 
@@ -401,6 +401,7 @@ AC_SUBST(WITH_LIBGCRYPT_LIB)
 WITH_NSS_INCLUDE=
 WITH_NSS_LIB=
 if test "$with_crypto" = nss; then
+AC_MSG_WARN([Using the nss library with rpm is deprecated and support will be removed in a future release!])
 # If we have pkgconfig make sure CPPFLAGS are setup correctly for the nss
 # -I include path. Otherwise the below checks will fail because nspr.h
 # cannot be found.


### PR DESCRIPTION
The NSS library often changes in ways that somehow breaks rpm,
and these days upstream does not care about consumers of NSS other
than itself. This inflicts untold amounts of suffering on users
of rpm in distributions where rpm is linked to NSS.

Now that we have a couple of good, well-supported options, there is
no reason to keep supporting NSS as an option.

So now, we are deprecating it for later removal.

As a small, additional commit, I've added a warning for when beecrypt is selected, just to be slightly more in-your-face about the deprecation.

Closes #1175.