### PR TITLE
Implement a real stack for parametric macro locals

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -538,7 +538,7 @@ static ARGV_t runCall(const char *cmd,
 	rpmlog(RPMLOG_DEBUG, "Calling %s() on %s\n", cmd, fn);
 
     /* Hack to pass in the path as what looks like a macro argument */
-    rpmPushMacroFlags(NULL, "1", NULL, fn, 1, RPMMACRO_LITERAL);
+    rpmPushMacroFlags(NULL, "1", NULL, fn, RMIL_GLOBAL, RPMMACRO_LITERAL);
     char *exp = rpmExpand(cmd, NULL);
     rpmPopMacro(NULL, "1");
     if (*exp)

--- a/rpmio/rpmmacro.h
+++ b/rpmio/rpmmacro.h
@@ -44,6 +44,7 @@ extern const char * macrofiles;
 #define	RMIL_SPEC	-3
 #define	RMIL_OLDSPEC	-1
 #define	RMIL_GLOBAL	0
+#define RMIL_LOCAL	1
 
 /* Deprecated compatibility wrappers */
 #define addMacro(_mc, _n, _o, _b, _l) rpmPushMacro(_mc, _n, _o, _b, _l)

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -754,6 +754,20 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([%define + %undefine in nested levels 6])
+AT_KEYWORDS([macros define])
+AT_CHECK([
+runroot rpm \
+    --define "foo() %{expand:%define bar hello}111" \
+    --eval "%foo"
+],
+[0],
+[111
+],
+[warning: Macro %bar defined but not used within scope
+])
+AT_CLEANUP
+
 AT_SETUP([%define in conditional macro])
 AT_KEYWORDS([macros])
 AT_CHECK([

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -683,7 +683,7 @@ runroot rpm \
 ],
 [0],
 [1
-%xxx
+1
 .   .
 ])
 AT_CLEANUP
@@ -707,7 +707,6 @@ AT_CLEANUP
 AT_SETUP([%define + %undefine in nested levels 3])
 AT_KEYWORDS([macros define])
 AT_CHECK([
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 # %define macro twice in a nested scope
 runroot rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %define xxx 2} %{echo:%xxx}' \
@@ -725,8 +724,6 @@ AT_CLEANUP
 AT_SETUP([%define + %undefine in nested levels 4])
 AT_KEYWORDS([macros define global])
 AT_CHECK([
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
-# %define in a nested level covered by %global
 runroot rpm \
     --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %global xxx 2} %{echo:%xxx}' \
     --eval .'%foo'. \
@@ -736,11 +733,24 @@ runroot rpm \
 ],
 [0],
 [1
-2
+1
 .    .
 2
 ..
 %xxx
+])
+AT_CLEANUP
+
+AT_SETUP([%define + %undefine in nested levels 5])
+AT_KEYWORDS([macros define])
+AT_CHECK([
+runroot rpm \
+    --define "foo() %bar" \
+    --define "foo2() %{expand:%define bar hello}%{foo}" \
+    --eval "%foo2"
+],
+[0],
+[hello
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
Mixing up local stack and global data never was such a hot idea, as locals could get trapped between globals and not freed at appropriate times etc.
    
This clears the semantics wrt that, fixing a long-standing expected failure in the test-suite. Another semantics change is that you can no longer undefine a locally defined macro, which eliminates the ambiguity     of what should happen on %undefine if both global and local macros exist. As such, there's of course some potential for breakage too.

Besides clear semantics, this should speed up parametric macro execution as we no longer need to huff and puff the global table up and down on entry and exit. Furthermore, this paves way to using a hash for the macro table.