### PR TITLE
Testsuite cleanup

### DIFF
--- a/tests/local.at
+++ b/tests/local.at
@@ -4,6 +4,8 @@ m4_define([RPMTEST_SETUP],[[
 if ! [ -d testing/ ]; then
     cp -aP "${RPMTEST}" .
     chmod -R u+w testing/
+    mkdir -p testing/build
+    ln -s ../data/SOURCES testing/build/
 fi
 export RPMTEST="${PWD}/testing"
 export TOPDIR="${RPMTEST}/build"

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -24,9 +24,6 @@ AT_SETUP([rpmbuild -ba *.spec])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 run rpmbuild \
   -ba "${abs_srcdir}"/data/SPECS/hello.spec
@@ -41,9 +38,7 @@ AT_KEYWORDS([build])
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 AT_CHECK([
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-*.patch ${TOPDIR}/SOURCES
 run rpmbuild \
   -ba "${abs_srcdir}"/data/SPECS/hello-auto.spec
 ],
@@ -51,6 +46,7 @@ run rpmbuild \
 [ignore],
 [ignore])
 AT_CLEANUP
+
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])
@@ -70,9 +66,6 @@ AT_SETUP([rpmbuild --short-circuit -bl])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 run rpmbuild -bi "${abs_srcdir}"/data/SPECS/hello.spec &> /dev/null
 run rpmbuild --quiet -bl --short-circuit "${abs_srcdir}"/data/SPECS/hello.spec
@@ -662,9 +655,6 @@ AT_SETUP([rpmbuild debuginfo dwz])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -784,9 +774,6 @@ AT_SETUP([rpmbuild debuginfo dwz unique debug names])
 AT_KEYWORDS([build] [debuginfo] [dwz])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -873,10 +860,6 @@ AT_SETUP([rpmbuild debuginfo dwz gnu_debuglink crc])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Build a package that
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
@@ -907,11 +890,8 @@ AT_SETUP([rpmbuild implicit suid binary])
 AT_KEYWORDS([build] [debuginfo] [dwz] [suid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 rundebug rpmbuild --quiet \
   -ba "${abs_srcdir}"/data/SPECS/hello2-suid.spec
 
@@ -941,11 +921,8 @@ AT_SETUP([rpmbuild debuginfo gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 rundebug rpmbuild --quiet \
   --define "_include_gdb_index 1" \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
@@ -970,11 +947,8 @@ AT_SETUP([rpmbuild debuginfo no gdb index included])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 rundebug rpmbuild --quiet \
   --undefine "_include_gdb_index" \
   -ba "${abs_srcdir}"/data/SPECS/hello2.spec
@@ -998,13 +972,10 @@ AT_SETUP([rpmbuild debuginfo -g3 .debug_macro])
 AT_KEYWORDS([build] [debuginfo] [gdb])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo generated with -g3.
 # Specifically it uses -DDEBUG_DEFINE=1, which we want to see back
 # in the .debug_macro section of the .debug file.
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 rundebug rpmbuild --quiet \
   --define "_include_gdb_index 1" \
   -ba "${abs_srcdir}"/data/SPECS/hello-g3.spec
@@ -1031,11 +1002,8 @@ AT_SETUP([rpmbuild debuginfo unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # Note that the spec defines hello2 as name, but the source is hello-1.0.
 # Disable dwz to make debuginfo path rewrite checking easier.
 rundebug rpmbuild --quiet \
@@ -1070,11 +1038,8 @@ AT_SETUP([rpmbuild debuginfo no unique debug src dir])
 AT_KEYWORDS([build] [debuginfo])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 # Build a package that has some debuginfo
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # Note that the spec defines hello2 as name, but the source is hello-1.0.
 # Disable dwz to make debuginfo path rewrite checking easier.
 rundebug rpmbuild --quiet \
@@ -1106,10 +1071,6 @@ AT_SETUP([rpmbuild debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Build a package that has some debuginfo
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_debugsource_packages 1" \
@@ -1142,10 +1103,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_debugsource_packages 1" \
@@ -1171,10 +1128,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -1214,10 +1167,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --undefine "_unique_debug_names" \
@@ -1299,10 +1248,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -1384,10 +1329,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -1472,10 +1413,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -1537,10 +1474,6 @@ AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
 AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 rundebug rpmbuild --quiet \
   --define "_unique_debug_names 1" \
@@ -1608,9 +1541,6 @@ AT_SETUP([dynamic build requires rpmbuild -bs])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
 
 runroot rpmbuild \
   --quiet -bs /data/SPECS/buildrequires.spec
@@ -1630,9 +1560,6 @@ AT_SETUP([rpmbuild -br])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
 
 runroot rpmbuild \
   -br  --quiet /data/SPECS/buildrequires.spec
@@ -1653,9 +1580,6 @@ AT_SETUP([rpmbuild -ba])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
 
 runroot rpmbuild \
   -ba  --quiet /data/SPECS/buildrequires.spec
@@ -1677,9 +1601,6 @@ AT_SETUP([rpmbuild -br --nodeps])
 AT_KEYWORDS([build])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/buildrequires-1.0.tar.gz ${TOPDIR}/SOURCES
 
 runroot rpmbuild \
   -br  --quiet --nodeps /data/SPECS/buildrequires.spec
@@ -1703,14 +1624,14 @@ AT_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
 AT_CHECK_UNQUOTED([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
 
 runroot rpmbuild \
+  --define "_sourcedir /notthere" \
   -bb /data/SPECS/hello.spec
 ],
 [1],
 [],
-[error: Bad source: /build/SOURCES/hello-1.0.tar.gz: No such file or directory
+[error: Bad source: /notthere/hello-1.0.tar.gz: No such file or directory
 ])
 AT_CLEANUP
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1747,22 +1747,21 @@ done
 [ignore])
 AT_CLEANUP
 
-AT_SETUP([%if, %else, %elif test basic])
+AT_SETUP([spec conditionals])
 AT_KEYWORDS([if else elif build])
-AT_CHECK([
 RPMDB_INIT
+
+# %if, %else, %elif test basic
+AT_CHECK([
 runroot rpmbuild -ba --quiet \
     --define "testif 0"      \
    /data/SPECS/iftest.spec
 ],
 [0],
 [])
-AT_CLEANUP
 
-AT_SETUP([%if, %else, %elif test existing script])
-AT_KEYWORDS([if else elif build])
+# %if, %else, %elif test existing script
 AT_CHECK([
-RPMDB_INIT
 runroot rpmbuild -ba --quiet  \
     --define "testif 2"       \
     --define "fedora 1"       \
@@ -1770,12 +1769,8 @@ runroot rpmbuild -ba --quiet  \
 ],
 [0],
 [])
-AT_CLEANUP
 
-AT_SETUP([%if, %else, %elif test 1])
-AT_KEYWORDS([if else elif build])
 AT_CHECK([
-RPMDB_INIT
 runroot rpmbuild -ba --quiet \
  --define "testif 1"         \
  --define "variable1 1"      \
@@ -1789,14 +1784,8 @@ runroot rpmbuild -ba --quiet \
 ],
 [0],
 [])
-AT_CLEANUP
 
-
-
-AT_SETUP([%if, %else, %elif test 2])
-AT_KEYWORDS([if else elif build])
 AT_CHECK([
-RPMDB_INIT
 runroot rpmbuild -ba --quiet   \
  --define "testif 1"           \
  --define "variable1 0"        \
@@ -1810,14 +1799,8 @@ runroot rpmbuild -ba --quiet   \
 ],
 [1],
 [])
-AT_CLEANUP
 
-
-
-AT_SETUP([%if, %else, %elif test 3])
-AT_KEYWORDS([if else elif build])
 AT_CHECK([
-RPMDB_INIT
 runroot rpmbuild -ba --quiet      \
  --define "testif 1"              \
  --define "variable1 0"           \
@@ -1831,13 +1814,8 @@ runroot rpmbuild -ba --quiet      \
 ],
 [0],
 [])
-AT_CLEANUP
 
-
-AT_SETUP([%if, %else, %elif test 4])
-AT_KEYWORDS([if else elif build])
 AT_CHECK([
-RPMDB_INIT
 runroot rpmbuild -ba --quiet      \
  --define "testif 1"              \
  --define "variable1 0"           \
@@ -1857,13 +1835,9 @@ error:                                                        ^
 error: /data/SPECS/eliftest.spec:40: bad %elif condition:  rubbish:4-3
 
 ])
-AT_CLEANUP
 
-
-AT_SETUP([multiline %if test])
-AT_KEYWORDS([if macros build])
+# multiline %if test
 AT_CHECK([
-RPMDB_INIT
 runroot rpmbuild -ba --quiet      \
  data/SPECS/ifmultiline.spec
 ],

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -24,10 +24,6 @@ AT_SETUP([rpmbuild buildid none])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -58,10 +54,6 @@ AT_SETUP([rpmbuild buildid alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -150,10 +142,6 @@ AT_SETUP([rpmbuild buildid alldebug unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -241,10 +229,6 @@ AT_SETUP([rpmbuild buildid separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -332,10 +316,6 @@ AT_SETUP([rpmbuild buildid separate unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -422,10 +402,6 @@ AT_SETUP([rpmbuild buildid compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -526,10 +502,6 @@ AT_SETUP([rpmbuild buildid compat unique debug names])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -630,10 +602,6 @@ AT_SETUP([rpmbuild buildid duplicate alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links alldebug" \
@@ -698,10 +666,6 @@ AT_SETUP([rpmbuild buildid hardlink alldebug])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links alldebug" \
@@ -763,10 +727,6 @@ AT_SETUP([rpmbuild buildid duplicate separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links separate" \
@@ -828,10 +788,6 @@ AT_SETUP([rpmbuild buildid hardlink separate])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links separate" \
@@ -890,10 +846,6 @@ AT_SETUP([rpmbuild buildid duplicate compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # Should create two warnings
 rundebug rpmbuild --quiet \
   --define="_build_id_links compat" \
@@ -967,10 +919,6 @@ AT_SETUP([rpmbuild buildid hardlink compat])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_build_id_links compat" \
@@ -1040,10 +988,6 @@ AT_SETUP([rpmbuild buildid recompute])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # Make sure we get debuginfo
 export CFLAGS="-g"
 
@@ -1154,10 +1098,6 @@ AT_SETUP([rpmbuild buildid unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --define="_unique_build_ids 1" \
@@ -1202,10 +1142,6 @@ AT_SETUP([rpmbuild buildid non-unique r1 r2])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-cp "${abs_srcdir}"/data/SOURCES/hello-1.0.tar.gz "${abs_srcdir}"/data/SOURCES/hello-1.0-modernize.patch ${TOPDIR}/SOURCES
-
 # No warnings for hard links
 rundebug rpmbuild --quiet \
   --undefine="_unique_build_ids" \
@@ -1255,10 +1191,6 @@ AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
 AT_SKIP_IF([$LUA_DISABLED])
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -1290,10 +1222,6 @@ AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
 AT_SKIP_IF([$LUA_DISABLED])
-AS_MKDIR_P(${TOPDIR}/SOURCES)
-
-# Setup sources
-cp "${abs_srcdir}"/data/SOURCES/hello.c ${TOPDIR}/SOURCES
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -2,18 +2,21 @@
 
 AT_BANNER([RPM config file behavior])
 
-# Install over existing config file
-AT_SETUP([install config on existiting file])
+AT_SETUP([config file install/upgrade/erase])
 AT_KEYWORDS([install])
+RPMDB_INIT
+for v in "1.0" "2.0"; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver $v" \
+	--define "filedata foo" \
+          /data/SPECS/configtest.spec
+done
+
+# Install over existing config file
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 echo "otherstuff" > "${cf}"
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
@@ -27,15 +30,117 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmorig]
 )
-AT_CLEANUP
 
-# Install over existing config file
-AT_SETUP([install config(noreplace) on existing file])
-AT_KEYWORDS([install])
+# Install over existing identical config file, no backup needed
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
+rm -rf "${cf}"*
+
+echo "foo" > "${cf}"
+runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
+cat "${cf}"
+runroot rpm -e configtest
+test ! -f "${cf}"
+],
+[0],
+[foo
+],
+[])
+
+# Erase unmodified config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
+
+runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
+cat "${cf}"
+runroot rpm -e configtest
+test ! -f "${cf}"
+],
+[0],
+[foo
+],
+[])
+
+# Erase modified config file
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
+
+runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
+cat "${cf}"
+echo "otherstuff" > "${cf}"
+runroot rpm -e configtest
+cat "${cf}.rpmsave"
+test ! -f "${cf}"
+],
+[0],
+[foo
+otherstuff
+],
+[warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
+)
+
+# Upgrade package with config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
+
+runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
+cat "${cf}"
+runroot rpm -U /build/RPMS/noarch/configtest-2.0-1.noarch.rpm
+cat "${cf}"
+],
+[0],
+[foo
+foo
+],
+[])
+
+# Upgrade package with config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
+
+runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
+runroot rpm -Uvv --fsmdebug /build/RPMS/noarch/configtest-2.0-1.noarch.rpm > output.txt 2>&1
+grep -c  "touch" output.txt
+],
+[0],
+[1
+],
+[])
+
+# Upgrade package with locally modified config file, unchanged in pkg
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
+
+runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
+cat "${cf}"
+echo "otherstuff" > "${cf}"
+cat "${cf}"
+runroot rpm -U /build/RPMS/noarch/configtest-2.0-1.noarch.rpm
+cat "${cf}"
+],
+[0],
+[foo
+otherstuff
+otherstuff
+],
+[])
+AT_CLEANUP
+
+# ------------------------------
+AT_SETUP([config(noreplace) file install/upgrade/erase])
+AT_KEYWORDS([install])
+RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -43,6 +148,11 @@ runroot rpmbuild --quiet -bb \
 	--define "noreplace 1" \
           /data/SPECS/configtest.spec
 
+# Install over existing config file
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 echo "otherstuff" > "${cf}"
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -60,98 +170,12 @@ foo
 [warning: /etc/my.conf created as /etc/my.conf.rpmnew
 warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
-
-# Install over existing identical config file, no backup needed
-AT_SETUP([install config on existiting identical file])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-echo "foo" > "${cf}"
-runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
-cat "${cf}"
-runroot rpm -e configtest
-test ! -f "${cf}"
-],
-[0],
-[foo
-],
-[])
-AT_CLEANUP
-
-# Erase unmodified config file, no backup here
-AT_SETUP([erase unchanged config])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
-cat "${cf}"
-runroot rpm -e configtest
-test ! -f "${cf}"
-],
-[0],
-[foo
-],
-[])
-AT_CLEANUP
-
-# Erase modified config file
-AT_SETUP([erase changed config])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
-cat "${cf}"
-echo "otherstuff" > "${cf}"
-runroot rpm -e configtest
-cat "${cf}.rpmsave"
-test ! -f "${cf}"
-],
-[0],
-[foo
-otherstuff
-],
-[warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
-)
-AT_CLEANUP
 
 # Erase modified config(noreplace) file
-AT_SETUP([erase changed config(noreplace)])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -169,98 +193,9 @@ otherstuff
 AT_CLEANUP
 
 # ------------------------------
-# (Build and) upgrade package with config file, no backup here
-AT_SETUP([upgrade unchanged config])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-done
-
-runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
-cat "${cf}"
-runroot rpm -U /build/RPMS/noarch/configtest-2.0-1.noarch.rpm
-cat "${cf}"
-],
-[0],
-[foo
-foo
-],
-[])
-AT_CLEANUP
-
-# ------------------------------
-# (Build and) upgrade package with config file, no backup here
-AT_SETUP([upgrade unchanged config - touching test])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-done
-
-runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
-runroot rpm -Uvv --fsmdebug /build/RPMS/noarch/configtest-2.0-1.noarch.rpm > output.txt 2>&1
-grep -c  "touch" output.txt
-],
-[0],
-[1
-],
-[])
-AT_CLEANUP
-#
-# ------------------------------
-# Upgrade package with locally modified config file, unchanged in pkg
-AT_SETUP([upgrade modified config])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-done
-
-runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
-cat "${cf}"
-echo "otherstuff" > "${cf}"
-cat "${cf}"
-runroot rpm -U /build/RPMS/noarch/configtest-2.0-1.noarch.rpm
-cat "${cf}"
-],
-[0],
-[foo
-otherstuff
-otherstuff
-],
-[])
-AT_CLEANUP
-
-# ------------------------------
-# Upgrade package with unmodified config file, changed in pkg
 AT_SETUP([upgrade changing config])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -268,6 +203,12 @@ for v in "1.0" "2.0"; do
 	--define "filedata foo-$v" \
           /data/SPECS/configtest.spec
 done
+
+# Upgrade package with unmodified config file, changed in pkg
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -279,23 +220,14 @@ cat "${cf}"
 foo-2.0
 ],
 [])
-AT_CLEANUP
 
 # ------------------------------
 # Upgrade package with locally modified config file, changed in pkg
-AT_SETUP([upgrade changing, modified config 1])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -313,23 +245,13 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
 
 # ------------------------------
 # Modified config file matches the content from new package.
-AT_SETUP([upgrade changing, modified config 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -347,15 +269,10 @@ foo-2.0
 AT_CLEANUP
 
 # config(noreplace) variants of the same cases.
-#
 # ------------------------------
-# (Build and) upgrade package with config file, no backup here
-AT_SETUP([upgrade unchanged config(noreplace)])
+AT_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -364,6 +281,12 @@ for v in "1.0" "2.0"; do
 	--define "noreplace 1" \
           /data/SPECS/configtest.spec
 done
+#
+# Upgrade package with config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -375,25 +298,12 @@ cat "${cf}"
 foo
 ],
 [])
-AT_CLEANUP
 
-#
-# ------------------------------
 # Upgrade package with locally modified config file, unchanged in pkg
-AT_SETUP([upgrade modified config(noreplace)])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -411,14 +321,10 @@ otherstuff
 AT_CLEANUP
 
 # ------------------------------
-# Upgrade package with unmodified config file, changed in pkg
+# noreplace variants of the same
 AT_SETUP([upgrade changing config(noreplace)])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -426,6 +332,12 @@ for v in "1.0" "2.0"; do
 	--define "noreplace 1" \
           /data/SPECS/configtest.spec
 done
+
+# Upgrade package with unmodified config file, changed in pkg
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -437,24 +349,12 @@ cat "${cf}"
 foo-2.0
 ],
 [])
-AT_CLEANUP
 
-# ------------------------------
 # Upgrade package with locally modified config file, changed in pkg
-AT_SETUP([upgrade changing, modified config(noreplace) 1])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -472,24 +372,12 @@ foo-2.0
 ],
 [warning: /etc/my.conf created as /etc/my.conf.rpmnew]
 )
-AT_CLEANUP
 
-# ------------------------------
 # Modified config file matches the content from new package.
-AT_SETUP([upgrade changing, modified config(noreplace) 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -508,14 +396,9 @@ AT_CLEANUP
 
 # Shared config file variants of the same cases
 # ------------------------------
-# (Build and) upgrade package with config file, no backup here
-AT_SETUP([upgrade unchanged shared config])
+AT_SETUP([upgrade shared config])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
@@ -525,6 +408,12 @@ for s in "A" "B"; do
               /data/SPECS/configtest.spec
     done
 done
+
+# Upgrade package with config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -541,26 +430,11 @@ foo
 ],
 [])
 
-AT_CLEANUP
-#
-# ------------------------------
 # Upgrade package with locally modified config file, unchanged in pkg
-AT_SETUP([upgrade modified shared config])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -582,14 +456,9 @@ otherstuff
 AT_CLEANUP
 
 # ------------------------------
-# Upgrade package with unmodified config file, changed in pkg
 AT_SETUP([upgrade changing shared config])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
@@ -599,6 +468,12 @@ for s in "A" "B"; do
               /data/SPECS/configtest.spec
     done
 done
+
+# Upgrade package with unmodified config file, changed in pkg
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -614,26 +489,12 @@ cat "${cf}"
 foo-2.0
 ],
 [])
