### PR TITLE
debugedit: Do not 'edit_dwarf2' when just extracting build-id

### DIFF
--- a/tools/debugedit.c
+++ b/tools/debugedit.c
@@ -2865,7 +2865,8 @@ main (int argc, char *argv[])
 	      fprintf (stderr, "Stabs debuginfo not supported: %s\n", file);
 	      break;
 	    }
-	  if (strcmp (name, ".debug_info") == 0)
+	  if (!(do_build_id && no_recompute_build_id && !base_dir && !dest_dir)
+	      && strcmp (name, ".debug_info") == 0)
 	    edit_dwarf2 (dso);
 
 	  break;


### PR DESCRIPTION
No need to call edit_dwarf2() if debugedit is invoked just to extract
build-id (with `-i -n'). Otherwise, we will get `DWARF version 0
unhandled' warning for compressed .debug files:

  /usr/lib/rpm/debugedit: ./usr/lib/debug/...e.ko.debug: DWARF version 0 unhandled

Context: We have kernel modules elfcompressed in ALT.

@ldv-alt