### PR TITLE
Always close libelf handle

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1935,8 +1935,8 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
 			if (terminate)
 			    rc = 1;
 		    }
-		    elf_end (elf);
 		}
+		elf_end (elf);
 		close (fd);
 	    }
 	}


### PR DESCRIPTION
Otherwise executables that are not proper elf files are leaking libelf
handles. This results in file being left open (mmap'ed) and fails the
build on NFS as those files can't be deleted properly there.

Resolves: rhbz#1840728
See also: https://bugzilla.redhat.com/show_bug.cgi?id=1840728