### PR TITLE
Fix a minor memory leak on failed sqlite database open (RhBug:1896301)

### DIFF
--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -145,6 +145,8 @@ static int sqlite_init(rpmdb rdb, const char * dbhome)
 	    xx = sqlite3_open_v2(dbfile, &sdb, flags, NULL);
 	    /* Attempt to create if missing, discarding OPEN_READONLY (!) */
 	    if (xx == SQLITE_CANTOPEN && (flags & SQLITE_OPEN_READONLY)) {
+		/* Sqlite allocates resources even on failure to open (!) */
+		sqlite3_close(sdb);
 		flags &= ~SQLITE_OPEN_READONLY;
 		flags |= (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
 		retry_open++;


### PR DESCRIPTION
Curiously, sqlite allocates resources that need freeing even in case
of failure to open. Quoting from https://www.sqlite.org/c3ref/open.html:

> Whether or not an error occurs when it is opened, resources associated
> with the database connection handle should be released by passing it to
> sqlite3_close() when it is no longer required.

I disagree, but as it's documented behavior there's no point filing a
bug. So lets close the non-open connection and chug on.