### PR TITLE
Fix (work around) FA_TOUCH not scoping correctly over hardlinks

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,6 +59,7 @@ EXTRA_DIST += data/SPECS/configtest.spec
 EXTRA_DIST += data/SPECS/filedep.spec
 EXTRA_DIST += data/SPECS/flangtest.spec
 EXTRA_DIST += data/SPECS/hlinktest.spec
+EXTRA_DIST += data/SPECS/hlbreak.spec
 EXTRA_DIST += data/SPECS/iftest.spec
 EXTRA_DIST += data/SPECS/ifmultiline.spec
 EXTRA_DIST += data/SPECS/eliftest.spec

--- a/tests/data/SPECS/hlbreak.spec
+++ b/tests/data/SPECS/hlbreak.spec
@@ -1,0 +1,22 @@
+Name: hlbreak
+Version: %{ver}
+Release: 0
+License: GPL
+Summary: Testing changing hardlink behavior
+BuildArch: noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p %{buildroot}/opt
+echo "content" > %{buildroot}/opt/file2
+%if %{ver} == 1
+ln %{buildroot}/opt/file2 %{buildroot}/opt/file1
+%endif
+
+%files
+%if %{ver} == 1
+/opt/file1
+%endif
+/opt/file2

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -405,7 +405,29 @@ fox
 [])
 AT_CLEANUP
 
-AT_SETUP([minimize writes (links)])
+AT_SETUP([minimize writes (hardlinks)])
+AT_KEYWORDS([upgrade verify min_writes])
+RPMDB_INIT
+for v in "0" "1"; do
+    runroot rpmbuild --quiet -bb --define "ver ${v}" /data/SPECS/hlbreak.spec
+done
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U --define "_minimize_writes 1" /build/RPMS/noarch/hlbreak-0-0.noarch.rpm
+runroot rpm -Vav --nouser --nogroup
+runroot rpm -U --define "_minimize_writes 1" /build/RPMS/noarch/hlbreak-1-0.noarch.rpm
+runroot rpm -Vav --nouser --nogroup
+],
+[0],
+[.........    /opt/file2
+.........    /opt/file1
+.........    /opt/file2
+],
+)
+AT_CLEANUP
+
+
+AT_SETUP([minimize writes (symlinks)])
 AT_KEYWORDS([upgrade verify min_writes])
 RPMDB_INIT
 for v in "1.0" "2.0"; do


### PR DESCRIPTION
The existing FSM code doesn't correctly handle FA_TOUCH on hardlinked
file sets, which causes the hardlink set to break on at least some
upgrade scenarios when minimize_writes is enabled.

Only enable FA_TOUCH on non-hardlinked files to work around the issue
for now. While at it, rearrange the conditionals around min_writes to make
it a bit clearer. Testcase adopted from original reproducer by
Fabian Vogt, thanks!

Fixes: #1278