### PR TITLE
Add support for application private user data in transaction elements

### DIFF
--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -28,6 +28,7 @@
  */
 struct rpmte_s {
     rpmElementType type;	/*!< Package disposition (installed/removed). */
+    void *userdata;		/*!< Application private user data. */
 
     Header h;			/*!< Package header. */
     char * NEVR;		/*!< Package name-version-release. */
@@ -424,6 +425,17 @@ FD_t rpmteSetFd(rpmte te, FD_t fd)
 fnpyKey rpmteKey(rpmte te)
 {
     return (te != NULL ? te->key : NULL);
+}
+
+void rpmteSetUserdata(rpmte te, void *data)
+{
+    if (te)
+	te->userdata = data;
+}
+
+void *rpmteUserdata(rpmte te)
+{
+    return (te != NULL ? te->userdata : NULL);
 }
 
 rpmds rpmteDS(rpmte te, rpmTagVal tag)

--- a/lib/rpmte.h
+++ b/lib/rpmte.h
@@ -217,6 +217,20 @@ const char * rpmteNEVRA(rpmte te);
 fnpyKey rpmteKey(rpmte te);
 
 /** \ingroup rpmte
+ * Set private user data of transaction element.
+ * @param te		transaction element
+ * @param data		pointer to private user data
+ */
+void rpmteSetUserdata(rpmte te, void *data);
+
+/** \ingroup rpmte
+ * Retrieve private user data of transaction element.
+ * @param te		transaction element
+ * @return		pointer to private user data
+ */
+void *rpmteUserdata(rpmte te);
+
+/** \ingroup rpmte
  * Return failure status of transaction element.
  * If the element itself failed, this is 1, larger count means one of
  * it's parents failed.

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -153,6 +153,30 @@ rpmte_Key(rpmteObject * s, PyObject * unused)
 }
 
 static PyObject *
+rpmte_SetUserdata(rpmteObject * s, PyObject *arg)
+{
+    /* XXX how to insure this is a PyObject??? */
+    PyObject *o = rpmteUserdata(s->te);
+    rpmteSetUserdata(s->te, arg);
+    Py_INCREF(arg);
+    Py_XDECREF(o);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+rpmte_Userdata(rpmteObject * s)
+{
+    PyObject *po = Py_None;
+    void *data = rpmteUserdata(s->te);
+
+    if (data)
+	po = data;
+
+    Py_INCREF(po);
+    return po;
+}
+
+static PyObject *
 rpmte_DS(rpmteObject * s, PyObject * args, PyObject * kwds)
 {
     rpmds ds;
@@ -233,8 +257,12 @@ static struct PyMethodDef rpmte_methods[] = {
     {"Failed",	(PyCFunction)rpmte_Failed,	METH_NOARGS,
      "te.Failed() -- Return if there are any related errors."},
     {"Key",	(PyCFunction)rpmte_Key,		METH_NOARGS,
-     "te.Key() -- Return the associated opaque key aka user data\n\
+     "te.Key() -- Return the associated opaque retrieval key\n\
 	as passed e.g. as data arg ts.addInstall()"},
+    {"Userdata",	(PyCFunction)rpmte_Userdata,	METH_NOARGS,
+     "te.Userdata() -- Return associated user data (if any)\n"},
+    {"SetUserdata",	(PyCFunction)rpmte_SetUserdata,	METH_O,
+     "te.SetUserdata() -- Set associated user data (if any)\n"},
     {"DS",	(PyCFunction)rpmte_DS,		METH_VARARGS|METH_KEYWORDS,
 "te.DS(TagN) -- Return the TagN dependency set (or None).\n\
 	TagN is one of 'Providename', 'Requirename', 'Obsoletename',\n\

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -316,6 +316,20 @@ for e in ts:
 [adding upgrade to transaction failed]
 )
 
+RPMPY_TEST([transaction element userdata],[
+mydata = { 'foo': 'bar', 'capstest': 'lock' }
+ts = rpm.ts()
+ts.addInstall('${RPMDATA}/RPMS/foo-1.0-1.noarch.rpm', 'u')
+ts.addInstall('${RPMDATA}/RPMS/capstest-1.0-1.noarch.rpm', 'u')
+for e in ts:
+    e.SetUserdata(mydata[e.N()])
+for e in ts:
+    myprint(e.Userdata())
+],
+[bar
+lock]
+)
+
 AT_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
 AT_CHECK([


### PR DESCRIPTION
The "key" passed to rpmtsAddInstallEleemnt() and associated with transaction
elements is sometimes mistaken for user data, but it is not, as rpm relies
on it having a very specific meaning and is passed around with that very
assumption.

API users have all sorts of (legit!) needs, lets add a proper private user
data member to transaction elements.

The Python bindings to this are kinda dangerous if you liberally mix Python
and C as we can't know whether the pointer is an actual Python object or not
so we can only assume it is and hope for the best. Nobody in their right
mind should be setting user data from one language and accessing it from
another, really...