### PR TITLE
Execute tests in independent testing roots to enable parallel running

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -65,4 +65,4 @@ RUN ./configure \
   --enable-silent-rules \
   --enable-werror
 
-CMD make -j distcheck; rc=$?; find . -name rpmtests.log|xargs cat; exit $rc
+CMD make -j$(nproc) distcheck TESTSUITEFLAGS=-j$(nproc); rc=$?; find . -name rpmtests.log|xargs cat; exit $rc

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -154,6 +154,7 @@ KILLAGENT = gpgconf --kill gpg-agent
 
 # The chmod is needed when copying from read-only sources (eg in distcheck)
 populate_testing:
+	if [ -d testing ]; then chmod -R u+w testing/; fi
 	HOME=$(abs_builddir)/testing $(KILLAGENT) ||:
 	rm -rf testing
 	mkdir -p testing/$(bindir)
@@ -163,7 +164,6 @@ populate_testing:
 	(cd ${top_builddir} && \
 	          $(MAKE) DESTDIR=`pwd`/${subdir}/testing install)
 	cp -r ${srcdir}/data/ testing/
-	chmod -R u+w testing/data/
 	for d in dev etc magic tmp var; do if [ ! -d testing/$${d} ]; then mkdir testing/$${d}; fi; done
 	for node in urandom stdin stderr stdout null full; do ln -s /dev/$${node} testing/dev/$${node}; done
 	for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do [ -f /etc/$${cf} ] && ln -s /etc/$${cf} testing/etc/$${cf}; done
