### PR TITLE
Fix logic error in grabArgs()

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -948,7 +948,7 @@ grabArgs(MacroBuf mb, const rpmMacroEntry me, const char * se,
 	splitQuoted(&argv, s, " \t");
 	free(s);
 
-	cont = ((*lastc == '\0' || *lastc == '\n') && *(lastc-1) != '\\') ?
+	cont = (*lastc == '\0') || (*lastc == '\n' && *(lastc-1) != '\\') ?
 	       lastc : lastc + 1;
     }
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -179,6 +179,9 @@ runroot rpm \
     --eval '%foo %{quote:   2 3  5} %{quote:%{nil}}' \
     --eval '%foo x%{quote:y}z 123' \
     --eval '%foo x%{quote:%{nil}}z' \
+    --eval '%foo 1 \
+bar' \
+    --eval '%foo 1 \' \
 ],
 [0],
 [1:"1"
@@ -190,6 +193,8 @@ runroot rpm \
 2:"   2 3  5" ""
 2:"xyz" "123"
 1:"xz"
+2:"1" "\"bar
+2:"1" "\"
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
If there was a '\' at the end of the buffer, the code would
return a pointer after the trailing \0 leading to unallocated
memory access and weird results in some cases.

See commit 817959609b95afe34ce0f7f6c3dc5d7d0d9a8470.