### PR TITLE
Fix Fseek for offset > 2GiB

### DIFF
--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -382,7 +382,7 @@ static ssize_t fdWrite(FDSTACK_t fps, const void * buf, size_t count)
 
 static int fdSeek(FDSTACK_t fps, off_t pos, int whence)
 {
-    return lseek(fps->fdno, pos, whence);
+    return (lseek(fps->fdno, pos, whence) == -1) ? -1 : 0;
 }
 
 static int fdClose(FDSTACK_t fps)


### PR DESCRIPTION
rpmio wraps a number of different file types, regular files and ones with compression. The only file type that supports seeking is regular files. This uses `LSEEK(2)` under the hood. I believe this is defined to return `off_t` which is signed. The function returns the offset (which is non negative in the normal case), or `-1` on error.

There's two specific issues here, so two patches:

1. `off_t` is being truncated to `int` (usually 32bit) on 64 bit arch. As there's only one implementation we can change the signature. Also the Ftell returns `off_t` already so this simply brings it in line.
2. ~~The error checks are using `< 0` which is strictly correct - it's impossible to return a normal offset that's negative. Still, the function is documented as returning `-1`  so in the interest of correctness, I think it's worth fixing that too.~~