### PR TITLE
Allow parametric macros to opt out of option processing (#547)

### DIFF
--- a/doc/manual/macros.md
+++ b/doc/manual/macros.md
@@ -22,7 +22,8 @@ All whitespace surrounding \<body\> is removed.  Name may be composed
 of alphanumeric characters, and the character `_' and must be at least
 3 characters in length. A macro without an (opts) field is "simple" in that
 only recursive macro expansion is performed. A parameterized macro contains
-an (opts) field. The opts (i.e. string between parentheses) is passed
+an (opts) field. "-" as opts disables all option processing, otherwise
+the opts (i.e. string between parentheses) are passed
 exactly as is to getopt(3) for argc/argv processing at the beginning of
 a macro invocation. "--" can be used to separate options from arguments.
 While a parameterized macro is being expanded, the following shell-like

--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -80,7 +80,7 @@ static int cliDefine(const char *arg, int predefine)
     char *s, *t;
     /* XXX Convert '-' in macro name to underscore, skip leading %. */
     s = t = xstrdup(arg);
-    while (*t && !risspace(*t)) {
+    while (*t && !risspace(*t) && (*t != '(')) {
 	if (*t == '-') *t = '_';
 	t++;
     }

--- a/rpmio/Makefile.am
+++ b/rpmio/Makefile.am
@@ -16,7 +16,7 @@ usrlibdir = $(libdir)
 usrlib_LTLIBRARIES = librpmio.la
 librpmio_la_SOURCES = \
 	argv.c base64.c digest.h digest.c expression.c macro.c \
-	rpmhook.c rpmio.c rpmlog.c rpmmalloc.c \
+	rpmhook.c rpmio.c rpmlog.c rpmmalloc.c rgetopt.c \
 	rpmpgp.c rpmsq.c rpmsw.c url.c \
 	rpmio_internal.h rpmhook.h rpmvercmp.c rpmver.c \
 	rpmstring.c rpmfileutil.c rpmglob.c \

--- a/rpmio/rgetopt.c
+++ b/rpmio/rgetopt.c
@@ -15,6 +15,10 @@ int rgetopt(int argc, char * const argv[], const char *opts,
     int rc = 0;
     int c;
 
+    /* If option processing is disabled, get out */
+    if (strcmp(opts, "-") == 0)
+	return 1;
+
     /*
      * POSIX states optind must be 1 before any call but glibc uses 0
      * to (re)initialize getopt structures, eww.

--- a/rpmio/rgetopt.c
+++ b/rpmio/rgetopt.c
@@ -1,0 +1,40 @@
+#include "system.h"
+#include <string.h>
+#ifdef HAVE_GETOPT_H
+#include <getopt.h>
+#else
+extern char *optarg;
+extern int optind;
+#endif
+
+#include "rpmio/rpmmacro_internal.h"
+
+int rgetopt(int argc, char * const argv[], const char *opts,
+		rgetoptcb callback, void *data)
+{
+    int rc = 0;
+    int c;
+
+    /*
+     * POSIX states optind must be 1 before any call but glibc uses 0
+     * to (re)initialize getopt structures, eww.
+     */
+#ifdef __GLIBC__
+    optind = 0;
+#else
+    optind = 1;
+#endif
+
+    while ((c = getopt(argc, argv, opts)) != -1) {
+	if (c == '?' || strchr(opts, c) == NULL) {
+	    rc = -1;
+	    break;
+	}
+	if (callback && callback(c, optarg, optind, data) == -1) {
+	    rc = -1;
+	    break;
+	}
+    }
+    return (rc < 0) ? -optopt : optind;
+}
+

--- a/rpmio/rpmmacro_internal.h
+++ b/rpmio/rpmmacro_internal.h
@@ -19,6 +19,11 @@ extern "C" {
 RPM_GNUC_INTERNAL
 const char *findMacroEnd(const char *str);
 
+typedef int (*rgetoptcb)(int c, const char *oarg, int oint, void *data);
+
+RPM_GNUC_INTERNAL
+int rgetopt(int argc, char * const argv[], const char *opts,
+		rgetoptcb callback, void *data);
 
 #ifdef __cplusplus
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -193,6 +193,18 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([parametrized macro 6])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --define '%foo(-) %{*}' \
+    --eval '%foo 5 a -z -b2'
+],
+[0],
+[5 a -z -b2
+])
+AT_CLEANUP
+
 AT_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
Macros might want to pass along options meant for others while perhaps modifying some of them, without exposing it all to users.
    
Have "-" as the parametric macro opts string disable all options processing in rpm, allowing the macro to handle the raw argument list as they place.
    
Fixes: #547

The first two commits are infrastructure pre-requisites.