### PR TITLE
Implement a table-like shortcut to rpm macros in Lua

### DIFF
--- a/doc/manual/lua.md
+++ b/doc/manual/lua.md
@@ -65,6 +65,19 @@ end
 }
 ```
 
+Macros can be accessed via a global `macros` table in the Lua environment.
+Lua makes no difference between index and field name syntax so
+`macros.foo` and `macros['foo']` are equivalent, use what better suits the
+purpose. Like any real Lua table, non-existent items are returned as `nil`,
+and assignment can be used to define or undefine macros.
+
+Parametric macros (including all built-in macros) can be called in a Lua
+native manner via the `macros` table. The argument can be either a
+single string (`macros.with('thing')`), in which case it's expanded
+and split with the macro-native rules, or it can be a table
+`macros.dostuff({'one', 'two', 'three'})` in which case the table contents
+are used as literal arguments that are not expanded in any way.
+
 ## Available Lua extensions in RPM
 
 In addition to all Lua standard libraries (subject to the Lua version rpm is linked to), a few custom extensions are available in the RPM internal Lua interpreter. These can be used in all contexts where the internal Lua can be used.

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -762,16 +762,29 @@ doUndefine(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
     return 0;
 }
 
+static size_t doArgvDefine(MacroBuf mb, ARGV_t argv, int level, int expand)
+{
+    char *args = NULL;
+    size_t ret;
+    const char *se = argv[1];
+
+    /* handle the "programmatic" case where macro name is arg1 and body arg2 */
+    if (argv[2])
+	se = args = rstrscat(NULL, argv[1], " ", argv[2], NULL);
+
+    ret = doDefine(mb, se, level, expand);
+    free(args);
+    return ret;
+}
+
 static size_t doDef(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
-    const char *se = argv[1];
-    return doDefine(mb, se, mb->level, 0);
+    return doArgvDefine(mb, argv, mb->level, 0);
 }
 
 static size_t doGlobal(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
-    const char *se = argv[1];
-    return doDefine(mb, se, RMIL_GLOBAL, 1);
+    return doArgvDefine(mb, argv, RMIL_GLOBAL, 1);
 }
 
 static size_t doDump(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -593,6 +593,52 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([lua macros table])
+AT_KEYWORDS([macros lua])
+AT_SKIP_IF([$LUA_DISABLED])
+AT_CHECK([[
+runroot rpm \
+	--define "qtst() %{lua:for i=1, #arg do print(' '..i..':'..arg[i]) end}"\
+	--eval "%{lua:print(macros.with('zap'), macros.without('zap'))}" \
+	--eval "%{lua:print(macros.aaa)}" \
+	--eval "%{lua:macros.aaa='bbb'; macros['yyy']='zzz'}" \
+	--eval "%{lua:print(macros['aaa'], macros.yyy)}" \
+	--eval "%{lua:macros.aaa=nil"} \
+	--eval "%{lua:print(macros.aaa)}" \
+	--eval "%{lua:print(macros.qtst('a c'))}" \
+	--eval "%{lua:print(macros.qtst({'a', '', 'c'}))}" \
+	--eval "%{lua:print(macros.qtst('%{?aaa} %{yyy}'))}" \
+	--eval "%{lua:print(macros.qtst({'%{?aaa}', '%{yyy}'}))}" \
+	--eval "%{lua:macros.define({'this', 'that'}); print(macros.this)}"
+]],
+[0],
+[0	1
+nil
+
+bbb	zzz
+
+nil
+ 1:a 2:c
+ 1:a 2: 3:c
+ 1:zzz
+ 1:%{?aaa} 2:%{yyy}
+that
+])
+AT_CLEANUP
+
+AT_SETUP([lua macros recursion])
+AT_KEYWORDS([macros lua])
+AT_SKIP_IF([$LUA_DISABLED])
+AT_CHECK([[
+runroot rpm \
+	--define "%recurse() %{lua:io.write(' '..#arg); if #arg < 16 then table.insert(arg, #arg); macros.recurse(arg) end;}" \
+	--eval "%recurse"
+]],
+[0],
+[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+])
+AT_CLEANUP
+
 AT_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 AT_CHECK([


### PR DESCRIPTION
Add rpm macro context as a global table-like entity named 'macros' for
a more Lua-native experience with rpm macros.

Support basic indexing syntaxes (macros[k] and macros.k) for access, define
and undefine operations. Undefined macros return nil here and assigning
to nil will undefine (pop) the macro.

As a specialty, parametric macros are returned as native callable
variadic Lua functions. A string argument is passed to expand as is,
but if arguments are passed as a table, eg `r = macros.foo({1, 2, 3})`,
they are passed entirely as-is.

The macro context pointer in the userdata is not consistently used for
all operations here, but then all the macro operations in Lua are hardwired
to the global context anyway so it doesn't matter in practise. Properly
passing the context around in all cases is left for later commits.

GH is not letting me reopen #1398 :unamused: so opening a new one to pick up where we left off there, now that @mlschroe did all the heavy lifting :smile: 