### PR TITLE
Enable hardening flags where available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,10 @@ fi
 AS=${AS-as}
 AC_SUBST(AS)
 if test "$GCC" = yes; then
-    cflags_to_try="-fno-strict-aliasing -fstack-protector -Wempty-body"
+    cflags_to_try="-fno-strict-aliasing -fstack-protector -Wempty-body -fwrapv -fwrapv-pointer \
+	-fno-strict-overflow -fstack-protector-all -fno-delete-null-pointer-checks \
+	-fstack-check -fcf-protection=full -fstack-clash-protection \
+	-Werror=format-security"
     AC_MSG_CHECKING([supported compiler flags])
     old_cflags=$CFLAGS
     echo
@@ -50,7 +53,7 @@ if test "$GCC" = yes; then
         ],[])
         CFLAGS=$old_cflags
     done
-    RPMCFLAGS="-D_REENTRANT -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes $RPMCFLAGS"
+    RPMCFLAGS="-D_REENTRANT -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes $RPMCFLAGS"
 fi
 AC_ARG_ENABLE(werror, [AS_HELP_STRING([--enable-werror], [build with -Werror])],
 		[RPMCFLAGS="$RPMCFLAGS -Werror"], [])


### PR DESCRIPTION
We want to remove as many forms of undefined behavior as we can.  This
adds flags to make integer and pointer overflows well-defined.
Furthermore, it turns on strong stack protection.