### PR TITLE
lib/rpmdb.c: include fcntl.h for O_*

### DIFF
--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -8,6 +8,7 @@
 #include <utime.h>
 #include <errno.h>
 #include <dirent.h>
+#include <fcntl.h>
 
 #ifndef	DYING	/* XXX already in "system.h" */
 #include <fnmatch.h>


### PR DESCRIPTION
Fixes compilation on musl, otherwise it fails with undefined references
to various O_* symbols as mentioned here:

https://www.man7.org/linux/man-pages/man0/fcntl.h.0p.html