### PR TITLE
Disable implicit database creation on read-only handle

### DIFF
--- a/lib/backend/db3.c
+++ b/lib/backend/db3.c
@@ -868,10 +868,9 @@ static int db3_dbiOpen(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flag
 	    rc = (db->open)(db, NULL, dbi->dbi_file, NULL,
 			    dbtype, oflags, rdb->db_perms);
 
-	    /* Attempt to create if missing, discarding DB_RDONLY (!) */
-	    if (rc == ENOENT) {
+	    /* Attempt to create if missing, if not read-only */
+	    if (rc == ENOENT && !(oflags & DB_RDONLY)) {
 		oflags |= DB_CREATE;
-		oflags &= ~DB_RDONLY;
 		dbtype = (rpmtag == RPMDBI_PACKAGES) ?  DB_HASH : DB_BTREE;
 		retry_open--;
 	    } else {

--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -133,8 +133,8 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 	    rc = rpmpkgOpen(&pkgdb, path, oflags, 0666);
 	else
 	    rc = rpmpkgSalvage(&pkgdb, path);
- 	if (rc && errno == ENOENT && (rdb->db_flags & RPMDB_FLAG_SALVAGE) == 0) {
-	    oflags = O_RDWR|O_CREAT;
+	if (rc && errno == ENOENT && (oflags == O_RDWR) && (rdb->db_flags & RPMDB_FLAG_SALVAGE) == 0) {
+	    oflags |= O_CREAT;
 	    dbi->dbi_flags |= DBI_CREATED;
 	    rc = rpmpkgOpen(&pkgdb, path, oflags, 0666);
 	}

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -143,13 +143,9 @@ static int sqlite_init(rpmdb rdb, const char * dbhome)
 
 	while (retry_open--) {
 	    xx = sqlite3_open_v2(dbfile, &sdb, flags, NULL);
-	    /* Attempt to create if missing, discarding OPEN_READONLY (!) */
-	    if (xx == SQLITE_CANTOPEN && (flags & SQLITE_OPEN_READONLY)) {
+	    if (xx == SQLITE_CANTOPEN) {
 		/* Sqlite allocates resources even on failure to open (!) */
 		sqlite3_close(sdb);
-		flags &= ~SQLITE_OPEN_READONLY;
-		flags |= (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
-		retry_open++;
 	    }
 	}
 

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -355,7 +355,7 @@ static int doOpen(rpmdb db, int justPkgs)
 {
     int rc = pkgdbOpen(db, db->db_flags, NULL);
     if (!justPkgs) {
-	for (int dbix = 0; dbix < db->db_ndbi; dbix++) {
+	for (int dbix = 0; rc == 0 && dbix < db->db_ndbi; dbix++) {
 	    rc += indexOpen(db, db->db_tags[dbix], db->db_flags, NULL);
 	}
     }

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -489,7 +489,7 @@ static int openDatabase(const char * prefix,
 		int mode, int perms, int flags)
 {
     rpmdb db;
-    int rc;
+    int rc = 0;
     int justCheck = flags & RPMDB_FLAG_JUSTCHECK;
 
     if (dbp)
@@ -505,7 +505,8 @@ static int openDatabase(const char * prefix,
     rpmdbRock = db;
 
     /* Try to ensure db home exists, error out if we can't even create */
-    rc = rpmioMkpath(rpmdbHome(db), 0755, getuid(), getgid());
+    if ((mode & O_ACCMODE) != O_RDONLY)
+	rc = rpmioMkpath(rpmdbHome(db), 0755, getuid(), getgid());
     if (rc == 0) {
 	/* Open just bare minimum when rebuilding a potentially damaged db */
 	int justPkgs = (db->db_flags & RPMDB_FLAG_REBUILD) &&

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -177,11 +177,11 @@ rpmdbMatchIterator rpmtsInitIterator(const rpmts ts, rpmDbiTagVal rpmtag,
     if (ts == NULL)
 	return NULL;
 
-    if (ts && ts->keyring == NULL)
-	loadKeyring(ts);
-
     if (ts->rdb == NULL && rpmtsOpenDB(ts, ts->dbmode))
 	return NULL;
+
+    if (ts->keyring == NULL)
+	loadKeyring(ts);
 
     /* Parse out "N(EVR)" tokens from a label key if present */
     if (rpmtag == RPMDBI_LABEL && keyp != NULL && strchr(keyp, '(')) {

--- a/tests/local.at
+++ b/tests/local.at
@@ -34,13 +34,13 @@ ${PYTHON} test.py
 
 m4_define([RPMPY_CHECK],[
 AT_SKIP_IF([$PYTHON_DISABLED])
-RPMTEST_SETUP
 AT_CHECK([RPMPY_RUN([$1])], [], [$2], [$3])
 ])
 
 m4_define([RPMPY_TEST],[
 AT_SETUP([$1])
 AT_KEYWORDS([python])
+RPMDB_INIT
 RPMPY_CHECK([$2], [$3], [$4])
 AT_CLEANUP
 ])

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -42,6 +42,19 @@ runroot rpm \
 [0])
 AT_CLEANUP
 
+# Run rpm -qa on a non-existent rpmdb
+AT_SETUP([rpm -qa])
+AT_KEYWORDS([rpmdb query])
+AT_CHECK([
+RPMTEST_SETUP
+runroot rpm \
+  -qa
+],
+[1],
+[],
+[ignore])
+AT_CLEANUP
+
 # ------------------------------
 # Run rpm -q <package> where <package> exists in the db.
 AT_SETUP([rpm -q foo])

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -369,8 +369,8 @@ ts.run(callback=ncb, data=cbd)
 
 AT_SETUP([database iterators])
 AT_KEYWORDS([python rpmdb])
-AT_CHECK([
 RPMDB_INIT
+AT_CHECK([
 runroot rpm -i \
   --justdb --nodeps --ignorearch --ignoreos \
   /data/RPMS/foo-1.0-1.noarch.rpm \
@@ -467,8 +467,8 @@ AT_CLEANUP
 
 AT_SETUP([database cookies])
 AT_KEYWORDS([python rpmdb])
-AT_CHECK([
 RPMDB_INIT
+AT_CHECK([
 ],
 [0],
 [],


### PR DESCRIPTION
If somebody is opening a database in a read-only mode (eg for query then we really have no business to *create* such database if not existing.
    
This implicit discard of read-only flag is such a long standing behavior that this is likely to break stuff here and there.
