### PR TITLE
Add _without_check macro

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -378,6 +378,7 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 		goto exit;
 
 	if ((what & RPMBUILD_CHECK) &&
+	    (!rpmExpandNumeric("%{_without_check}")) &&
 	    (rc = doScript(spec, RPMBUILD_CHECK, "%check",
 			   getStringBuf(spec->check), test, sbp)))
 		goto exit;

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -473,6 +473,12 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba)
     if (_anyarch(buildAmount))
 	specFlags |= RPMSPEC_ANYARCH;
 #undef	_anyarch
+
+    if (!(buildAmount & RPMBUILD_CHECK)) {
+	rpmDefineMacro(NULL, "_without_check 1", 0);
+    } else if (!rpmMacroIsDefined(NULL, "_without_check")) {
+	rpmDefineMacro(NULL, "_without_check 0", 0);
+    }
     
     spec = rpmSpecParse(specFile, specFlags, buildRootURL);
     if (spec == NULL) {


### PR DESCRIPTION
signaling and controling whether %check is executed during build.
The macro can be set globally or in the spec file. The --nocheck
parameter of rpmbuild takes precedence, though. If --nocheck is
passed to rpmbuild the macro set accordingly. Otherwise it is set
to 0 if not defined previously.

Resolves: #316