-AT_CLEANUP
 
-# ------------------------------
 # Upgrade package with locally modified config file, changed in pkg
-AT_SETUP([upgrade changing, modified shared config 1])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo-$v" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -655,26 +516,12 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
 
-# ------------------------------
 # Modified config file matches the content from new package.
-AT_SETUP([upgrade changing, modified shared config 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo-$v" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -698,12 +545,9 @@ AT_CLEANUP
 # Shared config(noreplace) variants of the more interesting cases
 # ------------------------------
 # Upgrade package with locally modified config file, changed in pkg.
-AT_SETUP([upgrade changing, modified shared config(noreplace) 1])
+AT_SETUP([upgrade shared config(noreplace)])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -715,6 +559,11 @@ for s in "A" "B"; do
               /data/SPECS/configtest.spec
     done
 done
+
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -736,27 +585,13 @@ foo-2.0
 ],
 [warning: /etc/my.conf created as /etc/my.conf.rpmnew]
 )
-AT_CLEANUP
 
 # ------------------------------
 # Modified config file matches the content from new package.
-AT_SETUP([upgrade changing, modified shared config(noreplace) 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo-$v" \
-	    --define "noreplace 1" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -779,12 +614,12 @@ AT_CLEANUP
 
 ---------
 # Test pre-existing and post-install config ghost survival and erasure
-AT_SETUP([install/upgrade/erase ghost config])
+AT_SETUP([ghost config])
 AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
+rm -rf "${cf}"*
 
 for v in 1.0 2.0; do
     runroot rpmbuild --quiet -bb \

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -2,19 +2,23 @@
 
 AT_BANNER([RPM config symlink behavior])
 
-# Install over existing config file
-AT_SETUP([install config on existiting symlink])
+AT_SETUP([config symlinks])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
+for v in "1.0" "2.0"; do
+    runroot rpmbuild --quiet -bb \
+        --define "ver $v" \
 	--define "filedata foo" \
 	--define "filetype link" \
           /data/SPECS/configtest.spec
+done
+
+# Install over existing config file
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 ln -s "otherstuff" "${cf}"
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
@@ -28,21 +32,12 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmorig]
 )
