### PR TITLE
Prevent automatic garbage collection in git based %autosetup macros

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1210,6 +1210,7 @@ package or when debugging this package.\
 %{__git} init %{-q}\
 %{__git} config user.name "%{__scm_username}"\
 %{__git} config user.email "%{__scm_usermail}"\
+%{__git} config gc.auto 0\
 %{__git} add --force .\
 %{__git} commit %{-q} --allow-empty -a\\\
 	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"


### PR DESCRIPTION
The garbage collection happens in background, based on heuristic.
This means that sometimes, when subsequent commands run,
some files might disappear in the middle of an action.

For example, when a find is used in %prep:

    + /usr/bin/git commit -m ... --author 'rpm-build <rpm-build>'
    Auto packing the repository in background for optimum performance.
    See "git help gc" for manual housekeeping.
    ...
    + find ...
    find: './.git/objects/47': No such file or directory
    find: './.git/objects/46': No such file or directory
    find: './.git/objects/49': No such file or directory
    find: './.git/objects/4d': No such file or directory
    error: Bad exit status from /var/tmp/rpm-tmp.xxxxxx (%prep)