### PR TITLE
Fix Doxygen comments

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -340,7 +340,7 @@ char * headerGetAsString(Header h, rpmTagVal tag);
  */
 const char * headerGetString(Header h, rpmTagVal tag);
 
-/* \ingroup header
+/** \ingroup header
  * Return a simple number tag (or extension) from header
  * @param h		header
  * @param tag		tag to retrieve

--- a/lib/rpmtd.h
+++ b/lib/rpmtd.h
@@ -363,7 +363,7 @@ int rpmtdFromArgv(rpmtd td, rpmTagVal tag, ARGV_t argv);
  */
 int rpmtdFromArgi(rpmtd td, rpmTagVal tag, ARGI_t argi);
 
-/* \ingroup rpmtd
+/** \ingroup rpmtd
  * Perform deep copy of container.
  * Create a modifiable copy of tag data container (on string arrays each
  * string is separately allocated)
@@ -373,7 +373,7 @@ int rpmtdFromArgi(rpmtd td, rpmTagVal tag, ARGI_t argi);
  */
 rpmtd rpmtdDup(rpmtd td);
 
-/* \ingroup rpmtd
+/** \ingroup rpmtd
  * Push string array container contents to a string pool, return string ids.
  * @param td		Tag data container
  * @param pool		String pool

--- a/rpmio/rpmlog.h
+++ b/rpmio/rpmlog.h
@@ -96,7 +96,7 @@ typedef	enum rpmlogFac_e {
 #define	RPMLOG_NOWAIT	0x10	/*!< don't wait for console forks: DEPRECATED */
 #define	RPMLOG_PERROR	0x20	/*!< log to stderr as well */
 
-/* \ingroup rpmlog
+/** \ingroup rpmlog
  * Option flags for callback return value.
  */
 #define RPMLOG_DEFAULT	0x01	/*!< perform default logging */	

--- a/rpmio/rpmpgp.h
+++ b/rpmio/rpmpgp.h
@@ -745,7 +745,7 @@ typedef union pgpPktKey_u {
     struct pgpPktKeyV4_s v4;
 } pgpPktKey;
 
-/* \ingroup rpmpgp
+/** \ingroup rpmpgp
  * 5.6. Compressed Data Packet (Tag 8)
  *
  * The Compressed Data packet contains compressed data. Typically, this
@@ -774,7 +774,7 @@ typedef struct pgpPktCdata_s {
     uint8_t data[1];
 } pgpPktCdata;
 
-/* \ingroup rpmpgp
+/** \ingroup rpmpgp
  * 5.7. Symmetrically Encrypted Data Packet (Tag 9)
  *
  * The Symmetrically Encrypted Data packet contains data encrypted with
@@ -812,7 +812,7 @@ typedef struct pgpPktEdata_s {
     uint8_t data[1];
 } pgpPktEdata;
 
-/* \ingroup rpmpgp
+/** \ingroup rpmpgp
  * 5.8. Marker Packet (Obsolete Literal Packet) (Tag 10)
  *
  * An experimental version of PGP used this packet as the Literal
@@ -828,7 +828,7 @@ typedef struct pgpPktEdata_s {
  * in order to cause that version to report that newer software is
  * necessary to process the message.
  */
-/* \ingroup rpmpgp
+/** \ingroup rpmpgp
  * 5.9. Literal Data Packet (Tag 11)
  *
  * A Literal Data packet contains the body of a message; data that is
@@ -865,7 +865,7 @@ typedef struct pgpPktLdata_s {
     uint8_t filename[1];
 } pgpPktLdata;
 
-/* \ingroup rpmpgp
+/** \ingroup rpmpgp
  * 5.10. Trust Packet (Tag 12)
  *
  * The Trust packet is used only within keyrings and is not normally
@@ -882,7 +882,7 @@ typedef struct pgpPktTrust_s {
     uint8_t flag;
 } pgpPktTrust;
 
-/* \ingroup rpmpgp
+/** \ingroup rpmpgp
  * 5.11. User ID Packet (Tag 13)
  *
  * A User ID packet consists of data that is intended to represent the


### PR DESCRIPTION
Some of code documentation comments are misformed which causes corresponding doxygen docs not to be generated. I found out about this because I was looking the the [online docs](http://ftp.rpm.org/api/4.15.1/group__header.html#ga33376e8850c275b72059fe723a0d3066) for a function I knew existed but could not find it there.