### PR TITLE
Add darwin support to NDB.

### DIFF
--- a/lib/backend/ndb/rpmidx.c
+++ b/lib/backend/ndb/rpmidx.c
@@ -16,7 +16,14 @@
 #include <sys/mman.h>
 #include <errno.h>
 
+#ifdef __APPLE__
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#else
 #include <endian.h>
+#endif /* __APPLE__ */
 
 #include "rpmidx.h"
 #include "rpmxdb.h"

--- a/lib/backend/ndb/rpmxdb.c
+++ b/lib/backend/ndb/rpmxdb.c
@@ -14,7 +14,14 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/mman.h>
+#ifdef __APPLE__
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#else
 #include <endian.h>
+#endif /* __APPLE__ */
 #include <libgen.h>
 #include <dirent.h>
 


### PR DESCRIPTION
This seems to do the trick for getting NDB to compile on macOS.
We've been running this patch in production for a bit and it hasn't caused any issues for us.

Feedback welcome, My C is very very rusty, so there might be better ways of doing this :)