### PR TITLE
Unify builtin and user-defined parametric macro calling syntax

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -134,7 +134,7 @@ static int print_macro_trace = _PRINT_MACRO_TRACE;
 #define	_PRINT_EXPAND_TRACE	0
 static int print_expand_trace = _PRINT_EXPAND_TRACE;
 
-typedef void (*macroFunc)(MacroBuf mb, rpmMacroEntry me, ARGV_t argv);
+typedef size_t (*macroFunc)(MacroBuf mb, rpmMacroEntry me, ARGV_t argv);
 typedef size_t (*parseFunc)(MacroBuf mb, rpmMacroEntry me, ARGV_t argv);
 
 /* forward ref */
@@ -982,7 +982,7 @@ grabArgs(MacroBuf mb, ARGV_t *argvp, const char * se,
 	   lastc : lastc + 1;
 }
 
-static void doBody(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+static size_t doBody(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     if (*argv[1]) {
 	char *buf = NULL;
@@ -996,9 +996,10 @@ static void doBody(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 	    free(buf);
 	}
     }
+    return 0;
 }
 
-static void doOutput(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
+static size_t doOutput(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
 {
     char *buf = NULL;
     int loglevel = RPMLOG_NOTICE; /* assume echo */
@@ -1012,10 +1013,11 @@ static void doOutput(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
     (void) expandThis(mb, argv[1], 0, &buf);
     rpmlog(loglevel, "%s\n", buf);
     _free(buf);
+    return 0;
 }
 
 #ifdef WITH_LUA
-static void doLua(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
+static size_t doLua(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
 {
     rpmlua lua = NULL; /* Global state. */
     const char *scriptbuf = argv[1];
@@ -1047,10 +1049,11 @@ static void doLua(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
 	mbAppendStr(mb, printbuf);
 	free(printbuf);
     }
+    return 0;
 }
 #endif
 
-static void
+static size_t
 doSP(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     const char *b = "";
@@ -1066,9 +1069,10 @@ doSP(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
     expandMacro(mb, s, 0);
     free(s);
     free(buf);
+    return 0;
 }
 
-static void doUncompress(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+static size_t doUncompress(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     rpmCompressedMagic compressed = COMPRESSED_OTHER;
     char *b, *be, *buf = NULL;
@@ -1125,9 +1129,10 @@ static void doUncompress(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 
 exit:
     free(buf);
+    return 0;
 }
 
-static void doExpand(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+static size_t doExpand(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     if (*argv[1]) {
 	char *buf;
@@ -1135,20 +1140,16 @@ static void doExpand(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 	expandMacro(mb, buf, 0);
 	free(buf);
     }
+    return 0;
 }
 
-static void doVerbose(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+static size_t doVerbose(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     mbAppend(mb, rpmIsVerbose() ? '1' : '0');
+    return 0;
 }
 
-/**
- * Execute macro primitives.
- * @param mb		macro expansion state
- * @param g		beginning of field g
- * @param gn		length of field g
- */
-static void
+static size_t
 doFoo(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     char *buf = NULL;
@@ -1227,9 +1228,10 @@ doFoo(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 	mbAppendStr(mb, b);
     }
     free(buf);
+    return 0;
 }
 
-static void doLoad(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+static size_t doLoad(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     char *arg = NULL;
     if (expandThis(mb, argv[1], 0, &arg) == 0) {
@@ -1238,15 +1240,17 @@ static void doLoad(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 	}
     }
     free(arg);
+    return 0;
 }
 
-static void doTrace(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+static size_t doTrace(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
     mb->expand_trace = mb->macro_trace = mb->depth;
     if (mb->depth == 1) {
 	print_macro_trace = mb->macro_trace;
 	print_expand_trace = mb->expand_trace;
     }
+    return 0;
 }
 
 static struct builtins_s {

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -776,12 +776,8 @@ static size_t doGlobal(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 
 static size_t doDump(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
-    const char *se = argv[1];
-    const char *start = se;
     rpmDumpMacroTable(mb->mc, NULL);
-    while (iseol(*se))
-	se++;
-    return se - start;
+    return 0;
 }
 
 
@@ -1247,7 +1243,7 @@ static struct builtins_s {
     { "define",		doDef,		-1,	ME_PARSE },
     { "dirname",	doFoo,		1,	ME_FUNC },
     { "dnl",		doDnl,		-1,	ME_PARSE },
-    { "dump", 		doDump,		0,	ME_PARSE },
+    { "dump", 		doDump,		0,	ME_FUNC },
     { "echo",		doOutput,	1,	ME_FUNC },
     { "error",		doOutput,	1,	ME_FUNC },
     { "exists",		doFoo,		1,	ME_FUNC },

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -752,30 +752,14 @@ exit:
 static size_t
 doUndefine(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
-    const char *se = argv[1];
-    const char *start = se;
-    const char *s = se;
-    char *buf = xmalloc(strlen(s) + 1);
-    char *n = buf, *ne = n;
-    int c;
-
-    COPYNAME(ne, s, c);
-
-    /* Move scan over body */
-    while (iseol(*s))
-	s++;
-    se = s;
-
-    if (!validName(mb, n, ne - n, "%undefine")) {
+    const char *n = argv[1];
+    if (!validName(mb, n, strlen(n), "%undefine")) {
 	mb->error = 1;
-	goto exit;
+    } else {
+	popMacro(mb->mc, n);
     }
 
-    popMacro(mb->mc, n);
-
-exit:
-    _free(buf);
-    return se - start;
+    return 0;
 }
 
 static size_t doDef(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
@@ -1284,7 +1268,7 @@ static struct builtins_s {
     { "trace",		doTrace,	0,	ME_FUNC },
     { "u2p",		doFoo,		1,	ME_FUNC },
     { "uncompress",	doUncompress,	1,	ME_FUNC },
-    { "undefine",	doUndefine,	1,	ME_PARSE },
+    { "undefine",	doUndefine,	1,	ME_FUNC },
     { "url2path",	doFoo,		1,	ME_FUNC },
     { "verbose",	doVerbose,	0,	ME_FUNC },
     { "warn",		doOutput,	1,	ME_FUNC },

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -302,26 +302,54 @@ AT_CHECK([
 runroot rpm --eval "%{dirname}"
 runroot rpm --eval "%{dirname:}"
 runroot rpm --eval "%{dirname:dir}"
+runroot rpm --eval "%{dirname dir}"
 runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
 runroot rpm --eval "%{getncpus:}"
 runroot rpm --eval "%{getncpus:5}"
 runroot rpm --eval "%{define:}"
+runroot rpm --eval "%{define:foo}"
+runroot rpm --eval "%{define:foo bar}%{foo}"
 runroot rpm --eval "%{dump:foo}"
 ],
 [1],
 [
 dir
+dir
 /hello/%%
 
+bar
 ],
 [error: %dirname: argument expected
 error: %uncompress: argument expected
 error: %getncpus: unexpected argument
 error: %getncpus: unexpected argument
-error: %define: unexpected argument
+error: Macro % has illegal name (%define)
+error: Macro %foo has empty body
 error: %dump: unexpected argument
+])
+AT_CLEANUP
+
+AT_SETUP([macro arguments])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --define 'zzz xxx' \
+    --eval '%{defined zzz}' \
+    --eval '%{defined:zzz}' \
+    --eval '%defined zzz' \
+    --eval '%{defined aaa}' \
+    --eval '%{defined:aaa}' \
+    --eval '%defined aaa'
+],
+[0],
+[1
+1
+1
+0
+0
+0
 ])
 AT_CLEANUP
 

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -303,6 +303,8 @@ runroot rpm --eval "%{dirname}"
 runroot rpm --eval "%{dirname:}"
 runroot rpm --eval "%{dirname:dir}"
 runroot rpm --eval "%{dirname dir}"
+runroot rpm --eval "%dirname"
+runroot rpm --eval "%dirname dir"
 runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
@@ -317,11 +319,13 @@ runroot rpm --eval "%{dump:foo}"
 [
 dir
 dir
+dir
 /hello/%%
 
 bar
 ],
 [error: %dirname: argument expected
+error: %dirname: argument expected
 error: %uncompress: argument expected
 error: %getncpus: unexpected argument
 error: %getncpus: unexpected argument


### PR DESCRIPTION
Accept both %{foo:arg} and %{foo arg} notation for both builtins
and user-defined parametric macros, the former only ever has one
argument whereas the latter can have multiple.

"parse" type builtins such as %define are trickier and only work with
traditional syntax for now.