### PR TITLE
rpmbuild logging tweaks

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -424,11 +424,20 @@ exit:
     freeStringBuf(sink);
     free(cookie);
     spec->rootDir = NULL;
-    if (rc != RPMRC_OK && rc != RPMRC_MISSINGBUILDREQUIRES &&
-	    rpmlogGetNrecs() > 0) {
-	rpmlog(RPMLOG_NOTICE, _("\n\nRPM build errors:\n"));
-	rpmlogPrint(NULL);
+
+    /* Print a warning/error summary */
+    int nrecs = rpmlogGetNrecs();
+    if (nrecs && rc != RPMRC_MISSINGBUILDREQUIRES) {
+        int mkwarn = RPMLOG_MASK(RPMLOG_WARNING);
+        int mkerrs = RPMLOG_MASK(RPMLOG_ERR);
+        int nwarn = rpmlogGetNrecsByMask(mkwarn);
+	rpmlog(RPMLOG_NOTICE,
+               _("\n\nRPM build problems (%i warnings, %i errors):\n"),
+               nwarn, nrecs - nwarn);
+	rpmlogPrettyPrint(NULL, mkwarn, 1);
+	rpmlogPrettyPrint(NULL, mkerrs, 1);
     }
+
     rpmugFree();
     if (missing_buildreqs && !rc) {
 	rc = RPMRC_MISSINGBUILDREQUIRES;

--- a/build/build.c
+++ b/build/build.c
@@ -170,8 +170,10 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 	goto exit;
     }
     
-    buildTemplate = rpmExpand(mTemplate, NULL);
-    buildPost = rpmExpand(mPost, NULL);
+    if ((buildTemplate = rpmExpand(mTemplate, NULL)) == NULL)
+        goto exit;
+    if ((buildPost = rpmExpand(mPost, NULL)) == NULL)
+        goto exit;
 
     (void) fputs(buildTemplate, fp);
 
@@ -196,7 +198,8 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 	goto exit;
     }
 
-    buildCmd = rpmExpand(mCmd, " ", scriptName, NULL);
+    if ((buildCmd = rpmExpand(mCmd, " ", scriptName, NULL)) == NULL)
+        goto exit;
     (void) poptParseArgvString(buildCmd, &argc, &argv);
 
     rpmlog(RPMLOG_NOTICE, _("Executing(%s): %s\n"), name, buildCmd);

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -291,6 +291,11 @@ static int copyNextLineFromOFI(rpmSpec spec, OFI_t *ofi, int strip)
 		spec->lbuf = realloc(spec->lbuf, spec->lbufSize);
 	    }
 	}
+	if (ch != '\n') {
+	    spec->lbuf[spec->lbufOff++] = '\n';
+	    if (spec->lbufOff == spec->lbufSize)
+		spec->lbuf = realloc(spec->lbuf, ++spec->lbufSize);
+	}
 	spec->lbuf[spec->lbufOff] = '\0';
 	ofi->readPtr = from;
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -2005,6 +2005,7 @@ rpmExpand(const char *arg, ...)
     const char *s;
     va_list ap;
     rpmMacroContext mc;
+    int rc = 1;
 
     if (arg == NULL) {
 	ret = xstrdup("");
@@ -2026,8 +2027,13 @@ rpmExpand(const char *arg, ...)
     va_end(ap);
 
     mc = rpmmctxAcquire(NULL);
-    (void) doExpandMacros(mc, buf, 0, &ret);
+    rc = doExpandMacros(mc, buf, 0, &ret);
     rpmmctxRelease(mc);
+
+    if (rc) {
+        free(ret);
+        ret = NULL;
+    }
 
     free(buf);
 exit:

--- a/rpmio/rpmlog.c
+++ b/rpmio/rpmlog.c
@@ -101,11 +101,6 @@ rpmlogLvl rpmlogRecPriority(rpmlogRec rec)
     return (rec != NULL) ? rec->pri : (rpmlogLvl)-1;
 }
 
-static void rpmlogRecPrint(rpmlogRec rec, void *data)
-{
-    fprintf((FILE *)data, "    %s", rec->message);
-}
-
 static void rpmlogForeach(void (*func) (rpmlogRec, void*), void *data,
                           unsigned mask)
 {
@@ -122,18 +117,6 @@ static void rpmlogForeach(void (*func) (rpmlogRec, void*), void *data,
     }
 
     rpmlogCtxRelease(ctx);
-}
-
-void rpmlogPrint(FILE *f)
-{
-    rpmlogPrettyPrint(f, 0, 0);
-}
-
-void rpmlogPrettyPrint(FILE *f, unsigned mask, int color)
-{
-    if (f == NULL)
-	f = stderr;
-    rpmlogForeach(color ? rpmlogRecPrettyPrint : rpmlogRecPrint, f, mask);
 }
 
 void rpmlogClose (void)
