### PR TITLE
Fail CI on doxygen warnings

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -67,4 +67,7 @@ RUN ./configure \
   --enable-silent-rules \
   --enable-werror
 
+# --enable-werror equivalent for Doxygen
+RUN sed -i -e "/^WARN_AS_ERROR/s/ NO/ YES/g" doc/librpm.doxy.in
+
 CMD make -j$(nproc) distcheck TESTSUITEFLAGS=-j$(nproc); rc=$?; find . -name rpmtests.log|xargs cat; exit $rc

--- a/rpmio/argv.h
+++ b/rpmio/argv.h
@@ -129,7 +129,7 @@ int argvAdd(ARGV_t * argvp, const char *val);
  * Add a string to an argv array, does not need to be nil-terminated.
  * @param[out] *argvp	argv array
  * @param val		string arg to append
- * @paran len		string arg length
+ * @param len		string arg length
  * @return		0 always
  */
 int argvAddN(ARGV_t * argvp, const char *val, size_t len);


### PR DESCRIPTION
Fix the dumb typo in argvAddN() parameter documentation, and prevent such mishaps in the future.