### PR TITLE
rpmfiArchiveRead() use signed return value to handle -1 on error

### DIFF
--- a/lib/rpmarchive.h
+++ b/lib/rpmarchive.h
@@ -122,9 +122,9 @@ int rpmfiArchiveWriteFile(rpmfi fi, FD_t fd);
  * @param fi		file info
  * @param buf		pointer to buffer
  * @param size		number of bytes to read
- * @return		bytes actually read
+ * @return		bytes actually read, -1 on error
  */
-size_t rpmfiArchiveRead(rpmfi fi, void * buf, size_t size);
+ssize_t rpmfiArchiveRead(rpmfi fi, void * buf, size_t size);
 
 /** \ingroup payload
  * Has current file content stored in the archive

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -2261,7 +2261,7 @@ int rpmfiArchiveHasContent(rpmfi fi)
     return res;
 }
 
-size_t rpmfiArchiveRead(rpmfi fi, void * buf, size_t size)
+ssize_t rpmfiArchiveRead(rpmfi fi, void * buf, size_t size)
 {
     if (fi == NULL || fi->archive == NULL)
 	return -1;


### PR DESCRIPTION
size_t is unsigned, so returning -1 is not going to have the expected
behavior. Fix it to return ssize_t.

Signed-off-by: Jes Sorensen <jsorensen@fb.com>