### PR TITLE
Disable SSD auto-detection, mark %_minimize_writes as experimental

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1486,12 +1486,15 @@ static void ensureMacro(const char *name, const char *def)
 /* Enable / disable optimizations for solid state disks */
 static void setSSD(int enable)
 {
+    /* XXX _minimize_writes is not safe for mass-consumption yet */
+#if 0
     if (enable) {
 	rpmlog(RPMLOG_DEBUG, "optimizing for non-rotational disks\n");
 	ensureMacro("_minimize_writes", "1");
     } else {
 	rpmPopMacro(NULL, "_minimize_writes");
     }
+#endif
 }
 
 static int rpmtsFinish(rpmts ts)

--- a/macros.in
+++ b/macros.in
@@ -716,7 +716,7 @@ package or when debugging this package.\
 %_pkgverify_flags 0x0
 
 # Minimize writes during transactions (at the cost of more reads) to
-# conserve eg SSD disks.
+# conserve eg SSD disks (EXPERIMENTAL).
 # 1			enable
 # 0 			disable
 # -1 (or undefined)	autodetect on platforms where supported, otherwise


### PR DESCRIPTION
RhBug:1872141 (PR #1347) demonstrates how brittle and dangerous this
thing is. Until we can (re-)verify (digest and all) files not needing recreating from
fsm, this thing should be considered experimental and too dangerous
to automatically enable for casual users.