### PR TITLE
Harden against crafted inputs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ fi
 AS=${AS-as}
 AC_SUBST(AS)
 if test "$GCC" = yes; then
-    cflags_to_try="-fno-strict-aliasing -fstack-protector -Wempty-body"
+    cflags_to_try="-fno-strict-aliasing -fstack-protector -Wempty-body -fwrapv -fwrapv-pointer -fno-strict-overflow -fstack-protector-strong"
     AC_MSG_CHECKING([supported compiler flags])
     old_cflags=$CFLAGS
     echo

--- a/lib/header.c
+++ b/lib/header.c
@@ -1847,6 +1847,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
      * How much of a difference does this make?  A lot.  libfuzzer was
      * able to obtain over 50% more coverage.
      */
+    STATIC_ASSERT(sizeof(int32_t) == 4);
+    STATIC_ASSERT(sizeof(struct entryInfo_s) == 16);
+    STATIC_ASSERT(UINT32_MAX / sizeof(struct entryInfo_s) == (1U << 28) - 1);
     if (Size < 20 || Size > headerMaxbytes - 4)
 	return 0;
     uint32_t *new_data = xmalloc(Size + 4);

--- a/lib/header.c
+++ b/lib/header.c
@@ -289,9 +289,13 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	/* Verify the data actually fits */
 	len = dataLength(info.type, ds + info.offset,
 			 info.count, 1, ds + blob->dl);
-	end = info.offset + len;
-	if (hdrchkRange(blob->dl, end) || len <= 0)
+	/*
+	 * We already checked that blob->dl >= info.offset, so this cannot
+	 * overflow
+	 */
+	if (hdrchkRange(blob->dl - info.offset, len))
 	    goto err;
+	end = info.offset + len;
     }
     return 0; /* Everything ok */
 

--- a/lib/header.c
+++ b/lib/header.c
@@ -1839,7 +1839,7 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 
     /* Is there an immutable header region tag? */
     if (!(einfo.tag == regionTag)) {
-	rc = RPMRC_NOTFOUND;
+	rc = exact_size ? RPMRC_FAIL : RPMRC_NOTFOUND;
 	goto exit;
     }
 
@@ -1898,6 +1898,12 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     if (hdrchkRange(blob->il, blob->ril) || hdrchkRange(blob->dl, blob->rdl)) {
 	rasprintf(buf, _("region %d size: BAD, ril %d il %d rdl %d dl %d"),
 			regionTag, blob->ril, blob->il, blob->rdl, blob->dl);
+	goto exit;
+    }
+
+    /* Is the region empty?  That isn't allowed. */
+    if (blob->rdl < 1) {
+	rasprintf(buf, _("region %d: BAD, region is empty"), regionTag);
 	goto exit;
     }
 

--- a/lib/header.c
+++ b/lib/header.c
@@ -449,6 +449,9 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
     const char * se = pend;
     int length = 0;
 
+    if (hdrchkData(count))
+	return -1;
+
     switch (type) {
     case RPM_STRING_TYPE:
 	if (count != 1)

--- a/lib/header.c
+++ b/lib/header.c
@@ -299,6 +299,11 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg, int exact_size)
 	if (hdrchkRange(dl - info.offset, len))
 	    goto err;
 	end = info.offset + len;
+	if (blob->regionTag) {
+	    /* Verify that the data does not overlap the region trailer */
+	    if (end > blob->rdl - REGION_TAG_COUNT && info.offset < blob->rdl)
+		goto err;
+	}
     }
     return 0; /* Everything ok */
 

--- a/lib/header.c
+++ b/lib/header.c
@@ -256,7 +256,7 @@ Header headerNew(void)
     return headerCreate(NULL, 0);
 }
 
