### PR TITLE
Add a build root policy for removing executable bits from shared libr…

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -94,9 +94,11 @@
 %__brp_strip_comment_note %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump}
 %__brp_strip_shared %{_rpmconfigdir}/brp-strip-shared
 %__brp_strip_static_archive %{_rpmconfigdir}/brp-strip-static-archive %{__strip}
+%__brp_elfperms %{_rpmconfigdir}/brp-elfperms
 
 %__os_install_post    \
     %{?__brp_compress} \
+    %{?__brp_elfperms} \
     %{?__brp_strip} \
     %{?__brp_strip_static_archive} \
     %{?__brp_strip_comment_note} \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -8,7 +8,7 @@ CLEANFILES =
 EXTRA_DIST = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
-	brp-strip-shared brp-strip-static-archive \
+	brp-strip-shared brp-strip-static-archive brp-elfperms \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -25,7 +25,7 @@ EXTRA_DIST = \
 rpmconfig_SCRIPTS = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
-	brp-strip-shared brp-strip-static-archive \
+	brp-strip-shared brp-strip-static-archive brp-elfperms \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/brp-elfperms
+++ b/scripts/brp-elfperms
@@ -1,0 +1,13 @@
+#!/bin/sh
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+ELFCLASSIFY=/usr/bin/eu-elfclassify
+
+[ -x ${ELFCLASSIFY} ] || exit 0
+
+# Strip executable bits from ELF DSO's which are not actually executable
+find "$RPM_BUILD_ROOT" -type f \( -perm -0100 -or -perm -0010 -or -perm -0001 \) | ${ELFCLASSIFY} --shared --print0 --stdin | xargs -0 -r chmod a-x
+


### PR DESCRIPTION
…aries

Rpm has traditionally used executable bit on files to determine whether
requires for that file should be generated, but the downside is that we
have systems full of executable files that cannot actually be executed.
When available, use eu-elfclassify to determine files that are pure,
non-executable shared objects and remove executable bits from them
as a buildroot policy. This preserves the traditional behavior wrt
dependency generation but gets rid of the unwanted executable bits.