-AT_CLEANUP
 
 # Install over existing identical config link, no backup needed
-AT_SETUP([install config on existiting identical link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 ln -s "foo" "${cf}"
 readlink "${cf}"
@@ -56,21 +51,12 @@ test ! -L "${cf}"
 foo
 ],
 [])
-AT_CLEANUP
 
 # Erase unmodified config link, no backup here
-AT_SETUP([erase unchanged config link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -81,21 +67,12 @@ test ! -L "${cf}"
 [foo
 ],
 [])
-AT_CLEANUP
 
 # Erase modified config link
-AT_SETUP([erase changed config link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filedata foo" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -109,24 +86,12 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
 
-# ------------------------------
-# (Build and) upgrade package with config link, no backup here
-AT_SETUP([upgrade unchanged config link])
-AT_KEYWORDS([install])
+# Upgrade package with config link, no backup here
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -138,24 +103,13 @@ readlink "${cf}"
 foo
 ],
 [])
-AT_CLEANUP
 
 #
-# (Build and) upgrade package with config link, no backup here
-AT_SETUP([upgrade unchanged config link - touching test])
-AT_KEYWORDS([install])
+# Upgrade package with config link, no backup here
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 runroot rpm -Uvv --fsmdebug /build/RPMS/noarch/configtest-2.0-1.noarch.rpm > output.txt 2>&1
@@ -165,25 +119,12 @@ grep -c  "touch" output.txt
 [1
 ],
 [])
