### PR TITLE
Fix: bump up the limit of signature header to 64MB

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1903,7 +1903,7 @@ rpmRC hdrblobRead(FD_t fd, int magic, int exact_size, rpmTagVal regionTag, hdrbl
 
     if (regionTag == RPMTAG_HEADERSIGNATURES) {
 	il_max = 32;
-	dl_max = 64 * 1024;
+	dl_max = 64 * 1024 * 1024;
     }
 
     memset(block, 0, sizeof(block));


### PR DESCRIPTION
Since commits [Place file signatures into the signature header where they
belong][1] applied, run `rpm -Kv **.rpm' failed if signature header
is larger than 64KB. Here are steps:

1) A unsigned rpm package, the size is 227560 bytes
$ ls -al xz-src-5.2.5-r0.corei7_64.rpm
-rw-------. 1 mockbuild 1000 227560 Jun  3 09:59

2) Sign the rpm package
$ rpmsign --addsign ... xz-src-5.2.5-r0.corei7_64.rpm

3) The size of signed rpm is 312208 bytes
$ ls -al xz-src-5.2.5-r0.corei7_64.rpm
-rw-------. 1 mockbuild 1000 312208 Jun  3 09:48

4) Run `rpm -Kv' failed with signature hdr data out of range
$ rpm -Kv xz-src-5.2.5-r0.corei7_64.rpm
xz-src-5.2.5-r0.corei7_64.rpm:
error: xz-src-5.2.5-r0.corei7_64.rpm: signature hdr data: BAD, no. of
bytes(88864) out of range

From 1) and 3), the size of signed rpm package increased
312208 - 227560 = 84648, so the check of dl_max (64KB,65536)
is not enough.

As [1] said:

    This also means the signature header can be MUCH bigger than ever
    before,so bump up the limit (to 64MB, arbitrary something for now)

So [1] missed to multiply by 1024.

[1] https://github.com/rpm-software-management/rpm/commit/f558e886050c4e98f6cdde391df679a411b3f62c

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>