### PR TITLE
Disable Python hash seed randomization in brp-python-bytecompile

### DIFF
--- a/scripts/brp-python-bytecompile
+++ b/scripts/brp-python-bytecompile
@@ -57,6 +57,10 @@ EOF
 # For example, below /usr/lib/python2.6/, we're targeting /usr/bin/python2.6
 # and below /usr/lib/python3.1/, we're targeting /usr/bin/python3.1
 
+# Disable Python hash seed randomization
+# This helps to make byte-compilation more reproducible
+export PYTHONHASHSEED=0
+
 shopt -s nullglob
 for python_libdir in `find "$RPM_BUILD_ROOT" -type d|grep -E "/usr/lib(64)?/python[0-9]\.[0-9]$"`;
 do


### PR DESCRIPTION
Sometimes, byte-compilation might produce two functionally identical pyc files that are not byte-to-byte identical which might cause problems.

Disabled hash seed randomization does not solve this problem entirely but helps a lot by lowering probability.