### PR TITLE
[WIP] Use semaphore for compression in ZSTD.

### DIFF
--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -24,6 +24,9 @@
 
 #include "debug.h"
 
+/* Compression semaphore shared among threads.  */
+sem_t *comp_semaphore = NULL;
+
 typedef struct FDSTACK_s * FDSTACK_t;
 
 struct FDSTACK_s {
@@ -1135,6 +1138,7 @@ static rpmzstd rpmzstdNew(int fdno, const char *fmode)
 	if (threads > 0) {
 	    if (ZSTD_isError (ZSTD_CCtx_setParameter(_stream, ZSTD_c_nbWorkers, threads)))
 		rpmlog(RPMLOG_DEBUG, "zstd library does not support multi-threading\n");
+            ZSTD_useSemaphore (_stream, comp_semaphore);
 	}
 
 	nb = ZSTD_CStreamOutSize();

--- a/rpmio/rpmio.h
+++ b/rpmio/rpmio.h
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <semaphore.h>
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmsw.h>
@@ -135,6 +136,8 @@ typedef enum fdOpX_e {
  *
  */
 rpmop fdOp(FD_t fd, fdOpX opx);
+
+extern sem_t *comp_semaphore;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This proof-of-concept patch can handle when parallel compression happens in the context of parallel `.rpm` file creation.
It's mentioned here: #1324 and compression semaphore can handle that. `zstd` counterpart is here: facebook/zstd#2290.