### PR TITLE
Pull CI image from registry.fedoraproject.org

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora:32
 MAINTAINER rpm-maint@lists.rpm.org
 
 WORKDIR /srv/rpm


### PR DESCRIPTION
Dockerhub has added download rate limiting (and who could blame them)
But our CI getting blocked because of other projects being busy
downloading from Docker isn't so nice, hopefully Fedora's own registry
lets us work around this.