### PR TITLE
Stop untranslatable format strings from being translated

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -451,7 +451,7 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
     }
 
     if (c < -1) {
-	rpmlog(RPMLOG_ERR, _("%s: %s: %s\n"), poptStrerror(c), 
+	rpmlog(RPMLOG_ERR, "%s: %s: %s\n", poptStrerror(c),
 		poptBadOption(optCon, POPT_BADOPTION_NOALIAS), line);
 	goto exit;
     }

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -113,13 +113,13 @@ static char * realDateFormat(rpmtd td, const char * strftimeFormat, char **emsg)
 /* date formatting */
 static char * dateFormat(rpmtd td, char **emsg)
 {
-    return realDateFormat(td, _("%c"), emsg);
+    return realDateFormat(td, "%c", emsg);
 }
 
 /* day formatting */
 static char * dayFormat(rpmtd td, char **emsg)
 {
-    return realDateFormat(td, _("%a %b %d %Y"), emsg);
+    return realDateFormat(td, "%a %b %d %Y", emsg);
 }
 
 /* shell escape formatting */

--- a/lib/poptI.c
+++ b/lib/poptI.c
@@ -26,7 +26,7 @@ struct rpmInstallArguments_s rpmIArgs = {
 RPM_GNUC_NORETURN
 static void argerror(const char * desc)
 {
-    fprintf(stderr, _("%s: %s\n"), xgetprogname(), desc);
+    fprintf(stderr, "%s: %s\n", xgetprogname(), desc);
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
There's nothing to translate in "%s: %s" and the like, don't bother
people with this stuff.