### PR TITLE
Don't install man pages for disabled features

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -8,11 +8,35 @@ EXTRA_DIST += $(man_man1_DATA)
 
 man_man8dir = $(mandir)/man8
 man_man8_DATA = rpm.8 rpm-misc.8 rpmbuild.8 rpmdeps.8 rpmgraph.8 rpm2cpio.8
-man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8 rpm2archive.8
-man_man8_DATA += rpm-plugin-systemd-inhibit.8 rpm-plugin-audit.8 rpm-plugin-ima.8
-man_man8_DATA += rpm-plugin-prioreset.8 rpm-plugin-selinux.8 rpm-plugin-syslog.8
-man_man8_DATA += rpm-plugins.8
+man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8
+
 EXTRA_DIST += $(man_man8_DATA)
+
+if ENABLE_PLUGINS
+man_man8_DATA += rpm-plugin-prioreset.8 rpm-plugin-syslog.8
+man_man8_DATA += rpm-plugins.8
+
+if AUDIT
+man_man8_DATA += rpm-plugin-audit.8
+endif
+if DBUS
+man_man8_DATA += rpm-plugin-systemd-inhibit.8
+endif
+if IMA
+man_man8_DATA += rpm-plugin-ima.8
+endif
+if SELINUX
+man_man8_DATA += rpm-plugin-selinux.8
+endif
+endif
+
+if WITH_ARCHIVE
+man_man8_DATA += rpm2archive.8
+endif
+
+EXTRA_DIST += rpm-plugins.8 rpm-plugin-prioreset.8 rpm-plugin-syslog.8 
+EXTRA_DIST += rpm-plugin-audit.8 rpm-plugin-systemd-inhibit.8 
+EXTRA_DIST += rpm-plugin-ima.8 rpm-plugin-selinux.8 rpm2archive.8
 
 man_fr_man8dir = $(mandir)/fr/man8
 man_fr_man8_DATA = fr/rpm.8


### PR DESCRIPTION
Doesn't make much sense to install manuals for features that are not
enabled in a build. Conditionalize our man page installation where
necessary, taking care to include the manuals in tarballs regardless
of configured status.

Inspired by PR (#1247) from Thierry Vignaud