### PR TITLE
Eliminate use of obsolete gethostbyname() function

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -7,6 +7,8 @@
 
 #include <errno.h>
 #include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <netdb.h>
 #include <time.h>
 
@@ -42,21 +44,26 @@ static rpm_time_t getBuildTime(void)
 static char * buildHost(void)
 {
     char* hostname;
-    struct hostent *hbn;
     char *bhMacro;
 
     bhMacro = rpmExpand("%{?_buildhost}", NULL);
     if (strcmp(bhMacro, "") != 0) {
         rasprintf(&hostname, "%s", bhMacro);
     } else {
-        hostname = rcalloc(1024, sizeof(*hostname));
-        (void) gethostname(hostname, 1024);
-        hbn = gethostbyname(hostname);
-        if (hbn)
-            strcpy(hostname, hbn->h_name);
-        else
-            rpmlog(RPMLOG_WARNING,
+	hostname = rcalloc(NI_MAXHOST + 1, sizeof(*hostname));
+	if (gethostname(hostname, NI_MAXHOST) == 0) {
+	    struct addrinfo *ai, hints;
+	    memset(&hints, 0, sizeof(hints));
+	    hints.ai_flags = AI_CANONNAME;
+
+	    if (getaddrinfo(hostname, NULL, &hints, &ai) == 0) {
+		strcpy(hostname, ai->ai_canonname);
+	    } else {
+		rpmlog(RPMLOG_WARNING,
                     _("Could not canonicalize hostname: %s\n"), hostname);
+	    }
+	    freeaddrinfo(ai);
+	}
     }
     free(bhMacro);
     return(hostname);

--- a/configure.ac
+++ b/configure.ac
@@ -621,7 +621,7 @@ AC_CHECK_FUNCS([secure_getenv __secure_getenv])
 
 AC_CHECK_FUNCS(
    [mkstemp getcwd basename dirname realpath setenv unsetenv regcomp lchown \
-    utimes getline localtime_r statvfs ],
+    utimes getline localtime_r statvfs getaddrinfo ],
    [], [AC_MSG_ERROR([function required by rpm])])
 
 AC_LIBOBJ(fnmatch)

--- a/lib/rpmug.c
+++ b/lib/rpmug.c
@@ -174,7 +174,6 @@ static void loadLibs(void)
     endpwent();
     (void) getgrnam(GID_0_GROUP);
     endgrent();
-    (void) gethostbyname("localhost");
 }
 
 int rpmugInit(void)


### PR DESCRIPTION
We only actually used gethostbyname() for canonicalizing buildhost,
convert that to use getaddrinfo() instead: this is not a particularly
useful or interesting field so just grab whatever result comes first.

The other "use" was to initialize name services, but as we don't need
or use hostnames for any operation, we can just as well drop it. User
and group names are what we care about.