### PR TITLE
elfdeps: Generate dependencies on non-executable shared libraries

### DIFF
--- a/fileattrs/Makefile.am
+++ b/fileattrs/Makefile.am
@@ -6,7 +6,7 @@ AM_CFLAGS = @RPMCFLAGS@
 fattrsdir = $(rpmconfigdir)/fileattrs
 
 fattrs_DATA = \
-	debuginfo.attr desktop.attr elf.attr font.attr libtool.attr metainfo.attr \
+	debuginfo.attr desktop.attr elfexec.attr elflib.attr font.attr libtool.attr metainfo.attr \
 	perl.attr perllib.attr pkgconfig.attr python.attr pythondist.attr ocaml.attr \
 	script.attr
 

--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,4 +1,0 @@
-%__elf_provides		%{_rpmconfigdir}/elfdeps --provides
-%__elf_requires		%{_rpmconfigdir}/elfdeps --requires
-%__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
-%__elf_flags		exeonly

--- a/fileattrs/elfexec.attr
+++ b/fileattrs/elfexec.attr
@@ -1,0 +1,5 @@
+%__elfexec_provides		%{_rpmconfigdir}/elfdeps --provides
+%__elfexec_requires		%{_rpmconfigdir}/elfdeps --requires
+%__elfexec_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*executable
+%__elfexec_flags		exeonly
+%__elfexec_exclude_path		^/usr/lib/debug/

--- a/fileattrs/elflib.attr
+++ b/fileattrs/elflib.attr
@@ -1,0 +1,4 @@
+%__elflib_provides		%{_rpmconfigdir}/elfdeps  --assume-exec --provides
+%__elflib_requires		%{_rpmconfigdir}/elfdeps  --assume-exec --requires
+%__elflib_magic			^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*shared object
+%__elflib_exclude_path		^/usr/lib/debug/

--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -17,6 +17,7 @@ int soname_only = 0;
 int fake_soname = 1;
 int filter_soname = 1;
 int require_interp = 0;
+int assume_exec = 0;
 
 typedef struct elfInfo_s {
     Elf *elf;
@@ -294,7 +295,7 @@ static int processFile(const char *fn, int dtype)
     if (ehdr->e_type == ET_DYN || ehdr->e_type == ET_EXEC) {
 	ei->marker = mkmarker(ehdr);
     	ei->isDSO = (ehdr->e_type == ET_DYN);
-	ei->isExec = (st.st_mode & (S_IXUSR|S_IXGRP|S_IXOTH));
+	ei->isExec = assume_exec || (st.st_mode & (S_IXUSR|S_IXGRP|S_IXOTH));
 
 	processProgHeaders(ei, ehdr);
 	processSections(ei);
@@ -359,6 +360,7 @@ int main(int argc, char *argv[])
 	{ "no-fake-soname", 0, POPT_ARG_VAL, &fake_soname, 0, NULL, NULL },
 	{ "no-filter-soname", 0, POPT_ARG_VAL, &filter_soname, 0, NULL, NULL },
 	{ "require-interp", 0, POPT_ARG_VAL, &require_interp, -1, NULL, NULL },
+	{ "assume-exec", 0, POPT_ARG_VAL, &assume_exec, -1, NULL, NULL },
 	POPT_AUTOHELP 
 	POPT_TABLEEND
     };


### PR DESCRIPTION
This change adds `--assume-exec` option to `elfdeps` and splits up the file attrs for ELF executables and libraries so that libraries are not required to be executable.

This patch originates from SUSE Linux, but is commonly used across the Mandriva family as well (Mageia, OpenMandriva, ROSA).