@@ -171,6 +171,7 @@ populate_testing:
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 	HOME=$(abs_builddir)/testing gpg2 --import ${abs_srcdir}/data/keys/*.secret
+	chmod -R u-w testing/
 
 check_DATA = atconfig atlocal $(TESTSUITE)
 
@@ -191,4 +192,5 @@ installcheck-local: $(check_DATA) populate_testing
 clean-local:
 	test ! -f '$(TESTSUITE)' || $(SHELL) '$(TESTSUITE)' --clean
 	rm -f *.tmp
+	if [ -d testing ]; then chmod -R u+w testing/; fi
 	rm -rf testing

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -21,7 +21,7 @@ DBFORMAT=$(awk '/^%_db_backend/{print $2}' "${RPM_CONFIGDIR}/macros")
 export DBFORMAT
 
 # Popt looks into $HOME
-HOME="${RPMTEST}"
+HOME="${PWD}"
 export HOME
 
 TZ=UTC
@@ -29,7 +29,7 @@ export TZ
 
 unset SOURCE_DATE_EPOCH
 
-TOPDIR="${RPMTEST}/build"
+TOPDIR="${HOME}/build"
 
 RPM_XFAIL=${RPM_XFAIL-1}
 if grep -q 'WITH_LUA 1' "${abs_top_builddir}/config.h"; then
@@ -48,13 +48,25 @@ else
     CAP_DISABLED=true;
 fi
 
+function setup_env()
+{
+    if [ -d testing ]; then
+        RPMTEST=${PWD}/testing
+        HOME=${RPMTEST}
+        RPM_CONFIGDIR=${RPMTEST}/@RPMCONFIGDIR@
+        export RPMTEST HOME RPM_CONFIGDIR
+    fi
+}
+
 function run()
 {
+    setup_env
     "$@" --define "_buildhost testhost" --define "_tmppath ${RPMTEST}/tmp" --define "_topdir ${TOPDIR}" --define "_db_backend ${DBFORMAT}" --dbpath="${RPMTEST}/var/lib/rpm/"
 }
 
 function rundebug()
 {
+    setup_env
     cp ${RPMDATA}/macros.debug ${RPM_CONFIGDIR}/macros.d/
     "$@" --define "_buildhost testhost" --define "_tmppath ${RPMTEST}/tmp" --define "_topdir ${TOPDIR}" --define "_db_backend ${DBFORMAT}" --dbpath="${RPMTEST}/var/lib/rpm/"
     rm -f ${RPM_CONFIGDIR}/macros.d/macros.debug
@@ -62,6 +74,7 @@ function rundebug()
 
 function runroot()
 {
+    setup_env
     (unset RPM_CONFIGDIR RPM_POPTEXEC_PATH; cd ${RPMTEST} && \
      MAGIC="/magic/magic" FAKECHROOT_BASE="${RPMTEST}" fakechroot "$@" --define "_buildhost testhost" --define "_topdir /build" --noplugins --nouserns
     )
@@ -69,6 +82,7 @@ function runroot()
 
 function runroot_other()
 {
+    setup_env
     (unset RPM_CONFIGDIR RPM_POPTEXEC_PATH; cd ${RPMTEST} && \
      FAKECHROOT_BASE="${RPMTEST}" fakechroot "$@"
     )

--- a/tests/debugedit.at
+++ b/tests/debugedit.at
@@ -26,6 +26,7 @@ m4_define([RPM_DEBUGEDIT_SETUP],[[
 # Create some test binaries. Create and build them in different subdirs
 # to make sure they produce different relative/absolute paths.
 
+export HOME=${PWD}
 mkdir subdir_foo
 cp "${abs_srcdir}"/data/SOURCES/foo.c subdir_foo
 mkdir subdir_bar

--- a/tests/local.at
+++ b/tests/local.at
@@ -5,7 +5,7 @@ runroot rpm --initdb
 ]])
 
 m4_define([RPMDB_CLEAR],[[
-rm -rf "${abs_builddir}"/testing`rpm --eval '%_dbpath'`/*
+rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`/*
 ]])
 
 m4_define([RPMPY_RUN],[[
@@ -13,7 +13,7 @@ cat << EOF > test.py
 # coding=utf-8
 import rpm, sys, os
 dbpath=rpm.expandMacro('%_dbpath')
-rpm.addMacro('_dbpath', '${abs_builddir}/testing%s' % dbpath)
+rpm.addMacro('_dbpath', '${RPMTEST}%s' % dbpath)
 rpm.addMacro('_db_backend', os.getenv('DBFORMAT'))
 def myprint(msg = ''):
     sys.stdout.write('%s\n' % msg)

--- a/tests/local.at
+++ b/tests/local.at
@@ -1,11 +1,8 @@
 AT_TESTED([rpm rpmbuild rpmquery])
 
 m4_define([RPMDB_INIT],[[
+rm -rf "${RPMTEST}"$(run rpm --eval '%_dbpath')/*
 runroot rpm --initdb
-]])
-
-m4_define([RPMDB_CLEAR],[[
-rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`/*
 ]])
 
 m4_define([RPMPY_RUN],[[
@@ -30,7 +27,6 @@ AT_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 m4_define([RPMPY_TEST],[
 AT_SETUP([$1])
 AT_KEYWORDS([python])
-RPMDB_CLEAR
 RPMDB_INIT
 RPMPY_CHECK([$2], [$3], [$4])
 AT_CLEANUP

--- a/tests/local.at
+++ b/tests/local.at
@@ -1,9 +1,20 @@
 AT_TESTED([rpm rpmbuild rpmquery])
 
-m4_define([RPMDB_INIT],[[
-rm -rf "${RPMTEST}"$(run rpm --eval '%_dbpath')/*
-runroot rpm --initdb
+m4_define([RPMTEST_SETUP],[[
+if ! [ -d testing/ ]; then
+    cp -aP "${RPMTEST}" .
+    chmod -R u+w testing/
+fi
+export RPMTEST="${PWD}/testing"
+export TOPDIR="${RPMTEST}/build"
+export HOME="${RPMTEST}"
 ]])
+
+m4_define([RPMDB_INIT],[
+RPMTEST_SETUP
+rm -rf "${RPMTEST}"`rpm --eval '%_dbpath'`/*
+runroot rpm --initdb
+])
 
 m4_define([RPMPY_RUN],[[
 cat << EOF > test.py
@@ -21,13 +32,13 @@ ${PYTHON} test.py
 
 m4_define([RPMPY_CHECK],[
 AT_SKIP_IF([$PYTHON_DISABLED])
+RPMTEST_SETUP
 AT_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 ])
 
 m4_define([RPMPY_TEST],[
 AT_SETUP([$1])
 AT_KEYWORDS([python])
-RPMDB_INIT
 RPMPY_CHECK([$2], [$3], [$4])
 AT_CLEANUP
 ])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -24,7 +24,6 @@ AT_SETUP([rpmbuild -ba *.spec])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -42,7 +41,6 @@ AT_KEYWORDS([build])
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-*.patch ${TOPDIR}/SOURCES
@@ -59,7 +57,6 @@ AT_SETUP([rpmbuild --rebuild])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 
 run rpmbuild \
   --rebuild "${abs_srcdir}"/data/SRPMS/hello-1.0-1.src.rpm
@@ -73,7 +70,6 @@ AT_SETUP([rpmbuild --short-circuit -bl])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -92,7 +88,6 @@ AT_SETUP([rpmbuild -tb <tar with bad spec>])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -tb /data/SOURCES/hello-1.0.tar.gz
@@ -108,7 +103,6 @@ AT_SETUP([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 
 runroot rpmbuild -bb --quiet /data/SPECS/weirdnames.spec
 runroot rpm -qpl /build/RPMS/noarch/weirdnames-1.0-1.noarch.rpm
@@ -156,7 +150,6 @@ AT_SETUP([rpmbuild -tb])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-rm -rf ${TOPDIR}
 
 run rpmbuild \
   -ta "${RPMDATA}/SOURCES/hello-2.0.tar.gz"
@@ -219,7 +212,6 @@ AT_SETUP([rpmbuild %attr and %defattr])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([[
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/attrtest.spec
@@ -261,7 +253,6 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/hlinktest.spec
@@ -292,7 +283,6 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -bb --quiet --with unpackaged_files /data/SPECS/hlinktest.spec
@@ -313,7 +303,6 @@ AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -bb --quiet --with unpackaged_dirs /data/SPECS/hlinktest.spec
@@ -332,7 +321,6 @@ AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild -bb --quiet /data/SPECS/globtest.spec
 runroot rpm -qp \
@@ -365,7 +353,6 @@ AT_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild -bb --quiet \
 	/data/SPECS/prefixtest.spec
@@ -581,7 +568,6 @@ AT_SETUP([rpmbuild archive sanity])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/attrtest.spec
@@ -600,7 +586,6 @@ AT_SETUP([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 # Use macros.debug to generate a debuginfo package.
 export CFLAGS="-g"
@@ -638,7 +623,6 @@ AT_SETUP([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 # Use macros.debug to generate a debuginfo package.
 export CFLAGS="-g"
@@ -678,7 +662,6 @@ AT_SETUP([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -768,7 +751,6 @@ AT_SETUP([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 # Use macros.debug to generate a debuginfo package,
 # but pass --nodebuginfo to skip it.
@@ -802,7 +784,6 @@ AT_SETUP([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -892,7 +873,6 @@ AT_SETUP([rpmbuild debuginfo dwz gnu_debuglink crc])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that
@@ -927,7 +907,6 @@ AT_SETUP([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
@@ -962,7 +941,6 @@ AT_SETUP([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
@@ -992,7 +970,6 @@ AT_SETUP([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
@@ -1021,7 +998,6 @@ AT_SETUP([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo generated with -g3.
@@ -1055,7 +1031,6 @@ AT_SETUP([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
@@ -1095,7 +1070,6 @@ AT_SETUP([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
@@ -1132,7 +1106,6 @@ AT_SETUP([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
@@ -1169,7 +1142,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1199,7 +1171,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1243,7 +1214,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1329,7 +1299,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1415,7 +1384,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1504,7 +1472,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1570,7 +1537,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1642,7 +1608,6 @@ AT_SETUP([dynamic build requires rpmbuild -bs])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
@@ -1665,7 +1630,6 @@ AT_SETUP([rpmbuild -br])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
@@ -1689,7 +1653,6 @@ AT_SETUP([rpmbuild -ba])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
@@ -1714,7 +1677,6 @@ AT_SETUP([rpmbuild -br --nodeps])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
@@ -1741,7 +1703,6 @@ AT_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 runroot rpmbuild \
@@ -1757,7 +1718,6 @@ AT_SETUP([rpmbuild minimal spec])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 runroot rpmbuild \
   -bb --quiet /data/SPECS/mini.spec
@@ -1771,7 +1731,6 @@ AT_SETUP([rpmbuild missing doc])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 
 for val in 1 0; do
     runroot rpmbuild \

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -22,6 +22,7 @@ AT_BANNER([RPM build])
 # Check if rpmbuild -ba *.spec works
 AT_SETUP([rpmbuild -ba *.spec])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
@@ -39,6 +40,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
@@ -55,6 +57,7 @@ AT_CLEANUP
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 
@@ -68,6 +71,7 @@ AT_CLEANUP
 
 AT_SETUP([rpmbuild --short-circuit -bl])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
@@ -86,6 +90,7 @@ AT_CLEANUP
 # Check if tar unpacking works
 AT_SETUP([rpmbuild -tb <tar with bad spec>])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 
@@ -101,6 +106,7 @@ AT_CLEANUP
 # weird filename survival test
 AT_SETUP([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 
@@ -133,6 +139,7 @@ AT_CLEANUP
 
 AT_SETUP([rpmbuild package with illegal filenames])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 # XXX current output is not well suited for grab + compare, just ignore
 runroot rpmbuild -bb --quiet --with illegal /data/SPECS/weirdnames.spec
@@ -147,6 +154,7 @@ AT_CLEANUP
 # TODO: test that the rpms are actually created...
 AT_SETUP([rpmbuild -tb])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 rm -rf ${TOPDIR}
 
@@ -160,6 +168,7 @@ AT_CLEANUP
 
 AT_SETUP([rpmbuild scriptlet -f])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 
 runroot rpmbuild \
@@ -208,6 +217,7 @@ AT_CLEANUP
 # %attr/%defattr tests
 AT_SETUP([rpmbuild %attr and %defattr])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([[
 rm -rf ${TOPDIR}
 
@@ -248,6 +258,7 @@ AT_CLEANUP
 # hardlink tests
 AT_SETUP([rpmbuild hardlink])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
 rm -rf ${TOPDIR}
@@ -278,6 +289,7 @@ AT_CLEANUP
 
 AT_SETUP([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
 rm -rf ${TOPDIR}
@@ -298,6 +310,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
+RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
 rm -rf ${TOPDIR}
@@ -316,6 +329,7 @@ AT_CLEANUP
 
 AT_SETUP([rpmbuild glob])
 AT_KEYWORDS([build])
+RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT
 rm -rf ${TOPDIR}
@@ -386,6 +400,7 @@ AT_CLEANUP
 AT_SETUP([Weak and reverse requires])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 	--define "pkg weakdeps" \
@@ -414,6 +429,7 @@ AT_CLEANUP
 AT_SETUP([Build requires])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define "pkg buildreq" \
@@ -430,6 +446,7 @@ AT_CLEANUP
 AT_SETUP([Dependency generation 1])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define "_binary_payload w9.gzdio" \
@@ -471,6 +488,7 @@ AT_CLEANUP
 AT_SETUP([Dependency generation 2])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 		/data/SPECS/shebang.spec
@@ -485,6 +503,7 @@ AT_CLEANUP
 AT_SETUP([Dependency generation 3])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 cat << EOF > "${RPMTEST}"/tmp/bad.req
 #!/bin/sh
@@ -506,6 +525,7 @@ AT_CLEANUP
 AT_SETUP([Dependency generation 4])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_requires() foo(%{basename:%{1}})' \
@@ -521,6 +541,7 @@ AT_CLEANUP
 AT_SETUP([Dependency generation 5])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 
 runroot rpmbuild -bb --quiet \
 		--define '__script_mime text/plain' \
@@ -559,6 +580,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild archive sanity])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 runroot rpmbuild \
@@ -577,6 +599,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo minisymtab])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 # Use macros.debug to generate a debuginfo package.
@@ -614,6 +637,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo minisymtab strip -g])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 # Use macros.debug to generate a debuginfo package.
@@ -653,6 +677,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -742,6 +767,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild no debuginfo])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 # Use macros.debug to generate a debuginfo package,
@@ -775,6 +801,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -864,6 +891,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo dwz gnu_debuglink crc])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -898,6 +926,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -932,6 +961,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -961,6 +991,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -989,6 +1020,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1022,6 +1054,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1061,6 +1094,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1097,6 +1131,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1133,6 +1168,7 @@ AT_SETUP([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1162,6 +1198,7 @@ AT_SETUP([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1205,6 +1242,7 @@ AT_SETUP([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1290,6 +1328,7 @@ AT_SETUP([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1375,6 +1414,7 @@ AT_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1463,6 +1503,7 @@ AT_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1528,6 +1569,7 @@ AT_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1599,6 +1641,7 @@ AT_CLEANUP
 AT_SETUP([dynamic build requires rpmbuild -bs])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1621,6 +1664,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild -br])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1644,6 +1688,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild -ba])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1668,6 +1713,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild -br --nodeps])
 AT_KEYWORDS([build])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1694,6 +1740,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1709,6 +1756,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild minimal spec])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 runroot rpmbuild \
@@ -1722,6 +1770,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild missing doc])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 for val in 1 0; do
@@ -1742,6 +1791,7 @@ AT_CLEANUP
 AT_SETUP([%if, %else, %elif test basic])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet \
     --define "testif 0"      \
    /data/SPECS/iftest.spec
@@ -1753,6 +1803,7 @@ AT_CLEANUP
 AT_SETUP([%if, %else, %elif test existing script])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet  \
     --define "testif 2"       \
     --define "fedora 1"       \
@@ -1765,6 +1816,7 @@ AT_CLEANUP
 AT_SETUP([%if, %else, %elif test 1])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet \
  --define "testif 1"         \
  --define "variable1 1"      \
@@ -1785,6 +1837,7 @@ AT_CLEANUP
 AT_SETUP([%if, %else, %elif test 2])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet   \
  --define "testif 1"           \
  --define "variable1 0"        \
@@ -1805,6 +1858,7 @@ AT_CLEANUP
 AT_SETUP([%if, %else, %elif test 3])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet      \
  --define "testif 1"              \
  --define "variable1 0"           \
@@ -1824,6 +1878,7 @@ AT_CLEANUP
 AT_SETUP([%if, %else, %elif test 4])
 AT_KEYWORDS([if else elif build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet      \
  --define "testif 1"              \
  --define "variable1 0"           \
@@ -1849,6 +1904,7 @@ AT_CLEANUP
 AT_SETUP([multiline %if test])
 AT_KEYWORDS([if macros build])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -ba --quiet      \
  data/SPECS/ifmultiline.spec
 ],

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -249,7 +249,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild hardlink])
 AT_KEYWORDS([build])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf ${TOPDIR}
 
@@ -280,7 +279,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf ${TOPDIR}
 
@@ -301,7 +299,6 @@ AT_SETUP([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
 AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf ${TOPDIR}
 
@@ -320,7 +317,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild glob])
 AT_KEYWORDS([build])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf ${TOPDIR}
 
@@ -354,7 +350,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf ${TOPDIR}
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -591,7 +591,7 @@ rundebug rpmbuild --quiet \
 
 # Extract the main package and inspect the hello binary
 # It should contain .gnu_debugdata, but not the full .symtab
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm | cpio -diu
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm | cpio -diu
 test -f ./usr/local/bin/hello || exit 1
 readelf -S ./usr/local/bin/hello |\
    grep -q .gnu_debugdata; test $? == 0 || exit 1
@@ -599,7 +599,7 @@ readelf -S ./usr/local/bin/hello \
   | grep -q .symtab; test $? == 1 || exit 1
 
 # And the opposite for the debuginfo package
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 test -f ./usr/lib/debug/usr/local/bin/hello*.debug || exit 1
 readelf -S ./usr/lib/debug/usr/local/bin/hello*.debug \
@@ -629,7 +629,7 @@ rundebug rpmbuild --quiet \
 
 # Extract the main package and inspect the hello binary
 # It should contain .symtab (because of strip -g), so doesn't .gnu_debugdata.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm | cpio -diu
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm | cpio -diu
 test -f ./usr/local/bin/hello || exit 1
 readelf -S ./usr/local/bin/hello \
   | grep -q .gnu_debugdata; test $? == 1 || exit 1
@@ -637,7 +637,7 @@ readelf -S ./usr/local/bin/hello \
   | grep -q .symtab; test $? == 0 || exit 1
 
 # The debuginfo package should contain neither. The .symtab is NOBITS.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 test -f ./usr/lib/debug/usr/local/bin/hello*.debug || exit 1
 readelf -S ./usr/lib/debug/usr/local/bin/hello*.debug \
@@ -670,7 +670,7 @@ rundebug rpmbuild --quiet \
 
 # The debuginfo package should contain a .debug file for each binary
 # and a dwz multi file that contains the shared debuginfo between them.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 hello_file_debug=./usr/lib/debug/usr/local/bin/hello.debug
@@ -682,7 +682,7 @@ test -f $hello_multi_file || echo "no dwz multi file: $hello_multi_file"
 
 # Make sure the main package binaries contain the correct build-ids
 # linking them to the debug packages.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu
 hello_file=./usr/local/bin/hello
 hello2_file=./usr/local/bin/hello2
@@ -757,7 +757,7 @@ rundebug rpmbuild --quiet --nodebuginfo \
 
 # Extract the main package and inspect the hello binary
 # It should not contain .gnu_debugdata, but the full .symtab
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm | cpio -diu
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm | cpio -diu
 test -f ./usr/local/bin/hello || exit 1
 readelf -S ./usr/local/bin/hello |\
    grep -q .gnu_debugdata; test $? == 1 || exit 1
@@ -765,7 +765,7 @@ readelf -S ./usr/local/bin/hello \
   | grep -q .symtab; test $? == 0 || exit 1
 
 # And the opposite for the debuginfo package
-test ! -e ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm || exit 1
+test ! -e ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm || exit 1
 ],
 [0],
 [],
@@ -791,7 +791,7 @@ rundebug rpmbuild --quiet \
 
 # The debuginfo package should contain a .debug file for each binary
 # and a dwz multi file that contains the shared debuginfo between them.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 hello_file_debug=./usr/lib/debug/usr/local/bin/hello-*.debug
@@ -803,7 +803,7 @@ test -f $hello_multi_file || echo "no dwz multi file: $hello_multi_file"
 
 # Make sure the main package binaries contain the correct build-ids
 # linking them to the debug packages.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu
 hello_file=./usr/local/bin/hello
 hello2_file=./usr/local/bin/hello2
@@ -879,9 +879,9 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
 
 # Unpack the main and debuginfo rpms so we can check binaries and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu
 
 # Check that dwz has ran and a multi file has been produced
@@ -913,7 +913,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2-suid.spec
 
 # Unpack rpm so we can check the included binaries.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # List all binaries with suid bit set (should be one, hello).
@@ -948,7 +948,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
 
 # Unpack the debuginfo rpms so we can check the .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # Check that gdb-add-index has ran and a .gdb_index section has been added
@@ -977,7 +977,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
 
 # Unpack the debuginfo rpms so we can check the .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # Check that gdb-add-index has not ran and no .gdb_index section has been added
@@ -1007,7 +1007,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello-g3.spec
 
 # Unpack the debuginfo rpms so we can check the .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-g3-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-g3-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # We are looking for a line like:
@@ -1041,7 +1041,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
 
 # Unpack the debuginfo rpms so we can check the .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # Check that the source path is "unique"
@@ -1080,7 +1080,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
 
 # Unpack the debuginfo rpms so we can check the .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # Check that the source path is "unique"
@@ -1113,7 +1113,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
 
 # Unpack the debugsource rpm so we can check the sources are there.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debugsource-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debugsource-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # Check that hello.c is there.
@@ -1149,7 +1149,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello-cd.spec
 
 # Unpack the debuginfo rpms so we can check the sources are there.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debugsource-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debugsource-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # Check that hello.c is there.
@@ -1181,15 +1181,15 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages.spec
 
 # Check that there is just one debuginfo package.
-ls ${abs_builddir}/testing/build/RPMS/*/*debuginfo*rpm | wc --lines
+ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # Which contains hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello debug exists"
@@ -1224,15 +1224,15 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages.spec
 
 # Check that there are 3 debuginfo packages.
