### PR TITLE
Add OrderWithRequires dependency generation

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -919,6 +919,11 @@ rpmds rpmfcObsoletes(rpmfc fc)
     return rpmfcDependencies(fc, RPMTAG_OBSOLETENAME);
 }
 
+rpmds rpmfcOrderWithRequires(rpmfc fc)
+{
+    return rpmfcDependencies(fc, RPMTAG_ORDERNAME);
+}
+
 
 /* Versioned deps are less than unversioned deps */
 static int cmpVerDeps(const void *a, const void *b)
@@ -1007,6 +1012,7 @@ static const struct applyDep_s applyDepTable[] = {
     { RPMTAG_ENHANCENAME,	RPMSENSE_FIND_REQUIRES, "enhances" },
     { RPMTAG_CONFLICTNAME,	RPMSENSE_FIND_REQUIRES, "conflicts" },
     { RPMTAG_OBSOLETENAME,	RPMSENSE_FIND_REQUIRES, "obsoletes" },
+    { RPMTAG_ORDERNAME,	        RPMSENSE_FIND_REQUIRES, "orderwithrequires" },
     { 0, 0, NULL },
 };
 
@@ -1397,6 +1403,9 @@ static struct DepMsg_s depMsgs[] = {
   { "Enhances",		{ "%{?__find_enhances}", NULL, NULL, NULL },
 	RPMTAG_ENHANCENAME, RPMTAG_ENHANCEVERSION, RPMTAG_ENHANCEFLAGS,
 	0, -1 },
+  { "OrderWithRequires",	{ "%{?__find_orderwithrequires}", NULL, NULL, NULL },
+	RPMTAG_ORDERNAME, RPMTAG_ORDERFLAGS,
+	0, -1 },
   { NULL,		{ NULL, NULL, NULL, NULL },	0, 0, 0, 0, 0 }
 };
 
@@ -1470,6 +1479,7 @@ static rpmRC rpmfcApplyExternal(rpmfc fc)
 	case RPMTAG_ENHANCEFLAGS:
 	case RPMTAG_CONFLICTFLAGS:
 	case RPMTAG_OBSOLETEFLAGS:
+	case RPMTAG_ORDERNAME:
 	    if (fc->skipReq)
 		continue;
 	    tagflags = RPMSENSE_FIND_REQUIRES;

--- a/build/rpmfc.h
+++ b/build/rpmfc.h
@@ -148,6 +148,13 @@ rpmds rpmfcConflicts(rpmfc fc);
 rpmds rpmfcObsoletes(rpmfc fc);
 
 /** \ingroup rpmfc
+ * Retrieve file classification OrderWithRequires
+ * @param fc		file classifier
+ * @return		rpmds dependency set of fc obsoletes
+ */
+rpmds rpmfcOrderWithRequires(rpmfc fc);
+
+/** \ingroup rpmfc
  * Retrieve file classification dependencies
  * @param fc		file classifier
  * @param tagN		name tag of the wanted dependency

--- a/tools/rpmdeps.c
+++ b/tools/rpmdeps.c
@@ -23,6 +23,8 @@ static int print_conflicts;
 
 static int print_obsoletes;
 
+static int print_orderwithrequires;
+
 static int print_alldeps;
 
 static void rpmdsPrint(const char * msg, rpmds ds, FILE * fp)
@@ -58,6 +60,8 @@ static struct poptOption optionsTable[] = {
  { "conflicts", '\0', POPT_ARG_VAL, &print_conflicts, -1,
         NULL, NULL },
  { "obsoletes", '\0', POPT_ARG_VAL, &print_obsoletes, -1,
+        NULL, NULL },
+ { "orderwithrequires", '\0', POPT_ARG_VAL, &print_orderwithrequires, -1,
         NULL, NULL },
  { "alldeps", '\0', POPT_ARG_VAL, &print_alldeps, -1,
         NULL, NULL },
@@ -124,6 +128,8 @@ main(int argc, char *argv[])
 	    rpmdsPrint(NULL, rpmfcConflicts(fc), stdout);
 	if (print_obsoletes)
 	    rpmdsPrint(NULL, rpmfcObsoletes(fc), stdout);
+	if (print_orderwithrequires)
+	    rpmdsPrint(NULL, rpmfcOrderWithRequires(fc), stdout);
     }
 
     ec = 0;


### PR DESCRIPTION
It was possible to generate Requires, Recommends etc. using external dependency generators.
Adding ability to generate OrderWithRequires.

Example use case:

When a package contains a systemd unit, %systemd_* macros are usually used;
it is usefull to add "OrderWithRequires: systemd" in this case to ensure
that systemd is installed before that package.

It will help to avoid adding "%systemd_ordering" manually to all packages using systemd.
Having systemd preinstalled before packages with systemd scriptlets is really important,
otherwise those scriptlets fail silently, and the resulting ISO or chroot may be broken.

The same makes sense for e.g. systemd-sysusers, systemd-tmpfiles.

An RPM generator using this functionality was implemented: https://abf.io/import/order-rpm-generators
Rebuilding packages with systemd stuff in rosa2019.05 using this generator has already helped
to improve installation order, e.g. make e.g. openvpn be installed when systemd already exists
in a big transaction with ~3500 packages when building a big ISO image.
Before that openvpn was installed when systemd did not exist yet.

P.S. This patch adds %__find_orderwithrequires, maybe that is legacy code that should not be changed.