### PR TITLE
Bring back Python2 support

### DIFF
--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -300,6 +300,7 @@ static int prepareInitModule(void)
 }
 static int initModule(PyObject *m);
 
+#if PY_MAJOR_VERSION >= 3
 static int rpmModuleTraverse(PyObject *m, visitproc visit, void *arg) {
     Py_VISIT(pyrpmError);
     return 0;
@@ -334,8 +335,21 @@ PyInit__rpm(void)
     initModule(m);
     return m;
 }
+#else
+void init_rpm(void);   /* XXX eliminate gcc warning */
+void init_rpm(void)
+{
+    PyObject * m;
 
-/* Module initialization: */
+    if (!prepareInitModule()) return;
+    m = Py_InitModule3("_rpm", rpmModuleMethods, rpm__doc__);
+    if (m == NULL)
+       return;
+    initModule(m);
+}
+#endif
+
+/* Shared python2/3 module initialization: */
 static int initModule(PyObject *m)
 {
     PyObject * d;

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -67,7 +67,7 @@ static PyObject *ver_richcmp(rpmverObject *s, rpmverObject *o, int op)
     int v;
 
     if (!(verObject_Check(s) && verObject_Check(o)))
-	Py_RETURN_NOTIMPLEMENTED;
+	Py_INCREF(Py_NotImplemented), Py_NotImplemented;
 
     switch (op) {
     case Py_LT:
@@ -86,7 +86,7 @@ static PyObject *ver_richcmp(rpmverObject *s, rpmverObject *o, int op)
 	v = rpmverCmp(s->ver, o->ver) > 0;
 	break;
     default:
-	Py_RETURN_NOTIMPLEMENTED;
+	Py_INCREF(Py_NotImplemented), Py_NotImplemented;
     }
     return PyBool_FromLong(v);
 }


### PR DESCRIPTION
These patches were needed to get back support for Python2.

This gives users more time to migrate to Python3.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>