### PR TITLE
Mark man pages with RPMFILE_MAN and info pages with RPMFILE_INFO

### DIFF
--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -60,6 +60,8 @@ enum rpmfileAttrs_e {
     /* bits 9-10 unused */
     RPMFILE_PUBKEY	= (1 << 11),	/*!< from %%pubkey */
     RPMFILE_ARTIFACT	= (1 << 12),	/*!< from %%artifact */
+    RPMFILE_MAN	= (1 << 13),	/*!< from %%{_mandir} */
+    RPMFILE_INFO	= (1 << 14),	/*!< from %%{_infodir} */
 };
 
 typedef rpmFlags rpmfileAttrs;

--- a/macros.in
+++ b/macros.in
@@ -544,6 +544,12 @@ package or when debugging this package.\
 # Directories whose contents should be considered as documentation.
 %__docdir_path %{_datadir}/doc:%{_datadir}/man:%{_datadir}/info:%{_datadir}/gtk-doc/html:%{_datadir}/gnome/help:%{?_docdir}:%{?_mandir}:%{?_infodir}:%{?_javadocdir}:/usr/doc:/usr/man:/usr/info:/usr/X11R6/man
 
+# Directories whose contents should be considered man pages.
+%__mandir_path %{_datadir}/man:%{?_mandir}:/usr/man:/usr/X11R6/man
+
+# Directories whose contents should be considered info pages.
+%__infodir_path %{_datadir}/info:%{?_infodir}:/usr/info
+
 #
 # Path to scripts to autogenerate package dependencies,
 #


### PR DESCRIPTION
Define two additional file flags.  One for man pages and one for info pages.  These files are currently marked as RPMFILE_DOC during rpmbuild.  This patch also marks man pages with RPMFILE_MAN and info pages with RPMFILE_INFO.  The idea is that while they are still documentation, there will be further file flag details in the RPM header indicating what kind of docs they are.  This patch could be extended to allow rpm to carry options like --excludeman and --excludeinfo, though if that happens the file flags may want to exclude man and info pages from RPMFILE_DOC entirely.

My motivation for these additional file flags are for use in rpminspect when performing tests on man pages or info pages.  Right
now tools like rpminspect have to match man pages based on path and file type, which rpm already knows about.  If the RPM header can carry a flag marking each man page, it makes tests in other tools easier.  The same for info pages.

Signed-off-by: David Cantrell <dcantrell@redhat.com>