### PR TITLE
Make fdSeek return 0 on success, -1 on error

### DIFF
--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -382,7 +382,7 @@ static ssize_t fdWrite(FDSTACK_t fps, const void * buf, size_t count)
 
 static int fdSeek(FDSTACK_t fps, off_t pos, int whence)
 {
-    return lseek(fps->fdno, pos, whence);
+    return (lseek(fps->fdno, pos, whence) == -1) ? -1 : 0;
 }
 
 static int fdClose(FDSTACK_t fps)


### PR DESCRIPTION
This code eliminates a false positive failure when the destination position is > 2GiB. This is done by changing the contract for `Fseek`. Now it returns `0` on success instead of an `int` offset. Care should be used to interpret the result as there is a difference in semantics between the POSIX `fseek(2)`. Existing code is correct: negative results are still failures.