### PR TITLE
Support building on arm64 macOS

### DIFF
--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1039,6 +1039,8 @@ static void defaultMachine(rpmrcCtx ctx, const char ** arch, const char ** os)
 	    strcpy(un.machine, "i386");
 #elif defined(__x86_64__)
 	    strcpy(un.machine, "x86_64");
+#elif defined(__aarch64__)
+	    strcpy(un.machine, "aarch64");
 #else
 	    #warning "No architecture defined! Automatic detection may not work!"
 #endif 


### PR DESCRIPTION
What it says on the tin.

As it stands right now building `rpm` natively on a M1 box just gets you `error: No compatible architectures found for build` if you try to `rpmbuild` anything, so we need to detect when `__arm64__` is defined and set the build architecture to `aarch64`.