### PR TITLE
Add support for dependency generators for RPMTAG_ORDERNAME

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -919,6 +919,11 @@ rpmds rpmfcObsoletes(rpmfc fc)
     return rpmfcDependencies(fc, RPMTAG_OBSOLETENAME);
 }
 
+rpmds rpmfcOrder(rpmfc fc)
+{
+    return rpmfcDependencies(fc, RPMTAG_ORDERNAME);
+}
+
 
 /* Versioned deps are less than unversioned deps */
 static int cmpVerDeps(const void *a, const void *b)
@@ -1397,6 +1402,9 @@ static struct DepMsg_s depMsgs[] = {
   { "Enhances",		{ "%{?__find_enhances}", NULL, NULL, NULL },
 	RPMTAG_ENHANCENAME, RPMTAG_ENHANCEVERSION, RPMTAG_ENHANCEFLAGS,
 	0, -1 },
+  { "OrderWithRequires",	{ "%{?__find_order}", NULL, NULL, NULL },
+	RPMTAG_ORDERNAME, RPMTAG_ORDERVERSION, RPMTAG_ORDERFLAGS,
+	0, -1 },
   { NULL,		{ NULL, NULL, NULL, NULL },	0, 0, 0, 0, 0 }
 };
 
@@ -1470,6 +1478,7 @@ static rpmRC rpmfcApplyExternal(rpmfc fc)
 	case RPMTAG_ENHANCEFLAGS:
 	case RPMTAG_CONFLICTFLAGS:
 	case RPMTAG_OBSOLETEFLAGS:
+	case RPMTAG_ORDERFLAGS:
 	    if (fc->skipReq)
 		continue;
 	    tagflags = RPMSENSE_FIND_REQUIRES;

--- a/build/rpmfc.h
+++ b/build/rpmfc.h
@@ -148,6 +148,13 @@ rpmds rpmfcConflicts(rpmfc fc);
 rpmds rpmfcObsoletes(rpmfc fc);
 
 /** \ingroup rpmfc
+ * Retrieve file classification order (aka orderwithrequires)
+ * @param fc		file classifier
+ * @return		rpmds dependency set of fc order
+ */
+rpmds rpmfcOrder(rpmfc fc);
+
+/** \ingroup rpmfc
  * Retrieve file classification dependencies
  * @param fc		file classifier
  * @param tagN		name tag of the wanted dependency


### PR DESCRIPTION
aka OrderWithRequires. Use __find_order in the attribute files

Resolves: #1257

Please test!