### PR TITLE
Fix "#pragma omp priority" failure

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -143,10 +143,9 @@ of GPG, available from
     http://www.gnupg.org/
 
 OpenMP multithreading support is automatically enabled if your C compiler has
-support for OpenMP version 4.5 or higher (to disable, pass the --disable-openmp
-option to configure).  For GCC, OpenMP 4.5 is fully supported since GCC 6.1,
-which is available from
-    http://www.gnu.org/
+support for OpenMP (to disable, pass the --disable-openmp option to configure).
+Suitable compilers are listed at
+    https://www.openmp.org/resources/openmp-compilers-tools/
 
 To compile RPM:
 --------------

--- a/build/pack.c
+++ b/build/pack.c
@@ -22,6 +22,10 @@
 
 #include "debug.h"
 
+#if _OPENMP < 201511
+#define priority(x)
+#endif
+
 static int rpmPackageFilesArchive(rpmfiles fi, int isSrc,
 				  FD_t cfd, ARGV_t dpaths,
 				  rpm_loff_t * archiveSize, char ** failedFile)

--- a/configure.ac
+++ b/configure.ac
@@ -167,32 +167,11 @@ AC_SUBST(WITH_LZMA_LIB)
 
 # AC_OPENMP supports --enable/disable-openmp out of the box, but it doesn't
 # actually give us a way to conditionalize the build based on that. Argh.
-# Version 4.5 (201511) introduced "priority" clause for tasks.
 OPENMP_CFLAGS=
 AC_OPENMP
 AS_IF([test "x$ac_cv_prog_c_openmp" != x &&
        test "x$ac_cv_prog_c_openmp" != xunsupported],[
-  old_CFLAGS=$CFLAGS
-  CFLAGS="$CFLAGS $OPENMP_CFLAGS"
-  AC_MSG_CHECKING([OpenMP is at least version 4.5])
-  AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM(
-      [#include <omp.h>],
-      [#if _OPENMP < 201511
-       #error
-       #endif
-      ]
-    )],
-    [AC_MSG_RESULT([yes])
-     AC_DEFINE(ENABLE_OPENMP, 1, [Enable multithreading support?])
-    ],
-    [AC_MSG_RESULT([no])
-     if test "$enable_openmp" = "yes"; then
-       AC_MSG_ERROR([OpenMP too old])
-     fi
-    ]
-  )
-  CFLAGS=$old_CFLAGS
+  AC_DEFINE(ENABLE_OPENMP, 1, [Enable multithreading support?])
 ])
 AC_SUBST(OPENMP_CFLAGS)
 


### PR DESCRIPTION
This fixes, although indirectly, the common `make` failure with the `priority` clause reported in issue #1433. The culprit of that failure was pretty simple - we should have reset `OPENMP_CFLAGS` to the empty value in case we were disabling OpenMP in the respective check in the `configure` script.

However, I thought it would be simpler to just get rid of that check altogether, as we don't really need it. More details in the commit messages.