### PR TITLE
debugedit: Fix missing relocation of .debug_types section.

### DIFF
--- a/tests/data/SOURCES/bar.c
+++ b/tests/data/SOURCES/bar.c
@@ -1,5 +1,16 @@
 #include "foobar.h"
 
+struct debug_types_section1 var_bar1;
+
+/* Use different DW_AT_stmt_list in .debug_types having it outside foobar.h.
+   Also use two types in .debug_types for multiple COMDAT sections in object
+   files.  */
+struct debug_types_section_bar
+{
+  int stringp_bar, stb;
+};
+struct debug_types_section_bar var_bar;
+
 int number = NUMBER;
 
 int

--- a/tests/data/SOURCES/baz.c
+++ b/tests/data/SOURCES/baz.c
@@ -1,5 +1,16 @@
 #include "foobar.h"
 
+struct debug_types_section1 var_baz1;
+
+/* Use different DW_AT_stmt_list in .debug_types having it outside foobar.h.
+   Also use two types in .debug_types for multiple COMDAT sections in object
+   files.  */
+struct debug_types_section_baz
+{
+  int stringp_baz, stz;
+};
+struct debug_types_section_baz var_baz;
+
 int
 main ()
 {

--- a/tests/data/SOURCES/foo.c
+++ b/tests/data/SOURCES/foo.c
@@ -1,5 +1,16 @@
 #include "foobar.h"
 
+struct debug_types_section1 var_foo1;
+
+/* Use different DW_AT_stmt_list in .debug_types having it outside foobar.h.
+   Also use two types in .debug_types for multiple COMDAT sections in object
+   files.  */
+struct debug_types_section_foo
+{
+  int stringp_foo, stf;
+};
+struct debug_types_section_foo var_foo;
+
 int
 foo ()
 {

--- a/tests/data/SOURCES/foobar.h
+++ b/tests/data/SOURCES/foobar.h
@@ -4,3 +4,9 @@ extern int number;
 
 extern int foo (void);
 extern int bar (int);
+
+struct debug_types_section1
+{
+  /* Test both DW_FORM_strp and DW_FORM_string.  */
+  int stringp1, st1;
+};

--- a/tests/debugedit.at
+++ b/tests/debugedit.at
@@ -22,6 +22,7 @@ AT_BANNER([RPM debugedit])
 AT_TESTED([debugedit])
 
 # Helper to create some test binaries.
+# Optional parameter can specify additional gcc parameters.
 m4_define([RPM_DEBUGEDIT_SETUP],[[
 # Create some test binaries. Create and build them in different subdirs
 # to make sure they produce different relative/absolute paths.
@@ -36,11 +37,11 @@ cp "${abs_srcdir}"/data/SOURCES/foobar.h subdir_headers
 cp "${abs_srcdir}"/data/SOURCES/baz.c .
 
 # First three object files (foo.o subdir_bar/bar.o and baz.o)
-gcc -g3 -Isubdir_headers -c subdir_foo/foo.c
+gcc -g3 -Isubdir_headers $1 -c subdir_foo/foo.c
 cd subdir_bar
-gcc -g3 -I../subdir_headers -c bar.c
+gcc -g3 -I../subdir_headers $1 -c bar.c
 cd ..
-gcc -g3 -I$(pwd)/subdir_headers -c $(pwd)/baz.c
+gcc -g3 -I$(pwd)/subdir_headers $1 -c $(pwd)/baz.c
 
 # Then a partially linked object file (somewhat like a kernel module).
 # This will still have relocations between the debug sections.
@@ -245,6 +246,98 @@ AT_CHECK([[debugedit -b $(pwd) -d /foo/bar/baz ./foobarbaz.exe]])
 AT_CHECK([[
 readelf --debug-dump=info ./foobarbaz.exe | grep -E 'DW_AT_(name|comp_dir)' \
         | rev | cut -d: -f1 | rev | cut -c2- | grep ^/foo/bar/baz | sort -u
+]],[0],[expout])
+
+AT_CLEANUP
+
+# ===
+# Make sure -fdebug-types-section has updated strings in objects.
+# ===
+AT_SETUP([debugedit .debug_types objects])
+AT_KEYWORDS([debugtypes] [debugedit])
+RPM_DEBUGEDIT_SETUP([-fdebug-types-section])
+
+AT_DATA([expout],
+[st1
+stf
+stringp1
+stringp_foo
+st1
+stb
+stringp1
+stringp_bar
+st1
+stringp1
+stringp_baz
+stz
+])
+
+AT_CHECK([[debugedit -b $(pwd) -d /foo/bar/baz ./foo.o]])
+AT_CHECK([[debugedit -b $(pwd) -d /foo/bar/baz ./subdir_bar/bar.o]])
+AT_CHECK([[debugedit -b $(pwd) -d /foo/bar/baz ./baz.o]])
+AT_CHECK([[
+for i in ./foo.o ./subdir_bar/bar.o ./baz.o;do \
+  readelf --debug-dump=info $i \
+          | awk '/Abbrev Number:.*DW_TAG_type_unit/{p=1}{if(p)print}/^$/{p=0}' \
+          | sed -n 's/^.*> *DW_AT_name *:.* \(stringp[^ ]*\|st.\)$/\1/p' \
+          | sort;
+done
+]],[0],[expout])
+
+AT_CLEANUP
+
+# ===
+# Make sure -fdebug-types-section has updated strings in partial linked object.
+# ===
+AT_SETUP([debugedit .debug_types partial])
+AT_KEYWORDS([debugtypes] [debugedit])
+RPM_DEBUGEDIT_SETUP([-fdebug-types-section])
+
+AT_DATA([expout],
+[st1
+stb
+stf
+stringp1
+stringp_bar
+stringp_baz
+stringp_foo
+stz
+])
+
+AT_CHECK([[debugedit -b $(pwd) -d /foo/bar/baz ./foobarbaz.part.o]])
+AT_CHECK([[
+readelf --debug-dump=info ./foobarbaz.part.o \
+        | awk '/Abbrev Number:.*DW_TAG_type_unit/{p=1}{if(p)print}/^$/{p=0}' \
+        | sed -n 's/^.*> *DW_AT_name *:.* \(stringp[^ ]*\|st.\)$/\1/p' \
+        | sort
+]],[0],[expout])
+
+AT_CLEANUP
+
+# ===
+# Make sure -fdebug-types-section has updated strings in executable.
+# ===
+AT_SETUP([debugedit .debug_types exe])
+AT_KEYWORDS([debugtypes] [debugedit])
+RPM_DEBUGEDIT_SETUP([-fdebug-types-section])
+
+AT_DATA([expout],
+[st1
+stb
+stf
+stringp1
+stringp_bar
+stringp_baz
+stringp_foo
+stz
+])
+
+AT_CHECK([[debugedit -b $(pwd) -d /foo/bar/baz ./foobarbaz.exe]])
+AT_CHECK([[
+readelf --debug-dump=info ./foobarbaz.exe \
+        | awk '/Abbrev Number:.*DW_TAG_type_unit/{p=1}{if(p)print}/^$/{p=0}' \
+        | sed -n 's/^.*> *DW_AT_name *:.* \(stringp[^ ]*\|st.\)$/\1/p' \
+        | sort
 ]],[0],[expout])
 
 AT_CLEANUP

--- a/tools/debugedit.c
+++ b/tools/debugedit.c
@@ -1965,6 +1965,106 @@ line_rel_cmp (const void *a, const void *b)
 }
 
 static int
+edit_info (DSO *dso, int phase)
+{
+  unsigned char *ptr, *endcu, *endsec;
+  uint32_t value;
+  htab_t abbrev;
+  struct abbrev_tag tag, *t;
+
+  ptr = debug_sections[DEBUG_INFO].data;
+  setup_relbuf(dso, &debug_sections[DEBUG_INFO], &reltype);
+  endsec = ptr + debug_sections[DEBUG_INFO].size;
+  while (ptr < endsec)
+    {
+      if (ptr + 11 > endsec)
+	{
+	  error (0, 0, "%s: .debug_info CU header too small",
+		 dso->filename);
+	  return 1;
+	}
+
+      endcu = ptr + 4;
+      endcu += read_32 (ptr);
+      if (endcu == ptr + 0xffffffff)
+	{
+	  error (0, 0, "%s: 64-bit DWARF not supported", dso->filename);
+	  return 1;
+	}
+
+      if (endcu > endsec)
+	{
+	  error (0, 0, "%s: .debug_info too small", dso->filename);
+	  return 1;
+	}
+
+      cu_version = read_16 (ptr);
+      if (cu_version != 2 && cu_version != 3 && cu_version != 4)
+	{
+	  error (0, 0, "%s: DWARF version %d unhandled", dso->filename,
+		 cu_version);
+	  return 1;
+	}
+
+      value = read_32_relocated (ptr);
+      if (value >= debug_sections[DEBUG_ABBREV].size)
+	{
+	  if (debug_sections[DEBUG_ABBREV].data == NULL)
+	    error (0, 0, "%s: .debug_abbrev not present", dso->filename);
+	  else
+	    error (0, 0, "%s: DWARF CU abbrev offset too large",
+		   dso->filename);
+	  return 1;
+	}
+
+      if (ptr_size == 0)
+	{
+	  ptr_size = read_8 (ptr);
+	  if (ptr_size != 4 && ptr_size != 8)
+	    {
+	      error (0, 0, "%s: Invalid DWARF pointer size %d",
+		     dso->filename, ptr_size);
+	      return 1;
+	    }
+	}
+      else if (read_8 (ptr) != ptr_size)
+	{
+	  error (0, 0, "%s: DWARF pointer size differs between CUs",
+		 dso->filename);
+	  return 1;
+	}
+
+      abbrev = read_abbrev (dso,
+			    debug_sections[DEBUG_ABBREV].data + value);
+      if (abbrev == NULL)
+	return 1;
+
+      while (ptr < endcu)
+	{
+	  tag.entry = read_uleb128 (ptr);
+	  if (tag.entry == 0)
+	    continue;
+	  t = htab_find_with_hash (abbrev, &tag, tag.entry);
+	  if (t == NULL)
+	    {
+	      error (0, 0, "%s: Could not find DWARF abbreviation %d",
+		     dso->filename, tag.entry);
+	      htab_delete (abbrev);
+	      return 1;
+	    }
+
+	  ptr = edit_attributes (dso, ptr, t, phase);
+	  if (ptr == NULL)
+	    break;
+	}
+
+      htab_delete (abbrev);
+    }
+
+  return 0;
+}
+
+static int
 edit_dwarf2 (DSO *dso)
 {
   Elf_Data *data;
@@ -2100,385 +2200,299 @@ edit_dwarf2 (DSO *dso)
       return 1;
     }
 
-  if (debug_sections[DEBUG_INFO].data != NULL)
+  if (debug_sections[DEBUG_INFO].data == NULL)
+    return 0;
+
+  unsigned char *ptr, *endcu, *endsec;
+  uint32_t value;
+  htab_t abbrev;
+  struct abbrev_tag tag, *t;
+  int phase;
+  bool info_rel_updated = false;
+  bool macro_rel_updated = false;
+
+  for (phase = 0; phase < 2; phase++)
     {
-      unsigned char *ptr, *endcu, *endsec;
-      uint32_t value;
-      htab_t abbrev;
-      struct abbrev_tag tag, *t;
-      int phase;
-      bool info_rel_updated = false;
-      bool macro_rel_updated = false;
+      /* If we don't need to update anyhing, skip phase 1. */
+      if (phase == 1
+	  && !need_strp_update
+	  && !need_string_replacement
+	  && !need_stmt_update)
+	break;
 
-      for (phase = 0; phase < 2; phase++)
+      rel_updated = false;
+      if (edit_info (dso, phase))
+       return 1;
+
+      /* Remember whether any .debug_info relocations might need
+	 to be updated. */
+      info_rel_updated = rel_updated;
+
+      /* We might have to recalculate/rewrite the debug_line
+	 section.  We need to do that before going into phase one
+	 so we have all new offsets.  We do this separately from
+	 scanning the dirs/file names because the DW_AT_stmt_lists
+	 might not be in order or skip some padding we might have
+	 to (re)move. */
+      if (phase == 0 && need_stmt_update)
 	{
-	  /* If we don't need to update anyhing, skip phase 1. */
-	  if (phase == 1
-	      && !need_strp_update
-	      && !need_string_replacement
-	      && !need_stmt_update)
-	    break;
+	  edit_dwarf2_line (dso);
 
-	  ptr = debug_sections[DEBUG_INFO].data;
-	  setup_relbuf(dso, &debug_sections[DEBUG_INFO], &reltype);
-	  rel_updated = false;
-	  endsec = ptr + debug_sections[DEBUG_INFO].size;
-	  while (ptr < endsec)
+	  /* The line table programs will be moved
+	     forward/backwards a bit in the new data. Update the
+	     debug_line relocations to the new offsets. */
+	  int rndx = debug_sections[DEBUG_LINE].relsec;
+	  if (rndx != 0)
 	    {
-	      if (ptr + 11 > endsec)
-		{
-		  error (0, 0, "%s: .debug_info CU header too small",
-			 dso->filename);
-		  return 1;
-		}
+	      LINE_REL *rbuf;
+	      size_t rels;
+	      Elf_Data *rdata = elf_getdata (dso->scn[rndx], NULL);
+	      int rtype = dso->shdr[rndx].sh_type;
+	      rels = dso->shdr[rndx].sh_size / dso->shdr[rndx].sh_entsize;
+	      rbuf = malloc (rels * sizeof (LINE_REL));
+	      if (rbuf == NULL)
+		error (1, errno, "%s: Could not allocate line relocations",
+		       dso->filename);
 
-	      endcu = ptr + 4;
-	      endcu += read_32 (ptr);
-	      if (endcu == ptr + 0xffffffff)
+	      /* Sort them by offset into section. */
+	      for (size_t i = 0; i < rels; i++)
 		{
-		  error (0, 0, "%s: 64-bit DWARF not supported", dso->filename);
-		  return 1;
-		}
-
-	      if (endcu > endsec)
-		{
-		  error (0, 0, "%s: .debug_info too small", dso->filename);
-		  return 1;
-		}
-
-	      cu_version = read_16 (ptr);
-	      if (cu_version != 2 && cu_version != 3 && cu_version != 4)
-		{
-		  error (0, 0, "%s: DWARF version %d unhandled", dso->filename,
-			 cu_version);
-		  return 1;
-		}
-
-	      value = read_32_relocated (ptr);
-	      if (value >= debug_sections[DEBUG_ABBREV].size)
-		{
-		  if (debug_sections[DEBUG_ABBREV].data == NULL)
-		    error (0, 0, "%s: .debug_abbrev not present", dso->filename);
-		  else
-		    error (0, 0, "%s: DWARF CU abbrev offset too large",
-			   dso->filename);
-		  return 1;
-		}
-
-	      if (ptr_size == 0)
-		{
-		  ptr_size = read_8 (ptr);
-		  if (ptr_size != 4 && ptr_size != 8)
+		  if (rtype == SHT_RELA)
 		    {
-		      error (0, 0, "%s: Invalid DWARF pointer size %d",
-			     dso->filename, ptr_size);
-		      return 1;
-		    }
-		}
-	      else if (read_8 (ptr) != ptr_size)
-		{
-		  error (0, 0, "%s: DWARF pointer size differs between CUs",
-			 dso->filename);
-		  return 1;
-		}
-
-	      abbrev = read_abbrev (dso,
-				    debug_sections[DEBUG_ABBREV].data + value);
-	      if (abbrev == NULL)
-		return 1;
-
-	      while (ptr < endcu)
-		{
-		  tag.entry = read_uleb128 (ptr);
-		  if (tag.entry == 0)
-		    continue;
-		  t = htab_find_with_hash (abbrev, &tag, tag.entry);
-		  if (t == NULL)
-		    {
-		      error (0, 0, "%s: Could not find DWARF abbreviation %d",
-			     dso->filename, tag.entry);
-		      htab_delete (abbrev);
-		      return 1;
-		    }
-
-		  ptr = edit_attributes (dso, ptr, t, phase);
-		  if (ptr == NULL)
-		    break;
-		}
-
-	      htab_delete (abbrev);
-	    }
-
-	  /* Remember whether any .debug_info relocations might need
-	     to be updated. */
-	  info_rel_updated = rel_updated;
-
-	  /* We might have to recalculate/rewrite the debug_line
-	     section.  We need to do that before going into phase one
-	     so we have all new offsets.  We do this separately from
-	     scanning the dirs/file names because the DW_AT_stmt_lists
-	     might not be in order or skip some padding we might have
-	     to (re)move. */
-	  if (phase == 0 && need_stmt_update)
-	    {
-	      edit_dwarf2_line (dso);
-
-	      /* The line table programs will be moved
-		 forward/backwards a bit in the new data. Update the
-		 debug_line relocations to the new offsets. */
-	      int rndx = debug_sections[DEBUG_LINE].relsec;
-	      if (rndx != 0)
-		{
-		  LINE_REL *rbuf;
-		  size_t rels;
-		  Elf_Data *rdata = elf_getdata (dso->scn[rndx], NULL);
-		  int rtype = dso->shdr[rndx].sh_type;
-		  rels = dso->shdr[rndx].sh_size / dso->shdr[rndx].sh_entsize;
-		  rbuf = malloc (rels * sizeof (LINE_REL));
-		  if (rbuf == NULL)
-		    error (1, errno, "%s: Could not allocate line relocations",
-			   dso->filename);
-
-		  /* Sort them by offset into section. */
-		  for (size_t i = 0; i < rels; i++)
-		    {
-		      if (rtype == SHT_RELA)
-			{
-			  GElf_Rela rela;
-			  if (gelf_getrela (rdata, i, &rela) == NULL)
-			    error (1, 0, "Couldn't get relocation: %s",
-				   elf_errmsg (-1));
-			  rbuf[i].r_offset = rela.r_offset;
-			  rbuf[i].ndx = i;
-			}
-		      else
-			{
-			  GElf_Rel rel;
-			  if (gelf_getrel (rdata, i, &rel) == NULL)
-			    error (1, 0, "Couldn't get relocation: %s",
-				   elf_errmsg (-1));
-			  rbuf[i].r_offset = rel.r_offset;
-			  rbuf[i].ndx = i;
-			}
-		    }
-		  qsort (rbuf, rels, sizeof (LINE_REL), line_rel_cmp);
-
-		  size_t lndx = 0;
-		  for (size_t i = 0; i < rels; i++)
-		    {
-		      /* These relocations only happen in ET_REL files
-			 and are section offsets. */
-		      GElf_Addr r_offset;
-		      size_t ndx = rbuf[i].ndx;
-
-		      GElf_Rel rel;
 		      GElf_Rela rela;
-		      if (rtype == SHT_RELA)
-			{
-			  if (gelf_getrela (rdata, ndx, &rela) == NULL)
-			    error (1, 0, "Couldn't get relocation: %s",
-				   elf_errmsg (-1));
-			  r_offset = rela.r_offset;
-			}
-		      else
-			{
-			  if (gelf_getrel (rdata, ndx, &rel) == NULL)
-			    error (1, 0, "Couldn't get relocation: %s",
-				   elf_errmsg (-1));
-			  r_offset = rel.r_offset;
-			}
-
-		      while (lndx < dso->lines.used
-			     && r_offset > (dso->lines.table[lndx].old_idx
-					    + 4
-					    + dso->lines.table[lndx].unit_length))
-			lndx++;
-
-		      if (lndx >= dso->lines.used)
-			error (1, 0,
-			       ".debug_line relocation offset out of range");
-
-		      /* Offset (pointing into the line program) moves
-			 from old to new index including the header
-			 size diff. */
-		      r_offset += (ssize_t)((dso->lines.table[lndx].new_idx
-					     - dso->lines.table[lndx].old_idx)
-					    + dso->lines.table[lndx].size_diff);
-
-		      if (rtype == SHT_RELA)
-			{
-			  rela.r_offset = r_offset;
-			  if (gelf_update_rela (rdata, ndx, &rela) == 0)
-			    error (1, 0, "Couldn't update relocation: %s",
-				   elf_errmsg (-1));
-			}
-		      else
-			{
-			  rel.r_offset = r_offset;
-			  if (gelf_update_rel (rdata, ndx, &rel) == 0)
-			    error (1, 0, "Couldn't update relocation: %s",
-				   elf_errmsg (-1));
-			}
+		      if (gelf_getrela (rdata, i, &rela) == NULL)
+			error (1, 0, "Couldn't get relocation: %s",
+			       elf_errmsg (-1));
+		      rbuf[i].r_offset = rela.r_offset;
+		      rbuf[i].ndx = i;
 		    }
-
-		  elf_flagdata (rdata, ELF_C_SET, ELF_F_DIRTY);
-		  free (rbuf);
-		}
-	    }
-
-	  /* The .debug_macro section also contains offsets into the
-	     .debug_str section and references to the .debug_line
-	     tables, so we need to update those as well if we update
-	     the strings or the stmts.  */
-	  if ((need_strp_update || need_stmt_update)
-	      && debug_sections[DEBUG_MACRO].data)
-	    {
-	      /* There might be multiple (COMDAT) .debug_macro sections.  */
-	      struct debug_section *macro_sec = &debug_sections[DEBUG_MACRO];
-	      while (macro_sec != NULL)
-		{
-		  setup_relbuf(dso, macro_sec, &reltype);
-		  rel_updated = false;
-
-		  ptr = macro_sec->data;
-		  endsec = ptr + macro_sec->size;
-		  int op = 0, macro_version, macro_flags;
-		  int offset_len = 4, line_offset = 0;
-
-		  while (ptr < endsec)
+		  else
 		    {
-		      if (!op)
-			{
-			  macro_version = read_16 (ptr);
-			  macro_flags = read_8 (ptr);
-			  if (macro_version < 4 || macro_version > 5)
-			    error (1, 0, "unhandled .debug_macro version: %d",
-				   macro_version);
-			  if ((macro_flags & ~2) != 0)
-			    error (1, 0, "unhandled .debug_macro flags: 0x%x",
-				   macro_flags);
+		      GElf_Rel rel;
+		      if (gelf_getrel (rdata, i, &rel) == NULL)
+			error (1, 0, "Couldn't get relocation: %s",
+			       elf_errmsg (-1));
+		      rbuf[i].r_offset = rel.r_offset;
+		      rbuf[i].ndx = i;
+		    }
+		}
+	      qsort (rbuf, rels, sizeof (LINE_REL), line_rel_cmp);
 
-			  offset_len = (macro_flags & 0x01) ? 8 : 4;
-			  line_offset = (macro_flags & 0x02) ? 1 : 0;
+	      size_t lndx = 0;
+	      for (size_t i = 0; i < rels; i++)
+		{
+		  /* These relocations only happen in ET_REL files
+		     and are section offsets. */
+		  GElf_Addr r_offset;
+		  size_t ndx = rbuf[i].ndx;
 
-			  if (offset_len != 4)
-			    error (0, 1,
-				   "Cannot handle 8 byte macro offsets: %s",
-				   dso->filename);
-
-			  /* Update the line_offset if it is there.  */
-			  if (line_offset)
-			    {
-			      if (phase == 0)
-				ptr += offset_len;
-			      else
-				{
-				  size_t idx, new_idx;
-				  idx = do_read_32_relocated (ptr);
-				  new_idx = find_new_list_offs (&dso->lines,
-								idx);
-				  write_32_relocated (ptr, new_idx);
-				}
-			    }
-			}
-
-		      op = read_8 (ptr);
-		      if (!op)
-			continue;
-		      switch(op)
-			{
-			case DW_MACRO_GNU_define:
-			case DW_MACRO_GNU_undef:
-			  read_uleb128 (ptr);
-			  ptr = ((unsigned char *) strchr ((char *) ptr, '\0')
-				 + 1);
-			  break;
-			case DW_MACRO_GNU_start_file:
-			  read_uleb128 (ptr);
-			  read_uleb128 (ptr);
-			  break;
-			case DW_MACRO_GNU_end_file:
-			  break;
-			case DW_MACRO_GNU_define_indirect:
-			case DW_MACRO_GNU_undef_indirect:
-			  read_uleb128 (ptr);
-			  if (phase == 0)
-			    {
-			      size_t idx = read_32_relocated (ptr);
-			      record_existing_string_entry_idx (&dso->strings,
-								idx);
-			    }
-			  else
-			    {
-			      struct stridxentry *entry;
-			      size_t idx, new_idx;
-			      idx = do_read_32_relocated (ptr);
-			      entry = string_find_entry (&dso->strings, idx);
-			      new_idx = strent_offset (entry->entry);
-			      write_32_relocated (ptr, new_idx);
-			    }
-			  break;
-			case DW_MACRO_GNU_transparent_include:
-			  ptr += offset_len;
-			  break;
-			default:
-			  error (1, 0, "Unhandled DW_MACRO op 0x%x", op);
-			  break;
-			}
+		  GElf_Rel rel;
+		  GElf_Rela rela;
+		  if (rtype == SHT_RELA)
+		    {
+		      if (gelf_getrela (rdata, ndx, &rela) == NULL)
+			error (1, 0, "Couldn't get relocation: %s",
+			       elf_errmsg (-1));
+		      r_offset = rela.r_offset;
+		    }
+		  else
+		    {
+		      if (gelf_getrel (rdata, ndx, &rel) == NULL)
+			error (1, 0, "Couldn't get relocation: %s",
+			       elf_errmsg (-1));
+		      r_offset = rel.r_offset;
 		    }
 
-		  if (rel_updated)
-		    macro_rel_updated = true;
-		  macro_sec = macro_sec->next;
+		  while (lndx < dso->lines.used
+			 && r_offset > (dso->lines.table[lndx].old_idx
+					+ 4
+					+ dso->lines.table[lndx].unit_length))
+		    lndx++;
+
+		  if (lndx >= dso->lines.used)
+		    error (1, 0,
+			   ".debug_line relocation offset out of range");
+
+		  /* Offset (pointing into the line program) moves
+		     from old to new index including the header
+		     size diff. */
+		  r_offset += (ssize_t)((dso->lines.table[lndx].new_idx
+					 - dso->lines.table[lndx].old_idx)
+					+ dso->lines.table[lndx].size_diff);
+
+		  if (rtype == SHT_RELA)
+		    {
+		      rela.r_offset = r_offset;
+		      if (gelf_update_rela (rdata, ndx, &rela) == 0)
+			error (1, 0, "Couldn't update relocation: %s",
+			       elf_errmsg (-1));
+		    }
+		  else
+		    {
+		      rel.r_offset = r_offset;
+		      if (gelf_update_rel (rdata, ndx, &rel) == 0)
+			error (1, 0, "Couldn't update relocation: %s",
+			       elf_errmsg (-1));
+		    }
 		}
+
+	      elf_flagdata (rdata, ELF_C_SET, ELF_F_DIRTY);
+	      free (rbuf);
 	    }
-
-	  /* Same for the debug_str section. Make sure everything is
-	     in place for phase 1 updating of debug_info
-	     references. */
-	  if (phase == 0 && need_strp_update)
-	    {
-	      Strtab *strtab = dso->strings.str_tab;
-	      Elf_Data *strdata = debug_sections[DEBUG_STR].elf_data;
-	      int strndx = debug_sections[DEBUG_STR].sec;
-	      Elf_Scn *strscn = dso->scn[strndx];
-
-	      /* Out with the old. */
-	      strdata->d_size = 0;
-	      /* In with the new. */
-	      strdata = elf_newdata (strscn);
-
-	      /* We really should check whether we had enough memory,
-		 but the old ebl version will just abort on out of
-		 memory... */
-	      strtab_finalize (strtab, strdata);
-	      debug_sections[DEBUG_STR].size = strdata->d_size;
-	      dso->strings.str_buf = strdata->d_buf;
-	    }
-
 	}
 
-      /* After phase 1 we might have rewritten the debug_info with
-	 new strp, strings and/or linep offsets.  */
-      if (need_strp_update || need_string_replacement || need_stmt_update)
-	dirty_section (DEBUG_INFO);
-      if (need_strp_update || need_stmt_update)
-	dirty_section (DEBUG_MACRO);
-      if (need_stmt_update)
-	dirty_section (DEBUG_LINE);
-
-      /* Update any relocations addends we might have touched. */
-      if (info_rel_updated)
-	update_rela_data (dso, &debug_sections[DEBUG_INFO]);
-
-      if (macro_rel_updated)
+      /* The .debug_macro section also contains offsets into the
+	 .debug_str section and references to the .debug_line
+	 tables, so we need to update those as well if we update
+	 the strings or the stmts.  */
+      if ((need_strp_update || need_stmt_update)
+	  && debug_sections[DEBUG_MACRO].data)
 	{
+	  /* There might be multiple (COMDAT) .debug_macro sections.  */
 	  struct debug_section *macro_sec = &debug_sections[DEBUG_MACRO];
 	  while (macro_sec != NULL)
 	    {
-	      update_rela_data (dso, macro_sec);
+	      setup_relbuf(dso, macro_sec, &reltype);
+	      rel_updated = false;
+
+	      ptr = macro_sec->data;
+	      endsec = ptr + macro_sec->size;
+	      int op = 0, macro_version, macro_flags;
+	      int offset_len = 4, line_offset = 0;
+
+	      while (ptr < endsec)
+		{
+		  if (!op)
+		    {
+		      macro_version = read_16 (ptr);
+		      macro_flags = read_8 (ptr);
+		      if (macro_version < 4 || macro_version > 5)
+			error (1, 0, "unhandled .debug_macro version: %d",
+			       macro_version);
+		      if ((macro_flags & ~2) != 0)
+			error (1, 0, "unhandled .debug_macro flags: 0x%x",
+			       macro_flags);
+
+		      offset_len = (macro_flags & 0x01) ? 8 : 4;
+		      line_offset = (macro_flags & 0x02) ? 1 : 0;
+
+		      if (offset_len != 4)
+			error (0, 1,
+			       "Cannot handle 8 byte macro offsets: %s",
+			       dso->filename);
+
+		      /* Update the line_offset if it is there.  */
+		      if (line_offset)
+			{
+			  if (phase == 0)
+			    ptr += offset_len;
+			  else
+			    {
+			      size_t idx, new_idx;
+			      idx = do_read_32_relocated (ptr);
+			      new_idx = find_new_list_offs (&dso->lines,
+							    idx);
+			      write_32_relocated (ptr, new_idx);
+			    }
+			}
+		    }
+
+		  op = read_8 (ptr);
+		  if (!op)
+		    continue;
+		  switch(op)
+		    {
+		    case DW_MACRO_GNU_define:
+		    case DW_MACRO_GNU_undef:
+		      read_uleb128 (ptr);
+		      ptr = ((unsigned char *) strchr ((char *) ptr, '\0')
+			     + 1);
+		      break;
+		    case DW_MACRO_GNU_start_file:
+		      read_uleb128 (ptr);
+		      read_uleb128 (ptr);
+		      break;
+		    case DW_MACRO_GNU_end_file:
+		      break;
+		    case DW_MACRO_GNU_define_indirect:
+		    case DW_MACRO_GNU_undef_indirect:
+		      read_uleb128 (ptr);
+		      if (phase == 0)
+			{
+			  size_t idx = read_32_relocated (ptr);
+			  record_existing_string_entry_idx (&dso->strings,
+							    idx);
+			}
+		      else
+			{
+			  struct stridxentry *entry;
+			  size_t idx, new_idx;
+			  idx = do_read_32_relocated (ptr);
+			  entry = string_find_entry (&dso->strings, idx);
+			  new_idx = strent_offset (entry->entry);
+			  write_32_relocated (ptr, new_idx);
+			}
+		      break;
+		    case DW_MACRO_GNU_transparent_include:
+		      ptr += offset_len;
+		      break;
+		    default:
+		      error (1, 0, "Unhandled DW_MACRO op 0x%x", op);
+		      break;
+		    }
+		}
+
+	      if (rel_updated)
+		macro_rel_updated = true;
 	      macro_sec = macro_sec->next;
 	    }
+	}
+
+      /* Same for the debug_str section. Make sure everything is
+	 in place for phase 1 updating of debug_info
+	 references. */
+      if (phase == 0 && need_strp_update)
+	{
+	  Strtab *strtab = dso->strings.str_tab;
+	  Elf_Data *strdata = debug_sections[DEBUG_STR].elf_data;
+	  int strndx = debug_sections[DEBUG_STR].sec;
+	  Elf_Scn *strscn = dso->scn[strndx];
+
+	  /* Out with the old. */
+	  strdata->d_size = 0;
+	  /* In with the new. */
+	  strdata = elf_newdata (strscn);
+
+	  /* We really should check whether we had enough memory,
+	     but the old ebl version will just abort on out of
+	     memory... */
+	  strtab_finalize (strtab, strdata);
+	  debug_sections[DEBUG_STR].size = strdata->d_size;
+	  dso->strings.str_buf = strdata->d_buf;
+	}
+
+    }
+
+  /* After phase 1 we might have rewritten the debug_info with
+     new strp, strings and/or linep offsets.  */
+  if (need_strp_update || need_string_replacement || need_stmt_update)
+    dirty_section (DEBUG_INFO);
+  if (need_strp_update || need_stmt_update)
+    dirty_section (DEBUG_MACRO);
+  if (need_stmt_update)
+    dirty_section (DEBUG_LINE);
+
+  /* Update any relocations addends we might have touched. */
+  if (info_rel_updated)
+    update_rela_data (dso, &debug_sections[DEBUG_INFO]);
+
+  if (macro_rel_updated)
+    {
+      struct debug_section *macro_sec = &debug_sections[DEBUG_MACRO];
+      while (macro_sec != NULL)
+	{
+	  update_rela_data (dso, macro_sec);
+	  macro_sec = macro_sec->next;
 	}
     }
 

--- a/tools/debugedit.c
+++ b/tools/debugedit.c
@@ -433,7 +433,8 @@ typedef struct debug_section
     int sec, relsec;
     REL *relbuf;
     REL *relend;
-    struct debug_section *next; /* Only happens for COMDAT .debug_macro.  */
+    /* Only happens for COMDAT .debug_macro and .debug_types.  */
+    struct debug_section *next;
   } debug_section;
 
 static debug_section debug_sections[] =
@@ -1269,7 +1270,9 @@ static int dirty_elf;
 static void
 dirty_section (unsigned int sec)
 {
-  elf_flagdata (debug_sections[sec].elf_data, ELF_C_SET, ELF_F_DIRTY);
+  for (struct debug_section *secp = &debug_sections[sec]; secp != NULL;
+       secp = secp->next)
+    elf_flagdata (secp->elf_data, ELF_C_SET, ELF_F_DIRTY);
   dirty_elf = 1;
 }
 
@@ -1469,12 +1472,7 @@ read_dwarf2_line (DSO *dso, uint32_t off, char *comp_dir)
 
   if (get_line_table (dso, off, &table) == false
       || table == NULL)
-    {
-      if (table != NULL)
-	error (0, 0, ".debug_line offset 0x%x referenced multiple times",
-	       off);
-      return false;
-    }
+    return false;
 
   /* Skip to the directory table. The rest of the header has already
      been read and checked by get_line_table. */
@@ -1965,22 +1963,25 @@ line_rel_cmp (const void *a, const void *b)
 }
 
 static int
-edit_info (DSO *dso, int phase)
+edit_info (DSO *dso, int phase, struct debug_section *sec)
 {
   unsigned char *ptr, *endcu, *endsec;
   uint32_t value;
   htab_t abbrev;
   struct abbrev_tag tag, *t;
 
-  ptr = debug_sections[DEBUG_INFO].data;
-  setup_relbuf(dso, &debug_sections[DEBUG_INFO], &reltype);
-  endsec = ptr + debug_sections[DEBUG_INFO].size;
+  ptr = sec->data;
+  if (ptr == NULL)
+    return 0;
+
+  setup_relbuf(dso, sec, &reltype);
+  endsec = ptr + sec->size;
   while (ptr < endsec)
     {
-      if (ptr + 11 > endsec)
+      if (ptr + (sec == &debug_sections[DEBUG_INFO] ? 11 : 23) > endsec)
 	{
-	  error (0, 0, "%s: .debug_info CU header too small",
-		 dso->filename);
+	  error (0, 0, "%s: %s CU header too small",
+		 dso->filename, sec->name);
 	  return 1;
 	}
 
@@ -1994,7 +1995,7 @@ edit_info (DSO *dso, int phase)
 
       if (endcu > endsec)
 	{
-	  error (0, 0, "%s: .debug_info too small", dso->filename);
+	  error (0, 0, "%s: %s too small", dso->filename, sec->name);
 	  return 1;
 	}
 
@@ -2033,6 +2034,9 @@ edit_info (DSO *dso, int phase)
 		 dso->filename);
 	  return 1;
 	}
+
+      if (sec != &debug_sections[DEBUG_INFO])
+	ptr += 12; /* Skip type_signature and type_offset.  */
 
       abbrev = read_abbrev (dso,
 			    debug_sections[DEBUG_ABBREV].data + value);
@@ -2095,7 +2099,7 @@ edit_dwarf2 (DSO *dso)
 		  struct debug_section *debug_sec = &debug_sections[j];
 		  if (debug_sections[j].data)
 		    {
-		      if (j != DEBUG_MACRO)
+		      if (j != DEBUG_MACRO && j != DEBUG_TYPES)
 			{
 			  error (0, 0, "%s: Found two copies of %s section",
 				 dso->filename, name);
@@ -2103,22 +2107,21 @@ edit_dwarf2 (DSO *dso)
 			}
 		      else
 			{
-			  /* In relocatable files .debug_macro might
-			     appear multiple times as COMDAT
-			     section.  */
+			  /* In relocatable files .debug_macro and .debug_types
+			     might appear multiple times as COMDAT section.  */
 			  struct debug_section *sec;
 			  sec = calloc (sizeof (struct debug_section), 1);
 			  if (sec == NULL)
 			    error (1, errno,
-				   "%s: Could not allocate more macro sections",
-				   dso->filename);
-			  sec->name = ".debug_macro";
+				   "%s: Could not allocate more %s sections",
+				   dso->filename, name);
+			  sec->name = name;
 
-			  struct debug_section *macro_sec = debug_sec;
-			  while (macro_sec->next != NULL)
-			    macro_sec = macro_sec->next;
+			  struct debug_section *multi_sec = debug_sec;
+			  while (multi_sec->next != NULL)
+			    multi_sec = multi_sec->next;
 
-			  macro_sec->next = sec;
+			  multi_sec->next = sec;
 			  debug_sec = sec;
 			}
 		    }
@@ -2155,23 +2158,23 @@ edit_dwarf2 (DSO *dso)
 			  + (dso->shdr[i].sh_type == SHT_RELA),
 			  debug_sections[j].name) == 0)
 	 	{
-		  if (j == DEBUG_MACRO)
+		  if (j == DEBUG_MACRO || j == DEBUG_TYPES)
 		    {
 		      /* Pick the correct one.  */
 		      int rel_target = dso->shdr[i].sh_info;
-		      struct debug_section *macro_sec = &debug_sections[j];
-		      while (macro_sec != NULL)
+		      struct debug_section *multi_sec = &debug_sections[j];
+		      while (multi_sec != NULL)
 			{
-			  if (macro_sec->sec == rel_target)
+			  if (multi_sec->sec == rel_target)
 			    {
-			      macro_sec->relsec = i;
+			      multi_sec->relsec = i;
 			      break;
 			    }
-			  macro_sec = macro_sec->next;
+			  multi_sec = multi_sec->next;
 			}
-		      if (macro_sec == NULL)
-			error (0, 1, "No .debug_macro reloc section: %s",
-			       dso->filename);
+		      if (multi_sec == NULL)
+			error (0, 1, "No %s reloc section: %s",
+			       debug_sections[j].name, dso->filename);
 		    }
 		  else
 		    debug_sections[j].relsec = i;
@@ -2203,12 +2206,10 @@ edit_dwarf2 (DSO *dso)
   if (debug_sections[DEBUG_INFO].data == NULL)
     return 0;
 
-  unsigned char *ptr, *endcu, *endsec;
-  uint32_t value;
-  htab_t abbrev;
-  struct abbrev_tag tag, *t;
+  unsigned char *ptr, *endsec;
   int phase;
   bool info_rel_updated = false;
+  bool types_rel_updated = false;
   bool macro_rel_updated = false;
 
   for (phase = 0; phase < 2; phase++)
@@ -2221,12 +2222,25 @@ edit_dwarf2 (DSO *dso)
 	break;
 
       rel_updated = false;
-      if (edit_info (dso, phase))
-       return 1;
+      if (edit_info (dso, phase, &debug_sections[DEBUG_INFO]))
+	return 1;
 
       /* Remember whether any .debug_info relocations might need
 	 to be updated. */
       info_rel_updated = rel_updated;
+
+      rel_updated = false;
+      struct debug_section *types_sec = &debug_sections[DEBUG_TYPES];
+      while (types_sec != NULL)
+	{
+	  if (edit_info (dso, phase, types_sec))
+	    return 1;
+	  types_sec = types_sec->next;
+	}
+
+      /* Remember whether any .debug_types relocations might need
+	 to be updated. */
+      types_rel_updated = rel_updated;
 
       /* We might have to recalculate/rewrite the debug_line
 	 section.  We need to do that before going into phase one
@@ -2475,8 +2489,11 @@ edit_dwarf2 (DSO *dso)
 
   /* After phase 1 we might have rewritten the debug_info with
      new strp, strings and/or linep offsets.  */
-  if (need_strp_update || need_string_replacement || need_stmt_update)
+  if (need_strp_update || need_string_replacement || need_stmt_update) {
     dirty_section (DEBUG_INFO);
+    if (debug_sections[DEBUG_TYPES].data != NULL)
+      dirty_section (DEBUG_TYPES);
+  }
   if (need_strp_update || need_stmt_update)
     dirty_section (DEBUG_MACRO);
   if (need_stmt_update)
@@ -2485,6 +2502,15 @@ edit_dwarf2 (DSO *dso)
   /* Update any relocations addends we might have touched. */
   if (info_rel_updated)
     update_rela_data (dso, &debug_sections[DEBUG_INFO]);
+  if (types_rel_updated)
+    {
+      struct debug_section *types_sec = &debug_sections[DEBUG_TYPES];
+      while (types_sec != NULL)
+	{
+	  update_rela_data (dso, types_sec);
+	  types_sec = types_sec->next;
+	}
+    }
 
   if (macro_rel_updated)
     {
@@ -3034,6 +3060,17 @@ main (int argc, char *argv[])
       struct debug_section *next = macro_sec->next;
       free (macro_sec);
       macro_sec = next;
+    }
+
+  /* In case there were multiple (COMDAT) .debug_types sections,
+     free them.  */
+  struct debug_section *types_sec = &debug_sections[DEBUG_TYPES];
+  types_sec = types_sec->next;
+  while (types_sec != NULL)
+    {
+      struct debug_section *next = types_sec->next;
+      free (types_sec);
+      types_sec = next;
     }
 
   poptFreeContext (optCon);


### PR DESCRIPTION
There is a new testcase: `debugedit .debug_types *`