### PR TITLE
Treat unparsable macros like undefined macros

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1490,7 +1490,6 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	    mbErr(mb, 1,
 		    _("A %% is followed by an unparseable macro\n"));
 #endif
-	    s = se;
 	    continue;
 	}
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -6,10 +6,13 @@ AT_BANNER([RPM macros])
 AT_SETUP([simple rpm --eval])
 AT_KEYWORDS([macros])
 AT_CHECK([
-runroot rpm --define "this that" --eval '%{this}'
+runroot rpm --define "this that" --eval '%{this}' --eval '%not_defined' --eval '%{not_defined}' --eval '%{}'
 ],
 [0],
 [that
+%not_defined
+%{not_defined}
+%{}
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
This seems to be the intention of the code but it did
not work because macro parsing was resumed at the wrong
point of the input string. Without this commit, "%{}"
expanded to "%" instead of "%{}".