### PR TITLE
doPatch: send patch name to %__patch

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -97,9 +97,10 @@ static char *doPatch(rpmSpec spec, uint32_t c, int strip, const char *db,
     /* Avoid the extra cost of fork and pipe for uncompressed patches */
     if (compressed != COMPRESSED_NOT) {
 	patchcmd = rpmExpand("{ %{uncompress: ", fn, "} || echo patch_fail ; } | "
-                             "%{__patch} ", args, NULL);
+                         "RPM_PATCH_NAME=", sp->path,
+                             " %{__patch} ", args, NULL);
     } else {
-	patchcmd = rpmExpand("%{__patch} ", args, " < ", fn, NULL);
+	patchcmd = rpmExpand("RPM_PATCH_NAME=", sp->path, " %{__patch} ", args, " < ", fn, NULL);
     }
 
     free(arg_fuzz);


### PR DESCRIPTION
when people override %__patch, they are able to process the patch name
now with this change

we need this change for creating repositories with expanded sources for CentOS Stream.