-AT_CLEANUP
 
-#
-# ------------------------------
 # Upgrade package with modified config link, unchanged in pkg. No backup.
-AT_SETUP([upgrade modified config link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -201,14 +142,9 @@ otherstuff
 AT_CLEANUP
 
 # ------------------------------
-# Upgrade package with unmodified config link, changed in pkg
-AT_SETUP([upgrade changing config link])
+AT_SETUP([changing config symlinks])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -216,6 +152,12 @@ for v in "1.0" "2.0"; do
 	--define "filetype link" \
           /data/SPECS/configtest.spec
 done
+
+# Upgrade package with unmodified config link, changed in pkg
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -227,24 +169,12 @@ readlink "${cf}"
 foo-2.0
 ],
 [])
-AT_CLEANUP
 
-# ------------------------------
 # Upgrade package with locally modified config link, changed in pkg
-AT_SETUP([upgrade changing, modified config link 1])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -262,24 +192,12 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
 
-# ------------------------------
 # Modified config link matches the content from new package.
-AT_SETUP([upgrade changing, modified config link 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-	--define "filetype link" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -299,14 +217,9 @@ AT_CLEANUP
 # config(noreplace) variants of the same cases.
 #
 # ------------------------------
-# (Build and) upgrade package with config file, no backup here
-AT_SETUP([upgrade unchanged config(noreplace) link])
+AT_SETUP([upgrade unchanged config(noreplace) links])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -315,6 +228,12 @@ for v in "1.0" "2.0"; do
 	--define "noreplace 1" \
           /data/SPECS/configtest.spec
 done
+
+# Upgrade package with config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -326,26 +245,12 @@ readlink "${cf}"
 foo
 ],
 [])
-AT_CLEANUP
 
-#
-# ------------------------------
 # Upgrade package with locally modified config file, unchanged in pkg
-AT_SETUP([upgrade modified config(noreplace) link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo" \
-	--define "filetype link" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -363,13 +268,9 @@ otherstuff
 AT_CLEANUP
 
 # ------------------------------
-# Upgrade package with unmodified config file, changed in pkg
-AT_SETUP([upgrade changing config(noreplace) link])
+AT_SETUP([upgrade changing config(noreplace) links])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -380,6 +281,12 @@ for v in "1.0" "2.0"; do
           /data/SPECS/configtest.spec
 done
 
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
+
+# Upgrade package with unmodified config file, changed in pkg
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
 runroot rpm -U /build/RPMS/noarch/configtest-2.0-1.noarch.rpm
@@ -390,25 +297,12 @@ readlink "${cf}"
 foo-2.0
 ],
 [])
-AT_CLEANUP
 
-# ------------------------------
 # Upgrade package with locally modified config file, changed in pkg
-AT_SETUP([upgrade changing, modified config(noreplace) link 1])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-	--define "filetype link" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -426,25 +320,12 @@ foo-2.0
 ],
 [warning: /etc/my.conf created as /etc/my.conf.rpmnew]
 )
-AT_CLEANUP
 
-# ------------------------------
 # Modified config link matches the content from new package.
