### PR TITLE
Fix brown paperbag regression in c223d84fbf1ebb7a862f297e65878a2a7865…

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -58,11 +58,11 @@ static char * buildHost(void)
 
 	    if (getaddrinfo(hostname, NULL, &hints, &ai) == 0) {
 		strcpy(hostname, ai->ai_canonname);
+		freeaddrinfo(ai);
 	    } else {
 		rpmlog(RPMLOG_WARNING,
                     _("Could not canonicalize hostname: %s\n"), hostname);
 	    }
-	    freeaddrinfo(ai);
 	}
     }
     free(bhMacro);


### PR DESCRIPTION
…3e8e

Only call free on the success path, getaddrinfo() is like most this
type functions and only allocates on success and so, in failure we'd
end up freeing an uninitialized pointer.
Reported by Scott Andrews on rpm-list.