### PR TITLE
Fix bogus test-suite failure when input is not a tty (#1290)

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -415,6 +415,8 @@ AT_SETUP([rpmsign --addsign])
 AT_KEYWORDS([rpmsign signature])
 RPMDB_INIT
 gpg2 --import ${RPMTEST}/data/keys/*.secret
+# Our keys have no passphrases to be asked, silence GPG_TTY warning
+export GPG_TTY=""
 
 # rpmsign --addsign --rpmv3 <unsigned>
 AT_CHECK([


### PR DESCRIPTION
When running with a non-tty input (such as inside mock), the --addsign
test will fail due to GPG_TTY related warning getting emitted since commit
52c0198e245fcac55440ed1e0211d33f84681a7a. Our test-keys do not have
passphrases that need to be asked, so just silence the warning by
manually setting GPG_TTY to an empty value.

Fixes: #1290