### PR TITLE
Check that type and length are not out of range

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -450,11 +450,15 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 	}
 	break;
 
+#define NUM_TYPES (sizeof(typeSizes)/sizeof(typeSizes[0]))
+	STATIC_ASSERT(NUM_TYPES == 16);
+	STATIC_ASSERT(RPM_MAX_TYPE < NUM_TYPES);
+#undef NUM_TYPE
     default:
-	if (typeSizes[type] == -1)
+	if (type > RPM_MAX_TYPE || typeSizes[type] == -1)
 	    return -1;
-	length = typeSizes[(type & 0xf)] * count;
-	if (length < 0 || (se && (s + length) > se))
+	length = typeSizes[type] * count;
+	if (length < 0 || (se && (length > se - s)))
 	    return -1;
 	break;
     }

--- a/system.h
+++ b/system.h
@@ -102,4 +102,13 @@ extern int fdatasync(int fildes);
 
 #include "misc/fnmatch.h"
 
+/* Static assertion macro */
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L
+# define STATIC_ASSERT(x) _Static_assert((x), #x)
+#elif defined __cplusplus && __cplusplus >= 201103L
+# define STATIC_ASSERT(x) static_assert((x), #x)
+#else
+# define STATIC_ASSERT(x) ((void)sizeof(struct { int static_assertion_failed:(2 * !!(x) - 1);}))
+#endif
+
 #endif	/* H_SYSTEM */


### PR DESCRIPTION
This avoids a potential out-of-bounds read in dataLength().