### PR TITLE
RFE: Support rpm version comparison in expressions

### DIFF
--- a/doc/manual/macros
+++ b/doc/manual/macros
@@ -241,15 +241,18 @@ newline is deleted). Note the 2nd % needed to escape the arguments to
 
 Expression expansion can be performed using "%[expression]".  An
 expression consists of terms that can be combined using
-operators.  Rpm supports two kinds of terms, numbers made up
-from digits and strings enclosed in double quotes.  Rpm will
-expand macros when evaluating terms.
+operators.  Rpm supports three kinds of terms, numbers made up
+from digits, strings enclosed in double quotes (eg "somestring") and
+versions enclosed in double quotes preceded by v (eg v"3:1.2-1").
+Rpm will expand macros when evaluating terms.
 
 You can use the standard operators to combine terms: logical
 operators &&, ||, !, relational operators !=, ==, <, > , <=, >=,
 arithmetic operators +, -, /, *, the ternary operator ? :, and
 parentheses.  For example, "%[ 3 + 4 * (1 + %two) ]" will expand
-to "15" if "%two" expands to "2".
+to "15" if "%two" expands to "2". Version terms are compared using
+rpm version ([epoch:]version[-release]) comparison algorithm,
+rather than regular string comparison.
 
 Note that the "%[expression]" expansion is different to the
 "%{expr:expression}" macro.  With the latter, the macros in the

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -55,6 +55,12 @@ static int valueCmpString(Value v1, Value v2)
     return strcmp(v1->data.s, v2->data.s);
 }
 
+static void valueReset(Value v)
+{
+  if (v->type == VALUE_TYPE_STRING)
+    v->data.s = _free(v->data.s);
+}
+
 /**
  */
 static Value valueMakeInteger(int i)
@@ -83,8 +89,7 @@ static Value valueMakeString(char *s)
  */
 static void valueSetInteger(Value v, int i)
 {
-  if (v->type == VALUE_TYPE_STRING)
-    v->data.s = _free(v->data.s);
+  valueReset(v);
   v->type = VALUE_TYPE_INTEGER;
   v->data.i = i;
 }
@@ -93,8 +98,7 @@ static void valueSetInteger(Value v, int i)
  */
 static void valueSetString(Value v, char *s)
 {
-  if (v->type == VALUE_TYPE_STRING)
-    v->data.s = _free(v->data.s);
+  valueReset(v);
   v->type = VALUE_TYPE_STRING;
   v->data.s = s;
 }
@@ -104,8 +108,7 @@ static void valueSetString(Value v, char *s)
 static void valueFree( Value v)
 {
   if (v) {
-    if (v->type == VALUE_TYPE_STRING)
-	v->data.s = _free(v->data.s);
+    valueReset(v);
     free(v);
   }
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -465,6 +465,7 @@ AT_KEYWORDS([macros])
 AT_CHECK([[
 runroot rpm --define "aaa hello" --eval '%[%aaa]'
 runroot rpm --eval '%[%{foo]'
+runroot rpm --eval '%[v""]'
 ]],
 [1],
 [],
@@ -472,7 +473,27 @@ runroot rpm --eval '%[%{foo]'
 error:                                                         ^
 error: expanded string: hello
 error: Unterminated {: {foo 
+error: invalid version: v""
+error:                    ^
 ])
+AT_CLEANUP
+
+AT_SETUP([expression version comparison])
+AT_KEYWORDS([macros])
+AT_CHECK([[
+runroot rpm \
+    --eval '%[v"1.0" == v"1.0"]' \
+    --eval '%[v"1.0~rc" < v"1.0"]' \
+    --eval '%[v"1.0~rc" > v"1.0"]' \
+    --eval '%[v"1.0-rc" > v"1.0"]' \
+]],
+[0],
+[1
+1
+0
+1
+],
+[])
 AT_CLEANUP
 
 AT_SETUP([simple lua --eval])


### PR DESCRIPTION
Adds rpm version as a new expression value type, denoted by v"" (similar to Python u"", b"" etc), which are compared using rpm version comparison algorithm rather than regular string comparison.

For example in specs:
```
%if v"%{python_version}" < v"3.9"
...
%endif
```

...but also command lines, arbitrary macros etc: `rpm --eval '%[v"1:1.2" < v"2.0"]'`
    
Fixes: #1217
