### PR TITLE
Fix some address-sanitizer findings

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2838,6 +2838,7 @@ static rpmTag copyTagsFromMainDebug[] = {
     RPMTAG_OS,
     RPMTAG_PLATFORM,
     RPMTAG_OPTFLAGS,
+    0
 };
 
 /* this is a hack: patch the summary and the description to include

--- a/rpmio/rpmstrpool.c
+++ b/rpmio/rpmstrpool.c
@@ -88,11 +88,12 @@ static inline unsigned int rstrnlenhash(const char * str, size_t n, size_t * len
     unsigned int hash = 0xe4721b68;
     const char * s = str;
 
-    while (*s != '\0' && n-- > 0) {
+    while (n > 0 && *s != '\0') {
       hash += *s;
       hash += (hash << 10);
       hash ^= (hash >> 6);
       s++;
+      n--;
     }
     hash += (hash << 3);
     hash ^= (hash >> 11);


### PR DESCRIPTION
- Fix possible read beyond buffer in rstrnlenhash()
- Add missing terminator to copyTagsFromMainDebug array