-AT_SETUP([upgrade changing, modified config(noreplace) link 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filedata foo-$v" \
-	--define "filetype link" \
-	--define "noreplace 1" \
-          /data/SPECS/configtest.spec
-done
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 readlink "${cf}"
@@ -464,13 +345,9 @@ AT_CLEANUP
 
 # Shared config link variants of the same cases
 # ------------------------------
-# (Build and) upgrade package with config file, no backup here
-AT_SETUP([upgrade unchanged shared config link])
+AT_SETUP([upgrade unchanged shared config links])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -482,6 +359,12 @@ for s in "A" "B"; do
               /data/SPECS/configtest.spec
     done
 done
+
+# Upgrade package with config file, no backup here
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -498,27 +381,11 @@ foo
 ],
 [])
 
-AT_CLEANUP
-#
-# ------------------------------
 # Upgrade package with locally modified config file, unchanged in pkg
-AT_SETUP([upgrade modified shared config link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo" \
-	    --define "filetype link" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -540,13 +407,9 @@ otherstuff
 AT_CLEANUP
 
 # ------------------------------
-# Upgrade package with unmodified config file, changed in pkg
-AT_SETUP([upgrade changing shared config link])
+AT_SETUP([upgrade changing shared config links])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -558,6 +421,12 @@ for s in "A" "B"; do
               /data/SPECS/configtest.spec
     done
 done
+
+# Upgrade package with unmodified config file, changed in pkg
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -573,27 +442,12 @@ readlink "${cf}"
 foo-2.0
 ],
 [])
-AT_CLEANUP
 
-# ------------------------------
 # Upgrade package with locally modified config file, changed in pkg
-AT_SETUP([upgrade changing, modified shared config link 1])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo-$v" \
-	    --define "filetype link" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -615,27 +469,12 @@ otherstuff
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
 
-# ------------------------------
 # Modified config link matches the content from new package.
-AT_SETUP([upgrade changing, modified shared config link 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo-$v" \
-	    --define "filetype link" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -658,13 +497,9 @@ AT_CLEANUP
 
 # Shared config(noreplace) variants of the more interesting cases
 # ------------------------------
-# Upgrade package with locally modified config file, changed in pkg.
-AT_SETUP([upgrade changing, modified shared config(noreplace) link 1])
+AT_SETUP([upgrade changing shared config(noreplace) links])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
@@ -677,6 +512,12 @@ for s in "A" "B"; do
               /data/SPECS/configtest.spec
     done
 done
+
+# Upgrade package with locally modified config file, changed in pkg.
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \
@@ -698,28 +539,12 @@ foo-2.0
 ],
 [warning: /etc/my.conf created as /etc/my.conf.rpmnew]
 )
-AT_CLEANUP
 
-# ------------------------------
 # Modified config link matches the content from new package.
-AT_SETUP([upgrade changing, modified shared config(noreplace) link 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-for s in "A" "B"; do
-    for v in "1.0" "2.0"; do
-        runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
-            --define "ver $v" \
-	    --define "filedata foo-$v" \
-	    --define "filetype link" \
-	    --define "noreplace 1" \
-              /data/SPECS/configtest.spec
-    done
-done
+rm -rf "${cf}"*
 
 runroot rpm -U \
     /build/RPMS/noarch/configtest-A-1.0-1.noarch.rpm \

--- a/tests/rpmconfig3.at
+++ b/tests/rpmconfig3.at
@@ -1,14 +1,10 @@
-#    rpmconfig2.at: rpm config symlink behavior tests
+#    rpmconfig3.at: rpm config file type change tests
 
 AT_BANNER([RPM config filetype changes])
 
-# non-modified config changes to non-config and back, no backups
 AT_SETUP([upgrade config to/from non-config])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -22,6 +18,12 @@ runroot rpmbuild --quiet -bb \
 	--define "filedata bar" \
 	--define "noconfig 1" \
           /data/SPECS/configtest.spec
+
+# non-modified config changes to non-config and back, no backups
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}" "${cf}".rpm*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -36,28 +38,12 @@ bar
 foo
 ],
 [])
-AT_CLEANUP
 
 # modified config changes to non-config and back, back up on first upgrade
-AT_SETUP([upgrade modified config to/from non-config 1])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype file" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype file" \
-	--define "filedata bar" \
-	--define "noconfig 1" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -78,28 +64,12 @@ foo
 ],
 [warning: /etc/my.conf saved as /etc/my.conf.rpmsave]
 )
-AT_CLEANUP
 
 # modified config changes to identical non-config and back, no backups
-AT_SETUP([upgrade modified config to/from non-config 2])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype file" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype file" \
-	--define "filedata bar" \
-	--define "noconfig 1" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -119,13 +89,9 @@ foo
 [])
 AT_CLEANUP
 
-# non-modified config file changes to config symlink and back, no backups
 AT_SETUP([upgrade config to/from config link])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -138,6 +104,12 @@ runroot rpmbuild --quiet -bb \
 	--define "filetype link" \
 	--define "filedata bar" \
           /data/SPECS/configtest.spec
+
+# non-modified config file changes to config symlink and back, no backups
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}" "${cf}".rpm*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -152,27 +124,12 @@ bar
 foo
 ],
 [])
-AT_CLEANUP
 
 # Modified config changes to config symlink
-AT_SETUP([upgrade modified config to config link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
 rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype file" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype link" \
-	--define "filedata bar" \
-          /data/SPECS/configtest.spec
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -230,13 +187,9 @@ otherstuff
 )
 AT_CLEANUP
 
-# Non-modified config file changes to directory.
 AT_SETUP([upgrade config to directory])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -248,6 +201,12 @@ runroot rpmbuild --quiet -bb \
         --define "ver 2.0" \
 	--define "filetype dir" \
           /data/SPECS/configtest.spec
+
+# Non-modified config file changes to directory.
+AT_CHECK([
+RPMDB_INIT
+cf="${RPMTEST}"/etc/my.conf
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"
@@ -258,26 +217,12 @@ test -d "${cf}"
 [foo
 ],
 [])
-AT_CLEANUP
 
 # Modified config changes to directory
-AT_SETUP([upgrade modified config to directory])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 cf="${RPMTEST}"/etc/my.conf
-rm -rf "${cf}" "${cf}".rpm*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype file" \
-	--define "filedata foo" \
-          /data/SPECS/configtest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype dir" \
-          /data/SPECS/configtest.spec
+rm -rf "${cf}"*
 
 runroot rpm -U /build/RPMS/noarch/configtest-1.0-1.noarch.rpm
 cat "${cf}"

--- a/tests/rpmdeps.at
+++ b/tests/rpmdeps.at
@@ -3,31 +3,8 @@
 AT_BANNER([RPM dependencies])
 
 # ------------------------------
-# 
-AT_SETUP([missing dependency])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs deptest-two" \
-	  /data/SPECS/deptest.spec
-
-runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
-],
-[1],
-[],
-[error: Failed dependencies:
-	deptest-two is needed by deptest-one-1.0-1.noarch
-])
-AT_CLEANUP
-
-# ------------------------------
-# 
-AT_SETUP([cross-depending packages])
-AT_KEYWORDS([install])
-AT_CHECK([
+AT_SETUP([unversioned requires])
+AT_KEYWORDS([install depends])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -39,6 +16,22 @@ runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
 	--define "reqs deptest-one" \
 	  /data/SPECS/deptest.spec
+
+# missing dependency
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
+],
+[1],
+[],
+[error: Failed dependencies:
+	deptest-two is needed by deptest-one-1.0-1.noarch
+])
+
+# cross-depending packages
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -107,9 +100,8 @@ AT_CLEANUP
 
 # ------------------------------
 # 
