### PR TITLE
Fix 4.16.0 regression causing invalid spec file name on rpmbuild -ts

### DIFF
--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -91,6 +91,21 @@ runroot rpmbuild \
 ])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild -ts <spec>])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+
+runroot rpmbuild --quiet -ts /data/SOURCES/hello-2.0.tar.gz
+runroot rpm -qpl /build/SRPMS/hello-2.0-1.src.rpm
+],
+[0],
+[hello-2.0.tar.gz
+hello.spec
+],
+[])
+AT_CLEANUP
+
 # weird filename survival test
 AT_SETUP([rpmbuild package with weird filenames])
 AT_KEYWORDS([build])


### PR DESCRIPTION
Commit acf5e00281d73a2f8034091241c7b0e2ba00e383 cut a couple of corners
too many, causing the temporary file name used to extract the spec from
the tarball to end up in the src.rpm too.

Revert back to creating %_specdir for tar builds, it might not be
optimal but it's not exactly harmful either (%_sourcedir is different).
The "truly correct" solutions get increasingly complicated for such
a silly thing as this is. In addition to creating the %_specdir, we
also need to rename the file to its proper name, simplify that code
a bit while at it and add a test-case.

Fixes: #1386