### PR TITLE
Fix data race in packageBinaries() function

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -765,7 +765,7 @@ rpmRC packageBinaries(rpmSpec spec, const char *cookie, int cheating)
     #pragma omp parallel
     #pragma omp single
     for (int i = 0; i < npkgs; i++) {
-	pkg = tasks[i];
+	Package pkg = tasks[i];
 	#pragma omp task untied priority(i)
 	{
 	pkg->rc = packageBinary(spec, pkg, cookie, cheating, &pkg->filename);


### PR DESCRIPTION
The pkg variable used in the parallel loop was declared outside
of the omp parallel construct, so it was shared among tasks.  This
had the potential to cause a data race.  The gcc openmp implementation
did not hit this problem, but I uncovered it while trying to compile with
clang.  My best guess as to what was happening is that after the last
task was launched, all tasks had the same value of pkg and were operating
on the same data at the same time.

This patch marks the variable as firstprivate, so each tasks gets its
own copy of the variable.