### PR TITLE
Don't check source package provides against installed conflicts

### DIFF
--- a/lib/depends.c
+++ b/lib/depends.c
@@ -1040,16 +1040,16 @@ int rpmtsCheck(rpmts ts)
 	checkDS(ts, dcache, p, rpmteNEVRA(p), rpmteDS(p, RPMTAG_OBSOLETENAME),
 		tscolor);
 
+	/* Skip obsoletion and provides checks for source packages (ie build) */
+	if (rpmteIsSource(p))
+	    continue;
+
 	/* Check provides against conflicts in installed packages. */
 	while (rpmdsNext(provides) >= 0) {
 	    checkInstDeps(ts, dcache, p, RPMTAG_CONFLICTNAME, NULL, provides, 0);
 	    if (reqnothash && depexistsHashHasEntry(reqnothash, rpmdsNId(provides)))
 		checkInstDeps(ts, dcache, p, RPMTAG_REQUIRENAME, NULL, provides, 1);
 	}
-
-	/* Skip obsoletion checks for source packages (ie build) */
-	if (rpmteIsSource(p))
-	    continue;
 
 	/* Check package name (not provides!) against installed obsoletes */
 	checkInstDeps(ts, dcache, p, RPMTAG_OBSOLETENAME, NULL, rpmteDS(p, RPMTAG_NAME), 0);

--- a/lib/rpmal.c
+++ b/lib/rpmal.c
@@ -247,6 +247,10 @@ void rpmalAdd(rpmal al, rpmte p)
     rpmalNum pkgNum;
     availablePackage alp;
 
+    /* Source packages don't provide anything to depsolving */
+    if (rpmteIsSource(p))
+	return;
+
     if (al->size == al->alloced) {
 	al->alloced += al->delta;
 	al->list = xrealloc(al->list, sizeof(*al->list) * al->alloced);


### PR DESCRIPTION
Fixes regressions from commit 75ec16e660e784d7897b37cac1a2b9b135825f25: the newly added provides of to-be-built packages were being used for dependency resolution, such as spec satifying its own buildrequires, and matched against conflicts in installed packages.
    
Source packages cannot obsolete anything or provide capabilities or files to transactions, don't add them to rpmal at all. Explicitly skip checks against source provides, similarly to what we already did with obsoletes.

Fixes: #1189
