### PR TITLE
New transaction callback mode based around transaction elements

### DIFF
--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -95,7 +95,7 @@ void * rpmShowProgress(const void * arg,
 			fnpyKey key,
 			void * data)
 {
-    Header h = (Header) arg;
+    rpmte te = (rpmte) arg;
     int flags = (int) ((long)data);
     void * rc = NULL;
     const char * filename = (const char *)key;
@@ -143,21 +143,18 @@ void * rpmShowProgress(const void * arg,
 	}
 		
 	rpmcliHashesCurrent = 0;
-	if (h == NULL || !(flags & INSTALL_LABEL))
+	if (te == NULL || !(flags & INSTALL_LABEL))
 	    break;
 	if (flags & INSTALL_HASH) {
-	    char *s = headerGetAsString(h, RPMTAG_NEVR);
+	    const char *s = rpmteNEVR(te);
 	    if (isatty (STDOUT_FILENO))
 		fprintf(stdout, "%4d:%-33.33s", rpmcliProgressCurrent + 1, s);
 	    else
 		fprintf(stdout, "%-38.38s", s);
 	    (void) fflush(stdout);
-	    free(s);
 	} else {
-	    char *s = headerGetAsString(h, RPMTAG_NEVRA);
-	    fprintf(stdout, "%s\n", s);
+	    fprintf(stdout, "%s\n", rpmteNEVRA(te));
 	    (void) fflush(stdout);
-	    free(s);
 	}
 	break;
 
@@ -231,6 +228,7 @@ static void setNotifyFlag(struct rpmInstallArguments_s * ia,
 
     notifyFlags = ia->installInterfaceFlags | (rpmIsVerbose() ? INSTALL_LABEL : 0 );
     rpmtsSetNotifyCallback(ts, rpmShowProgress, (void *) ((long)notifyFlags));
+    rpmtsSetNotifyStyle(ts, 1);
 }
 
 struct rpmEIU {

--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -29,6 +29,7 @@
 struct rpmte_s {
     rpmElementType type;	/*!< Package disposition (installed/removed). */
 
+    void *priv;			/*!< Private user data. */
     Header h;			/*!< Package header. */
     char * NEVR;		/*!< Package name-version-release. */
     char * NEVRA;		/*!< Package name-version-release.arch. */
@@ -424,6 +425,17 @@ FD_t rpmteSetFd(rpmte te, FD_t fd)
 fnpyKey rpmteKey(rpmte te)
 {
     return (te != NULL ? te->key : NULL);
+}
+
+void rpmteSetPriv(rpmte te, void *priv)
+{
+    if (te)
+	te->priv = priv;
+}
+
+void *rpmtePriv(rpmte te)
+{
+    return (te != NULL ? te->priv : NULL);
 }
 
 rpmds rpmteDS(rpmte te, rpmTagVal tag)

--- a/lib/rpmte.h
+++ b/lib/rpmte.h
@@ -217,6 +217,20 @@ const char * rpmteNEVRA(rpmte te);
 fnpyKey rpmteKey(rpmte te);
 
 /** \ingroup rpmte
+ * Set private user data of transaction element.
+ * @param te		transaction element
+ * @param priv		pointer to private user data
+ */
+void rpmteSetPriv(rpmte te, void *priv);
+
+/** \ingroup rpmte
+ * Retrieve private user data of transaction element.
+ * @param te		transaction element
+ * @return		pointer to private user data
+ */
+void *rpmtePriv(rpmte te);
+
+/** \ingroup rpmte
  * Return failure status of transaction element.
  * If the element itself failed, this is 1, larger count means one of
  * it's parents failed.

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -925,13 +925,19 @@ void * rpmtsNotify(rpmts ts, rpmte te,
 {
     void * ptr = NULL;
     if (ts && ts->notify) {
+	void *arg = NULL;
 	Header h = NULL;
 	fnpyKey cbkey = NULL;
 	if (te) {
-	    h = rpmteHeader(te);
+	    if (ts->notifyStyle == 0) {
+		h = rpmteHeader(te);
+		arg = h;
+	    } else {
+		arg = te;
+	    }
 	    cbkey = rpmteKey(te);
 	}
-	ptr = ts->notify(h, what, amount, total, cbkey, ts->notifyData);
+	ptr = ts->notify(arg, what, amount, total, cbkey, ts->notifyData);
 
 	if (h) {
 	    headerFree(h); /* undo rpmteHeader() ref */
@@ -1040,6 +1046,21 @@ int rpmtsSetNotifyCallback(rpmts ts,
 	ts->notifyData = notifyData;
     }
     return 0;
+}
+
+int rpmtsSetNotifyStyle(rpmts ts, int style)
+{
+    if (ts != NULL)
+	ts->notifyStyle = style;
+    return 0;
+}
+
+int rpmtsGetNotifyStyle(rpmts ts)
+{
+    int style = 0;
+    if (ts != NULL)
+	style = ts->notifyStyle;
+    return style;
 }
 
 tsMembers rpmtsMembers(rpmts ts)

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -586,6 +586,18 @@ int rpmtsSetNotifyCallback(rpmts ts,
 		rpmCallbackData notifyData);
 
 /** \ingroup rpmts
+ * Set transaction notify callback style.
+ *
+ * @param ts		transaction set
+ * @param style		0 (default) for header, 1 for transaction element
+ * 			as the first argument
+ * @return		0 on success
+ */
+int rpmtsSetNotifyStyle(rpmts ts, int style);
+
+int rpmtsGetNotifyStyle(rpmts ts);
+
+/** \ingroup rpmts
  * Create an empty transaction set.
  * @return		new transaction set
  */

--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -50,6 +50,7 @@ struct rpmts_s {
 
     rpmCallbackFunction notify;	/*!< Callback function. */
     rpmCallbackData notifyData;	/*!< Callback private data. */
+    int notifyStyle;		/*!< Callback style (header vs rpmte) */
 
     rpmprobFilterFlags ignoreSet;
 				/*!< Bits to filter current problems. */

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1471,6 +1471,8 @@ static int rpmtsSetup(rpmts ts, rpmprobFilterFlags ignoreSet)
     return 0;
 }
 
+/* XXX _minimize_writes is not safe for mass-consumption yet */
+#if 0
 /* Push a macro with current value or default if no previous value exists */
 static void ensureMacro(const char *name, const char *def)
 {
@@ -1486,16 +1488,18 @@ static void ensureMacro(const char *name, const char *def)
 /* Enable / disable optimizations for solid state disks */
 static void setSSD(int enable)
 {
-    /* XXX _minimize_writes is not safe for mass-consumption yet */
-#if 0
     if (enable) {
 	rpmlog(RPMLOG_DEBUG, "optimizing for non-rotational disks\n");
 	ensureMacro("_minimize_writes", "1");
     } else {
 	rpmPopMacro(NULL, "_minimize_writes");
     }
-#endif
 }
+#else
+static void setSSD(int enable)
+{
+}
+#endif
 
 static int rpmtsFinish(rpmts ts)
 {

--- a/python/rpm/transaction.py
+++ b/python/rpm/transaction.py
@@ -108,8 +108,8 @@ class TransactionSet(TransactionSetCore):
             if not TransactionSetCore.addErase(self, h):
                 raise rpm.error("adding erasure to transaction failed")
 
-    def run(self, callback, data):
-        rc = TransactionSetCore.run(self, callback, data, self._probFilter)
+    def run(self, callback, data, cbstyle=0):
+        rc = TransactionSetCore.run(self, callback, data, self._probFilter, cbstyle)
 
         # crazy backwards compatibility goo: None for ok, list of problems
         # if transaction didn't complete and empty list if it completed

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -153,6 +153,30 @@ rpmte_Key(rpmteObject * s, PyObject * unused)
 }
 
 static PyObject *
+rpmte_SetPriv(rpmteObject * s, PyObject *arg)
+{
+    /* XXX how to insure this is a PyObject??? */
+    PyObject *o = rpmtePriv(s->te);
+    rpmteSetPriv(s->te, arg);
+    Py_INCREF(arg);
+    Py_XDECREF(o);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+rpmte_Priv(rpmteObject * s)
+{
+    PyObject *po = Py_None;
+    void *priv = rpmtePriv(s->te);
+
+    if (priv)
+	po = priv;
+
+    Py_INCREF(po);
+    return po;
+}
+
+static PyObject *
 rpmte_DS(rpmteObject * s, PyObject * args, PyObject * kwds)
 {
     rpmds ds;
@@ -233,8 +257,12 @@ static struct PyMethodDef rpmte_methods[] = {
     {"Failed",	(PyCFunction)rpmte_Failed,	METH_NOARGS,
      "te.Failed() -- Return if there are any related errors."},
     {"Key",	(PyCFunction)rpmte_Key,		METH_NOARGS,
-     "te.Key() -- Return the associated opaque key aka user data\n\
+     "te.Key() -- Return the associated opaque retrieval key\n\
 	as passed e.g. as data arg ts.addInstall()"},
+    {"Priv",	(PyCFunction)rpmte_Priv,	METH_NOARGS,
+     "te.Priv() -- Return associated user data (if any)\n"},
+    {"SetPriv",	(PyCFunction)rpmte_SetPriv,	METH_O,
+     "te.Priv() -- Set associated user data (if any)\n"},
     {"DS",	(PyCFunction)rpmte_DS,		METH_VARARGS|METH_KEYWORDS,
 "te.DS(TagN) -- Return the TagN dependency set (or None).\n\
 	TagN is one of 'Providename', 'Requirename', 'Obsoletename',\n\

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -316,6 +316,20 @@ for e in ts:
 [adding upgrade to transaction failed]
 )
 
+RPMPY_TEST([transaction element userdata],[
+mydata = { 'foo': 'bar', 'capstest': 'lock' }
+ts = rpm.ts()
+ts.addInstall('${RPMDATA}/RPMS/foo-1.0-1.noarch.rpm', 'u')
+ts.addInstall('${RPMDATA}/RPMS/capstest-1.0-1.noarch.rpm', 'u')
+for e in ts:
+    e.SetPriv(mydata[e.N()])
+for e in ts:
+    myprint(e.Priv())
+],
+[bar
+lock]
+)
+
 AT_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
 AT_CHECK([


### PR DESCRIPTION
This adds a new optional transaction callback mode where instead of a header, the associated rpm transaction element is passed as the first argument, eliminating a whole class of problems with trying to find which package a given callback was associated with etc. Also added is a private user data storage for transaction elements, which is now trivially retrievable in the (new style) callback. This all makes things nicer for things like depsolvers, especially in Python side the difference is *huge* but nice in C side too.
More details in commit messages.

The exact arguments both in C and Python callbacks are open to discussion! This is just a quick draft to finally address an ages old misdesign (the Python callback horror in particular) 