-AT_SETUP([versioned conflict in transaction])
+AT_SETUP([versioned conflicts])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -120,6 +112,10 @@ runroot rpmbuild --quiet -bb \
 runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
 	  /data/SPECS/deptest.spec
+
+# versioned conflict in transaction
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -128,23 +124,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	deptest-two < 2.0 conflicts with deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-# ------------------------------
-# 
-AT_SETUP([versioned conflict in database])
-AT_KEYWORDS([install])
+# versioned conflict in database
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "cfls deptest-two < 2.0" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
@@ -292,11 +275,10 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied WITH require])
+AT_SETUP([unsatisfied WITH requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
-RPMDB_INIT
 
+RPMDB_INIT
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "reqs (deptest-two with flavor = dekstop)" \
@@ -311,6 +293,10 @@ runroot rpmbuild --quiet -bb \
 	--define "pkg three" \
 	--define "provs flavor = desktop" \
 	  /data/SPECS/deptest.spec
+
+# unsatisfied WITH require in transaction
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -319,27 +305,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	(deptest-two with flavor = dekstop) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([unsatisfied WITH require (rpmdb)])
-AT_KEYWORDS([install, boolean])
+# unsatisfied WITH require in rpmdb
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two with flavor = dekstop)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	--define "provs flavor = server" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	--define "provs flavor = desktop" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 
@@ -352,9 +321,8 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ])
 AT_CLEANUP
 
