### PR TITLE
Enable thread autodetection for a parallel compression.

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -351,9 +351,12 @@ package or when debugging this package.\
 #		"w9.bzdio"	bzip2 level 9.
 #		"w6.xzdio"	xz level 6, xz's default.
 #		"w7T16.xzdio"	xz level 7 using 16 threads
+#		"w7T0.xzdio"	xz level 7 using %{getncpus} threads
+#		"w7T.xzdio"	xz level 7 using %{getncpus} threads
 #		"w6.lzdio"	lzma-alone level 6, lzma's default
 #		"w3.zstdio"	zstd level 3, zstd's default
 #		"w19T8.zstdio"	zstd level 19 using 8 threads
+#		"w7T0.zstdio"	zstd level 7 using %{getncpus} threads
 #		"w.ufdio"	uncompressed
 #
 #%_source_payload	w9.gzdio

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -1087,8 +1087,12 @@ static rpmzstd rpmzstdNew(int fdno, const char *fmode)
 	    continue;
 	case 'T':
 	    c = *s++;
-	    if (c >= (int)'0' && c <= (int)'9')
+	    if (c >= (int)'0' && c <= (int)'9') {
 		threads = strtol(s-1, (char **)&s, 10);
+		/* T0 means automatic detection */
+		if (threads == 0)
+		  threads = -1;
+	    }
 	    continue;
 	default:
 	    if (c >= (int)'0' && c <= (int)'9') {
@@ -1127,9 +1131,11 @@ static rpmzstd rpmzstdNew(int fdno, const char *fmode)
 	    goto err;
 	}
 
-	if (threads > 0)
+	threads = get_compression_threads(threads);
+	if (threads > 0) {
 	    if (ZSTD_isError (ZSTD_CCtx_setParameter(_stream, ZSTD_c_nbWorkers, threads)))
 		rpmlog(RPMLOG_DEBUG, "zstd library does not support multi-threading\n");
+	}
 
 	nb = ZSTD_CStreamOutSize();
     }


### PR DESCRIPTION
When using xz or zstd, it can be handy to automatically detect
number of threads. We can use `%{getncpus}` for that.