### PR TITLE
Work around buggy signature region preventing resigning (RhBug:1851508)

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -399,11 +399,19 @@ exit:
 static void unloadImmutableRegion(Header *hdrp, rpmTagVal tag)
 {
     struct rpmtd_s td;
+    Header oh = NULL;
 
     if (headerGet(*hdrp, tag, &td, HEADERGET_DEFAULT)) {
-	Header oh = headerCopyLoad(td.data);
-	Header nh = headerCopy(oh);
+	oh = headerCopyLoad(td.data);
 	rpmtdFreeData(&td);
+    } else {
+	/* XXX should we warn if the immutable region is corrupt/missing? */
+	oh = headerLink(*hdrp);
+    }
+
+    if (oh) {
+	/* Perform a copy to eliminate crud from buggy signing tools etc */
+	Header nh = headerCopy(oh);
 	headerFree(*hdrp);
 	*hdrp = headerLink(nh);
 	headerFree(nh);


### PR DESCRIPTION
Various proprietary packages in the wild have subtly malformed data
in the signature header, in particular wrt the immutable region size,
presumably from using some in-house/3rd party signing tools which do
not understand the immutable region business at all. This can prevent
resigning and signature deletion on such packages due to the more
thorough checking that rpmsign does.

As the old wisdom goes, be liberal in what you accept... we can easily
work around the crud by just taking a fresh copy of the contents that
are legit as such (otherwise the package would be uninstallable).