### PR TITLE
Add support for passing real local arguments to Lua scriptlets

### DIFF
--- a/doc/manual/lua.md
+++ b/doc/manual/lua.md
@@ -39,6 +39,32 @@ The above is a silly example and doesn't even begin to show how powerful a featu
 %sources %{lua: for i, s in ipairs(sources) do print(s.." ") end}
 ```
 
+Parametric Lua macros receive their options and arguments as two local
+tables "opt" and "arg", where "opt" holds processed option values keyed by
+the option character, and "arg" contains arguments numerically indexed.
+These tables are always present regardless of whether options or arguments
+were actually passed to simplify use.
+
+```
+%foo(a:b) %{lua:
+if opt.b then
+   print('do b')
+else
+   print('or not')
+end
+if opt.a == 's' then
+   print('do s')
+end
+if #arg == 0 then
+   print('no arguments :(')
+else
+   for i = 1, #arg do
+      print(arg[i])
+   end
+end
+}
+```
+
 ## Available Lua extensions in RPM
 
 In addition to all Lua standard libraries (subject to the Lua version rpm is linked to), a few custom extensions are available in the RPM internal Lua interpreter. These can be used in all contexts where the internal Lua can be used.

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -138,7 +138,7 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
 	umask(oldmask);
 	pid_t pid = getpid();
 
-	if (chdir("/") == 0 && rpmluaRunScript(lua, script, sname) == 0) {
+	if (chdir("/") == 0 && rpmluaRunScript(lua, script, sname, NULL, NULL) == 0) {
 	    rc = RPMRC_OK;
 	}
 	if (pid != getpid()) {

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1065,7 +1065,7 @@ static void doLua(MacroBuf mb, int chkexist, int negate, const char * f, size_t 
     rpmluaPushPrintBuffer(lua);
     mc->depth = mb->depth;
     mc->level = mb->level;
-    if (rpmluaRunScript(lua, scriptbuf, NULL) == -1)
+    if (rpmluaRunScript(lua, scriptbuf, NULL, NULL, NULL) == -1)
 	mb->error = 1;
     mc->depth = odepth;
     mc->level = olevel;

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -589,13 +589,17 @@ int rpmluaRunScript(rpmlua _lua, const char *script, const char *name,
     INITSTATE(_lua, lua);
     lua_State *L = lua->L;
     int ret = -1;
+    static const char *lualocal =
+	"local opt = select(1, ...); local arg = select(2, ...);";
 
     if (name == NULL)
 	name = "<lua>";
     if (script == NULL)
 	script = "";
 
-    if (luaL_loadbuffer(L, script, strlen(script), name) != 0) {
+    char *buf = rstrscat(NULL, lualocal, script, NULL);
+
+    if (luaL_loadbuffer(L, buf, strlen(buf), name) != 0) {
 	rpmlog(RPMLOG_ERR, _("invalid syntax in lua script: %s\n"),
 		 lua_tostring(L, -1));
 	lua_pop(L, 1);
@@ -645,6 +649,7 @@ int rpmluaRunScript(rpmlua _lua, const char *script, const char *name,
     ret = 0;
 
 exit:
+    free(buf);
     return ret;
 }
 

--- a/rpmio/rpmlua.h
+++ b/rpmio/rpmlua.h
@@ -24,7 +24,7 @@ void rpmluaRegister(rpmlua lua, const void *regfuncs, const char *lib);
 int rpmluaCheckScript(rpmlua lua, const char *script,
 		      const char *name);
 int rpmluaRunScript(rpmlua lua, const char *script,
-		    const char *name);
+		    const char *name, const char *opts, ARGV_t args);
 int rpmluaRunScriptFile(rpmlua lua, const char *filename);
 void rpmluaInteractive(rpmlua lua);
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -509,6 +509,20 @@ runroot rpm --eval '%{lua:print(5*5)}'
 ])
 AT_CLEANUP
 
+AT_SETUP([lua macro arguments])
+AT_KEYWORDS([macros lua])
+AT_SKIP_IF([$LUA_DISABLED])
+AT_CHECK([[
+runroot rpm \
+	--define "foo(a:) %{lua:print(opt.a, arg[1])}" \
+	--define "bar() %{lua:print(rpm.expand('%foo -a'..arg[2]..' '..arg[1]))}" \
+	--eval '%bar 5 3'
+]],
+[0],
+[3	5
+])
+AT_CLEANUP
+
 AT_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 AT_CHECK([

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -256,7 +256,7 @@ filetriggerin(/foo*)<lua>:
 filetriggerin(/usr/bin*): 0
 /usr/bin/hello
 
-filetriggerin(/usr/bin*)<lua>: 0.0
+filetriggerin(/usr/bin*)<lua>: 0
 /usr/bin/hello
 
 transfiletriggerin(/usr/bin*): 0


### PR DESCRIPTION
Up to now, any communication with Lua scriptlets has required use of global tables. This PR adds support for real argument passing via the internal rpmlua API and converts the install scriptlet machinery to use that. More details in commit messages.

This appears more of a cleanup than new functionality as such, but is a pre-requisite for #1092 .