### PR TITLE
Add API for clone rpmps iterator (func rpmpsiClone)

### DIFF
--- a/lib/rpmps.c
+++ b/lib/rpmps.c
@@ -69,6 +69,17 @@ rpmpsi rpmpsFreeIterator(rpmpsi psi)
     return NULL;
 }
 
+rpmpsi rpmpsiClone(rpmpsi psi)
+{
+    rpmpsi clonedPsi = NULL;
+    if (psi != NULL) {
+	clonedPsi = xcalloc(1, sizeof(*clonedPsi));
+	clonedPsi->ps = rpmpsLink(psi->ps);
+	clonedPsi->ix = psi->ix;
+    }
+    return clonedPsi;
+}
+
 rpmProblem rpmpsiNext(rpmpsi psi)
 {
     rpmProblem p = NULL;

--- a/lib/rpmps.h
+++ b/lib/rpmps.h
@@ -48,6 +48,13 @@ rpmpsi rpmpsInitIterator(rpmps ps);
 rpmpsi rpmpsFreeIterator(rpmpsi psi);
 
 /** \ingroup rpmps
+ * Clone problem set iterator.
+ * @param psi		problem set iterator
+ * @return		new (cloned) problem set iterator
+ */
+rpmpsi rpmpsiClone(rpmpsi psi);
+
+/** \ingroup rpmps
  * Return next problem from iterator
  * @param psi		problem set iterator
  * @return		next problem (weak ref), NULL on termination


### PR DESCRIPTION
There is missing API for cloning iterators in rpm library. PR adds function for cloning rpm problem set iterator.

The same is needed for others iterators.
Why cloning of iterator is required? Eg. for implementing post-increment operator++(int) in C++ wrapper.