### PR TITLE
Implement alternative transaction callback style

### DIFF
--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -928,13 +928,19 @@ void * rpmtsNotify(rpmts ts, rpmte te,
 {
     void * ptr = NULL;
     if (ts && ts->notify) {
+	void *arg = NULL;
 	Header h = NULL;
 	fnpyKey cbkey = NULL;
 	if (te) {
-	    h = rpmteHeader(te);
+	    if (ts->notifyStyle == 0) {
+		h = rpmteHeader(te);
+		arg = h;
+	    } else {
+		arg = te;
+	    }
 	    cbkey = rpmteKey(te);
 	}
-	ptr = ts->notify(h, what, amount, total, cbkey, ts->notifyData);
+	ptr = ts->notify(arg, what, amount, total, cbkey, ts->notifyData);
 
 	if (h) {
 	    headerFree(h); /* undo rpmteHeader() ref */
@@ -1052,6 +1058,21 @@ int rpmtsSetNotifyCallback(rpmts ts,
 	ts->notifyData = notifyData;
     }
     return 0;
+}
+
+int rpmtsSetNotifyStyle(rpmts ts, int style)
+{
+    if (ts != NULL)
+	ts->notifyStyle = style;
+    return 0;
+}
+
+int rpmtsGetNotifyStyle(rpmts ts)
+{
+    int style = 0;
+    if (ts != NULL)
+	style = ts->notifyStyle;
+    return style;
 }
 
 int rpmtsSetChangeCallback(rpmts ts, rpmtsChangeFunction change, void *data)

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -606,6 +606,24 @@ int rpmtsSetNotifyCallback(rpmts ts,
 		rpmCallbackData notifyData);
 
 /** \ingroup rpmts
+ * Set transaction notify callback style.
+ *
+ * @param ts		transaction set
+ * @param style		0 (default) for header, 1 for transaction element
+ * 			as the first argument
+ * @return		0 on success
+ */
+int rpmtsSetNotifyStyle(rpmts ts, int style);
+
+/** \ingroup rpmts
+ * Get transaction notify callback style.
+ *
+ * @param ts		transaction set
+ * @return		current callback style (see above)
+ */
+int rpmtsGetNotifyStyle(rpmts ts);
+
+/** \ingroup rpmts
  * Set transaction change callback function and argument.
  *
  * The change callback gets called when transaction elements are added,

--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -50,6 +50,7 @@ struct rpmts_s {
 
     rpmCallbackFunction notify;	/*!< Callback function. */
     rpmCallbackData notifyData;	/*!< Callback private data. */
+    int notifyStyle;		/*!< Callback style (header vs rpmte) */
 
     rpmtsChangeFunction change;	/*!< Change callback function. */
     void *changeData;		/*!< Change callback private data. */

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -330,6 +330,43 @@ for e in ts:
 lock]
 )
 
+RPMPY_TEST([transaction callback 1],[
+def ocb(what, amount, total, key, data):
+    print(what, amount, total, type(key), data)
+    return -1
+
+def ncb(arg, what, amount, total, data):
+    print(type(arg), what, amount, total, data)
+    return -1
+
+cbd = "mine"
+ts = rpm.ts()
+ts.addInstall('${RPMDATA}/RPMS/foo-1.0-1.noarch.rpm', 'mykey', 'u')
+ts.setFlags(rpm.RPMTRANS_FLAG_TEST)
+print("- old -")
+ts.run(callback=ocb, data=cbd)
+ts.cbStyle = 1
+print("- new -")
+ts.run(callback=ncb, data=cbd)
+],
+[- old -
+2097152 0 1 <class 'NoneType'> mine
+1048576 0 1 <class 'str'> mine
+4 0 0 <class 'str'> mine
+4194304 1 1 <class 'NoneType'> mine
+32 6 1 <class 'NoneType'> mine
+16 0 1 <class 'NoneType'> mine
+64 6 1 <class 'NoneType'> mine
+- new -
+<class 'NoneType'> 2097152 0 1 mine
+<class 'rpm.te'> 1048576 0 1 mine
+<class 'rpm.te'> 4 0 0 mine
+<class 'NoneType'> 4194304 1 1 mine
+<class 'NoneType'> 32 6 1 mine
+<class 'NoneType'> 16 0 1 mine
+<class 'NoneType'> 64 6 1 mine]
+)
+
 AT_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
 AT_CHECK([


### PR DESCRIPTION
Add API to get and set callback style, defaulting to the good ole
header first style and add a new style where a transaction element
is passed in place of the header, allowing a much saner interaction.

This is doubly so in Python, where the old style callback is a
braindamaged mess. In the new mode the "key" is not passed as separate
argument at all, it can be just as well retrieved via te.Key() for
the callbacks needing it.