@@ -376,6 +359,23 @@ static void rpmlogRecPrettyPrint(rpmlogRec rec, void *data)
     FILE *f = (FILE *)data;
     fprintf(f, "    ");
     rpmlogDefault(f, rec);
+}
+
+static void rpmlogRecPrint(rpmlogRec rec, void *data)
+{
+    fprintf((FILE *)data, "    %s", rec->message);
+}
+
+void rpmlogPrettyPrint(FILE *f, unsigned mask, int color)
+{
+    if (f == NULL)
+	f = stderr;
+    rpmlogForeach(color ? rpmlogRecPrettyPrint : rpmlogRecPrint, f, mask);
+}
+
+void rpmlogPrint(FILE *f)
+{
+    rpmlogPrettyPrint(f, 0, 0);
 }
 
 /* FIX: rpmlogMsgPrefix[] dependent, not unqualified */

--- a/rpmio/rpmlog.c
+++ b/rpmio/rpmlog.c
@@ -126,9 +126,14 @@ static void rpmlogForeach(void (*func) (rpmlogRec, void*), void *data,
 
 void rpmlogPrint(FILE *f)
 {
+    rpmlogPrettyPrint(f, 0, 0);
+}
+
+void rpmlogPrettyPrint(FILE *f, unsigned mask, int color)
+{
     if (f == NULL)
 	f = stderr;
-    rpmlogForeach(rpmlogRecPrint, f, 0);
+    rpmlogForeach(color ? rpmlogRecPrettyPrint : rpmlogRecPrint, f, mask);
 }
 
 void rpmlogClose (void)
@@ -364,6 +369,13 @@ static int rpmlogDefault(FILE *stdlog, rpmlogRec rec)
 	logerror();
 
     return (rec->pri <= RPMLOG_CRIT ? RPMLOG_EXIT : 0);
+}
+
+static void rpmlogRecPrettyPrint(rpmlogRec rec, void *data)
+{
+    FILE *f = (FILE *)data;
+    fprintf(f, "    ");
+    rpmlogDefault(f, rec);
 }
 
 /* FIX: rpmlogMsgPrefix[] dependent, not unqualified */

--- a/rpmio/rpmlog.c
+++ b/rpmio/rpmlog.c
@@ -11,6 +11,9 @@
 #include <rpm/rpmmacro.h>
 #include "debug.h"
 