-static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
+static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg, int exact_size)
 {
     struct entryInfo_s info;
     int i, len = 0;
@@ -2021,7 +2021,7 @@ rpmRC hdrblobInit(const void *uh, size_t uc,
 	goto exit;
 
     /* Sanity check the rest of the header structure. */
-    if (hdrblobVerifyInfo(blob, emsg))
+    if (hdrblobVerifyInfo(blob, emsg, exact_size))
 	goto exit;
 
     rc = RPMRC_OK;

--- a/lib/header.c
+++ b/lib/header.c
@@ -1998,12 +1998,42 @@ rpmRC hdrblobInit(const void *uh, size_t uc,
 		rpmTagVal regionTag, int exact_size,
 		struct hdrblob_s *blob, char **emsg)
 {
+    size_t nb;
     rpmRC rc = RPMRC_FAIL;
+    int32_t il_max = HEADER_TAGS_MAX;
+    int32_t dl_max = HEADER_DATA_MAX;
+
+    if (uc && uc < 2 * sizeof(blob->ei) + sizeof(struct entryInfo_s)) {
+	rasprintf(emsg, _("hdr len: BAD, hdr len %zu too short"), uc);
+	goto exit;
+    }
+
+    if (regionTag == RPMTAG_HEADERSIGNATURES) {
+	il_max = 32;
+	dl_max = 64 * 1024 * 1024;
+    }
 
     memset(blob, 0, sizeof(*blob));
     blob->ei = (int32_t *) uh; /* discards const */
+
     blob->il = ntohl(blob->ei[0]);
+    if (hdrchkRange(il_max, blob->il)) {
+	rasprintf(emsg, _("hdr tags: BAD, no. of tags(%d) out of range"), blob->il);
+	goto exit;
+    }
+
     blob->dl = ntohl(blob->ei[1]);
+    if (hdrchkRange(dl_max, blob->dl)) {
+	rasprintf(emsg, _("hdr data: BAD, no. of bytes(%d) out of range"), blob->dl);
+	goto exit;
+    }
+
+    nb = (blob->il * sizeof(struct entryInfo_s)) + blob->dl;
+    if (uc && uc < sizeof(blob->il) + sizeof(blob->dl) + nb) {
+	rasprintf(emsg, _("hdr len: BAD, hdr len %zu too short"), uc);
+	goto exit;
+    }
+
     blob->pe = (entryInfo) &(blob->ei[2]);
     blob->pvlen = sizeof(blob->il) + sizeof(blob->dl) +
 		  (blob->il * sizeof(*blob->pe)) + blob->dl;

--- a/lib/header.c
+++ b/lib/header.c
@@ -2071,6 +2071,11 @@ rpmRC hdrblobInit(const void *uh, size_t uc,
     int32_t il_max = HEADER_TAGS_MAX;
     int32_t dl_max = HEADER_DATA_MAX;
 
+    if ((uintptr_t)uh & 3) {
+	rasprintf(emsg, _("hdr align: BAD, header is not 4-byte aligned"));
+	goto exit;
+    }
+
     if (uc && uc < 2 * sizeof(blob->ei) + sizeof(struct entryInfo_s)) {
 	rasprintf(emsg, _("hdr len: BAD, hdr len %zu too short"), uc);
 	goto exit;

--- a/lib/header.c
+++ b/lib/header.c
@@ -1863,9 +1863,9 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     /* Is there an immutable header region tag trailer? */
     memset(&trailer, 0, sizeof(trailer));
     regionEnd = blob->dataStart + einfo.offset;
+    /* regionEnd is not guaranteed to be aligned */
     (void) memcpy(&trailer, regionEnd, REGION_TAG_COUNT);
-    regionEnd += REGION_TAG_COUNT;
-    blob->rdl = regionEnd - blob->dataStart;
+    blob->rdl = einfo.offset + REGION_TAG_COUNT;
 
     ei2h(&trailer, &einfo);
 

--- a/lib/header.c
+++ b/lib/header.c
@@ -18,13 +18,6 @@
 
 #include "debug.h"
 
-/* Static assertion macro */
-#if __STDC_VERSION__ < 201112L
-# define STATIC_ASSERT(x) ((void)sizeof(struct { int static_assertion_failed:(2 * !!(x) - 1);}))
-#else
-# define STATIC_ASSERT(x) _Static_assert((x), #x)
-#endif
-
 /** \ingroup header
  */
 const unsigned char rpm_header_magic[8] = {

--- a/lib/header.c
+++ b/lib/header.c
@@ -1837,7 +1837,8 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     }
 
     /* Is the trailer within the data area? */
-    if (hdrchkRange(blob->dl, einfo.offset + REGION_TAG_COUNT)) {
+    if (hdrchkData(einfo.offset) ||
+	    hdrchkRange(blob->dl, einfo.offset + REGION_TAG_COUNT)) {
 	rasprintf(buf,
 		_("region offset: BAD, tag %d type %d offset %d count %d"),
 		einfo.tag, einfo.type, einfo.offset, einfo.count);

--- a/lib/header.c
+++ b/lib/header.c
@@ -280,6 +280,8 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg, int exact_size)
 	    goto err;
 	if (hdrchkType(info.type))
 	    goto err;
+	if (hdrchkData(info.count))
+	    goto err;
 	if (hdrchkAlign(info.type, info.offset))
 	    goto err;
 	if (hdrchkRange(dl, info.offset))

--- a/lib/header.c
+++ b/lib/header.c
@@ -262,6 +262,7 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg, int exact_size)
     int i, len = 0;
     int32_t end = 0;
     const char *ds = (const char *) blob->dataStart;
+    int32_t dl = (exact_size && blob->regionTag) ? blob->rdl - REGION_TAG_COUNT : blob->dl;
     int32_t il = (blob->regionTag) ? blob->il-1 : blob->il;
     entryInfo pe = (blob->regionTag) ? blob->pe+1 : blob->pe;
     /* Can't typecheck signature header tags, sigh */
@@ -281,19 +282,19 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg, int exact_size)
 	    goto err;
 	if (hdrchkAlign(info.type, info.offset))
 	    goto err;
-	if (hdrchkRange(blob->dl, info.offset))
+	if (hdrchkRange(dl, info.offset))
 	    goto err;
 	if (typechk && hdrchkTagType(info.tag, info.type))
 	    goto err;
 
 	/* Verify the data actually fits */
 	len = dataLength(info.type, ds + info.offset,
-			 info.count, 1, ds + blob->dl);
+			 info.count, 1, ds + dl);
 	/*
 	 * We already checked that blob->dl >= info.offset, so this cannot
 	 * overflow
 	 */
-	if (hdrchkRange(blob->dl - info.offset, len))
+	if (hdrchkRange(dl - info.offset, len))
 	    goto err;
 	end = info.offset + len;
     }

--- a/lib/header.c
+++ b/lib/header.c
@@ -1861,11 +1861,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
     memcpy(new_data + 2, Data + 4, Size - 4);
     new_data[1] = ntohl(Size - 4 - il * sizeof(struct entryInfo_s));
-    Header h = headerImport(new_data, 0, 0);
-    if (!h)
+    Header h = headerImport(new_data, 0, HEADERIMPORT_FAST);
+    if (!h) {
 	free(new_data);
-    else
-	headerFree(h);
+	return 0;
+    }
+    unsigned int export_len;
+    free(headerExport(h, &export_len));
+    headerFree(h);
     return 0;
 }
 #endif

--- a/lib/header.c
+++ b/lib/header.c
@@ -475,11 +475,20 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 	}
 	break;
 
