### PR TITLE
Exclude SIGALRM from the blocked signals

### DIFF
--- a/rpmio/rpmsq.c
+++ b/rpmio/rpmsq.c
@@ -186,6 +186,7 @@ int rpmsqBlock(int op)
 	    sigdelset(&newMask, SIGILL);
 	    sigdelset(&newMask, SIGSEGV);
 	    sigdelset(&newMask, SIGTSTP);
+	    sigdelset(&newMask, SIGALRM);
 	    ret = pthread_sigmask(SIG_BLOCK, &newMask, &oldMask);
 	}
     } else if (op == SIG_UNBLOCK) {


### PR DESCRIPTION
If an alarm is needed in one of the script in the RPM, it will be ignored because of the blocked signals.
For example, if you use flock with -w, the alarm after the timeout will never be received:
---
%pre
flock -x -w 19 /tmp/lock sleep 99
---