### PR TITLE
Fix warnings from set but unused, variables in macro.c and rpmlua.c

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -892,7 +892,6 @@ static void splitQuoted(ARGV_t *av, const char * str, const char * seps)
 static int mbopt(int c, const char *oarg, int oint, void *data)
 {
     MacroBuf mb = data;
-    rpmMacroEntry me = mb->me;
     char *name = NULL, *body = NULL;
 
     /* Define option macros. */

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -988,7 +988,7 @@ static int fd_seek(lua_State *L)
     int op = luaL_checkoption(L, 2, "cur", modenames);
     off_t offset = luaL_optinteger(L, 3, 0);
 
-    op = Fseek(*fdp, offset, op);
+    op = Fseek(*fdp, offset, mode[op]);
 
     if (op < 0 || Ferror(*fdp)) {
 	return luaL_error(L, "%s: seek failed: %s",


### PR DESCRIPTION
macro.c: In function ‘mbopt’:
macro.c:895:19: warning: unused variable ‘me’ [-Wunused-variable]
  895 |     rpmMacroEntry me = mb->me;
      |                   ^~

rpmlua.c: In function ‘fd_seek’:
rpmlua.c:985:22: warning: unused variable ‘mode’ [-Wunused-variable]
  985 |     static const int mode[] = {SEEK_SET, SEEK_CUR, SEEK_END};
      |                      ^~~~

The former is actually unused, the latter should be used.