### PR TITLE
Use int64_t for lengths

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1867,13 +1867,7 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 	goto exit;
     }
 
-    /*
-     * Trailer offset is negative and has a special meaning.  Be sure to negate
-     * *after* the division, so the negation cannot overflow.  The parentheses
-     * around the division are required!
-     *
-     * Thankfully, the modulus operator works fine on negative numbers.
-     */
+    /* Negate after division to avoid overflow.  Watch out for precedence! */
     blob->ril = -(einfo.offset/sizeof(*blob->pe));
     /* Does the region actually fit within the header? */
     if ((einfo.offset % sizeof(*blob->pe)) || hdrchkRange(blob->il, blob->ril) ||

--- a/lib/header.c
+++ b/lib/header.c
@@ -132,9 +132,10 @@ static const size_t headerMaxbytes = (256*1024*1024);
 /**
  * Reasonableness check on count values.
  * Catches nasty stuff like negative or zero counts, which would cause
- * integer underflows in strtaglen().
+ * integer underflows in strtaglen(), and excessive counts, which would
+ * cause integer overflows in dataLength().
  */
-#define hdrchkCount(_count) ((_count) == 0)
+#define hdrchkCount(_count) ((_count) == 0 || hdrchkData(_count))
 
 /**
  * Sanity check on type values.


### PR DESCRIPTION
This prevents an integer overflow in dataLength().