### PR TITLE
Improve error handling in Python pubkey constructor

### DIFF
--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -27,10 +27,14 @@ static PyObject *rpmPubkey_new(PyTypeObject *subtype,
 	return NULL;
 
     if (pgpParsePkts(PyBytes_AsString(key), &pkt, &pktlen) <= 0) {
-	PyErr_SetString(PyExc_ValueError, "invalid pubkey");
+	PyErr_SetString(PyExc_ValueError, "invalid PGP armor");
 	return NULL;
     }
     pubkey = rpmPubkeyNew(pkt, pktlen);
+    if (pubkey == NULL) {
+	PyErr_SetString(PyExc_ValueError, "invalid pubkey");
+	return NULL;
+    }
 
     return rpmPubkey_Wrap(subtype, pubkey);
 }


### PR DESCRIPTION
pkgParsePkts() only parses the PGP armor, the actual pubkey is only
parsed as a part of rpmPubkeyNew() whose return we need to check for
separately. Emit different messages in these cases.

Thanks to @KOLANICH for pointing this out and initial patch.