### PR TITLE
rpmio: Fix lzopen_internal mode parsing when 'Tn' is used

### DIFF
--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -798,6 +798,7 @@ static LZFILE *lzopen_internal(const char *mode, int fd, int xz)
 		 * should've processed
 		 * */
 		while (isdigit(*++mode));
+		--mode;
 	    }
 #ifdef HAVE_LZMA_MT
 	    else


### PR DESCRIPTION
When there is number after "T" (suggested number of threads or "0" for
getncpus), lzopen_internal() mode parser would skip one byte, and when
it's at the end of the string it would then parse undesired garbage from
the memory, making intermittent compression failures.

Fixes: 7740d1098 ("Add support for multithreaded xz compression")
Signed-off-by: Vitaly Chikunov <vt@altlinux.org>

Cc: @ldv-alt