### PR TITLE
Improved errors handling.

### DIFF
--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -31,6 +31,8 @@ static PyObject *rpmPubkey_new(PyTypeObject *subtype,
 	return NULL;
     }
     pubkey = rpmPubkeyNew(pkt, pktlen);
+    if (!pubkey)
+	return NULL;
 
     return rpmPubkey_Wrap(subtype, pubkey);
 }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -1069,7 +1069,16 @@ int pgpPrtParams(const uint8_t * pkts, size_t pktlen, unsigned int pkttype,
 	p += (pkt.body - pkt.head) + pkt.blen;
     }
 
-    rc = (digp && (p == pend)) ? 0 : -1;
+	rc = 0;
+    if(!digp){
+		rpmlog(RPMLOG_WARNING, "pgpPrtParams: Key params have not been found\n");
+		rc = -1;
+	}
+
+	if(p != pend){
+		rpmlog(RPMLOG_WARNING, "pgpPrtParams: The parsing has not consumed the whole stream: pos = %ld, remaining = %ld\n", pktlen - (pend - p), pend - p);
+		rc = -1;
+	}
 
     if (ret && rc == 0) {
 	*ret = digp;


### PR DESCRIPTION
I was really hard to get that that I cannot import a key is just a bug in librpm and its python bindings. This PR makes it a bit more clear.