### PR TITLE
Fix python(abi) requires generator, it picked files from almost good directories

### DIFF
--- a/fileattrs/python.attr
+++ b/fileattrs/python.attr
@@ -25,4 +25,3 @@
 }
 
 %__python_path ^((%{_prefix}/lib(64)?/python[[:digit:]]+\\.[[:digit:]]+/.*\\.(py[oc]?|so))|(%{_bindir}/python[[:digit:]]+\\.[[:digit:]]+))$
-%__python_magic [Pp]ython.*(executable|byte-compiled)


### PR DESCRIPTION
Fix python(abi) requires generator, it picked files from almost good directories

The %__python_magic filter suddenly got actually working with file 5.39:

Before:

    file.cpython-38.opt-1.pyc: data

After:

    file.cpython-38.opt-1.pyc: python 3.8 byte-compiled

Hence, the filter started to pick all Python files regardless of their location.
Later, in the actual generator, paths like this were considered:

    /opt/usr/lib/python3.X/...

And generated requirements on python(abi).

We don't actually need to filter the files by file magic,
so we drop it to get the previously accidentally working behavior.

We could choose if the path and magic filters are applied as OR or AND.
However, we don't want either.

We actually want to mach any files in Python directories regardless of their magic.
We *could* filter by file type (and executable bit) for provides,
but that would require us to split the attr files into two.