### PR TITLE
Implement a transaction set change notification callback

### DIFF
--- a/lib/depends.c
+++ b/lib/depends.c
@@ -135,6 +135,7 @@ static int removePackage(rpmts ts, Header h, rpmte depends)
 
     tsmem->order[tsmem->orderCount] = p;
     tsmem->orderCount++;
+    rpmtsNotifyChange(ts, RPMTS_EVENT_ADD, p, depends);
 
     return 0;
 }
@@ -430,6 +431,7 @@ static int addPackage(rpmts ts, Header h,
 	oc = findPos(ts, tscolor, p, (op == RPMTE_UPGRADE));
 	/* If we're replacing a previously added element, free the old one */
 	if (oc >= 0 && oc < tsmem->orderCount) {
+	    rpmtsNotifyChange(ts, RPMTS_EVENT_DEL, tsmem->order[oc], p);
 	    rpmalDel(tsmem->addedPackages, tsmem->order[oc]);
 	    tsmem->order[oc] = rpmteFree(tsmem->order[oc]);
 	/* If newer NEVR was already added, we're done */
@@ -450,6 +452,8 @@ static int addPackage(rpmts ts, Header h,
     if (oc == tsmem->orderCount) {
 	tsmem->orderCount++;
     }
+    rpmtsNotifyChange(ts, RPMTS_EVENT_ADD, p, NULL);
+
     
     if (tsmem->addedPackages == NULL) {
 	tsmem->addedPackages = rpmalCreate(ts, 5);

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -179,6 +179,26 @@ enum rpmtxnFlags_e {
 };
 typedef rpmFlags rpmtxnFlags;
 
+typedef enum rpmtsEvent_e {
+    RPMTS_EVENT_ADD		= 1,
+    RPMTS_EVENT_DEL		= 2,
+} rpmtsEvent;
+
+/** \ingroup rpmts
+ * Transaction change callback type.
+ *
+ * On explicit install/erase add events, "other" is NULL, on implicit
+ * add events (erasures due to obsolete/upgrade, replaced by newer)
+ * it points to the replacing package.
+ *
+ * @param event		Change event (see rpmtsEvent enum)
+ * @param te		Transaction element
+ * @param other		Related transaction element (or NULL)
+ * @param data		Application private data from rpmtsSetChangeCallback()
+ */
+typedef int (*rpmtsChangeFunction)
+		(int event, rpmte te, rpmte other, void *data);
+
 /** \ingroup rpmts
  * Perform dependency resolution on the transaction set.
  *
@@ -584,6 +604,19 @@ rpmPlugins rpmtsPlugins(rpmts ts);
 int rpmtsSetNotifyCallback(rpmts ts,
 		rpmCallbackFunction notify,
 		rpmCallbackData notifyData);
+
+/** \ingroup rpmts
+ * Set transaction change callback function and argument.
+ *
+ * The change callback gets called when transaction elements are added,
+ * replaced or removed from a transaction set.
+ *
+ * @param ts		transaction set
+ * @param notify	element change callback
+ * @param data		element change callback private data
+ * @return		0 on success
+ */
+int rpmtsSetChangeCallback(rpmts ts, rpmtsChangeFunction notify, void *data);
 
 /** \ingroup rpmts
  * Create an empty transaction set.

--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -51,6 +51,9 @@ struct rpmts_s {
     rpmCallbackFunction notify;	/*!< Callback function. */
     rpmCallbackData notifyData;	/*!< Callback private data. */
 
+    rpmtsChangeFunction change;	/*!< Change callback function. */
+    void *changeData;		/*!< Change callback private data. */
+
     rpmprobFilterFlags ignoreSet;
 				/*!< Bits to filter current problems. */
 
@@ -122,6 +125,10 @@ rpmRC rpmtsSetupTransactionPlugins(rpmts ts);
 RPM_GNUC_INTERNAL
 rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
 		       rpmScript script, int arg1, int arg2);
+
+
+RPM_GNUC_INTERNAL
+int rpmtsNotifyChange(rpmts ts, int event, rpmte te, rpmte other);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add support for an optional callback hook for reveiving notifications
about added and deleted transaction elements. This lets API clients
easily track which elements get created and/or replaced by a single
rpmtsAddFoo() call and adjust their own book-keeping accordingly.
Also makes for an easy place to set application private data pointers
for newly added elements.