-AT_SETUP([satisfied WITH require])
+AT_SETUP([satisfied WITH requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -367,15 +335,16 @@ runroot rpmbuild --quiet -bb \
 	--define "provs flavor = desktop" \
 	  /data/SPECS/deptest.spec
 
+# satisfied WITH require in transaction
+AT_CHECK([
+RPMDB_INIT
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
 [0],
 [],
 [])
-AT_CLEANUP
 
-AT_SETUP([satisfied WITH require (rpmdb)])
-AT_KEYWORDS([install, boolean])
+# satisfied WITH require in rpmdb
 AT_CHECK([
 RPMDB_INIT
 
@@ -400,9 +369,8 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied WITHOUT require])
+AT_SETUP([unsatisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -414,6 +382,10 @@ runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
 	--define "provs flavor = server" \
 	  /data/SPECS/deptest.spec
+
+# unsatisfied WITHOUT require in transaction
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -422,22 +394,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	(deptest-two without flavor) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([unsatisfied WITHOUT require (rpmdb)])
-AT_KEYWORDS([install, boolean])
+# unsatisfied WITHOUT require in rpmdb
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two without flavor)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	--define "provs flavor = server" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 
@@ -450,9 +410,8 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ])
 AT_CLEANUP
 
-AT_SETUP([satisfied WITHOUT require])
+AT_SETUP([satisfied WITHOUT requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -463,27 +422,20 @@ runroot rpmbuild --quiet -bb \
 runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
 	  /data/SPECS/deptest.spec
+
+# satisfied WITHOUT require in transaction
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
 [0],
 [],
 [])
-AT_CLEANUP
 
-AT_SETUP([satisfied WITHOUT require (rpmdb)])
-AT_KEYWORDS([install, boolean])
+# satisfied WITHOUT require in rpmdb
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two without flavor)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 
@@ -496,9 +448,8 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied AND require - all missing])
+AT_SETUP([AND requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -506,6 +457,15 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs (deptest-two and deptest-three)" \
 	  /data/SPECS/deptest.spec
 
+for pkg in two three; do
+    runroot rpmbuild --quiet -bb \
+	--define "pkg ${pkg}" \
+	  /data/SPECS/deptest.spec
+done
+
+AT_CHECK([
+RPMDB_INIT
+# unsatisfied AND require - all missing
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
 [1],
@@ -513,21 +473,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 [error: Failed dependencies:
 	(deptest-two and deptest-three) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([unsatisfied AND require - first is missing])
-AT_KEYWORDS([install, boolean])
+# unsatisfied AND require - first is missing
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two and deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -536,21 +485,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	(deptest-two and deptest-three) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([unsatisfied AND require - second is missing])
-AT_KEYWORDS([install, boolean])
+# unsatisfied AND require - second is missing
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two and deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -559,25 +497,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	(deptest-two and deptest-three) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([satisfied AND require])
-AT_KEYWORDS([install, boolean])
+# satisfied AND require
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two and deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -588,9 +511,8 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied OR require - all missing])
+AT_SETUP([OR requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -598,6 +520,15 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs (deptest-two or deptest-three)" \
 	  /data/SPECS/deptest.spec
 
+for pkg in two three; do
+    runroot rpmbuild --quiet -bb \
+	--define "pkg ${pkg}" \
+	  /data/SPECS/deptest.spec
+done
+
+# unsatisfied OR require - all missing
+AT_CHECK([
+RPMDB_INIT
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
 [1],
@@ -605,67 +536,30 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 [error: Failed dependencies:
 	(deptest-two or deptest-three) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([satisfied OR require - first is missing])
-AT_KEYWORDS([install, boolean])
+# satisfied OR require - first is missing
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two or deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
 [0],
 [],
 [])
-AT_CLEANUP
 
-AT_SETUP([satisfied OR require - second is missing])
-AT_KEYWORDS([install, boolean])
+# satisfied OR require - second is missing
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two or deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
 [0],
 [],
 [])
-AT_CLEANUP
 
-AT_SETUP([satisfied OR require - both present])
-AT_KEYWORDS([install, boolean])
+# satisfied OR require - both present
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two or deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -676,9 +570,8 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied IF require])
+AT_SETUP([IF requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -686,9 +579,15 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs (deptest-two if deptest-three)" \
 	  /data/SPECS/deptest.spec
 
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
+for pkg in two three; do
+    runroot rpmbuild --quiet -bb \
+	--define "pkg ${pkg}" \
 	  /data/SPECS/deptest.spec
+done
+
+# unsatisfied IF require
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -697,25 +596,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	(deptest-two if deptest-three) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([satisfied IF require])
-AT_KEYWORDS([install, boolean])
+# satisfied IF require
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two if deptest-three)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -724,15 +608,24 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [])
 AT_CLEANUP
 
-AT_SETUP([unsatisfied IF-ELSE require])
+AT_SETUP([IF-ELSE requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "reqs (deptest-two if deptest-three else deptest-four)" \
 	  /data/SPECS/deptest.spec
+
+for pkg in two three four; do
+    runroot rpmbuild --quiet -bb \
+	--define "pkg ${pkg}" \
+	  /data/SPECS/deptest.spec
+done
+
+# unsatisfied IF-ELSE require
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 ],
@@ -741,46 +634,20 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm
 [error: Failed dependencies:
 	(deptest-two if deptest-three else deptest-four) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([satisfied IF-ELSE require - right clause])
-AT_KEYWORDS([install, boolean])
+# satisfied IF-ELSE require - right clause
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two if deptest-three else deptest-four)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg four" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm
 ],
 [0],
 [],
 [])
-AT_CLEANUP
 
-AT_SETUP([satisfied IF-ELSE require - left clause])
-AT_KEYWORDS([install, boolean])
+# satisfied IF-ELSE require - left clause
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two if deptest-three else deptest-four)" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
@@ -791,9 +658,8 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([unsatisfied nested AND-OR require])
+AT_SETUP([nested AND-OR requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -801,10 +667,15 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs (deptest-two and (deptest-three or deptest-four))" \
 	  /data/SPECS/deptest.spec
 
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
+for pkg in two three; do
+    runroot rpmbuild --quiet -bb \
+	--define "pkg ${pkg}" \
 	  /data/SPECS/deptest.spec
+done
 
+AT_CHECK([
+RPMDB_INIT
+# unsatisfied nested AND-OR require
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
 [2],
@@ -812,25 +683,10 @@ runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarc
 [error: Failed dependencies:
 	(deptest-two and (deptest-three or deptest-four)) is needed by deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
-AT_SETUP([satisfied nested AND-OR require])
-AT_KEYWORDS([install, boolean])
+# satisfied nested AND-OR require
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two and (deptest-three or deptest-four))" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],
@@ -841,9 +697,8 @@ AT_CLEANUP
 
 # ------------------------------
 #
-AT_SETUP([satisfied nested AND-IF require - without right clause])
+AT_SETUP([nested AND-IF requires])
 AT_KEYWORDS([install, boolean])
-AT_CHECK([
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
@@ -851,38 +706,25 @@ runroot rpmbuild --quiet -bb \
 	--define "reqs (deptest-two and (deptest-three if deptest-four))" \
 	  /data/SPECS/deptest.spec
 
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
+for pkg in two three four; do
+    runroot rpmbuild --quiet -bb \
+	--define "pkg ${pkg}" \
 	  /data/SPECS/deptest.spec
+done
+
+# satisfied nested AND-IF require - without right clause
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm
 ],
 [0],
 [],
 [])
-AT_CLEANUP
 
-AT_SETUP([satisfied nested AND-IF require - with right clause])
-AT_KEYWORDS([install, boolean])
+# satisfied nested AND-IF require - with right clause
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "reqs (deptest-two and (deptest-three if deptest-four))" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg four" \
-	  /data/SPECS/deptest.spec
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg three" \
-	  /data/SPECS/deptest.spec
 
 runroot rpm -U /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-four-1.0-1.noarch.rpm /build/RPMS/noarch/deptest-three-1.0-1.noarch.rpm
 ],

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -554,11 +554,9 @@ runroot rpm -q versiontest
 # TODO: the same with epoch vs no epoch
 AT_CLEANUP
 
-# Test upgrade of obsoleted package in same transaction
-AT_SETUP([rpm -U obsoleted package 1])
-AT_CHECK([
+AT_SETUP([rpm -U obsoleted packages])
+AT_KEYWORDS([install obsolete])
 RPMDB_INIT
-
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
 	--define "obs deptest-two <= 1.0" \
@@ -567,6 +565,9 @@ runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
 	/data/SPECS/deptest.spec
 
+# Test upgrade of obsoleted package in same transaction
+AT_CHECK([
+RPMDB_INIT
 
 runroot rpm -Uv \
   /build/RPMS/noarch/deptest-two-1.0-1.noarch.rpm \
@@ -581,21 +582,10 @@ deptest-one-1.0-1.noarch
 ],
 [warning: package deptest-two-1.0-1.noarch was already added, replacing with deptest-one-1.0-1.noarch
 ])
-AT_CLEANUP
 
 # Test upgrade of obsoleted package in same transaction
-AT_SETUP([rpm -U obsoleted package 2])
 AT_CHECK([
 RPMDB_INIT
-
-runroot rpmbuild --quiet -bb \
-	--define "pkg one" \
-	--define "obs deptest-two <= 1.0" \
-	/data/SPECS/deptest.spec
-runroot rpmbuild --quiet -bb \
-	--define "pkg two" \
-	/data/SPECS/deptest.spec
-
 
 runroot rpm -Uv \
   /build/RPMS/noarch/deptest-one-1.0-1.noarch.rpm \

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -35,12 +35,9 @@ foo
 [])
 AT_CLEANUP
 
-AT_SETUP([upgrade regular file to/from broken link])
+AT_SETUP([upgrade regular file to/from link])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-tf="${RPMTEST}"/opt/foo
-rm -rf "${RPMTEST}"/opt/*
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -53,6 +50,12 @@ runroot rpmbuild --quiet -bb \
 	--define "filetype link" \
 	--define "filedata stuff" \
           /data/SPECS/replacetest.spec
+
+# upgrade regular file to/from broken link
+AT_CHECK([
+RPMDB_INIT
+tf="${RPMTEST}"/opt/foo
+rm -rf "${RPMTEST}"/opt/*
 
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 cat "${tf}"
@@ -67,27 +70,13 @@ stuff
 foo
 ],
 [])
-AT_CLEANUP
 
-AT_SETUP([upgrade regular file to/from file link])
-AT_KEYWORDS([install])
 AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
 
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype file" \
-	--define "filedata foo" \
-          /data/SPECS/replacetest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype link" \
-	--define "filedata goo" \
-          /data/SPECS/replacetest.spec
-
+# upgrade regular file to/from file link
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 cat "${tf}"
 runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
@@ -97,7 +86,7 @@ cat "${tf}"
 ],
 [0],
 [foo
-goo
+stuff
 foo
 ],
 [])
@@ -431,10 +420,7 @@ AT_CLEANUP
 
 AT_SETUP([upgrade empty directory to broken link])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-tf="${RPMTEST}"/opt/foo
-rm -rf "${RPMTEST}"/opt/*
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -446,6 +432,26 @@ runroot rpmbuild --quiet -bb \
 	--define "filetype link" \
 	--define "filedata woot" \
           /data/SPECS/replacetest.spec
+
+# upgrade empty directory to broken link
+AT_CHECK([
+RPMDB_INIT
+tf="${RPMTEST}"/opt/foo
+rm -rf "${RPMTEST}"/opt/*
+
+runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
+test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
+],
+[2],
+[],
+[	file /opt/foo from install of replacetest-2.0-1.noarch conflicts with file from package replacetest-1.0-1.noarch
+])
+
+# upgrade empty directory to file link
+AT_CHECK([
+RPMDB_INIT
+tf="${RPMTEST}"/opt/foo
+rm -rf "${RPMTEST}"/opt/*
 
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
@@ -458,37 +464,7 @@ AT_CLEANUP
 
 AT_SETUP([upgrade empty directory to file link])
 AT_KEYWORDS([install])
-AT_CHECK([
 RPMDB_INIT
-tf="${RPMTEST}"/opt/foo
-rm -rf "${RPMTEST}"/opt/*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype dir" \
-          /data/SPECS/replacetest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype link" \
-	--define "filedata woot" \
-          /data/SPECS/replacetest.spec
-
-runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
-test -d "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
-],
-[2],
-[],
-[	file /opt/foo from install of replacetest-2.0-1.noarch conflicts with file from package replacetest-1.0-1.noarch
-])
-AT_CLEANUP
-
-AT_SETUP([upgrade removed empty directory to file link])
-AT_KEYWORDS([install])
-AT_CHECK([
-RPMDB_INIT
-tf="${RPMTEST}"/opt/foo
-rm -rf "${RPMTEST}"/opt/*
 
 runroot rpmbuild --quiet -bb \
         --define "ver 1.0" \
@@ -500,6 +476,12 @@ runroot rpmbuild --quiet -bb \
 	--define "filetype link" \
 	--define "filedata goo" \
           /data/SPECS/replacetest.spec
+
+# upgrade removed empty directory to file link
+AT_CHECK([
+RPMDB_INIT
+tf="${RPMTEST}"/opt/foo
+rm -rf "${RPMTEST}"/opt/*
 
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 test -d "${tf}" && rmdir "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm
@@ -509,25 +491,12 @@ readlink "${tf}"
 [goo
 ],
 [])
-AT_CLEANUP
 
-AT_SETUP([upgrade replaced empty directory to file link])
-AT_KEYWORDS([install])
+# upgrade replaced empty directory to file link
 AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 1.0" \
-	--define "filetype dir" \
-          /data/SPECS/replacetest.spec
-
-runroot rpmbuild --quiet -bb \
-        --define "ver 2.0" \
-	--define "filetype link" \
-	--define "filedata goo" \
-          /data/SPECS/replacetest.spec
 
 runroot rpm -U /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 test -d "${tf}" && rmdir "${tf}" && ln -sf goo "${tf}" && runroot rpm -U /build/RPMS/noarch/replacetest-2.0-1.noarch.rpm

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -280,13 +280,9 @@ runroot rpm -Va --nouser --nogroup
 AT_CLEANUP
 
 # ------------------------------
-# Upgraded verification with min_writes 1 (files)
-AT_SETUP([Upgraded verification with min_writes 1 (files)])
+AT_SETUP([minimize writes (files)])
 AT_KEYWORDS([upgrade verify min_writes])
-AT_CHECK([
 RPMDB_INIT
-tf="${RPMTEST}"/opt/foo
-rm -rf "${tf}" "${tf}".rpm*
 
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
@@ -303,6 +299,11 @@ for v in "3.0" "4.0"; do
 	--define "filedata fox" \
           /data/SPECS/replacetest.spec
 done
+
+AT_CHECK([
+RPMDB_INIT
+tf="${RPMTEST}"/opt/foo
+rm -rf "${tf}"*
 
 runroot rpm -i /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 cat "${tf}"
@@ -346,33 +347,11 @@ fox
 fox
 ],
 [])
-AT_CLEANUP
 
-
-# ------------------------------
-# Upgraded verification with min_writes 2 (files)
-AT_SETUP([Upgraded verification with min_writes 2 (files)])
-AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
-rm -rf "${tf}" "${tf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filetype file" \
-	--define "filedata foo" \
-          /data/SPECS/replacetest.spec
-done
-
-for v in "3.0" "4.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filetype file" \
-	--define "filedata fox" \
-          /data/SPECS/replacetest.spec
-done
+rm -rf "${tf}"*
 
 runroot rpm -i /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 cat "${tf}"
@@ -426,15 +405,9 @@ fox
 [])
 AT_CLEANUP
 
-# ------------------------------
-# Upgraded verification with min_writes 3 (LINKs)
-AT_SETUP([Upgraded verification with min_writes 3 (LINKs)])
+AT_SETUP([minimize writes (links)])
 AT_KEYWORDS([upgrade verify min_writes])
-AT_CHECK([
 RPMDB_INIT
-tf="${RPMTEST}"/opt/foo
-rm -rf "${tf}" "${tf}".rpm*
-
 for v in "1.0" "2.0"; do
     runroot rpmbuild --quiet -bb \
         --define "ver $v" \
@@ -450,6 +423,11 @@ for v in "3.0" "4.0"; do
 	--define "filedata fox" \
           /data/SPECS/replacetest.spec
 done
+
+AT_CHECK([
+RPMDB_INIT
+tf="${RPMTEST}"/opt/foo
+rm -rf "${tf}"*
 
 runroot rpm -i /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 readlink "${tf}"
@@ -490,31 +468,11 @@ fox
 fox
 ],
 [])
-AT_CLEANUP
-# ------------------------------
-# Upgraded verification with min_writes 4 (LINKs)
-AT_SETUP([Upgraded verification with min_writes 4 (LINKs)])
-AT_KEYWORDS([upgrade verify min_writes])
+
 AT_CHECK([
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${tf}" "${tf}".rpm*
-
-for v in "1.0" "2.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filetype link" \
-	--define "filedata doh" \
-          /data/SPECS/replacetest.spec
-done
-
-for v in "3.0" "4.0"; do
-    runroot rpmbuild --quiet -bb \
-        --define "ver $v" \
-	--define "filetype link" \
-	--define "filedata fox" \
-          /data/SPECS/replacetest.spec
-done
 
 runroot rpm -i /build/RPMS/noarch/replacetest-1.0-1.noarch.rpm
 readlink "${tf}"
@@ -565,7 +523,7 @@ fox
 [])
 AT_CLEANUP
 
-AT_SETUP([Upgraded verification with min_writes 5 (suid files)])
+AT_SETUP([minimize writes (SUID files)])
 AT_KEYWORDS([upgrade verify min_writes])
 AT_CHECK([
 RPMDB_INIT


### PR DESCRIPTION
Merge tests to groups when they share built content to avoid redundant builds over and over again, eliminate redundant copies on build tests etc. Besides removing gobs of crud, makes it run faster too.