### PR TITLE
Add pre-flight check for erased packages too

### DIFF
--- a/lib/rpmprob.c
+++ b/lib/rpmprob.c
@@ -119,7 +119,10 @@ char * rpmProblemString(rpmProblem prob)
 		pkgNEVR, str1);
 	break;
     case RPMPROB_PKG_INSTALLED:
-	rasprintf(&buf, _("package %s is already installed"), pkgNEVR);
+	if (prob->num1)
+	    rasprintf(&buf, _("package %s is already installed"), pkgNEVR);
+	else
+	    rasprintf(&buf, _("package %s is not installed"), pkgNEVR);
 	break;
     case RPMPROB_BADRELOCATE:
 	rasprintf(&buf, _("path %s in package %s is not relocatable"),

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1346,6 +1346,23 @@ static void checkAdded(rpmts ts, rpmprobFilterFlags probFilter, rpmte p)
 	rpmteAddRelocProblems(p);
 }
 
+static void checkRemoved(rpmts ts, rpmprobFilterFlags probFilter, rpmte p)
+{
+    unsigned int offset = rpmteDBInstance(p);
+    int found = 0;
+    rpmdbMatchIterator mi;
+
+    mi = rpmtsInitIterator(ts, RPMDBI_PACKAGES, &offset, sizeof(offset));
+    while (rpmdbNextIterator(mi)) {
+	found = 1;
+	break;
+    }
+    rpmdbFreeIterator(mi);
+
+    if (!found)
+	rpmteAddProblem(p, RPMPROB_PKG_INSTALLED, NULL, NULL, 0);
+}
+
 /*
  * For packages being installed:
  * - verify package arch/os.
@@ -1372,6 +1389,9 @@ static rpmps checkProblems(rpmts ts)
 	case TR_ADDED:
 	    checkAdded(ts, probFilter, p);
 	    ninst++;
+	    break;
+	case TR_REMOVED:
+	    checkRemoved(ts, probFilter, p);
 	    break;
 	default:
 	    break;


### PR DESCRIPTION
This essentially adds a check ensuring removed packages still exist when we're about to commit to the transaction, ie that nobody removed the package while we were enjoying the view.
    
RPMPROB_PKG_INSTALLED is (ab)used for the purpose here - it's related to the package install status anyhow and adding a separate value would be just a whole bunch of boilerplate code, but I suppose I could be conviced otherwise too.