-ls ${abs_builddir}/testing/build/RPMS/*/*debuginfo*rpm | wc --lines
+ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # First contains hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello debug exists"
@@ -1241,12 +1241,12 @@ else
 fi
 
 # Second contains hello2.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello2 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello2 debug exists"
@@ -1260,12 +1260,12 @@ echo -n "Recommends: "
 runroot rpm -qp --recommends /build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm | sed -E 's/([[-.a-z0-9]]+)\(.*\) = ([[-.0-9]]+)/\1\(ignore-arch\) = \2/'
 
 # Third contains hello3.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test3-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello3 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello3 debug exists"
@@ -1309,15 +1309,15 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages.spec
 
 # Check that there are 3 debuginfo packages.
-ls ${abs_builddir}/testing/build/RPMS/*/*debuginfo*rpm | wc --lines
+ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # First contains hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello debug exists"
@@ -1326,12 +1326,12 @@ else
 fi
 
 # Second contains hello2.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello2 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello2 debug exists"
@@ -1345,12 +1345,12 @@ echo -n "Recommends: "
 runroot rpm -qp --recommends /build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm | sed -E 's/([[-.a-z0-9]]+)\(.*\) = ([[-.0-9]]+)/\1\(ignore-arch\) = \2/'
 
 # Third contains hello3.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test3-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello3 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello3 debug exists"
@@ -1394,15 +1394,15 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages.spec
 
 # Check that there are 3 debuginfo packages.
-ls ${abs_builddir}/testing/build/RPMS/*/*debuginfo*rpm | wc --lines
+ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # First contains hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello debug exists"
@@ -1415,12 +1415,12 @@ echo -n "Recommends: "
 runroot rpm -qp --recommends /build/RPMS/*/test-debuginfo-1.0-1.*.rpm | sed -E 's/([[-.a-z0-9]]+)\(.*\) = ([[-.0-9]]+)/\1\(ignore-arch\) = \2/'
 
 # Second contains hello2.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello2 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello2 debug exists"
@@ -1433,12 +1433,12 @@ echo -n "Recommends: "
 runroot rpm -qp --recommends /build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm | sed -E 's/([[-.a-z0-9]]+)\(.*\) = ([[-.0-9]]+)/\1\(ignore-arch\) = \2/'
 
 # Third contains hello3.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test3-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello3 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test3-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello3 debug exists"
@@ -1482,15 +1482,15 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages-exclude.spec
 
 # Check that there are 2 debuginfo packages.
