### PR TITLE
‘hdrblobInit’: check pointer is 8-byte aligned

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1970,6 +1970,11 @@ rpmRC hdrblobInit(const void *uh, size_t uc,
 {
     rpmRC rc = RPMRC_FAIL;
 
+    if (chkAlign(uh, uint64_t)) {
+	rasprintf(emsg, _("hdr align: BAD, header is not 8-byte aligned"));
+	goto exit;
+    }
+
     memset(blob, 0, sizeof(*blob));
     blob->ei = (int32_t *) uh; /* discards const */
     blob->il = ntohl(blob->ei[0]);

--- a/system.h
+++ b/system.h
@@ -102,4 +102,11 @@ extern int fdatasync(int fildes);
 
 #include "misc/fnmatch.h"
 
+/* Check that pointer `x` is aligned enough for a variable of type `t` */
+#if __STDC_VERSION__ >= 201112L
+# define chkAlign(x, t) ((uintptr_t)(x) & (_Alignof(t) - 1))
+#else
+# define chkAlign(x, t) ((uintptr_t)(x) & (sizeof(t) - 1))
+#endif
+
 #endif	/* H_SYSTEM */


### PR DESCRIPTION
Otherwise, we will dereference a misaligned pointer, which is undefined
behavior.