### PR TITLE
Support failing build on duplicate files (#1158)

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -406,6 +406,9 @@ package or when debugging this package.\
 # Note: The default value should be 0 for legacy compatibility.
 %_unpackaged_files_terminate_build	1
 
+# Should duplicate files in %files terminate a build?
+%_duplicate_files_terminate_build	0
+
 #
 # Should missing %doc files in the build directory terminate a build?
 #


### PR DESCRIPTION
Add macro %_duplicate_files_terminate_build to allow terminating build
on duplicate file-list entries. As there are common packaging scenarios
where duplicates are kind of required to achieve a thing reasonably
(eg a directory full of files and just one of them needs different
permissions/flags), default to off until we grow a way to better deal
with that.

Fixes: #1158