### PR TITLE
don't error out if OpenMP is too old

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,7 +188,7 @@ AS_IF([test "x$ac_cv_prog_c_openmp" != x &&
     ],
     [AC_MSG_RESULT([no])
      if test "$enable_openmp" = "yes"; then
-       AC_MSG_ERROR([OpenMP too old])
+       AC_MSG_WARN([OpenMP too old (forcefully disabled)])
      fi
     ]
   )


### PR DESCRIPTION
Don't error out if OpenMP is too old to be used with rpm but instead
display a warning and don't use any pragma omp

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>