### PR TITLE
Remove invalid TODO comment on Lua scriptlet cwd

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -132,7 +132,6 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
     rpmluaPop(lua);
 
     /* Lua scripts can change our cwd and umask, save and restore */
-    /* XXX TODO: use cwd from chroot state to save unnecessary open here */
     cwd = open(".", O_RDONLY);
     if (cwd != -1) {
 	mode_t oldmask = umask(0);


### PR DESCRIPTION
Contrary to what the TODO comment said, we cannot rely on chroot cwd
because an API user could've changed to some other directory in the
meanwhile. For Lua scripts, we simply need to save whatever the directory
we are in and return to that, to avoid breaking API users.