### PR TITLE
Upgrade FA_TOUCH to FA_CREATE if the file went away (RhBug:1872141)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,6 +73,7 @@ EXTRA_DIST += data/SPECS/scriptfail.spec
 EXTRA_DIST += data/SPECS/scriptfile.spec
 EXTRA_DIST += data/SPECS/selfconflict.spec
 EXTRA_DIST += data/SPECS/shebang.spec
+EXTRA_DIST += data/SPECS/suicidal.spec
 EXTRA_DIST += data/SPECS/replacetest.spec
 EXTRA_DIST += data/SPECS/triggers.spec
 EXTRA_DIST += data/SPECS/filetriggers.spec

--- a/tests/data/SPECS/suicidal.spec
+++ b/tests/data/SPECS/suicidal.spec
@@ -1,0 +1,19 @@
+Name: suicidal
+Version: 1
+Release: %{rel}
+License: GPL
+Group: Testing
+Summary: Testing suicidal package behavior
+BuildArch: noarch
+
+%description
+
+%build
+mkdir -p %{buildroot}/opt
+echo shoot > %{buildroot}/opt/foot
+
+%pre -p <lua>
+os.remove('/opt/foot')
+
+%files
+/opt/foot

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -683,3 +683,42 @@ test -e ${RPMTEST}/opt/vattrtest/a || exit 1
 [],
 [])
 AT_CLEANUP
+
+AT_SETUP([rpm -U <suicidal>])
+AT_KEYWORDS([install])
+RPMDB_INIT
+
+for r in 1 2; do
+    runroot rpmbuild -bb --quiet \
+		--define "rel ${r}" \
+		/data/SPECS/suicidal.spec
+done
+
+AT_CHECK([
+RPMDB_INIT
+
+for r in 1 2; do
+    runroot rpm -U \
+	--define "_minimize_writes 0" \
+	/build/RPMS/noarch/suicidal-1-${r}.noarch.rpm
+done
+runroot rpm -V --nouser --nogroup suicidal
+],
+[0],
+[],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+
+for r in 1 2; do
+    runroot rpm -U \
+	--define "_minimize_writes 1" \
+	/build/RPMS/noarch/suicidal-1-${r}.noarch.rpm
+done
+runroot rpm -V --nouser --nogroup suicidal
+],
+[0],
+[],
+[])
+AT_CLEANUP


### PR DESCRIPTION
When %_minimize_writes is enabled, we determine unchanged files during
fingerprinting and only update their metadata (FA_TOUCH) instead of
always recreating from scratch (FA_CREATE) during install. However
package scriptlets (and administrators) can and will do arbitrary stuff
in the meanwhile, such as rm -f their own files in %pre, hoping to
get a fresh copy of contents no matter what. Or something.
Now, if the file was determined to not need changing by rpm, this will
just fail with chown & friends trying to touch non-existent file.
One can consider this a case of package shooting itself in the foot, but
when a package update fails or succeeds depending on %_minimize_writes this
to me suggests the feature is at fault as much as the package.

Do fsmVerify() on all files to be FA_TOUCH'ed to detect files whose
type changed or were removed since fingerprinting. This still doesn't
ensure correctness if something tampers with the contents in the meanwhile,
(for that we'd need to run the file through the whole machinery again,
checksumming and all) but covers the most glaring cases.