### PR TITLE
Arrange different timestamp for %changelog entries from the same day

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,6 +54,7 @@ EXTRA_DIST += data/SPECS/hello-g3.spec
 EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
 EXTRA_DIST += data/SPECS/versiontest.spec
+EXTRA_DIST += data/SPECS/chlog.spec
 EXTRA_DIST += data/SPECS/conflicttest.spec
 EXTRA_DIST += data/SPECS/configtest.spec
 EXTRA_DIST += data/SPECS/filedep.spec

--- a/tests/data/SPECS/chlog.spec
+++ b/tests/data/SPECS/chlog.spec
@@ -1,0 +1,25 @@
+Name: chlog
+Summary: Testing changelog behavior
+Version: 1.2
+Release: 5
+License: GPL
+
+%description
+%{summary}
+
+%files
+
+%changelog
+* Tue Jan 19 2021 Tester <tester@example.com> - 1.2-5
+- Oh no not again
+* Mon Jan 18 2021 Tester <tester@example.com> - 1.2-4
+- This really isn't my day...
+* Mon Jan 18 2021 Tester <tester@example.com> - 1.2-3
+- Oh, it's Monday
+* Mon Jan 18 2021  <tester@example.com> - 1.2-2
+- Fixup one
+* Mon Jan 18 2021 Tester <tester@example.com> - 1.2-1
+- Rebase to 1.2
+* Sun Feb 02 2020 Tester <tester@example.com> - 1.0-1
+- Initial version
+

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -285,3 +285,31 @@ foo-bus = 1.0-1
 ],
 [])
 AT_CLEANUP
+
+AT_SETUP([rpmspec changelog])
+AT_KEYWORDS([rpmspec changelog])
+AT_CHECK([[
+runroot rpmspec -q --qf '[* %{CHANGELOGTIME:date} %{CHANGELOGNAME}\n%{CHANGELOGTEXT}\n\n]' /data/SPECS/chlog.spec
+]],
+[0],
+[* Tue Jan 19 12:00:00 2021 Tester <tester@example.com> - 1.2-5
+- Oh no not again
+
+* Mon Jan 18 12:00:03 2021 Tester <tester@example.com> - 1.2-4
+- This really isn't my day...
+
+* Mon Jan 18 12:00:02 2021 Tester <tester@example.com> - 1.2-3
+- Oh, it's Monday
+
+* Mon Jan 18 12:00:01 2021 <tester@example.com> - 1.2-2
+- Fixup one
+
+* Mon Jan 18 12:00:00 2021 Tester <tester@example.com> - 1.2-1
+- Rebase to 1.2
+
+* Sun Feb  2 12:00:00 2020 Tester <tester@example.com> - 1.0-1
+- Initial version
+
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
The traditional %changelog entry format produces identical timestamp
(UTC noon) for entries from the same day. Us humans are mostly interested
in the relative chronological order of things, manually inserting
second-precision timestamps for spec changes is just absurd.
However when the topmost changelog entry is used for setting
SOURCE_DATE_EPOCH for reproducable builds, those identical timestamps
for obviously different builds become problematic.

Automatically differentiate the timestamps from the same day by one second
each, starting from noon this allows for over 43000 entries per day. To
ensure reproducable results, we need to walk the entries in the opposite
order to how we originally parse them, complicating things a little.

This allows the traditional changelog format to be used for reproducable
builds in a meaningful manner, without unnecessarily forcing the cumbersome
and problematic full timestamp format everywhere.

[1] https://pagure.io/rpmdevtools/issue/63
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1715412,
    https://github.com/rpm-software-management/rpm/pull/739