### PR TITLE
Remove support for redundant %_filter_GLIBC_PRIVATE mechanism

### DIFF
--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,4 +1,4 @@
-%__elf_provides		%{_rpmconfigdir}/elfdeps --provides %{?__filter_GLIBC_PRIVATE:--filter-private}
-%__elf_requires		%{_rpmconfigdir}/elfdeps --requires %{?__filter_GLIBC_PRIVATE:--filter-private}
+%__elf_provides		%{_rpmconfigdir}/elfdeps --provides
+%__elf_requires		%{_rpmconfigdir}/elfdeps --requires
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
 %__elf_flags		exeonly

--- a/macros.in
+++ b/macros.in
@@ -538,10 +538,6 @@ package or when debugging this package.\
 # Use internal dependency generator rather than external helpers?
 %_use_internal_dependency_generator	1
 
-#
-# Filter GLIBC_PRIVATE Provides: and Requires:
-%_filter_GLIBC_PRIVATE			0
-
 # Directories whose contents should be considered as documentation.
 %__docdir_path %{_datadir}/doc:%{_datadir}/man:%{_datadir}/info:%{_datadir}/gtk-doc/html:%{_datadir}/gnome/help:%{?_docdir}:%{?_mandir}:%{?_infodir}:%{?_javadocdir}:/usr/doc:/usr/man:/usr/info:/usr/X11R6/man
 

--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -13,7 +13,6 @@
 #include <rpm/rpmstring.h>
 #include <rpm/argv.h>
 
-int filter_private = 0;
 int soname_only = 0;
 int fake_soname = 1;
 int filter_soname = 1;
@@ -34,11 +33,6 @@ typedef struct elfInfo_s {
     ARGV_t requires;
     ARGV_t provides;
 } elfInfo;
-
-static int skipPrivate(const char *s)
-{ 
-    return (filter_private && rstreq(s, "GLIBC_PRIVATE"));
-}
 
 /*
  * Rough soname sanity filtering: all sane soname's dependencies need to
@@ -144,7 +138,7 @@ static void processVerDef(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 		    soname = rstrdup(s);
 		    auxoffset += aux->vda_next;
 		    continue;
-		} else if (soname && !soname_only && !skipPrivate(s)) {
+		} else if (soname && !soname_only) {
 		    addDep(&ei->provides, soname, s, ei->marker);
 		}
 	    }
@@ -183,7 +177,7 @@ static void processVerNeed(Elf_Scn *scn, GElf_Shdr *shdr, elfInfo *ei)
 		if (s == NULL)
 		    break;
 
-		if (ei->isExec && soname && !soname_only && !skipPrivate(s)) {
+		if (ei->isExec && soname && !soname_only) {
 		    addDep(&ei->requires, soname, s, ei->marker);
 		}
 		auxoffset += aux->vna_next;
@@ -361,7 +355,6 @@ int main(int argc, char *argv[])
     struct poptOption opts[] = {
 	{ "provides", 'P', POPT_ARG_VAL, &provides, -1, NULL, NULL },
 	{ "requires", 'R', POPT_ARG_VAL, &requires, -1, NULL, NULL },
-	{ "filter-private", 0, POPT_ARG_VAL, &filter_private, -1, NULL, NULL },
 	{ "soname-only", 0, POPT_ARG_VAL, &soname_only, -1, NULL, NULL },
 	{ "no-fake-soname", 0, POPT_ARG_VAL, &fake_soname, 0, NULL, NULL },
 	{ "no-filter-soname", 0, POPT_ARG_VAL, &filter_soname, 0, NULL, NULL },


### PR DESCRIPTION
This was kinda ugly-but-necessary when added back in 2003 (commit
752cac72e220dcad4e6fce39508e714e59e3e0a1) but entirely redundant
since the "new" dependency generator in rpm >= 4.9.x with arbitrary
filtering support. The handful of packages using it can just as well
achieve the same (and more) without special hacks in rpm with:

	%global __requires_exclude GLIBC_PRIVATE
	%global __provides_exclude GLIBC_PRIVATE