### PR TITLE
Eliminate special conditional syntaxes from builtin macros

### DIFF
--- a/doc/manual/macros.md
+++ b/doc/manual/macros.md
@@ -80,6 +80,7 @@ to perform useful operations. The current list is
 
 	%{basename:...}	basename(1) macro analogue
 	%{dirname:...}	dirname(1) macro analogue
+	%{exists:...}	test file existence, expands to 1/0
 	%{suffix:...}	expand to suffix part of a file name
 	%{url2path:...}	convert url to a local path
 	%{getenv:...}	getenv(3) macro analogue

--- a/doc/manual/macros.md
+++ b/doc/manual/macros.md
@@ -66,6 +66,7 @@ to perform useful operations. The current list is
 	%getncpus	return the number of CPUs
 	%getconfdir	expand to rpm "home" directory (typically /usr/lib/rpm)
 	%dnl		discard to next line (without expanding)
+	%verbose	expand to 1 if rpm is in verbose mode, 0 if not
 
 	%{echo:...}	print ... to stdout
 	%{warn:...}	print warning: ... to stderr
@@ -96,8 +97,6 @@ to perform useful operations. The current list is
 			intermediate whitespace to a single space
 	%{quote:...}	quote a parametric macro argument, needed to pass
 			empty strings or strings with whitespace
-	%{verbose:...}	expand ... if rpm is in verbose mode (%{!verbose:...}
-			works for non-verbose mode)
 
 	%{S:...}	expand ... to <source> file name
 	%{P:...}	expand ... to <patch> file name

