### PR TITLE
lib/rpmrc.c: include fcntl.h for O_*

### DIFF
--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1,5 +1,6 @@
 #include "system.h"
 
+#include <fcntl.h>
 #include <stdarg.h>
 #include <pthread.h>
 


### PR DESCRIPTION
Fixes compilation on musl, otherwise it fails with undefined references
to various O_* symbols as mentioned here:

https://www.man7.org/linux/man-pages/man0/fcntl.h.0p.html

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>