-ls ${abs_builddir}/testing/build/RPMS/*/*debuginfo*rpm | wc --lines
+ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # First contains hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello debug exists"
@@ -1499,12 +1499,12 @@ else
 fi
 
 # Second contains hello2.debug but NOT hello3.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello2 | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello2 debug exists"
@@ -1547,15 +1547,15 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/test-subpackages-pathpostfixes.spec
 
 # Check that there are 2 debuginfo packages.
-ls ${abs_builddir}/testing/build/RPMS/*/*debuginfo*rpm | wc --lines
+ls ${RPMTEST}/build/RPMS/*/*debuginfo*rpm | wc --lines
 
 # First contains hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello debug exists"
@@ -1569,12 +1569,12 @@ rm ./usr/lib/debug/bin/$debug_name
 orig_debugname=$debugname
 
 # Second contains hello.foobar.debug but NOT hello.debug
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-1.0-1.*.rpm \
   | cpio -diu --quiet
 # Extract the debug name from the exe (.gnu_debuglink section, first string)
 debug_name=$(readelf -p .gnu_debuglink ./bin/hello | grep hello | cut -c13-)
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/test-test2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 if test -f ./usr/lib/debug/bin/$debug_name; then
   echo "hello.foobar debug exists"

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -24,7 +24,6 @@ AT_SETUP([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -59,7 +58,6 @@ AT_SETUP([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -152,7 +150,6 @@ AT_SETUP([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -244,7 +241,6 @@ AT_SETUP([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -336,7 +332,6 @@ AT_SETUP([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -427,7 +422,6 @@ AT_SETUP([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -532,7 +526,6 @@ AT_SETUP([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -637,7 +630,6 @@ AT_SETUP([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -706,7 +698,6 @@ AT_SETUP([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -772,7 +763,6 @@ AT_SETUP([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -838,7 +828,6 @@ AT_SETUP([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -901,7 +890,6 @@ AT_SETUP([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -979,7 +967,6 @@ AT_SETUP([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -1053,7 +1040,6 @@ AT_SETUP([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -1168,7 +1154,6 @@ AT_SETUP([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -1217,7 +1202,6 @@ AT_SETUP([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
@@ -1271,7 +1255,6 @@ AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
 AT_SKIP_IF([$LUA_DISABLED])
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources
@@ -1307,7 +1290,6 @@ AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
 AT_SKIP_IF([$LUA_DISABLED])
-rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Setup sources

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -83,9 +83,9 @@ runroot rpm -ql -p /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
 
 # Extract the both packages to check the build-id files link to the
 # main and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 # Check there is a build-id symlink for the main file.
@@ -174,9 +174,9 @@ runroot rpm -ql -p /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
 
 # Extract the both packages to check the build-id files link to the
 # main and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 # Check there is a build-id symlink for the main file.
@@ -265,9 +265,9 @@ runroot rpm -ql -p /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
 
 # Extract the both packages to check the build-id files link to the
 # main and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 # Check there is a build-id symlink for the main file.
@@ -355,9 +355,9 @@ runroot rpm -ql -p /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
 
 # Extract the both packages to check the build-id files link to the
 # main and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 # Check there is a build-id symlink for the main file.
@@ -447,9 +447,9 @@ runroot rpm -ql -p /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
 
 # Extract the both packages to check the build-id files link to the
 # main and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 # Check there is a build-id symlink for the main file.
@@ -550,9 +550,9 @@ runroot rpm -ql -p /build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
 
 # Extract the both packages to check the build-id files link to the
 # main and .debug files.
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-debuginfo-1.0-1.*.rpm \
   | cpio -diu
 
 # Check there is a build-id symlink for the main file.
@@ -640,7 +640,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2cp.spec 2>&1 | grep "^warning: " \
   | cut -f1-3 -d' '
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -654,7 +654,7 @@ test -L "$id_file" && echo "main id in main package"
 id_dup_file="./usr/lib/debug/.build-id/${id:0:2}/${id:2}.1"
 test -L "$id_dup_file" && echo "main dup id in main package"
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # alldebug, so they are all here
@@ -708,7 +708,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2ln.spec 2>&1 | grep "^warning: " \
   | cut -f1-3 -d' '
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -722,7 +722,7 @@ test -L "$id_file" && echo "main id in main package"
 id_dup_file="./usr/lib/debug/.build-id/${id:0:2}/${id:2}.1"
 test -L "$id_dup_file" && echo "main dup id in main package"
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # alldebug, so they are all here
@@ -773,7 +773,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2cp.spec 2>&1 | grep "^warning: " \
   | cut -f1-3 -d' '
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -787,7 +787,7 @@ test -L "$id_file" && echo "main id in main package"
 id_dup_file="./usr/lib/.build-id/${id:0:2}/${id:2}.1"
 test -L "$id_dup_file" && echo "main dup id in main package"
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # separate, so debug ids are here
@@ -838,7 +838,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2ln.spec 2>&1 | grep "^warning: " \
   | cut -f1-3 -d' '
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -852,7 +852,7 @@ test -L "$id_file" && echo "main id in main package"
 id_dup_file="./usr/lib/.build-id/${id:0:2}/${id:2}.1"
 test -L "$id_dup_file" && echo "main dup id in main package"
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # separate, so debug ids are here
@@ -900,7 +900,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2cp.spec 2>&1 | grep "^warning: " \
   | cut -f1-3 -d' '
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -914,7 +914,7 @@ test -L "$id_file" && echo "main id in main package"
 id_dup_file="./usr/lib/.build-id/${id:0:2}/${id:2}.1"
 test -L "$id_dup_file" && echo "main dup id in main package"
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # compat, so main (and debug) ids are (also) here
@@ -977,7 +977,7 @@ rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2ln.spec 2>&1 | grep "^warning: " \
   | cut -f1-3 -d' '
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -991,7 +991,7 @@ test -L "$id_file" && echo "main id in main package"
 id_dup_file="./usr/lib/.build-id/${id:0:2}/${id:2}.1"
 test -L "$id_dup_file" && echo "main dup id in main package"
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello2-debuginfo-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 # compat, so main (and debug) ids are (also) here
@@ -1053,7 +1053,7 @@ rundebug rpmbuild --quiet \
   --undefine="_no_recompute_build_ids" \
   -ba "${abs_srcdir}"/data/SPECS/hello.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -1072,7 +1072,7 @@ rundebug rpmbuild --quiet \
   --undefine="_no_recompute_build_ids" \
   -ba "${abs_srcdir}"/data/SPECS/hello-r2.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-2.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-2.*.rpm \
   | cpio -diu --quiet
 
 # Extract the build-id from the main file
@@ -1097,7 +1097,7 @@ rundebug rpmbuild --quiet \
   --define="_no_recompute_build_ids 1" \
   -ba "${abs_srcdir}"/data/SPECS/hello.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -1125,7 +1125,7 @@ rundebug rpmbuild --quiet \
   --define="_no_recompute_build_ids 1" \
   -ba "${abs_srcdir}"/data/SPECS/hello-r2.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-2.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-2.*.rpm \
   | cpio -diu --quiet
 
 # Extract the build-id from the main file
@@ -1163,7 +1163,7 @@ rundebug rpmbuild --quiet \
   --define="_unique_build_ids 1" \
   -ba "${abs_srcdir}"/data/SPECS/hello.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -1180,7 +1180,7 @@ rundebug rpmbuild --quiet \
   --define="_unique_build_ids 1" \
   -ba "${abs_srcdir}"/data/SPECS/hello-r2.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-2.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-2.*.rpm \
   | cpio -diu --quiet
 
 # Extract the build-id from the main file
@@ -1213,7 +1213,7 @@ rundebug rpmbuild --quiet \
   --undefine="_unique_debug_srcs" \
   -ba "${abs_srcdir}"/data/SPECS/hello.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-1.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-1.*.rpm \
   | cpio -diu --quiet
 
 hello_file=./usr/local/bin/hello
@@ -1232,7 +1232,7 @@ rundebug rpmbuild --quiet \
   --undefine="_unique_debug_srcs" \
   -ba "${abs_srcdir}"/data/SPECS/hello-r2.spec
 
-rpm2cpio ${abs_builddir}/testing/build/RPMS/*/hello-1.0-2.*.rpm \
+rpm2cpio ${RPMTEST}/build/RPMS/*/hello-1.0-2.*.rpm \
   | cpio -diu --quiet
 
 # Extract the build-id from the main file

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -23,6 +23,7 @@ AT_BANNER([RPM buildid tests])
 AT_SETUP([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -57,6 +58,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -149,6 +151,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -240,6 +243,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -331,6 +335,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -421,6 +426,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -525,6 +531,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -629,6 +636,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -697,6 +705,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -762,6 +771,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -827,6 +837,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -889,6 +900,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -966,6 +978,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1039,6 +1052,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1153,6 +1167,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1201,6 +1216,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
 
@@ -1253,6 +1269,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 AT_SKIP_IF([$LUA_DISABLED])
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)
@@ -1288,6 +1305,7 @@ AT_CLEANUP
 AT_SETUP([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
+RPMDB_INIT
 AT_SKIP_IF([$LUA_DISABLED])
 rm -rf ${TOPDIR}
 AS_MKDIR_P(${TOPDIR}/SOURCES)

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -9,7 +9,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -37,7 +36,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -71,7 +69,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -97,7 +94,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -122,7 +118,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -151,7 +146,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -182,7 +176,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -211,7 +204,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -238,7 +230,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -270,7 +261,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -299,7 +289,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -334,7 +323,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -368,7 +356,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -399,7 +386,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -432,7 +418,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -462,7 +447,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -498,7 +482,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -532,7 +515,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -569,7 +551,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -608,7 +589,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -644,7 +624,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -686,7 +665,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -726,7 +704,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -769,7 +746,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -809,7 +785,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in 1.0 2.0; do
     runroot rpmbuild --quiet -bb \

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -6,7 +6,6 @@ AT_BANNER([RPM config file behavior])
 AT_SETUP([install config on existiting file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -35,7 +34,6 @@ AT_CLEANUP
 AT_SETUP([install config(noreplace) on existing file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -70,7 +68,6 @@ AT_CLEANUP
 AT_SETUP([install config on existiting identical file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -97,7 +94,6 @@ AT_CLEANUP
 AT_SETUP([erase unchanged config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -123,7 +119,6 @@ AT_CLEANUP
 AT_SETUP([erase changed config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -153,7 +148,6 @@ AT_CLEANUP
 AT_SETUP([erase changed config(noreplace)])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -185,7 +179,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -215,7 +208,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged config - touching test])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -243,7 +235,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -276,7 +267,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -306,7 +296,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -342,7 +331,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -377,7 +365,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged config(noreplace)])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -409,7 +396,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config(noreplace)])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -443,7 +429,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -474,7 +459,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config(noreplace) 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -511,7 +495,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config(noreplace) 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -546,7 +529,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged shared config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -584,7 +566,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified shared config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -624,7 +605,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing shared config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -661,7 +641,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -704,7 +683,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -745,7 +723,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config(noreplace) 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -789,7 +766,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config(noreplace) 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -830,7 +806,6 @@ AT_CLEANUP
 AT_SETUP([install/upgrade/erase ghost config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -6,7 +6,6 @@ AT_BANNER([RPM config symlink behavior])
 AT_SETUP([install config on existiting symlink])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -36,7 +35,6 @@ AT_CLEANUP
 AT_SETUP([install config on existiting identical link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -66,7 +64,6 @@ AT_CLEANUP
 AT_SETUP([erase unchanged config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -93,7 +90,6 @@ AT_CLEANUP
 AT_SETUP([erase changed config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -124,7 +120,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -155,7 +150,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged config link - touching test])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -185,7 +179,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -219,7 +212,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -250,7 +242,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config link 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -287,7 +278,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config link 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -323,7 +313,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged config(noreplace) link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -356,7 +345,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config(noreplace) link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -391,7 +379,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing config(noreplace) link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -423,7 +410,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config(noreplace) link 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -461,7 +447,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified config(noreplace) link 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -498,7 +483,6 @@ AT_CLEANUP
 AT_SETUP([upgrade unchanged shared config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -537,7 +521,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified shared config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -578,7 +561,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing shared config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -616,7 +598,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config link 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -660,7 +641,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config link 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -702,7 +682,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config(noreplace) link 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -747,7 +726,6 @@ AT_CLEANUP
 AT_SETUP([upgrade changing, modified shared config(noreplace) link 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -9,7 +9,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -38,7 +37,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -67,7 +65,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -93,7 +90,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -123,7 +119,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -153,7 +148,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -182,7 +176,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -215,7 +208,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -245,7 +237,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -281,7 +272,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -316,7 +306,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -348,7 +337,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -382,7 +370,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -413,7 +400,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -450,7 +436,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -486,7 +471,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -524,7 +508,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -564,7 +547,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -601,7 +583,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -644,7 +625,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -685,7 +665,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -729,7 +708,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do

--- a/tests/rpmconfig3.at
+++ b/tests/rpmconfig3.at
@@ -6,7 +6,6 @@ AT_BANNER([RPM config filetype changes])
 AT_SETUP([upgrade config to/from non-config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -44,7 +43,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config to/from non-config 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -88,7 +86,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config to/from non-config 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -129,7 +126,6 @@ AT_CLEANUP
 AT_SETUP([upgrade config to/from config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -166,7 +162,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config to config link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -206,7 +201,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config link to config])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -246,7 +240,6 @@ AT_CLEANUP
 AT_SETUP([upgrade config to directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
@@ -278,7 +271,6 @@ AT_CLEANUP
 AT_SETUP([upgrade modified config to directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*

--- a/tests/rpmconfig3.at
+++ b/tests/rpmconfig3.at
@@ -9,7 +9,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -46,7 +45,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -89,7 +87,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -129,7 +126,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -165,7 +161,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -204,7 +199,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -243,7 +237,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -274,7 +267,6 @@ AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -3,10 +3,8 @@
 AT_BANNER([RPM implicit file conflicts])
 
 # ------------------------------
-# (Build and) install conflicting package (should fail)
-AT_SETUP([package with file conflict])
+AT_SETUP([packages with file conflicts])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -17,18 +15,17 @@ for p in "one" "two"; do
           /data/SPECS/conflicttest.spec
 done
 
+AT_CHECK([
+RPMDB_INIT
+# (Build and) install conflicting package (should fail)
 runroot rpm -U /build/RPMS/noarch/conflictone-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/conflicttwo-1.0-1.noarch.rpm
 ],
 [1],
 [ignore],
 [ignore])
-AT_CLEANUP
 
-# ------------------------------
 # Install conflicting packages in same transaction (should fail)
-AT_SETUP([two packages with a conflicting file])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 
@@ -42,10 +39,8 @@ runroot rpm -U \
 AT_CLEANUP
 
 # ------------------------------
-# (Build and) install package with shareable file
-AT_SETUP([package with shareable file])
+AT_SETUP([shareable files])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -56,18 +51,17 @@ for p in "one" "two"; do
           /data/SPECS/conflicttest.spec
 done
 
+# (Build and) install package with shareable file
+AT_CHECK([
+RPMDB_INIT
 runroot rpm -U /build/RPMS/noarch/conflictone-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/conflicttwo-1.0-1.noarch.rpm
 ],
 [0],
 [ignore],
 [ignore])
-AT_CLEANUP
 
-# ------------------------------
 # Install packages with shareable file in same transaction
-AT_SETUP([two packages with shareable file])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -7,7 +7,6 @@ AT_BANNER([RPM implicit file conflicts])
 AT_SETUP([package with file conflict])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -31,7 +30,6 @@ AT_CLEANUP
 AT_SETUP([two packages with a conflicting file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U \
@@ -48,7 +46,6 @@ AT_CLEANUP
 AT_SETUP([package with shareable file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -72,7 +69,6 @@ AT_CLEANUP
 AT_SETUP([two packages with shareable file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U \
@@ -89,7 +85,6 @@ AT_CLEANUP
 AT_SETUP([non-conflicting identical basenames])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -107,7 +102,6 @@ AT_CLEANUP
 AT_SETUP([conflicting identical basenames])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -127,7 +121,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf conflict, prefer 64bit 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -149,7 +142,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf conflict, prefer 64bit 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -176,7 +168,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf conflict, prefer 64bit 3])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -203,7 +194,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf conflict, prefer 32bit 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -225,7 +215,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf conflict, prefer 32bit 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -252,7 +241,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf conflict, prefer 32bit 3])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignoreos --ignorearch --nodeps \
@@ -279,7 +267,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf vs non-elf file conflict 1])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -300,7 +287,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf vs non-elf file conflict 2])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -325,7 +311,6 @@ AT_CLEANUP
 AT_SETUP([multilib elf vs non-elf file conflict 3])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -351,7 +336,6 @@ AT_CLEANUP
 AT_SETUP([replacing directory with symlink])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
@@ -375,7 +359,6 @@ AT_CLEANUP
 AT_SETUP([replacing symlink with directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
@@ -400,7 +383,6 @@ AT_CLEANUP
 AT_SETUP([real file with shared ghost])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 fn="${RPMTEST}"/usr/share/my.version
 rm -rf "${TOPDIR}" "${fn}"

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -6,7 +6,6 @@ AT_BANNER([RPM implicit file conflicts])
 AT_SETUP([packages with file conflicts])
 AT_KEYWORDS([install])
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 for p in "one" "two"; do
     runroot rpmbuild --quiet -bb \
@@ -42,7 +41,6 @@ AT_CLEANUP
 AT_SETUP([shareable files])
 AT_KEYWORDS([install])
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 for p in "one" "two"; do
     runroot rpmbuild --quiet -bb \
@@ -80,7 +78,6 @@ AT_SETUP([non-conflicting identical basenames])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
 rm -rf "${RPMTEST}"/opt/mydir
@@ -97,7 +94,6 @@ AT_SETUP([conflicting identical basenames])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
 rm -rf "${RPMTEST}"/opt/mydir
@@ -331,7 +327,6 @@ AT_SETUP([replacing directory with symlink])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
 
 runroot rpmbuild --quiet -bb \
@@ -354,7 +349,6 @@ AT_SETUP([replacing symlink with directory])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest*
 
 runroot rpmbuild --quiet -bb \
@@ -379,7 +373,6 @@ AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 fn="${RPMTEST}"/usr/share/my.version
-rm -rf "${TOPDIR}" "${fn}"
 
 runroot rpmbuild --quiet -bb \
     --define "pkg one" --define "filedata one" \

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -23,7 +23,6 @@ AT_BANNER([RPM database access])
 AT_SETUP([rpm --initdb])
 AT_KEYWORDS([rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 ],
 [0],
@@ -36,7 +35,6 @@ AT_CLEANUP
 AT_SETUP([rpm -qa])
 AT_KEYWORDS([rpmdb query])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 runroot rpm \
   -qa
@@ -49,7 +47,6 @@ AT_CLEANUP
 AT_SETUP([rpm -q foo])
 AT_KEYWORDS([rpmdb query])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -69,7 +66,6 @@ AT_CLEANUP
 AT_SETUP([rpm -q foo-])
 AT_KEYWORDS([rpmdb query])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -87,7 +83,6 @@ AT_CLEANUP
 AT_SETUP([rpmdb header numbering])
 AT_KEYWORDS([rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 for i in 1 2 3; do
@@ -108,7 +103,6 @@ AT_CLEANUP
 AT_SETUP([rpm -q --querybynumber])
 AT_KEYWORDS([rpmdb query])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -143,7 +137,6 @@ AT_SETUP([rpm -i *.noarch.rpm])
 AT_KEYWORDS([rpmdb install])
 
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -159,7 +152,6 @@ AT_SETUP([rpm -U --replacepkgs 1])
 AT_KEYWORDS([rpmdb install])
 
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 tpkg="/data/RPMS/foo-1.0-1.noarch.rpm"
@@ -181,7 +173,6 @@ AT_SETUP([rpm -U --replacepkgs 2])
 AT_KEYWORDS([rpmdb install])
 
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
@@ -202,7 +193,6 @@ AT_SETUP([rpm --reinstall 1])
 AT_KEYWORDS([rpmdb install])
 
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 tpkg="/data/RPMS/hello-2.0-1.i686.rpm"
@@ -224,7 +214,6 @@ AT_CLEANUP
 AT_SETUP([rpm -i --relocate=.. *.i386.rpm])
 AT_KEYWORDS([rpmdb install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -243,7 +232,6 @@ AT_CLEANUP
 AT_SETUP([rpm -i --relocate=.. *.ppc64.rpm])
 AT_KEYWORDS([rpmdb install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -259,7 +247,6 @@ AT_CLEANUP
 AT_SETUP([rpmdb --rebuilddb])
 AT_KEYWORDS([rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --noscripts --nodeps --ignorearch \
@@ -284,7 +271,6 @@ AT_CLEANUP
 AT_SETUP([rpmdb --rebuilddb and verify empty database])
 AT_KEYWORDS([rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 runroot rpmdb --rebuilddb
 runroot rpmdb --verifydb
@@ -299,7 +285,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U and verify status])
 AT_KEYWORDS([install rpmdb query])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -322,7 +307,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U with _install_lang and verify status])
 AT_KEYWORDS([install rpmdb query])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -348,7 +332,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U and verify files on disk])
 AT_KEYWORDS([install rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/opt/*
@@ -369,7 +352,6 @@ AT_CLEANUP
 AT_SETUP([rpm -e and verify files removed])
 AT_KEYWORDS([install rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/opt/*

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -286,7 +286,6 @@ AT_SETUP([rpm -U and verify status])
 AT_KEYWORDS([install rpmdb query])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "pkg status" \
@@ -308,7 +307,6 @@ AT_SETUP([rpm -U with _install_lang and verify status])
 AT_KEYWORDS([install rpmdb query])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
           /data/SPECS/flangtest.spec
@@ -333,7 +331,6 @@ AT_SETUP([rpm -U and verify files on disk])
 AT_KEYWORDS([install rpmdb])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/opt/*
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec
@@ -353,7 +350,6 @@ AT_SETUP([rpm -e and verify files removed])
 AT_KEYWORDS([install rpmdb])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 rm -rf "${RPMTEST}"/opt/*
 
 runroot rpmbuild --quiet -bb /data/SPECS/selfconflict.spec

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -7,7 +7,6 @@ AT_BANNER([RPM dependencies])
 AT_SETUP([missing dependency])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -30,7 +29,6 @@ AT_CLEANUP
 AT_SETUP([cross-depending packages])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -56,7 +54,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied versioned require])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -92,7 +89,6 @@ AT_CLEANUP
 AT_SETUP([satisfied versioned require])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -118,7 +114,6 @@ AT_CLEANUP
 AT_SETUP([versioned conflict in transaction])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -145,7 +140,6 @@ AT_CLEANUP
 AT_SETUP([versioned conflict in database])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -171,7 +165,6 @@ AT_CLEANUP
 AT_SETUP([install and verify self-conflicting package])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -193,7 +186,6 @@ AT_CLEANUP
 AT_SETUP([explicit file conflicts])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -232,7 +224,6 @@ AT_CLEANUP
 AT_SETUP([erase to break dependencies])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -260,7 +251,6 @@ AT_CLEANUP
 AT_SETUP([erase to break colored file dependency])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -289,7 +279,6 @@ AT_CLEANUP
 AT_SETUP([erase on wrong-colored file dependency])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -317,7 +306,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied WITH require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -348,7 +336,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied WITH require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -381,7 +368,6 @@ AT_CLEANUP
 AT_SETUP([satisfied WITH require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -405,7 +391,6 @@ AT_CLEANUP
 AT_SETUP([satisfied WITH require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -433,7 +418,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied WITHOUT require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -459,7 +443,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied WITHOUT require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -487,7 +470,6 @@ AT_CLEANUP
 AT_SETUP([satisfied WITHOUT require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -510,7 +492,6 @@ AT_CLEANUP
 AT_SETUP([satisfied WITHOUT require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -537,7 +518,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied AND require - all missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -558,7 +538,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied AND require - first is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -583,7 +562,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied AND require - second is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -608,7 +586,6 @@ AT_CLEANUP
 AT_SETUP([satisfied AND require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -637,7 +614,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied OR require - all missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -658,7 +634,6 @@ AT_CLEANUP
 AT_SETUP([satisfied OR require - first is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -681,7 +656,6 @@ AT_CLEANUP
 AT_SETUP([satisfied OR require - second is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -704,7 +678,6 @@ AT_CLEANUP
 AT_SETUP([satisfied OR require - both present])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -733,7 +706,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied IF require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -758,7 +730,6 @@ AT_CLEANUP
 AT_SETUP([satisfied IF require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -785,7 +756,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied IF-ELSE require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -806,7 +776,6 @@ AT_CLEANUP
 AT_SETUP([satisfied IF-ELSE require - right clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -829,7 +798,6 @@ AT_CLEANUP
 AT_SETUP([satisfied IF-ELSE require - left clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -858,7 +826,6 @@ AT_CLEANUP
 AT_SETUP([unsatisfied nested AND-OR require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -883,7 +850,6 @@ AT_CLEANUP
 AT_SETUP([satisfied nested AND-OR require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -912,7 +878,6 @@ AT_CLEANUP
 AT_SETUP([satisfied nested AND-IF require - without right clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -935,7 +900,6 @@ AT_CLEANUP
 AT_SETUP([satisfied nested AND-IF require - with right clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -8,7 +8,6 @@ AT_SETUP([missing dependency])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -30,7 +29,6 @@ AT_SETUP([cross-depending packages])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -55,7 +53,6 @@ AT_SETUP([unsatisfied versioned require])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -90,7 +87,6 @@ AT_SETUP([satisfied versioned require])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -115,7 +111,6 @@ AT_SETUP([versioned conflict in transaction])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -141,7 +136,6 @@ AT_SETUP([versioned conflict in database])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -166,7 +160,6 @@ AT_SETUP([install and verify self-conflicting package])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -187,7 +180,6 @@ AT_SETUP([explicit file conflicts])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -225,7 +217,6 @@ AT_SETUP([erase to break dependencies])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -252,7 +243,6 @@ AT_SETUP([erase to break colored file dependency])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg hello" \
@@ -280,7 +270,6 @@ AT_SETUP([erase on wrong-colored file dependency])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg hello" \
@@ -307,7 +296,6 @@ AT_SETUP([unsatisfied WITH require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -337,7 +325,6 @@ AT_SETUP([unsatisfied WITH require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -369,7 +356,6 @@ AT_SETUP([satisfied WITH require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -392,7 +378,6 @@ AT_SETUP([satisfied WITH require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -419,7 +404,6 @@ AT_SETUP([unsatisfied WITHOUT require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -444,7 +428,6 @@ AT_SETUP([unsatisfied WITHOUT require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -471,7 +454,6 @@ AT_SETUP([satisfied WITHOUT require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -493,7 +475,6 @@ AT_SETUP([satisfied WITHOUT require (rpmdb)])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -519,7 +500,6 @@ AT_SETUP([unsatisfied AND require - all missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -539,7 +519,6 @@ AT_SETUP([unsatisfied AND require - first is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -563,7 +542,6 @@ AT_SETUP([unsatisfied AND require - second is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -587,7 +565,6 @@ AT_SETUP([satisfied AND require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -615,7 +592,6 @@ AT_SETUP([unsatisfied OR require - all missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -635,7 +611,6 @@ AT_SETUP([satisfied OR require - first is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -657,7 +632,6 @@ AT_SETUP([satisfied OR require - second is missing])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -679,7 +653,6 @@ AT_SETUP([satisfied OR require - both present])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -707,7 +680,6 @@ AT_SETUP([unsatisfied IF require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -731,7 +703,6 @@ AT_SETUP([satisfied IF require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -757,7 +728,6 @@ AT_SETUP([unsatisfied IF-ELSE require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -777,7 +747,6 @@ AT_SETUP([satisfied IF-ELSE require - right clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -799,7 +768,6 @@ AT_SETUP([satisfied IF-ELSE require - left clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -827,7 +795,6 @@ AT_SETUP([unsatisfied nested AND-OR require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -851,7 +818,6 @@ AT_SETUP([satisfied nested AND-OR require])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -879,7 +845,6 @@ AT_SETUP([satisfied nested AND-IF require - without right clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -901,7 +866,6 @@ AT_SETUP([satisfied nested AND-IF require - with right clause])
 AT_KEYWORDS([install, boolean])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -440,9 +440,7 @@ error: open of not_pkg.rpm failed: No such file or directory
 AT_CLEANUP
 
 # ------------------------------
-# Test normal upgrade
-AT_SETUP([rpm -U upgrade to newer])
-AT_CHECK([
+AT_SETUP([rpm upgrade/downgrade])
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -452,6 +450,9 @@ for v in "1.0" "2.0"; do
           /data/SPECS/versiontest.spec
 done
 
+# Test normal upgrade
+AT_CHECK([
+RPMDB_INIT
 runroot rpm -U /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
 runroot rpm -q versiontest
@@ -460,10 +461,8 @@ runroot rpm -q versiontest
 [versiontest-2.0-1.noarch
 ],
 [])
-AT_CLEANUP
 
 # Test upgrading to older package (should fail)
-AT_SETUP([rpm -U upgrade to older])
 AT_CHECK([
 RPMDB_INIT
 
@@ -474,10 +473,8 @@ runroot rpm -U /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
 [],
 [	package versiontest-2.0-1.noarch (which is newer than versiontest-1.0-1.noarch) is already installed
 ])
-AT_CLEANUP
 
 # Test downgrading to older package with --oldpackage
-AT_SETUP([rpm -U --oldpackage downgrade])
 AT_CHECK([
 RPMDB_INIT
 
@@ -489,10 +486,8 @@ runroot rpm -q versiontest
 [versiontest-1.0-1.noarch
 ],
 [ignore])
-AT_CLEANUP
 
 # Test upgrade of different versions in same transaction
-AT_SETUP([rpm -U two versions of same package 1])
 AT_CHECK([
 RPMDB_INIT
 
@@ -509,10 +504,8 @@ versiontest-2.0-1.noarch
 ],
 [warning: package versiontest-1.0-1.noarch was already added, replacing with versiontest-2.0-1.noarch
 ])
-AT_CLEANUP
 
 # Test upgrade of different versions in same transaction
-AT_SETUP([rpm -U two versions of same package 2])
 AT_CHECK([
 RPMDB_INIT
 
@@ -529,6 +522,37 @@ versiontest-2.0-1.noarch
 ],
 [warning: package versiontest-2.0-1.noarch was already added, skipping versiontest-1.0-1.noarch
 ])
+
+# Test install of two different versions in same transaction
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -i \
+  /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
+  /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-2.0-1.noarch
+versiontest-1.0-1.noarch
+],
+[])
+
+# Test install of two different versions in same transaction
+# TODO: test only one was installed
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -i \
+  /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
+  /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-1.0-1.noarch
+],
+[])
+# TODO: the same with epoch vs no epoch
 AT_CLEANUP
 
 # Test upgrade of obsoleted package in same transaction
@@ -588,42 +612,6 @@ deptest-one-1.0-1.noarch
 [warning: package deptest-one-1.0-1.noarch was already added, skipping deptest-two-1.0-1.noarch
 ])
 AT_CLEANUP
-
-# Test install of two different versions in same transaction
-AT_SETUP([rpm -i two versions of same package])
-AT_CHECK([
-RPMDB_INIT
-
-runroot rpm -i \
-  /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
-  /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
-runroot rpm -q versiontest
-],
-[0],
-[versiontest-2.0-1.noarch
-versiontest-1.0-1.noarch
-],
-[])
-AT_CLEANUP
-
-# Test install of two different versions in same transaction
-# TODO: test only one was installed
-AT_SETUP([rpm -i identical versions of same package])
-AT_CHECK([
-RPMDB_INIT
-
-runroot rpm -i \
-  /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm \
-  /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm
-runroot rpm -q versiontest
-],
-[0],
-[versiontest-1.0-1.noarch
-],
-[])
-AT_CLEANUP
-
-# TODO: the same with epoch vs no epoch
 
 AT_SETUP([rpm -U with invalid --relocate])
 AT_KEYWORDS([install relocate])

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -442,7 +442,6 @@ AT_CLEANUP
 # ------------------------------
 AT_SETUP([rpm upgrade/downgrade])
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -21,7 +21,6 @@ AT_BANNER([RPM install tests])
 AT_SETUP([rpm -U <manifest>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
@@ -36,7 +35,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <manifest notfound 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 echo /data/RPMS/hello-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
@@ -52,7 +50,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <manifest notfound 2>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
@@ -68,7 +65,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <notfound>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -83,7 +79,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <unsigned 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -97,7 +92,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <unsigned 2>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -113,7 +107,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <corrupted unsigned 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
@@ -160,7 +153,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <corrupted unsigned 2>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 pkg="hello-2.0-1.x86_64.rpm"
@@ -204,7 +196,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <signed nokey 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -219,7 +210,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <signed nokey 2>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --ignorearch --ignoreos --nodeps \
@@ -236,7 +226,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <signed 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -251,7 +240,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <signed 2>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -267,7 +255,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <corrupted signed 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
@@ -288,7 +275,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <corrupted signed 2>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
@@ -311,7 +297,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U <corrupted signed 3>])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
@@ -453,7 +438,6 @@ AT_CLEANUP
 # Test normal upgrade
 AT_SETUP([rpm -U upgrade to newer])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -476,7 +460,6 @@ AT_CLEANUP
 # Test upgrading to older package (should fail)
 AT_SETUP([rpm -U upgrade to older])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
@@ -491,7 +474,6 @@ AT_CLEANUP
 # Test downgrading to older package with --oldpackage
 AT_SETUP([rpm -U --oldpackage downgrade])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/versiontest-2.0-1.noarch.rpm
@@ -507,7 +489,6 @@ AT_CLEANUP
 # Test upgrade of different versions in same transaction
 AT_SETUP([rpm -U two versions of same package 1])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -Uv \
@@ -528,7 +509,6 @@ AT_CLEANUP
 # Test upgrade of different versions in same transaction
 AT_SETUP([rpm -U two versions of same package 2])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -Uv \
@@ -549,7 +529,6 @@ AT_CLEANUP
 # Test upgrade of obsoleted package in same transaction
 AT_SETUP([rpm -U obsoleted package 1])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -579,7 +558,6 @@ AT_CLEANUP
 # Test upgrade of obsoleted package in same transaction
 AT_SETUP([rpm -U obsoleted package 2])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -609,7 +587,6 @@ AT_CLEANUP
 # Test install of two different versions in same transaction
 AT_SETUP([rpm -i two versions of same package])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -628,7 +605,6 @@ AT_CLEANUP
 # TODO: test only one was installed
 AT_SETUP([rpm -i identical versions of same package])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -i \
@@ -647,7 +623,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U with invalid --relocate])
 AT_KEYWORDS([install relocate])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -664,7 +639,6 @@ AT_CLEANUP
 AT_SETUP([rpm -U --badreloc with invalid --relocate])
 AT_KEYWORDS([install relocate])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -680,7 +654,6 @@ AT_CLEANUP
 AT_SETUP([rpm -i with/without --excludedocs])
 AT_KEYWORDS([install excludedocs])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/testdoc.spec

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -357,6 +357,7 @@ AT_CLEANUP
 AT_SETUP([rpm -U *.src.rpm])
 AT_KEYWORDS([install])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 runroot rpm \
@@ -372,6 +373,7 @@ AT_CLEANUP
 AT_SETUP([rpm -i *.src.rpm])
 AT_KEYWORDS([install])
 AT_CHECK([
+RPMDB_INIT
 rm -rf ${TOPDIR}
 
 runroot rpm \
@@ -388,6 +390,7 @@ AT_CLEANUP
 AT_SETUP([rpm -i <nonexistent file>])
 AT_KEYWORDS([install])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -i no_such_file
 ],
@@ -400,6 +403,7 @@ AT_CLEANUP
 AT_SETUP([rpm -i --nomanifest <garbage text file>])
 AT_KEYWORDS([install])
 AT_CHECK([
+RPMDB_INIT
 junk="${RPMTEST}/textfile"
 cat << EOF > "${junk}"
 no_such.file
@@ -418,6 +422,7 @@ AT_CLEANUP
 AT_SETUP([rpm -i <garbage text file])
 AT_KEYWORDS([install])
 AT_CHECK([
+RPMDB_INIT
 junk="${RPMTEST}/not_an.rpm"
 cat << EOF > "${junk}"
 no_such.file

--- a/tests/rpmio.at
+++ b/tests/rpmio.at
@@ -21,7 +21,6 @@ AT_BANNER([I/O])
 AT_SETUP([SIGPIPE from install scriptlet])
 AT_KEYWORDS([signals])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/sigpipe.spec
@@ -51,7 +50,6 @@ AT_CLEANUP
 AT_SETUP([rpmlog error handling])
 AT_KEYWORDS([log])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -qpl /data/RPMS/hello-2.0-1.x86_64.rpm > /dev/full

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -87,6 +87,7 @@ AT_CLEANUP
 AT_SETUP([parametrized macro 1])
 AT_KEYWORDS([macros])
 AT_CHECK([
+RPMDB_INIT
 cat << EOF > ${RPMTEST}/mtest
 %bar() bar
 %foo()\\
@@ -204,6 +205,7 @@ AT_CLEANUP
 AT_SETUP([uncompress macro 2])
 AT_KEYWORDS([macros])
 AT_CHECK([
+RPMDB_INIT
 echo xxxxxxxxxxxxxxxxxxxxxxxxx > ${RPMTEST}/tmp/"some%%ath"
 runroot rpm \
     --eval "%{uncompress:/tmp/some%%%%ath}"
@@ -571,6 +573,7 @@ AT_SETUP([lua library path])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
+RPMDB_INIT
 f=$(rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
 echo "bar = 'graak'" > ${f}
 runroot rpm \

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -87,7 +87,7 @@ AT_CLEANUP
 AT_SETUP([parametrized macro 1])
 AT_KEYWORDS([macros])
 AT_CHECK([
-cat << EOF > ${abs_builddir}/testing/mtest
+cat << EOF > ${RPMTEST}/mtest
 %bar() bar
 %foo()\\
 %bar\\

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -574,7 +574,7 @@ AT_KEYWORDS([macros lua])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-f=$(rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
+f=$(run rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
 echo "bar = 'graak'" > ${f}
 runroot rpm \
   --eval '%{lua:require "foo"; print(bar)}'

--- a/tests/rpmorder.at
+++ b/tests/rpmorder.at
@@ -3,7 +3,6 @@ AT_BANNER([RPM install/erase ordering])
 AT_SETUP([basic install/erase order 1])
 AT_KEYWORDS([install erase order])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -49,7 +48,6 @@ AT_CLEANUP
 AT_SETUP([basic install/erase order 2])
 AT_KEYWORDS([install erase order])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -95,7 +93,6 @@ AT_CLEANUP
 AT_SETUP([basic install/erase order 3])
 AT_KEYWORDS([install erase order])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -319,7 +319,6 @@ for e in ts:
 AT_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 runroot rpm -i \
   --justdb --nodeps --ignorearch --ignoreos \
@@ -418,7 +417,6 @@ AT_CLEANUP
 AT_SETUP([database cookies])
 AT_KEYWORDS([python rpmdb])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 ],
 [0],

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -22,6 +22,7 @@ AT_BANNER([RPM queries])
 AT_SETUP([rpm --qf -p *.i386.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -36,6 +37,7 @@ AT_CLEANUP
 AT_SETUP([rpm --qf -p *.src.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -q --qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" \
   -p /data/SRPMS/hello-1.0-1.src.rpm
@@ -50,6 +52,7 @@ AT_CLEANUP
 AT_SETUP([rpm -ql -p *.src.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -ql \
   -p /data/SRPMS/hello-1.0-1.src.rpm
@@ -65,6 +68,7 @@ AT_CLEANUP
 AT_SETUP([rpm -ql multiple *.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -ql \
   /data/SRPMS/hello-1.0-1.src.rpm /data/RPMS/hello-1.0-1.i386.rpm
@@ -83,6 +87,7 @@ AT_CLEANUP
 AT_SETUP([rpmspec -q])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmspec \
   -q --qf "%{name}" /data/SPECS/hello.spec
 ],
@@ -95,6 +100,7 @@ AT_CLEANUP
 AT_SETUP([rpm -ql -p *.i386.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -ql \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -112,6 +118,7 @@ AT_CLEANUP
 AT_SETUP([rpm -qp <manifest>])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 cat << EOF > ${RPMTEST}/query.mft
 /data/RPMS/hello-1.0-1.i386.rpm
 /data/RPMS/hello-1.0-1.ppc64.rpm
@@ -133,6 +140,7 @@ AT_CLEANUP
 AT_SETUP([rpm -q --scripts -p *.i386.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   -q --scripts \
   -p /data/RPMS/hello-1.0-1.i386.rpm
@@ -197,6 +205,7 @@ AT_CLEANUP
 AT_SETUP([integer array query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{filemodes}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -213,6 +222,7 @@ AT_CLEANUP
 AT_SETUP([formatted filesbypkg query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%-10{=NAME} %{FILENAMES}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -229,6 +239,7 @@ AT_CLEANUP
 AT_SETUP([hex formatted integer array extension query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%5{longfilesizes:hex}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -245,6 +256,7 @@ AT_CLEANUP
 AT_SETUP([base64 extension query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%{pkgid:base64}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -258,6 +270,7 @@ AT_CLEANUP
 AT_SETUP([pgpsig extension query])
 AT_KEYWORDS([query signature])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
     --queryformat="%{rsaheader:pgpsig}" \
     -qp /data/RPMS/hello-2.0-1.x86_64-signed.rpm
@@ -272,6 +285,7 @@ AT_CLEANUP
 AT_SETUP([integer array perms format query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{filemodes:perms}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -288,6 +302,7 @@ AT_CLEANUP
 AT_SETUP([string array query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{basenames} ]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -301,6 +316,7 @@ AT_CLEANUP
 AT_SETUP([empty string array query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{basenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -314,6 +330,7 @@ AT_CLEANUP
 AT_SETUP([empty string array extension array format])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{filenames}]]" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -327,6 +344,7 @@ AT_CLEANUP
 AT_SETUP([empty string array extension query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%{filenames}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -340,6 +358,7 @@ AT_CLEANUP
 AT_SETUP([different sizes arrays query 1])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{basenames} %{changelogname}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -356,6 +375,7 @@ AT_CLEANUP
 AT_SETUP([different sizes arrays query 2])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{name} %{changelogtime}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -370,6 +390,7 @@ AT_CLEANUP
 AT_SETUP([different sizes arrays query 3])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{name} %{basenames}]\n]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -384,6 +405,7 @@ AT_CLEANUP
 AT_SETUP([different sizes arrays query 4])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="[[%{=name} %{basenames}\n]]" \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -400,6 +422,7 @@ AT_CLEANUP
 AT_SETUP([non-existent string tag])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%{vendor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -413,6 +436,7 @@ AT_CLEANUP
 AT_SETUP([non-existent integer tag query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%{installcolor}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -426,6 +450,7 @@ AT_CLEANUP
 AT_SETUP([conditional queryformat])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%|name?{%{name}}:{no}| %|installtime?{%{installtime}}:{(not installed)}|" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -439,6 +464,7 @@ AT_CLEANUP
 AT_SETUP([invalid tag query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%{notag}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -453,6 +479,7 @@ AT_CLEANUP
 AT_SETUP([invalid data for format query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%{name:depflags}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -466,6 +493,7 @@ AT_CLEANUP
 AT_SETUP([invalid format width query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat="%ss{size}" \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm
@@ -479,6 +507,7 @@ AT_CLEANUP
 AT_SETUP([xml format])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm -qp --xml  data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
@@ -778,6 +807,7 @@ AT_CLEANUP
 AT_SETUP([query file attribute filtering])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
 
@@ -832,6 +862,7 @@ AT_CLEANUP
 AT_SETUP([formatting name humansi, humaniec])
 AT_KEYWORDS([query, humansi, humaniec])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat '%{SIZE:humansi} %{SIZE:humaniec}\n' \
   -qp /data/RPMS/hello-1.0-1.i386.rpm
@@ -854,6 +885,7 @@ AT_CLEANUP
 AT_SETUP([incomplete escape sequence for format query])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
 runroot rpm \
   --queryformat='%{NAME}\n\' \
   -qp /data/RPMS/foo-1.0-1.noarch.rpm

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -155,7 +155,6 @@ AT_SETUP([rpm -q on installed package])
 AT_KEYWORDS([rpmdb install query])
 
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm \

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -401,7 +401,7 @@ runroot rpmbuild --quiet -bb \
 	--define "grp $(id -g -n)" \
           /data/SPECS/replacetest.spec
 
-mkdir "${RPMTEST}"/opt/f00f
+mkdir -p "${RPMTEST}"/opt/f00f
 ln -s f00f "${RPMTEST}"/opt/foo
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 test -L "${tf}" && test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
@@ -432,7 +432,7 @@ runroot rpmbuild --quiet -bb \
 	--define "filedata README2" \
           /data/SPECS/replacetest.spec
 
-mkdir "${RPMTEST}"/opt/f00f
+mkdir -p "${RPMTEST}"/opt/f00f
 ln -s f00f "${RPMTEST}"/opt/foo
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 test -L "${tf}" && test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -4,7 +4,6 @@ AT_BANNER([RPM file replacement])
 AT_SETUP([upgrade to/from regular file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
@@ -40,7 +39,6 @@ AT_CLEANUP
 AT_SETUP([upgrade regular file to/from broken link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -76,7 +74,6 @@ AT_CLEANUP
 AT_SETUP([upgrade regular file to/from file link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -112,7 +109,6 @@ AT_CLEANUP
 AT_SETUP([upgrade broken link to broken link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -145,7 +141,6 @@ AT_CLEANUP
 AT_SETUP([upgrade file link to file link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -178,7 +173,6 @@ AT_CLEANUP
 AT_SETUP([upgrade directory link to directory link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -211,7 +205,6 @@ AT_CLEANUP
 AT_SETUP([upgrade regular file to directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -242,7 +235,6 @@ AT_CLEANUP
 AT_SETUP([upgrade broken link to directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -273,7 +265,6 @@ AT_CLEANUP
 AT_SETUP([upgrade file link to directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -304,7 +295,6 @@ AT_CLEANUP
 AT_SETUP([upgrade directory link to directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -335,7 +325,6 @@ AT_CLEANUP
 AT_SETUP([upgrade empty directory to empty directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -363,7 +352,6 @@ AT_CLEANUP
 AT_SETUP([upgrade empty directory to regular file])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -392,7 +380,6 @@ AT_CLEANUP
 AT_SETUP([upgrade locally symlinked directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -428,7 +415,6 @@ AT_CLEANUP
 AT_SETUP([upgrade invalid locally symlinked directory])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -460,7 +446,6 @@ AT_CLEANUP
 AT_SETUP([upgrade empty directory to broken link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -489,7 +474,6 @@ AT_CLEANUP
 AT_SETUP([upgrade empty directory to file link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -518,7 +502,6 @@ AT_CLEANUP
 AT_SETUP([upgrade removed empty directory to file link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -548,7 +531,6 @@ AT_CLEANUP
 AT_SETUP([upgrade replaced empty directory to file link])
 AT_KEYWORDS([install])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -579,7 +561,6 @@ AT_SETUP([upgrade empty directory to file link with pretrans])
 AT_KEYWORDS([install])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -7,7 +7,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -42,7 +41,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -77,7 +75,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -112,7 +109,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -144,7 +140,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -176,7 +171,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -208,7 +202,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -238,7 +231,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -268,7 +260,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -298,7 +289,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -328,7 +318,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -355,7 +344,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -383,7 +371,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -418,7 +405,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -449,7 +435,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -477,7 +462,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -505,7 +489,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -534,7 +517,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -564,7 +546,6 @@ AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -7,7 +7,6 @@ AT_KEYWORDS([script])
 AT_SKIP_IF([$LUA_DISABLED])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 for v in 1.0 2.0; do
@@ -128,7 +127,6 @@ AT_SETUP([basic scripts and arguments])
 AT_KEYWORDS([verify])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts.spec
@@ -164,7 +162,6 @@ AT_SETUP([basic trigger scripts and arguments])
 AT_KEYWORDS([trigger script])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb --define "rel 1" /data/SPECS/scripts.spec
@@ -222,7 +219,6 @@ AT_KEYWORDS([file trigger script])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 runroot rpmbuild --quiet -bb /data/SPECS/hello-script.spec
@@ -324,7 +320,6 @@ AT_SETUP([basic file triggers 2])
 AT_KEYWORDS([filetrigger script])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec
 for v in 1.0 2.0 3.0; do

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -6,7 +6,6 @@ AT_SETUP([basic script failures 1])
 AT_KEYWORDS([script])
 AT_SKIP_IF([$LUA_DISABLED])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -128,7 +127,6 @@ AT_CLEANUP
 AT_SETUP([basic scripts and arguments])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -165,7 +163,6 @@ AT_CLEANUP
 AT_SETUP([basic trigger scripts and arguments])
 AT_KEYWORDS([trigger script])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -224,7 +221,6 @@ AT_SETUP([basic file trigger scripts])
 AT_KEYWORDS([file trigger script])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -327,7 +323,6 @@ AT_CLEANUP
 AT_SETUP([basic file triggers 2])
 AT_KEYWORDS([filetrigger script])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -8,7 +8,6 @@ AT_SETUP([rpmkeys -Kv <unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i386.rpm
 ],
@@ -29,7 +28,6 @@ AT_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 cp "${RPMTEST}"/data/misc/hello.intro "${RPMTEST}"/data/misc/hello.payload .
 gzip -cd < hello.payload > hello.uc-payload
@@ -58,7 +56,6 @@ AT_SETUP([rpmkeys -Kv <corrupted unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -82,7 +79,6 @@ AT_SETUP([rpmkeys -Kv <corrupted unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -106,7 +102,6 @@ AT_SETUP([rpmkeys -Kv <corrupted unsigned> 3])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -131,7 +126,6 @@ AT_SETUP([rpmkeys -Kv <corrupted unsigned> 4])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -151,7 +145,6 @@ AT_SETUP([rpmkeys -Kv <unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild -bb --quiet \
 	--define "%optflags -O2 -g" \
@@ -189,7 +182,6 @@ AT_SETUP([rpmkeys --import rsa])
 AT_KEYWORDS([rpmkeys import])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -qi gpg-pubkey-1964c5fc-58e63918|grep -v Date|grep -v Version:
@@ -254,7 +246,6 @@ AT_SETUP([rpmkeys -K <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmkeys -K /data/RPMS/hello-2.0-1.x86_64-signed.rpm
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
@@ -273,7 +264,6 @@ AT_SETUP([rpmkeys -Kv <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64-signed.rpm; echo $?
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub; echo $?
@@ -319,7 +309,6 @@ AT_SETUP([rpmkeys -Kv <corrupted signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -354,7 +343,6 @@ AT_SETUP([rpmkeys -Kv <corrupted signed> 2])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -390,7 +378,6 @@ AT_SETUP([rpmkeys -Kv <corrupted signed> 3])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64-signed.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}
@@ -428,7 +415,6 @@ AT_SETUP([rpmsign --addsign --rpmv3 <unsigned>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 run rpmsign --key-id 1964C5FC --rpmv3 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
@@ -461,7 +447,6 @@ AT_SETUP([rpmsign --addsign <unsigned>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
 run rpmsign --key-id 1964C5FC --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
@@ -493,7 +478,6 @@ AT_SETUP([rpmsign --delsign <package>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 echo PRE-DELSIGN
@@ -519,7 +503,6 @@ AT_SETUP([rpmsign --addsign <signed>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64-signed.rpm "${RPMTEST}"/tmp/
 run rpmsign --key-id 1964C5FC --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64-signed.rpm 2>&1 |grep -q "already contains identical signature, skipping"
@@ -533,7 +516,6 @@ AT_SETUP([rpmsign --addsign <corrupted>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 pkg="hello-2.0-1.x86_64.rpm"
 cp "${RPMTEST}"/data/RPMS/${pkg} "${RPMTEST}"/tmp/${pkg}

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -7,7 +7,6 @@ AT_BANNER([RPM signatures and digests])
 AT_SETUP([rpmkeys -Kv <unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -29,7 +28,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -59,7 +57,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted unsigned> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -84,7 +81,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -109,7 +105,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted unsigned> 3])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -135,7 +130,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted unsigned> 4])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -156,7 +150,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <unsigned> 2])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -195,7 +188,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys --import rsa])
 AT_KEYWORDS([rpmkeys import])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -261,7 +253,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -K <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -281,7 +272,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -328,7 +318,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted signed> 1])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -364,7 +353,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted signed> 2])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -401,7 +389,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -Kv <corrupted signed> 3])
 AT_KEYWORDS([rpmkeys digest signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -440,7 +427,6 @@ AT_CLEANUP
 AT_SETUP([rpmsign --addsign --rpmv3 <unsigned>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -474,7 +460,6 @@ AT_CLEANUP
 AT_SETUP([rpmsign --addsign <unsigned>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -507,7 +492,6 @@ AT_CLEANUP
 AT_SETUP([rpmsign --delsign <package>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -534,7 +518,6 @@ AT_CLEANUP
 AT_SETUP([rpmsign --addsign <signed>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -549,7 +532,6 @@ AT_CLEANUP
 AT_SETUP([rpmsign --addsign <corrupted>])
 AT_KEYWORDS([rpmsign signature])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -7,7 +7,6 @@ AT_BANNER([RPM verification])
 AT_SETUP([dependency problems])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -32,7 +31,6 @@ AT_CLEANUP
 AT_SETUP([files with no problems])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
@@ -48,7 +46,6 @@ AT_CLEANUP
 AT_SETUP([files with no problems in verbose mode])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
@@ -67,7 +64,6 @@ AT_CLEANUP
 AT_SETUP([directory replaced with a directory symlink])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -99,7 +95,6 @@ AT_SETUP([directory replaced with an invalid directory symlink])
 AT_KEYWORDS([verify])
 AT_XFAIL_IF([test `id -u` != 0 ])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
@@ -130,7 +125,6 @@ AT_CLEANUP
 AT_SETUP([verify from db, with problems present])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
@@ -152,7 +146,6 @@ AT_CLEANUP
 AT_SETUP([verify from package, with problems present])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
@@ -232,7 +225,6 @@ AT_SETUP([verifyscript failure])
 AT_KEYWORDS([verify])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
-RPMDB_CLEAR
 RPMDB_INIT
 
 rm -rf "${TOPDIR}"
@@ -250,7 +242,6 @@ AT_SETUP([verifyscript success])
 AT_KEYWORDS([verify])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
-RPMDB_CLEAR
 RPMDB_INIT
 
 rm -rf "${TOPDIR}"
@@ -269,7 +260,6 @@ AT_CLEANUP
 AT_SETUP([shared file timestamp behavior])
 AT_KEYWORDS([verify])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -298,7 +288,6 @@ AT_CLEANUP
 AT_SETUP([Upgraded verification with min_writes 1 (files)])
 AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
@@ -370,7 +359,6 @@ AT_CLEANUP
 AT_SETUP([Upgraded verification with min_writes 2 (files)])
 AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
@@ -449,7 +437,6 @@ AT_CLEANUP
 AT_SETUP([Upgraded verification with min_writes 3 (LINKs)])
 AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
@@ -516,7 +503,6 @@ AT_CLEANUP
 AT_SETUP([Upgraded verification with min_writes 4 (LINKs)])
 AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
@@ -590,7 +576,6 @@ AT_CLEANUP
 AT_SETUP([Upgraded verification with min_writes 5 (suid files)])
 AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
@@ -627,7 +612,6 @@ AT_SETUP([verify empty/no capabilities 1])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([$CAP_DISABLED])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --nocaps --ignoreos \
@@ -647,7 +631,6 @@ AT_SETUP([verify empty/no capabilities 2])
 AT_KEYWORDS([verify])
 AT_SKIP_IF([$CAP_DISABLED])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 
 runroot rpm -U --nocaps --nodeps --noscripts --ignorearch --ignoreos \

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -8,7 +8,6 @@ AT_SETUP([dependency problems])
 AT_KEYWORDS([verify])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
@@ -67,7 +66,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -98,7 +96,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-rm -rf "${TOPDIR}"
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -229,7 +226,6 @@ AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
-rm -rf "${TOPDIR}"
 runroot rpmbuild --quiet -bb /data/SPECS/verifyscript.spec
 runroot rpm -U --nodeps /build/RPMS/noarch/verifyscript-1.0-1.noarch.rpm
 rm -f "${RPMTEST}"/var/checkme
@@ -246,7 +242,6 @@ AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
-rm -rf "${TOPDIR}"
 runroot rpmbuild --quiet -bb /data/SPECS/verifyscript.spec
 runroot rpm -U --nodeps /build/RPMS/noarch/verifyscript-1.0-1.noarch.rpm
 touch "${RPMTEST}"/var/checkme
@@ -263,7 +258,6 @@ AT_SETUP([shared file timestamp behavior])
 AT_KEYWORDS([verify])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 # create packages sharing a file but with different timestamp
 for p in "one" "two"; do
@@ -293,7 +287,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -364,7 +357,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -442,7 +434,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -508,7 +499,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -581,7 +571,6 @@ AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-rm -rf "${TOPDIR}"
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -166,6 +166,8 @@ AT_CLEANUP
 AT_SETUP([verify file attribute filtering])
 AT_KEYWORDS([query])
 AT_CHECK([
+RPMDB_INIT
+
 runroot rpmbuild -bb --quiet \
   /data/SPECS/vattrtest.spec
 

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -4,7 +4,6 @@ AT_SETUP([rpmkeys -K <unsigned 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 for lvl in none digest signature all; do
     echo "LEVEL ${lvl}"
@@ -77,7 +76,6 @@ AT_SETUP([rpmkeys -K <unsigned 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 nomd5="0x20000"
 nopld="0x10000"
@@ -150,7 +148,6 @@ AT_SETUP([rpmkeys -K <signed 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 for lvl in none digest signature all; do
     echo "LEVEL ${lvl}"
@@ -223,7 +220,6 @@ AT_SETUP([rpmkeys -K <signed 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 for lvl in none digest signature all; do
@@ -297,7 +293,6 @@ AT_SETUP([rpmkeys -K <signed 3> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
 RPMDB_INIT
-rm -rf "${TOPDIR}"
 
 nomd5="0x20000"
 nopld="0x10000"

--- a/tests/rpmvfylevel.at
+++ b/tests/rpmvfylevel.at
@@ -3,7 +3,6 @@ AT_BANNER([RPM signature/digest verifylevel])
 AT_SETUP([rpmkeys -K <unsigned 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -77,7 +76,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -K <unsigned 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -151,7 +149,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -K <signed 1> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -225,7 +222,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -K <signed 2> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 
@@ -300,7 +296,6 @@ AT_CLEANUP
 AT_SETUP([rpmkeys -K <signed 3> verifylevel])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([
-RPMDB_CLEAR
 RPMDB_INIT
 rm -rf "${TOPDIR}"
 


### PR DESCRIPTION
Up to now we've run tests in a mish-mash of an environment where bits and pieces of previous tests might exist, and as state has been shared it's been impossible to execute tests in parallel.
    
This makes the pre-populated testing-root read-only to the owner to force all writers to perform an extra setup call to gain a private testing environment. Most of the users needing this already had RPMDB_INIT calls to ensure clean rpmdb state so that's where this is hooked onto.
    
There's a fair bit of gymnastics with the environment to make things match on both sides of fakechroot, some of which can hopefully go away eventually once the dust from this settles. This is also rather heavy as it is, on my laptop serial execution goes down from ~1m15s to ~1m45s, but then parallel execution with -j8 is down to ~50s. There should be a number of optimizations that can be made, such as setting up links for writable directories instead of copying the entire testing-tree around, but leaving that as a future exercise. This is more of an enabler than the goal state.

Note that this does *not* enable test-suite parallel running for `make -jN check`, because `make` does not export the -j argument in a way that we could pass to `./rpmtests` from the makefile. To enable that, one needs to pass a suitable -jN argument through TESTSUITEFLAGS, such as `make -j8 check TESTSUITEFLAGS="-j8"`. Or run invoke `rpmtests` manually.