--- a/macros.in
+++ b/macros.in
@@ -796,7 +796,7 @@ package or when debugging this package.\
   PKG_CONFIG_PATH=\"${PKG_CONFIG_PATH}:%{_libdir}/pkgconfig:%{_datadir}/pkgconfig\"\
   export PKG_CONFIG_PATH\
   \
-  %{verbose:set -x}\
+  %[%{verbose}?"set -x":""]\
   umask 022\
   cd \"%{u2p:%{_builddir}}\"\
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1313,7 +1313,7 @@ static void doLoad(MacroBuf mb, int chkexist, int negate,
 static void doTrace(MacroBuf mb, int chkexist, int negate,
 		    rpmMacroEntry me, const char * g, size_t gn)
 {
-    mb->expand_trace = mb->macro_trace = (negate ? 0 : mb->depth);
+    mb->expand_trace = mb->macro_trace = mb->depth;
     if (mb->depth == 1) {
 	print_macro_trace = mb->macro_trace;
 	print_expand_trace = mb->expand_trace;

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -644,7 +644,7 @@ static struct builtins_s {
     { "uncompress",	doUncompress,	ME_ARGFUNC },
     { "undefine",	doUndefine,	ME_PARSE },
     { "url2path",	doFoo,		ME_ARGFUNC },
-    { "verbose",	doVerbose,	ME_ARGFUNC },
+    { "verbose",	doVerbose,	ME_FUNC },
     { "warn",		doOutput,	ME_ARGFUNC },
     { NULL,		NULL,		0 }
 };
@@ -1204,14 +1204,7 @@ static void doExpand(MacroBuf mb, int chkexist, int negate,
 static void doVerbose(MacroBuf mb, int chkexist, int negate,
 		rpmMacroEntry me, const char * g, size_t gn)
 {
-    int verbose = (rpmIsVerbose() != 0);
-    /* Don't expand %{verbose:...} argument on false condition */
-    if (verbose != negate) {
-	char *buf = NULL;
-	expandThis(mb, g, gn, &buf);
-	mbAppendStr(mb, buf);
-	free(buf);
-    }
+    mbAppend(mb, rpmIsVerbose() ? '1' : '0');
 }
 
 /**

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1007,9 +1007,9 @@ static void doOutput(MacroBuf mb,  rpmMacroEntry me, const char * g, size_t gn)
     _free(buf);
 }
 
+#ifdef WITH_LUA
 static void doLua(MacroBuf mb,  rpmMacroEntry me, const char * g, size_t gn)
 {
-#ifdef WITH_LUA
     rpmlua lua = NULL; /* Global state. */
     char *scriptbuf = xmalloc(gn + 1);
     char *printbuf;
@@ -1044,10 +1044,8 @@ static void doLua(MacroBuf mb,  rpmMacroEntry me, const char * g, size_t gn)
 	free(printbuf);
     }
     free(scriptbuf);
-#else
-    mbErr(mb, 1, _("<lua> scriptlet support not built in\n"));
-#endif
 }
+#endif
 
 static void
 doSP(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
@@ -1269,7 +1267,9 @@ static struct builtins_s {
     { "getncpus",	doFoo,		ME_FUNC },
     { "global",		doGlobal,	ME_PARSE },
     { "load",		doLoad,		ME_ARGFUNC },
+#ifdef WITH_LUA
     { "lua",		doLua,		ME_ARGFUNC },
+#endif
     { "macrobody",	doBody,		ME_ARGFUNC },
     { "quote",		doFoo,		ME_ARGFUNC },
     { "shrink",		doFoo,		ME_ARGFUNC },

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -142,21 +142,6 @@ static void pushMacro(rpmMacroContext mc,
 	const char * n, const char * o, const char * b, int level, int flags);
 static void popMacro(rpmMacroContext mc, const char * n);
 static int loadMacroFile(rpmMacroContext mc, const char * fn);
-static void doBody(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doExpand(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doFoo(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doLoad(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doLua(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doOutput(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doSP(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doTrace(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doUncompress(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-static void doVerbose(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
-
-static const char * doDef(MacroBuf mb, rpmMacroEntry me, const char * se);
-static const char * doGlobal(MacroBuf mb, rpmMacroEntry me, const char * se);
-static const char * doDump(MacroBuf mb, rpmMacroEntry me, const char * se);
-static const char * doUndefine(MacroBuf mb, rpmMacroEntry me, const char * se);
 /* =============================================================== */
 
 static rpmMacroContext rpmmctxAcquire(rpmMacroContext mc)
@@ -601,43 +586,6 @@ static unsigned int getncpus(void)
 	ncpus = 1;
     return ncpus;
 }
-
-static struct builtins_s {
-    const char * name;
-    void *func;
-    int flags;
-} const builtinmacros[] = {
-    { "P",		doSP,		ME_ARGFUNC },
-    { "S",		doSP,		ME_ARGFUNC },
-    { "basename",	doFoo,		ME_ARGFUNC },
-    { "define",		doDef,		ME_PARSE },
-    { "dirname",	doFoo,		ME_ARGFUNC },
-    { "dnl",		doDnl,		ME_PARSE },
-    { "dump", 		doDump,		ME_PARSE },
-    { "echo",		doOutput,	ME_ARGFUNC },
-    { "error",		doOutput,	ME_ARGFUNC },
-    { "exists",		doFoo,		ME_ARGFUNC },
-    { "expand",		doExpand,	ME_ARGFUNC },
-    { "expr",		doFoo,		ME_ARGFUNC },
-    { "getconfdir",	doFoo,		ME_FUNC },
-    { "getenv",		doFoo,		ME_ARGFUNC },
-    { "getncpus",	doFoo,		ME_FUNC },
-    { "global",		doGlobal,	ME_PARSE },
-    { "load",		doLoad,		ME_ARGFUNC },
-    { "lua",		doLua,		ME_ARGFUNC },
-    { "macrobody",	doBody,		ME_ARGFUNC },
-    { "quote",		doFoo,		ME_ARGFUNC },
-    { "shrink",		doFoo,		ME_ARGFUNC },
-    { "suffix",		doFoo,		ME_ARGFUNC },
-    { "trace",		doTrace,	ME_FUNC },
-    { "u2p",		doFoo,		ME_ARGFUNC },
-    { "uncompress",	doUncompress,	ME_ARGFUNC },
-    { "undefine",	doUndefine,	ME_PARSE },
-    { "url2path",	doFoo,		ME_ARGFUNC },
-    { "verbose",	doVerbose,	ME_FUNC },
-    { "warn",		doOutput,	ME_ARGFUNC },
-    { NULL,		NULL,		0 }
-};
 
 static int
 validName(MacroBuf mb, const char *name, size_t namelen, const char *action)
@@ -1298,6 +1246,43 @@ static void doTrace(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 	print_expand_trace = mb->expand_trace;
     }
 }
+
+static struct builtins_s {
+    const char * name;
+    void *func;
+    int flags;
+} const builtinmacros[] = {
+    { "P",		doSP,		ME_ARGFUNC },
+    { "S",		doSP,		ME_ARGFUNC },
+    { "basename",	doFoo,		ME_ARGFUNC },
+    { "define",		doDef,		ME_PARSE },
+    { "dirname",	doFoo,		ME_ARGFUNC },
+    { "dnl",		doDnl,		ME_PARSE },
+    { "dump", 		doDump,		ME_PARSE },
+    { "echo",		doOutput,	ME_ARGFUNC },
+    { "error",		doOutput,	ME_ARGFUNC },
+    { "exists",		doFoo,		ME_ARGFUNC },
+    { "expand",		doExpand,	ME_ARGFUNC },
+    { "expr",		doFoo,		ME_ARGFUNC },
+    { "getconfdir",	doFoo,		ME_FUNC },
+    { "getenv",		doFoo,		ME_ARGFUNC },
+    { "getncpus",	doFoo,		ME_FUNC },
+    { "global",		doGlobal,	ME_PARSE },
+    { "load",		doLoad,		ME_ARGFUNC },
+    { "lua",		doLua,		ME_ARGFUNC },
+    { "macrobody",	doBody,		ME_ARGFUNC },
+    { "quote",		doFoo,		ME_ARGFUNC },
+    { "shrink",		doFoo,		ME_ARGFUNC },
+    { "suffix",		doFoo,		ME_ARGFUNC },
+    { "trace",		doTrace,	ME_FUNC },
+    { "u2p",		doFoo,		ME_ARGFUNC },
+    { "uncompress",	doUncompress,	ME_ARGFUNC },
+    { "undefine",	doUndefine,	ME_PARSE },
+    { "url2path",	doFoo,		ME_ARGFUNC },
+    { "verbose",	doVerbose,	ME_FUNC },
+    { "warn",		doOutput,	ME_ARGFUNC },
+    { NULL,		NULL,		0 }
+};
 
 static const char *setNegateAndCheck(const char *str, int *pnegate, int *pchkexist) {
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1512,25 +1512,6 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	    }
 	}
 
-	/* Expand builtin macros */
-	if (me && (me->flags & ME_BUILTIN)) {
-	    int havearg = (me->flags & ME_HAVEARG) ? 1 : 0;
-	    if (havearg != (g != NULL)) {
-		mbErr(mb, 1, "%%%s: %s\n", me->name, havearg ?
-			_("argument expected") : _("unexpected argument"));
-		continue;
-	    }
-	    if (me->flags & ME_PARSE) {
-		parseFunc parse = me->func;
-		s = parse(mb, me, se);
-	    } else {
-		macroFunc func = me->func;
-		func(mb, me, g, gn);
-		s = se;
-	    }
-	    continue;
-	}
-
 	/* XXX Special processing for flags and existance test */
 	if (*f == '-' || chkexist) {
 	    if ((me == NULL && !negate) ||	/* Without existance, skip %{?...} */
@@ -1552,6 +1533,25 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 	    /* XXX hack to permit non-overloaded %foo to be passed */
 	    c = '%';	/* XXX only need to save % */
 	    mbAppend(mb, c);
+	    continue;
+	}
+
+	/* Expand builtin macros */
+	if (me->flags & ME_BUILTIN) {
+	    int havearg = (me->flags & ME_HAVEARG) ? 1 : 0;
+	    if (havearg != (g != NULL)) {
+		mbErr(mb, 1, "%%%s: %s\n", me->name, havearg ?
+			_("argument expected") : _("unexpected argument"));
+		continue;
+	    }
+	    if (me->flags & ME_PARSE) {
+		parseFunc parse = me->func;
+		s = parse(mb, me, se);
+	    } else {
+		macroFunc func = me->func;
+		func(mb, me, g, gn);
+		s = se;
+	    }
 	    continue;
 	}
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1303,8 +1303,7 @@ static void doLoad(MacroBuf mb, int chkexist, int negate,
 {
     char *arg = NULL;
     if (g && gn > 0 && expandThis(mb, g, gn, &arg) == 0) {
-	/* Print failure iff %{load:...} or %{!?load:...} */
-	if (loadMacroFile(mb->mc, arg) && chkexist == negate) {
+	if (loadMacroFile(mb->mc, arg)) {
 	    mbErr(mb, 1, _("failed to load macro file %s\n"), arg);
 	}
     }

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -133,8 +133,7 @@ static int print_macro_trace = _PRINT_MACRO_TRACE;
 #define	_PRINT_EXPAND_TRACE	0
 static int print_expand_trace = _PRINT_EXPAND_TRACE;
 
-typedef void (*macroFunc)(MacroBuf mb, int chkexist, int negate,
-			rpmMacroEntry me, const char * g, size_t gn);
+typedef void (*macroFunc)(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
 typedef const char *(*parseFunc)(MacroBuf mb, rpmMacroEntry me, const char * se);
 
 /* forward ref */
@@ -143,26 +142,16 @@ static void pushMacro(rpmMacroContext mc,
 	const char * n, const char * o, const char * b, int level, int flags);
 static void popMacro(rpmMacroContext mc, const char * n);
 static int loadMacroFile(rpmMacroContext mc, const char * fn);
-static void doBody(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doExpand(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doFoo(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doLoad(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doLua(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doOutput(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doSP(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doTrace(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doUncompress(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
-static void doVerbose(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn);
+static void doBody(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doExpand(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doFoo(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doLoad(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doLua(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doOutput(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doSP(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doTrace(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doUncompress(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
+static void doVerbose(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn);
 
 static const char * doDef(MacroBuf mb, rpmMacroEntry me, const char * se);
 static const char * doGlobal(MacroBuf mb, rpmMacroEntry me, const char * se);
@@ -1036,8 +1025,7 @@ grabArgs(MacroBuf mb, ARGV_t *argvp, const char * se,
 	   lastc : lastc + 1;
 }
 
-static void doBody(MacroBuf mb, int chkexist, int negate,
-		rpmMacroEntry me, const char * g, size_t gn)
+static void doBody(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     if (gn > 0) {
 	char *buf = NULL;
@@ -1053,7 +1041,7 @@ static void doBody(MacroBuf mb, int chkexist, int negate,
     }
 }
 
-static void doOutput(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me, const char * g, size_t gn)
+static void doOutput(MacroBuf mb,  rpmMacroEntry me, const char * g, size_t gn)
 {
     char *buf = NULL;
     int loglevel = RPMLOG_NOTICE; /* assume echo */
@@ -1071,7 +1059,7 @@ static void doOutput(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me, co
     _free(buf);
 }
 
-static void doLua(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me, const char * g, size_t gn)
+static void doLua(MacroBuf mb,  rpmMacroEntry me, const char * g, size_t gn)
 {
 #ifdef WITH_LUA
     rpmlua lua = NULL; /* Global state. */
@@ -1114,8 +1102,7 @@ static void doLua(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me, const
 }
 
 static void
-doSP(MacroBuf mb, int chkexist, int negate,
-	    rpmMacroEntry me, const char * g, size_t gn)
+doSP(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     const char *b = "";
     char *buf = NULL;
@@ -1132,8 +1119,7 @@ doSP(MacroBuf mb, int chkexist, int negate,
     free(buf);
 }
 
-static void doUncompress(MacroBuf mb, int chkexist, int negate,
-		rpmMacroEntry me, const char * g, size_t gn)
+static void doUncompress(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     rpmCompressedMagic compressed = COMPRESSED_OTHER;
     char *b, *be, *buf = NULL;
@@ -1191,8 +1177,7 @@ exit:
     free(buf);
 }
 
-static void doExpand(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn)
+static void doExpand(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     if (gn > 0) {
 	char *buf;
@@ -1202,8 +1187,7 @@ static void doExpand(MacroBuf mb, int chkexist, int negate,
     }
 }
 
-static void doVerbose(MacroBuf mb, int chkexist, int negate,
-		rpmMacroEntry me, const char * g, size_t gn)
+static void doVerbose(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     mbAppend(mb, rpmIsVerbose() ? '1' : '0');
 }
@@ -1211,14 +1195,11 @@ static void doVerbose(MacroBuf mb, int chkexist, int negate,
 /**
  * Execute macro primitives.
  * @param mb		macro expansion state
- * @param chkexist	unused
- * @param negate	should logic be inverted?
  * @param g		beginning of field g
  * @param gn		length of field g
  */
 static void
-doFoo(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me,
-		const char * g, size_t gn)
+doFoo(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     char *buf = NULL;
     char *b = NULL;
@@ -1298,8 +1279,7 @@ doFoo(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me,
     free(buf);
 }
 
-static void doLoad(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn)
+static void doLoad(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     char *arg = NULL;
     if (g && gn > 0 && expandThis(mb, g, gn, &arg) == 0) {
@@ -1310,8 +1290,7 @@ static void doLoad(MacroBuf mb, int chkexist, int negate,
     free(arg);
 }
 
-static void doTrace(MacroBuf mb, int chkexist, int negate,
-		    rpmMacroEntry me, const char * g, size_t gn)
+static void doTrace(MacroBuf mb, rpmMacroEntry me, const char * g, size_t gn)
 {
     mb->expand_trace = mb->macro_trace = mb->depth;
     if (mb->depth == 1) {
@@ -1546,7 +1525,7 @@ expandMacro(MacroBuf mb, const char *src, size_t slen)
 		s = parse(mb, me, se);
 	    } else {
 		macroFunc func = me->func;
-		func(mb, chkexist, negate, me, g, gn);
+		func(mb, me, g, gn);
 		s = se;
 	    }
 	    continue;

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -627,6 +627,7 @@ static struct builtins_s {
     { "dump", 		doDump,		ME_PARSE },
     { "echo",		doOutput,	ME_ARGFUNC },
     { "error",		doOutput,	ME_ARGFUNC },
+    { "exists",		doFoo,		ME_ARGFUNC },
     { "expand",		doExpand,	ME_ARGFUNC },
     { "expr",		doFoo,		ME_ARGFUNC },
     { "getconfdir",	doFoo,		ME_FUNC },
@@ -1287,6 +1288,8 @@ doFoo(MacroBuf mb, int chkexist, int negate, rpmMacroEntry me,
     } else if (rstreq("getncpus", me->name)) {
 	sprintf(buf, "%u", getncpus());
 	b = buf;
+    } else if (rstreq("exists", me->name)) {
+	b = (access(buf, F_OK) == 0) ? "1" : "0";
     }
 
     if (b) {

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -782,6 +782,22 @@ runroot rpm --eval '%{verbose:zzz}'
 ])
 AT_CLEANUP
 
+AT_SETUP([%exists macro])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+	--eval "%{exists:/data}" \
+	--eval "%{exists:/zzz}" \
+	--eval "%{exists}"
+],
+[1],
+[1
+0
+],
+[error: %exists: argument expected
+])
+AT_CLEANUP
+
 AT_SETUP([macro with a line starting by "{"])
 AT_KEYWORDS([macros])
 AT_CHECK([

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -767,39 +767,18 @@ bar
 ])
 AT_CLEANUP
 
-AT_SETUP([%verbose negative test])
+AT_SETUP([%verbose macro])
 AT_KEYWORDS([macros verbose])
 AT_CHECK([
-runroot rpm \
-  --eval '%{verbose:%{echo:is verbose}}' \
-  --eval '%{verbose:is verbose text}'\
-  --eval '%{!verbose:%{echo:is not verbose}}'\
-  --eval '%{!verbose:is not verbose text}'
+runroot rpm --eval '%{verbose}'
+runroot rpm -v --eval '%{verbose}'
+runroot rpm --eval '%{verbose:zzz}'
 ],
-[0],
-[
-
-is not verbose
-
-is not verbose text
-])
-AT_CLEANUP
-
-AT_SETUP([%verbose positive test])
-AT_KEYWORDS([macros verbose])
-AT_CHECK([
-runroot rpm -v \
-  --eval '%{!verbose:%{echo:is not verbose}}' \
-  --eval '%{!verbose:is not verbose text}'\
-  --eval '%{verbose:%{echo:is verbose}}'\
-  --eval '%{verbose:is verbose text}'
+[1],
+[0
+1
 ],
-[0],
-[
-
-is verbose
-
-is verbose text
+[error: %verbose: unexpected argument
 ])
 AT_CLEANUP
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -526,6 +526,16 @@ runroot rpm \
 [])
 AT_CLEANUP
 
+AT_SETUP([test lua support])
+AT_KEYWORDS([macros lua])
+AT_CHECK([[
+lua_disabled=$(runroot rpm --eval '%[%{defined lua}?"0":"1"]'|tr -d '\n')
+test $lua_disabled = $LUA_DISABLED
+]],
+[1],
+[])
+AT_CLEANUP
+
 AT_SETUP([simple lua --eval])
 AT_KEYWORDS([macros lua])
 AT_CHECK([


### PR DESCRIPTION
Some builtin macros have their own special meaning for ! and ? which is inconsistent with the general meaning of those. This is confusing, bad and conflicts with the goal of making builtins more like normal macros.

This changes %{verbose} to return a simple boolean that can be used in an expression, and drops support for undocumented conditional %{?load:...} which can be avoided by using newly added boolean %{exists:...} instead. Also drop support for undocumented %{!trace} syntax to disable tracing, we can easily add some other syntax to support that if necessary. 

With that, builtin macros have no special syntaxes left, eliminate the internal arguments and make builtins follow general macro conditional syntax.