### PR TITLE
pythondistdeps.py: Adapt Python version marker workaround for setuptools 42+

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -261,6 +261,7 @@ if __name__ == "__main__":
             # [2] https://github.com/pypa/setuptools/pull/1275
             import platform
             platform.python_version = lambda: dist.py_version
+            platform.python_version_tuple = lambda: tuple(dist.py_version.split('.'))
 
             # This is the PEP 503 normalized name.
             # It does also convert dots to dashes, unlike dist.key.


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1853597#c11

pkg_resources from setuptools 42+ no longer only use platform.python_version(),
but also platform.python_version_tuple() -- this was updated in packaging 19.1+.

This fix makes it work again with both new and old setuptools,
hopefully for some while.

https://github.com/pypa/setuptools/commit/bf069fe9ddcadaa2c029067601d06a07d037d4f7
https://github.com/pypa/packaging/commit/86a443f3185024edd0b826afdd91d8f9a4917022