+#define each(rec, ctx) \
+    (rpmlogRec rec = ctx->recs; rec < &(ctx->recs[ctx->nrecs]); rec++)
+
 typedef struct rpmlogCtx_s * rpmlogCtx;
 struct rpmlogCtx_s {
     pthread_rwlock_t lock;
@@ -108,8 +111,7 @@ void rpmlogPrint(FILE *f)
     if (f == NULL)
 	f = stderr;
 
-    for (int i = 0; i < ctx->nrecs; i++) {
-	rpmlogRec rec = ctx->recs + i;
+    for each(rec, ctx) {
 	if (rec->message && *rec->message)
 	    fprintf(f, "    %s", rec->message);
     }
@@ -124,8 +126,7 @@ void rpmlogClose (void)
     if (ctx == NULL)
 	return;
 
-    for (int i = 0; i < ctx->nrecs; i++) {
-	rpmlogRec rec = ctx->recs + i;
+    for each(rec, ctx) {
 	rec->message = _free(rec->message);
     }
     ctx->recs = _free(ctx->recs);

--- a/rpmio/rpmlog.c
+++ b/rpmio/rpmlog.c
@@ -19,6 +19,7 @@ struct rpmlogCtx_s {
     pthread_rwlock_t lock;
     unsigned mask;
     int nrecs;
+    int nrecsPri[RPMLOG_NPRIORITIES];
     rpmlogRec recs;
     rpmlogCallback cbfunc;
     rpmlogCallbackData cbdata;
@@ -36,7 +37,7 @@ static rpmlogCtx rpmlogCtxAcquire(int write)
 {
     static struct rpmlogCtx_s _globalCtx = { PTHREAD_RWLOCK_INITIALIZER,
 					     RPMLOG_UPTO(RPMLOG_NOTICE),
-					     0, NULL, NULL, NULL, NULL };
+					     0, {0}, NULL, NULL, NULL, NULL };
     rpmlogCtx ctx = &_globalCtx;
     int xx;
 
@@ -59,10 +60,26 @@ static rpmlogCtx rpmlogCtxRelease(rpmlogCtx ctx)
 
 int rpmlogGetNrecs(void)
 {
+    return rpmlogGetNrecsByMask(0);
+}
+
+int rpmlogGetNrecsByMask(unsigned mask)
+{
     rpmlogCtx ctx = rpmlogCtxAcquire(0);
     int nrecs = -1;
-    if (ctx)
-	nrecs = ctx->nrecs;
+    if (ctx) {
+	if (!mask) {
+	    nrecs = ctx->nrecs;
+	} else {
+	    nrecs = 0;
+	    int bit = 1;
+	    for (int i = 0; i < RPMLOG_NPRIORITIES; i++) {
+	        if (mask & bit)
+	            nrecs += ctx->nrecsPri[i];
+	        bit <<= 1;
+	    }
+	}
+    }
     rpmlogCtxRelease(ctx);
     return nrecs;
 }
@@ -131,6 +148,7 @@ void rpmlogClose (void)
     }
     ctx->recs = _free(ctx->recs);
     ctx->nrecs = 0;
+    memset(ctx->nrecsPri, 0, sizeof(ctx->nrecsPri));
 
     rpmlogCtxRelease(ctx);
 }
@@ -403,6 +421,7 @@ static void dolog(struct rpmlogRec_s *rec, int saverec)
 	ctx->recs[ctx->nrecs+1].code = 0;
 	ctx->recs[ctx->nrecs+1].message = NULL;
 	ctx->nrecs++;
+	ctx->nrecsPri[rec->pri]++;
     }
     cbfunc = ctx->cbfunc;
     cbdata = ctx->cbdata;

--- a/rpmio/rpmlog.h
+++ b/rpmio/rpmlog.h
@@ -35,6 +35,7 @@ typedef enum rpmlogLvl_e {
     RPMLOG_NOTICE	= 5,	/*!< normal but significant condition */
     RPMLOG_INFO		= 6,	/*!< informational */
     RPMLOG_DEBUG	= 7	/*!< debug-level messages */
+#define	RPMLOG_NPRIORITIES 8	/*!< current number of priorities */
 } rpmlogLvl;
 
 #define	RPMLOG_PRIMASK	0x07	/* mask to extract priority part (internal) */
@@ -131,6 +132,13 @@ typedef void * rpmlogCallbackData;
   * 			0 to return after callback
   */
 typedef int (*rpmlogCallback) (rpmlogRec rec, rpmlogCallbackData data);
+
+/** \ingroup rpmlog
+ * Return number of rpmError() messages matching a log mask.
+ * @param mask		log mask to filter by (0 is no filtering)
+ * @return		number of messages matching the mask
+ */
+int rpmlogGetNrecsByMask(unsigned mask);
 
 /** \ingroup rpmlog
  * Return number of rpmError() ressages.

--- a/rpmio/rpmlog.h
+++ b/rpmio/rpmlog.h
@@ -139,6 +139,14 @@ typedef int (*rpmlogCallback) (rpmlogRec rec, rpmlogCallbackData data);
 int rpmlogGetNrecs(void)	;
 
 /** \ingroup rpmlog
+ * Print all rpmError() messages matching a log mask, possibly in color.
+ * @param f		file handle (NULL uses stderr)
+ * @param mask		log mask to filter by (0 is no filtering)
+ * @param color		should color be used if available?
+ */
+void rpmlogPrettyPrint(FILE *f, unsigned mask, int color);
+
+/** \ingroup rpmlog
  * Print all rpmError() messages.
  * @param f		file handle (NULL uses stderr)
  */


### PR DESCRIPTION
- ~Only print errors under "RPM build errors" (#793)~
- ~Add "RPM build warnings" section~
- [x] Count messages by type (in addition to `ctx->nrecs`)
- [x] Have a single "RPM build problems" section listing all warnings and errors encountered (#793)
- [x] Handle missing EOL before EOF
- [x] Clean spurious newlines in some warning messages
- [x] Error out if macro expansion fails (#145)
- ~Separate multi-line messages?~
- [ ] Add option to suppress intermediate errors (i.e. turn them into warnings) (#1277)
- [ ] Clean up rpmlog.h comments
