### PR TITLE
Really require everything in buildroot to be packaged

### DIFF
--- a/scripts/check-files
+++ b/scripts/check-files
@@ -27,6 +27,6 @@ trap "rm -f \"${FILES_DISK}\"" 0 2 3 5 10 13 15
 
 # Find non-directory files in the build root and compare to the manifest.
 # TODO: regex chars in last sed(1) expression should be escaped
-find "${RPM_BUILD_ROOT}" -type f -o -type l | LC_ALL=C sort > "${FILES_DISK}"
+find "${RPM_BUILD_ROOT}" | LC_ALL=C sort > "${FILES_DISK}"
 LC_ALL=C sort | diff -d "${FILES_DISK}" - | sed -n 's!^\(-\|< \)'"${RPM_BUILD_ROOT}"'\(.*\)$!   \2!gp'
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -307,10 +307,8 @@ runroot rpmbuild \
 ])
 AT_CLEANUP
 
-# rpm doesn't detect unpackaged directories but should, really
 AT_SETUP([rpmbuild unpackaged directories])
 AT_KEYWORDS([build])
-AT_XFAIL_IF([test $RPM_XFAIL -ne 0])
 RPMDB_INIT
 AT_CHECK([
 RPMDB_INIT


### PR DESCRIPTION
Previously we only checked for unpackaged files and symlinks, completely
ignoring eg extra directories that might be there. Just check for everything
instead. Related to #994.

Directories are a little tricky as some of them are almost always unowned
so we need to allow all path components leading to packaged files.