### PR TITLE
Don't auto-enable IO flushing on non-rotational disks

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1478,10 +1478,8 @@ static void setSSD(int enable)
     if (enable) {
 	rpmlog(RPMLOG_DEBUG, "optimizing for non-rotational disks\n");
 	ensureMacro("_minimize_writes", "1");
-	ensureMacro("_flush_io", "1");
     } else {
 	rpmPopMacro(NULL, "_minimize_writes");
-	rpmPopMacro(NULL, "_flush_io");
     }
 }
 

--- a/macros.in
+++ b/macros.in
@@ -722,10 +722,8 @@ package or when debugging this package.\
 # Flush file IO during transactions (at a severe cost in performance
 # for rotational disks).
 # 1			enable
-# 0 			disable
-# -1 (or undefined)	autodetect on platforms where supported, otherwise
-# 			default to disabled
-#%_flush_io		-1
+# <= 0 (or undefined)	disable
+#%_flush_io		0
 
 # Set to 1 to have IMA signatures written also on %config files.
 # Note that %config files may be changed and therefore end up with


### PR DESCRIPTION
Commit 47e2463d8a98a7535e141d59d17be17d5a30862c added logic to enable
%_flush_io automatically on non-rotational disks to avoid trashing system
caches and IO peaks on the grounds that this isn't so expensive on SSD,
but real world experience suggests otherwise. Install times go from
seconds to minutes which might not matter for the random individual system
but for build systems and the like churning away continuously...