### PR TITLE
only install rpm-plugin-selinux.8 if enabled

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -10,8 +10,11 @@ man_man8dir = $(mandir)/man8
 man_man8_DATA = rpm.8 rpm-misc.8 rpmbuild.8 rpmdeps.8 rpmgraph.8 rpm2cpio.8
 man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8 rpm2archive.8
 man_man8_DATA += rpm-plugin-systemd-inhibit.8 rpm-plugin-audit.8 rpm-plugin-ima.8
-man_man8_DATA += rpm-plugin-prioreset.8 rpm-plugin-selinux.8 rpm-plugin-syslog.8
+man_man8_DATA += rpm-plugin-prioreset.8 rpm-plugin-syslog.8
 man_man8_DATA += rpm-plugins.8
+if SELINUX
+man_man8_DATA += rpm-plugin-selinux.8
+endif
 EXTRA_DIST += $(man_man8_DATA)
 
 man_fr_man8dir = $(mandir)/fr/man8


### PR DESCRIPTION
This fixes installing rpm-plugin-selinux.8 even when using configure --disable-selinux