### PR TITLE
Remove compare of global array tagsByName to NULL

### DIFF
--- a/lib/tagname.c
+++ b/lib/tagname.c
@@ -234,7 +234,7 @@ int rpmTagGetNames(rpmtd tagnames, int fullname)
 
     pthread_once(&tagsLoaded, loadTags);
 
-    if (tagnames == NULL || tagsByName == NULL)
+    if (tagnames == NULL)
 	return 0;
 
     rpmtdReset(tagnames);


### PR DESCRIPTION
A 2016 change (57a96d2486c26142ebb168a1f00b0374d35bf044) apparently
changed tagsByName from dynamic allocation to being static, so that
Valgrind would not complain about lost memory. The definition is:

    static headerTagTableEntry tagsByName[TABLESIZE];

But a comparison was left of `tagsByName == NULL` in lib/tagname.c
and compiling with clang gives a warning, saying it is never NULL.