### PR TITLE
Warn and fall back to dummy database on unknown database backend config

### DIFF
--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -77,6 +77,11 @@ dbDetectBackend(rpmdb rdb)
 	}
     }
 
+    if (!cfg) {
+	rpmlog(RPMLOG_WARNING, _("invalid %%_db_backend: %s\n"), db_backend);
+	goto exit;
+    }
+
     /* If configured database doesn't exist, try autodetection */
     if (!tryBackend(dbhome, cfg)) {
 	for (ops = backends; ops && *ops; ops++) {
@@ -106,6 +111,7 @@ dbDetectBackend(rpmdb rdb)
     if (rdb->db_ops == NULL && cfg)
 	rdb->db_ops = cfg;
 
+exit:
     /* If all else fails... */
     if (rdb->db_ops == NULL) {
 	rdb->db_ops = &dummydb_dbops;


### PR DESCRIPTION
The rpmdb is our most precious piece of data, don't make assumptions on
invalid configuration. Together with our crazy create-db-on-read behavior,
total database loss is just one 'rpmdb --rebuilddb' away in some scenarios
with the former behavior: access an sqlite/ndb database with older
version not supporting those, silently fallback to creating empty bdb,
and if db is now rebuilt, poof the data is gone.

Detect and warn on unknown/invalid %_db_backend configuration and fall
back to using dummy backend where no damage can occur. Doesn't help with
the old versions out there, but lets at least be saner going forward.