### PR TITLE
Sync python dependency conversion with pyreq2rpm.

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -112,12 +112,12 @@ def convert_ordered(name, operator, version_id):
         # with ordered comparisons
         version_id = version_id[:-2]
         version = RpmVersion(version_id)
-        if '>' == operator:
-            # distutils does not behave this way, but this is
-            # their recommendation
-            # https://mail.python.org/archives/list/distutils-sig@python.org/thread/NWEQVTCX5CR2RKW2LT4H77PJTEINSX7P/
+        if operator == '>':
+            # distutils will allow a prefix match with '>'
             operator = '>='
-            version.increment()
+        if operator == '<=':
+            # distutils will not allow a prefix match with '<='
+            operator = '<'
     else:
         version = RpmVersion(version_id)
     return '{} {} {}'.format(name, operator, version)


### PR DESCRIPTION
This change better reflects the behavior of setuptools in situations that are processed successfully, but not covered in the specification.