### PR TITLE
Refactor handling of parameterized macro args

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -441,6 +441,15 @@ expandThis(MacroBuf mb, const char * src, size_t slen, char **target)
     return umb.error;
 }
 
+static void mbAllocBuf(MacroBuf mb, size_t slen)
+{
+    size_t blen = MACROBUFSIZ + slen;
+    mb->buf = xmalloc(blen + 1);
+    mb->buf[0] = '\0';
+    mb->tpos = 0;
+    mb->nb = blen;
+}
+
 static void mbAppend(MacroBuf mb, char c)
 {
     if (mb->nb < 1) {
@@ -1377,13 +1386,8 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
     source[slen] = '\0';
     s = source;
 
-    if (mb->buf == NULL) {
-	size_t blen = MACROBUFSIZ + slen;
-	mb->buf = xmalloc(blen + 1);
-	mb->buf[0] = '\0';
-	mb->tpos = 0;
-	mb->nb = blen;
-    }
+    if (mb->buf == NULL)
+	mbAllocBuf(mb, slen);
     tpos = mb->tpos; /* save expansion pointer for printExpand */
     store_macro_trace = mb->macro_trace;
     store_expand_trace = mb->expand_trace;

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1546,15 +1546,17 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	}
 
 	/* Setup args for "%name " macros with opts */
-	rpmMacroEntry prevme = mb->me;
-	ARGV_t prevarg = mb->args;
+	ARGV_t args = NULL;
 	if (me->opts != NULL) {
-	    ARGV_t args = NULL;
 	    argvAdd(&args, me->name);
 	    if (lastc)
 		se = grabArgs(mb, &args, fe, lastc);
-	    setupArgs(mb, me, args);
 	}
+
+	rpmMacroEntry prevme = mb->me;
+	ARGV_t prevarg = mb->args;
+	if (args != NULL)
+	    setupArgs(mb, me, args);
 
 	/* Recursively expand body of macro */
 	if (me->body && *me->body) {
@@ -1565,7 +1567,7 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	}
 
 	/* Free args for "%name " macros with opts */
-	if (me->opts != NULL)
+	if (args != NULL)
 	    freeArgs(mb);
 	mb->args = prevarg;
 	mb->me = prevme;


### PR DESCRIPTION
This splits of a setupArgs() function that will be also used when we add a new method to expand a specific macro.