### PR TITLE
Fix python ts.addErase() not raising exception on not-found packages

### DIFF
--- a/python/rpm/transaction.py
+++ b/python/rpm/transaction.py
@@ -85,24 +85,28 @@ class TransactionSet(TransactionSetCore):
 
     def addErase(self, item):
         hdrs = []
-        if isinstance(item, rpm.hdr):
-            hdrs = [item]
-        elif isinstance(item, rpm.mi):
+        # match iterators are passed on as-is
+        if isinstance(item, rpm.mi):
             hdrs = item
-        elif isinstance(item, int):
-            hdrs = self.dbMatch(rpm.RPMDBI_PACKAGES, item)
-        elif isinstance(item, str):
-            hdrs = self.dbMatch(rpm.RPMDBI_LABEL, item)
+        elif isinstance(item, rpm.hdr):
+            hdrs.append(item)
+        elif isinstance(item, (int, str)):
+            if isinstance(item, int):
+                dbi = rpm.RPMDBI_PACKAGES
+            else:
+                dbi = rpm.RPMDBI_LABEL
+
+            for h in self.dbMatch(dbi, item):
+                hdrs.append(h)
+
+            if not hdrs:
+                raise rpm.error("package not installed")
         else:
             raise TypeError("invalid type %s" % type(item))
 
         for h in hdrs:
             if not TransactionSetCore.addErase(self, h):
                 raise rpm.error("adding erasure to transaction failed")
-
-        # garbage collection should take care but just in case...
-        if isinstance(hdrs, rpm.mi):
-            del hdrs
 
     def run(self, callback, data):
         rc = TransactionSetCore.run(self, callback, data, self._probFilter)

--- a/python/rpm/transaction.py
+++ b/python/rpm/transaction.py
@@ -72,13 +72,16 @@ class TransactionSet(TransactionSetCore):
         upgrade = (how == "u")
 
         if not TransactionSetCore.addInstall(self, header, key, upgrade):
-            raise rpm.error("adding package to transaction failed")
+            if upgrade:
+                raise rpm.error("adding upgrade to transaction failed")
+            else:
+                raise rpm.error("adding install to transaction failed")
 
     def addReinstall(self, item, key):
         header = self._f2hdr(item)
 
         if not TransactionSetCore.addReinstall(self, header, key):
-            raise rpm.error("adding package to transaction failed")
+            raise rpm.error("adding reinstall to transaction failed")
 
     def addErase(self, item):
         hdrs = []
@@ -95,7 +98,7 @@ class TransactionSet(TransactionSetCore):
 
         for h in hdrs:
             if not TransactionSetCore.addErase(self, h):
-                raise rpm.error("package not installed")
+                raise rpm.error("adding erasure to transaction failed")
 
         # garbage collection should take care but just in case...
         if isinstance(hdrs, rpm.mi):

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -259,6 +259,28 @@ for e in ts:
 [foo-1.0-1.noarch]
 )
 
+RPMPY_TEST([add erasure to transaction],[
+ts = rpm.ts()
+for i in ['foo', 1234]:
+    myprint('addErase %s' % i)
+    try:
+        ts.addErase(i)
+    except rpm.error as err:
+        myprint(err)
+myprint('addErase mi')
+mi = ts.dbMatch('name', 'foo')
+try:
+    ts.addErase(mi)
+except rpm.error as err:
+    myprint(err)
+],
+[addErase foo
+package not installed
+addErase 1234
+package not installed
+addErase mi]
+)
+
 RPMPY_TEST([add bogus package to transaction 1],[
 ts = rpm.ts()
 h = rpm.hdr()

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -264,13 +264,13 @@ ts = rpm.ts()
 h = rpm.hdr()
 h['name'] = "foo"
 try:
-    ts.addInstall(h, 'foo', 'u')
+    ts.addInstall(h, 'foo', 'i')
 except rpm.error as err:
     myprint(err)
 for e in ts:
     myprint(e.NEVRA())
 ],
-[adding package to transaction failed]
+[adding install to transaction failed]
 )
 
 RPMPY_TEST([add bogus package to transaction 2],[
@@ -291,7 +291,7 @@ except rpm.error as err:
 for e in ts:
     myprint(e.NEVRA())
 ],
-[adding package to transaction failed]
+[adding upgrade to transaction failed]
 )
 
 AT_SETUP([database iterators])


### PR DESCRIPTION
The code would only raise an exception if TransactionSetCore.addErase()
returned an error, but the catch is that with many kinds of argument
types we'd silently skip the whole addition because no headers were found.

This looks to be a regression introduced some eleven years ago in
commit 9b20c706a4f93266450fae2f94007343b2e8fd9e.

Fixes: #1214