### PR TITLE
Check that count won't overflow

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -279,6 +279,8 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	    goto err;
 	if (hdrchkType(info.type))
 	    goto err;
+	if (hdrchkData(info.count))
+	    goto err;
 	if (hdrchkAlign(info.type, info.offset))
 	    goto err;
 	if (hdrchkRange(blob->dl, info.offset))


### PR DESCRIPTION
This is already checked in regionSwab() but it is better to check it
earlier, in case someone uses hdrblobInit() without hdrblobImport().