### PR TITLE
Implement argvAddN() API for adding partial strings to argv arrays

### DIFF
--- a/rpmio/argv.c
+++ b/rpmio/argv.c
@@ -130,6 +130,11 @@ int argiAdd(ARGI_t * argip, int ix, int val)
 
 int argvAdd(ARGV_t * argvp, const char *val)
 {
+    return argvAddN(argvp, val, strlen(val));
+}
+
+int argvAddN(ARGV_t * argvp, const char *val, size_t len)
+{
     ARGV_t argv;
     int argc;
 
@@ -138,8 +143,13 @@ int argvAdd(ARGV_t * argvp, const char *val)
     argc = argvCount(*argvp);
     *argvp = xrealloc(*argvp, (argc + 1 + 1) * sizeof(**argvp));
     argv = *argvp;
-    argv[argc++] = xstrdup(val);
-    argv[argc  ] = NULL;
+
+    char *newarg = xmalloc(len + 1);
+    strncpy(newarg, val, len);
+    newarg[len] = '\0';
+
+    argv[argc] = newarg;
+    argv[argc + 1] = NULL;
     return 0;
 }
 

--- a/rpmio/argv.h
+++ b/rpmio/argv.h
@@ -126,6 +126,15 @@ int argiAdd(ARGI_t * argip, int ix, int val);
 int argvAdd(ARGV_t * argvp, const char *val);
 
 /** \ingroup rpmargv
+ * Add a string to an argv array, does not need to be nil-terminated.
+ * @param[out] *argvp	argv array
+ * @param val		string arg to append
+ * @paran len		string arg length
+ * @return		0 always
+ */
+int argvAddN(ARGV_t * argvp, const char *val, size_t len);
+
+/** \ingroup rpmargv
  * Add a number to an argv array (converting to a string).
  * @param[out] *argvp	argv array
  * @param val		numeric arg to append


### PR DESCRIPTION
Support adding partial / non-terminated strings to argv without having
to jump through hoops at the call site. argvAdd() becomes just a special
case of argvAddN().