### PR TITLE
Treat /usr/share/gnome/help as docs

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -538,7 +538,7 @@ package or when debugging this package.\
 %_filter_GLIBC_PRIVATE			0
 
 # Directories whose contents should be considered as documentation.
-%__docdir_path %{_datadir}/doc:%{_datadir}/man:%{_datadir}/info:%{_datadir}/gtk-doc/html:%{?_docdir}:%{?_mandir}:%{?_infodir}:%{?_javadocdir}:/usr/doc:/usr/man:/usr/info:/usr/X11R6/man
+%__docdir_path %{_datadir}/doc:%{_datadir}/man:%{_datadir}/info:%{_datadir}/gtk-doc/html:%{_datadir}/gnome/help:%{?_docdir}:%{?_mandir}:%{?_infodir}:%{?_javadocdir}:/usr/doc:/usr/man:/usr/info:/usr/X11R6/man
 
 #
 # Path to scripts to autogenerate package dependencies,


### PR DESCRIPTION
rpmlint thinks that /usr/share/gnome/help is documentation:
`FilesCheck.py:188:doc_regex = re.compile(r'^/usr(/share|/X11R6)?/(doc|man|info)/|^/usr/share/gnome/help')`
and gives a warning that those files are not marked as docs in RPM packages.

It seems a good idea to treat help files as documentation (for example, if someone wants to reduce disk usage
by not installing documentation, he will also not want help files),
so let's add them to the default %__docdir_path