### PR TITLE
Add %postbuild section / Allow dynamic sub packages

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -382,7 +382,8 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 			   getStringBuf(spec->check), test, sbp)))
 		goto exit;
 
-	if ((rc = reparsePostbuild(spec)))
+	if (((what & RPMBUILD_INSTALL) || (what & RPMBUILD_PACKAGEBINARY)) &&
+	    (rc = reparsePostbuild(spec)))
 	    goto exit;
 
 	if ((what & RPMBUILD_PACKAGESOURCE) &&

--- a/build/build.c
+++ b/build/build.c
@@ -382,6 +382,9 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 			   getStringBuf(spec->check), test, sbp)))
 		goto exit;
 
+	if ((rc = reparsePostbuild(spec)))
+	    goto exit;
+
 	if ((what & RPMBUILD_PACKAGESOURCE) &&
 	    (rc = processSourceFiles(spec, buildArgs->pkgFlags)))
 		goto exit;

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -860,22 +860,23 @@ static int parseEmpty(rpmSpec spec, int prevParsePart)
     int nextPart, rc;
     char *line;
 
-    line = spec->line + sizeof("%end") - 1;
-    SKIPSPACE(line);
-    if (line[0] != '\0') {
-	rpmlog(RPMLOG_ERR,
-	    _("line %d: %%end doesn't take any arguments: %s\n"),
-	    spec->lineNum, spec->line);
-	goto exit;
-    }
+    if (!strncmp(spec->line, "%end", 4)) {
+	line = spec->line + sizeof("%end") - 1;
+	SKIPSPACE(line);
+	if (line[0] != '\0') {
+	    rpmlog(RPMLOG_ERR,
+		   _("line %d: %%end doesn't take any arguments: %s\n"),
+		   spec->lineNum, spec->line);
+	    goto exit;
+	}
 
-    if (prevParsePart == PART_EMPTY) {
-	rpmlog(RPMLOG_ERR,
-	    _("line %d: %%end not expected here, no section to close: %s\n"),
-	    spec->lineNum, spec->line);
-	goto exit;
+	if (prevParsePart == PART_EMPTY) {
+	    rpmlog(RPMLOG_ERR,
+		   _("line %d: %%end not expected here, no section to close: %s\n"),
+		   spec->lineNum, spec->line);
+	    goto exit;
+	}
     }
-
     if ((rc = readLine(spec, STRIP_TRAILINGSPACE|STRIP_COMMENTS)) > 0) {
 	nextPart = PART_NONE;
     } else if (rc < 0) {

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -1139,7 +1139,8 @@ exit:
     return spec;
 
 errxit:
-    rpmSpecFree(spec);
+    if (!secondary)
+	rpmSpecFree(spec);
     return NULL;
 }
 

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -144,6 +144,7 @@ struct rpmSpec_s {
     StringBuf build;		/*!< %build scriptlet. */
     StringBuf install;		/*!< %install scriptlet. */
     StringBuf check;		/*!< %check scriptlet. */
+    StringBuf postbuild;	/*!< %postbuild section */
     StringBuf clean;		/*!< %clean scriptlet. */
 
     StringBuf parsed;		/*!< parsed spec contents */
@@ -239,7 +240,8 @@ typedef enum rpmParseState_e {
     PART_PATCHLIST		= 40+PART_BASE, /*!< */
     PART_SOURCELIST		= 41+PART_BASE, /*!< */
     PART_BUILDREQUIRES		= 42+PART_BASE, /*!< */
-    PART_LAST			= 43+PART_BASE  /*!< */
+    PART_POSTBUILD		= 43+PART_BASE, /*!< */
+    PART_LAST			= 44+PART_BASE  /*!< */
 } rpmParseState; 
 
 
@@ -266,6 +268,9 @@ rpmSpec newSpec(void);
  */
 RPM_GNUC_INTERNAL
 void closeSpec(rpmSpec spec);
+
+
+rpmRC reparsePostbuild(rpmSpec spec);
 
 /** \ingroup rpmbuild
  * Read next line from spec file.

--- a/build/spec.c
+++ b/build/spec.c
@@ -222,6 +222,7 @@ rpmSpec newSpec(void)
     spec->build = NULL;
     spec->install = NULL;
     spec->check = NULL;
+    spec->postbuild = NULL;
     spec->clean = NULL;
     spec->parsed = NULL;
 
@@ -273,6 +274,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     spec->build = freeStringBuf(spec->build);
     spec->install = freeStringBuf(spec->install);
     spec->check = freeStringBuf(spec->check);
+    spec->postbuild = freeStringBuf(spec->postbuild);
     spec->clean = freeStringBuf(spec->clean);
     spec->parsed = freeStringBuf(spec->parsed);
     spec->buildrequires = freeStringBuf(spec->buildrequires);
@@ -451,6 +453,7 @@ const char * rpmSpecGetSection(rpmSpec spec, int section)
 	case RPMBUILD_BUILD:	return getStringBuf(spec->build);
 	case RPMBUILD_INSTALL:	return getStringBuf(spec->install);
 	case RPMBUILD_CHECK:	return getStringBuf(spec->check);
+	    //case RPMBUILD_POSTBUILD:	return getStringBuf(spec->postbuild);
 	case RPMBUILD_CLEAN:	return getStringBuf(spec->clean);
 	}
     }


### PR DESCRIPTION
This is a POC for the new dynamic sub package feature. It add a %postbuild (better names welcome) section that is not expanded during regular Spec parsing. It is fed to the spec parser after the build scripts have run. This allows to create sub packages based on the content of the buildroot.

There are still areas that require improvement: The line numbers and filename for the section should probably look more like we are parsing the spec file itself.

You currently cannot put the main package / initial preamble into the %postbuild section. This requires rethinking what kind of processing is done during (initial) build and how this affects other users of rpmSpecParse.

