### PR TITLE
Implement a table-like shortcut to rpm macros in Lua

### DIFF
--- a/doc/manual/lua.md
+++ b/doc/manual/lua.md
@@ -65,6 +65,47 @@ end
 }
 ```
 
+Besides the generic `rpm.expand()` macro expansion function, named macros
+can be accessed (and also defined and undefined) via a global `macros`
+table in the Lua environment using normal table accessors. For example:
+
+```
+if macros._libdir == '/usr/lib64' then
+   print('64bit')
+end
+if not macros['zzz'] then
+   macro['zzz'] = 123
+end
+if macros.aaa then
+   macros.aaa = nil
+end
+```
+
+Parametric macros can also be called as native Lua functions via this
+facility, for example:
+
+```
+if macros.with('foo') == 0 then
+    macros.bcond_with('bar')
+end
+```
+
+When called this way, the argument is either a single string or a table.
+With a string argument, these two are equal:
+
+```
+r = macros.foo(args)
+r = rpm.expand('%foo'..' '..args)
+```
+
+If the macro function call argument is a table sequence, then the arguments
+are automatically wrapped with `%{quote:...}` so whitespace is preserved,
+eg macro foo would receive three arguments when called this way:
+
+```
+r = macros.foo({'a', '', 'c'})
+```
+
 ## Available Lua extensions in RPM
 
 In addition to all Lua standard libraries (subject to the Lua version rpm is linked to), a few custom extensions are available in the RPM internal Lua interpreter. These can be used in all contexts where the internal Lua can be used.

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -1034,6 +1034,104 @@ static const luaL_Reg fd_m[] = {
     {NULL, NULL}
 };
 
+static rpmMacroContext *checkmc(lua_State *L, int ix)
+{
+    rpmMacroContext *mc = lua_touserdata(L, ix);
+    luaL_checkudata(L, ix, "rpm.mc");
+    return mc;
+}
+
+static int mc_call(lua_State *L)
+{
+    rpmMacroContext *mc = checkmc(L, lua_upvalueindex(1));
+    int n = 3; /* surrounding '%{', 'name', '}' */
+
+    if (lua_gettop(L) > 1)
+	luaL_error(L, "too many arguments");
+
+    lua_pushstring(L, "%{");
+    lua_pushvalue(L, lua_upvalueindex(2)); /* macro name */
+
+    if (lua_isstring(L, 1)) {
+	lua_pushstring(L, " ");
+	lua_pushvalue(L, 1);
+	n += 2;
+    } else if (lua_istable(L, 1)) {
+	int nitem = lua_rawlen(L, 1);
+	luaL_checkstack(L, (nitem + 1) * 3, "argument table too large");
+
+	for (int i = 1; i <= nitem; i++) {
+	    lua_pushstring(L, " %{quote:");
+	    lua_rawgeti(L, 1, i);
+	    lua_pushstring(L, "}");
+	    n += 3;
+	}
+    } else {
+	luaL_argerror(L, 1, "string or table expected");
+    }
+
+    lua_pushstring(L, "}");
+    lua_concat(L, n);
+
+    /* throw out previous args and call expand() with our result string */
+    lua_rotate(L, 1, 1);
+    lua_settop(L, 1);
+
+    return rpm_expand(L);
+}
+
+static int mc_index(lua_State *L)
+{
+    rpmMacroContext *mc = checkmc(L, 1);
+    const char *a = luaL_checkstring(L, 2);
+    int rc = 0;
+
+    if (rpmMacroIsDefined(NULL, a)) {
+	if (rpmMacroIsParametric(NULL, a)) {;
+	    /* closure with the macro context and the name */
+	    lua_pushcclosure(L, &mc_call, 2);
+	    rc = 1;
+	} else {
+	    lua_pushfstring(L, "%%{%s}", a);
+	    lua_rotate(L, 1, 1);
+	    lua_settop(L, 1);
+	    rc = rpm_expand(L);
+	}
+    }
+    return rc;
+}
+
+static int mc_newindex(lua_State *L)
+{
+    rpmMacroContext *mc = checkmc(L, 1);
+    const char *name = luaL_checkstring(L, 2);
+    if (lua_isnil(L, 3)) {
+	if (rpmPopMacro(*mc, name))
+	    luaL_error(L, "error undefining macro %s", name);
+    } else {
+	const char *body = luaL_checkstring(L, 3);
+	char *s = rstrscat(NULL, name, " ", body, NULL);
+	if (rpmDefineMacro(*mc, s, 0))
+	    luaL_error(L, "error defining macro %s", name);
+	free(s);
+    }
+    return 0;
+}
+
+static const luaL_Reg mc_m[] = {
+    {"__index", mc_index},
+    {"__newindex", mc_newindex},
+    {NULL, NULL}
+};
+
+static void createmt(lua_State *L, const char *name, rpmMacroContext mc)
+{
+    lua_pushglobaltable(L);
+    newinstance(L, "rpm.mc", mc);
+    lua_setfield(L, -2, name);
+    lua_pop(L, 1);
+}
+
 static const luaL_Reg rpmlib[] = {
     {"b64encode", rpm_b64encode},
     {"b64decode", rpm_b64decode},
@@ -1059,6 +1157,10 @@ static int luaopen_rpm(lua_State *L)
 {
     createclass(L, "rpm.ver", ver_m);
     createclass(L, "rpm.fd", fd_m);
+    createclass(L, "rpm.mc", mc_m);
+
+    createmt(L, "macros", rpmGlobalMacroContext);
+
     luaL_newlib(L, rpmlib);
     return 1;
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -546,6 +546,33 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([lua macros table])
+AT_KEYWORDS([macros lua])
+AT_SKIP_IF([$LUA_DISABLED])
+AT_CHECK([[
+runroot rpm \
+	--define "qtst() %{lua:for i=1, #arg do print(' '..i..':'..arg[i]) end}"\
+	--eval "%{lua:print(macros.with('zap'), macros.without('zap'))}" \
+	--eval "%{lua:print(macros.aaa)}" \
+	--eval "%{lua:macros.aaa='bbb'; macros['yyy']='zzz'}" \
+	--eval "%{lua:print(macros['aaa'], macros.yyy)}" \
+	--eval "%{lua:macros.aaa=nil"} \
+	--eval "%{lua:print(macros.aaa)}" \
+	--eval "%{lua:print(macros.qtst('a c'))}" \
+	--eval "%{lua:print(macros.qtst({'a', '', 'c'}))}"
+]],
+[0],
+[0	1
+nil
+
+bbb	zzz
+
+nil
+ 1:a 2:c
+ 1:a 2: 3:c
+])
+AT_CLEANUP
+
 AT_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 AT_CHECK([


### PR DESCRIPTION
Add rpm macro context as a global table-like entity named 'm' for
typing convenience into the Lua environment.

Support basic access with table indexing syntaxes (m[k] and m.k),
undefined macros return nil here. As a specialty, parametric macros
are returned as native callable variadic Lua functions, arguments
are converted to strings.