+#define NUM_TYPES (sizeof(typeSizes)/sizeof(typeSizes[0]))
+#if __STDC_VERSION__ < 201112L
+# define STATIC_ASSERT(x) ((void)sizeof(struct { int static_assertion_failed:(2 * !!(x) - 1);}))
+#else
+# define STATIC_ASSERT(x) _Static_assert((x), #x)
+#endif
+	STATIC_ASSERT(NUM_TYPES == 16);
+	STATIC_ASSERT(RPM_MAX_TYPE < NUM_TYPES);
+#undef NUM_TYPE
     default:
-	if (typeSizes[type] == -1)
+	if (type > RPM_MAX_TYPE || typeSizes[type] == -1)
 	    return -1;
-	length = typeSizes[(type & 0xf)] * count;
-	if (length < 0 || (se && (s + length) > se))
+	length = typeSizes[type] * count;
+	if (length < 0 || (se && (length > se - s)))
 	    return -1;
 	break;
     }

--- a/system.h
+++ b/system.h
@@ -102,4 +102,11 @@ extern int fdatasync(int fildes);
 
 #include "misc/fnmatch.h"
 
+/* Static assertion macro */
+#if __STDC_VERSION__ < 201112L
+# define STATIC_ASSERT(x) ((void)sizeof(struct { int static_assertion_failed:(2 * !!(x) - 1);}))
+#else
+# define STATIC_ASSERT(x) _Static_assert((x), #x)
+#endif
+
 #endif	/* H_SYSTEM */


### PR DESCRIPTION
This makes vulnerabilities less likely by:

- Preventing an out-of-bounds read on 32-bit systems.
- Adding `-fno-strict-overflow`, `-fwrapv`, and `-fwrapv-pointer`
- Avoid some undefined pointer arithmetic
- Requiring signature headers to be contiguous.