### PR TITLE
Only do early name services initialization if we actually chroot

### DIFF
--- a/lib/rpmchroot.c
+++ b/lib/rpmchroot.c
@@ -5,6 +5,7 @@
 #include <rpm/rpmstring.h>
 #include <rpm/rpmlog.h>
 #include "lib/rpmchroot.h"
+#include "lib/rpmug.h"
 #include "debug.h"
 
 int _rpm_nouserns = 0;
@@ -101,6 +102,10 @@ int rpmChrootSet(const char *rootDir)
 	    rpmlog(RPMLOG_ERR, _("Unable to open current directory: %m\n"));
 	    rc = -1;
 	}
+
+	/* Force preloading of dlopen()'ed libraries before chroot */
+	if (rpmugInit())
+	    rc = -1;
     }
 
     return rc;

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -35,7 +35,6 @@
 #include "rpmio/rpmlua.h"
 #include "rpmio/rpmio_internal.h"	/* XXX for rpmioSlurp */
 #include "lib/misc.h"
-#include "lib/rpmug.h"
 
 #include "debug.h"
 
@@ -1631,10 +1630,6 @@ int rpmReadConfigFiles(const char * file, const char * target)
     rpmrcCtx ctx = rpmrcCtxAcquire(1);
 
     pthread_once(&atexit_registered, register_atexit);
-
-    /* Force preloading of dlopen()'ed libraries in case we go chrooting */
-    if (rpmugInit())
-	goto exit;
 
     if (rpmInitCrypto())
 	goto exit;


### PR DESCRIPTION
There's no point or need to do all this fluff on library initialization,
we can just as well do it when we're told to use a chroot by
calling rpmChrootSet(), at which time we're still on familiar ground.
Eliminating unused cruft from initialization can't hurt our start-up
times either.