### PR TITLE
Support threading for zstd compression.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ AC_ARG_ENABLE([zstd],
               [enable_zstd=auto])
 
 AS_IF([test "x$enable_zstd" != "xno"], [
-  PKG_CHECK_MODULES([ZSTD], [libzstd], [have_zstd=yes], [have_zstd=no])
+  PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.3.8], [have_zstd=yes], [have_zstd=no])
   AS_IF([test "$enable_zstd" = "yes"], [
     if test "$have_zstd" = "no"; then
       AC_MSG_ERROR([--enable-zstd specified, but not available])

--- a/macros.in
+++ b/macros.in
@@ -350,9 +350,10 @@ package or when debugging this package.\
 #		"w9.gzdio"	gzip level 9 (default).
 #		"w9.bzdio"	bzip2 level 9.
 #		"w6.xzdio"	xz level 6, xz's default.
-#		"w7T16.xzdio"	xz level 7 using 16 thread (xz only)
+#		"w7T16.xzdio"	xz level 7 using 16 threads
 #		"w6.lzdio"	lzma-alone level 6, lzma's default
 #		"w3.zstdio"	zstd level 3, zstd's default
+#		"w19T8.zstdio"	zstd level 19 using 8 threads
 #		"w.ufdio"	uncompressed
 #
 #%_source_payload	w9.gzdio


### PR DESCRIPTION
Port zstd compression to the new API (ZSTD_compressStream2).

My motivation is to eventually enable multi-threaded compression which can help packages like Firefox where there's a single huge rpm that is being compressed.

Once the change is accepted, the following one-liner will enable parallel compression:
```c
ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, 4);
```