### PR TITLE
macros: force add files to git index

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1208,7 +1208,7 @@ package or when debugging this package.\
 %{__git} init %{-q}\
 %{__git} config user.name "%{__scm_username}"\
 %{__git} config user.email "%{__scm_usermail}"\
-%{__git} add .\
+%{__git} add --force .\
 %{__git} commit %{-q} --allow-empty -a\\\
 	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"
 


### PR DESCRIPTION
It's rarely the case that the user may set global ``core.excludesfile``, ``git add .`` may not add all the files as expect.
It will fail to build if the excluded files are patch-needed.