### PR TITLE
Fix changelog trimming to work relative to newest existing entry (#1301)

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -212,8 +212,12 @@ package or when debugging this package.\
 %__global_requires_exclude_from		%{?_docdir:%{_docdir}}
 %__global_provides_exclude_from		%{?_docdir:%{_docdir}}
 
+#	Maximum age of preserved changelog entries in binary packages,
+#	relative to newest existing entry. Unix timestamp format.
+%_changelog_trimage	0
+
 #	The Unix time of the latest kept changelog entry in binary packages.
-#	Any older entry is not packaged in binary packages.
+#	DEPRACATED, use %_changelog_trimage instead.
 %_changelog_trimtime	0
 
 #	If true, set the SOURCE_DATE_EPOCH environment variable


### PR DESCRIPTION
%_changelog_trimtime is an absolute timestamp which needs to be constantly
pushed forward to preserve the same relative age, and will start trimming
entries from unchanged packages until none are left, leading to unexpected
and confusing behavior (RhBug:1722806, ...)

It's better to trim by age relative to newest changelog entry. This way the
number of trimmed entries will not change unless the spec changes, and at
least one entry is always preserved. Introduce a new %_changelog_trimage
macro for this and mark the broken by design %_changelog_trimtime as
deprecated, but autoconvert an existing trimtime into relative for now.

As a seemingly unrelated change, move the "time" variable declaration
to a narrower scope to unmask the time() function for use on entry.

Fixes: #1301