### PR TITLE
Improve macro traceback behavior

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -458,7 +458,6 @@ static int mbInit(MacroBuf mb, MacroExpansionData *med, size_t slen)
 	mbErr(mb, 1,
 		_("Too many levels of recursion in macro expansion. It is likely caused by recursive macro declaration.\n"));
 	mb->depth--;
-	mb->expand_trace = 1;
 	return -1;
     }
     med->tpos = mb->tpos; /* save expansion pointer for printExpand */
@@ -471,7 +470,9 @@ static void mbFini(MacroBuf mb, MacroExpansionData *med)
 {
     mb->buf[mb->tpos] = '\0';
     mb->depth--;
-    if (mb->error != 0 || mb->expand_trace)
+    if (mb->error && rpmIsVerbose())
+	mb->expand_trace = 1;
+    if (mb->expand_trace)
 	printExpansion(mb, mb->buf + med->tpos, mb->buf + mb->tpos);
     mb->macro_trace = med->macro_trace;
     mb->expand_trace = med->expand_trace;

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -358,7 +358,7 @@ static void
 printExpansion(MacroBuf mb, const char * t, const char * te)
 {
     if (!(te > t)) {
-	rpmlog(RPMLOG_DEBUG, _("%3d<%*s(empty)\n"), mb->depth, (2 * mb->depth + 1), "");
+	fprintf(stderr, _("%3d<%*s(empty)\n"), mb->depth, (2 * mb->depth + 1), "");
 	return;
     }
 
@@ -374,10 +374,10 @@ printExpansion(MacroBuf mb, const char * t, const char * te)
 
     }
 
-    rpmlog(RPMLOG_DEBUG,"%3d<%*s", mb->depth, (2 * mb->depth + 1), "");
+    fprintf(stderr, "%3d<%*s", mb->depth, (2 * mb->depth + 1), "");
     if (te > t)
-	rpmlog(RPMLOG_DEBUG, "%.*s", (int)(te - t), t);
-    rpmlog(RPMLOG_DEBUG, "\n");
+	fprintf(stderr, "%.*s", (int)(te - t), t);
+    fprintf(stderr, "\n");
 }
 
 #define	SKIPBLANK(_s, _c)	\

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -922,3 +922,25 @@ read
 [])
 AT_CLEANUP
 
+AT_SETUP([macro traceback])
+AT_KEYWORDS([macros])
+AT_CHECK([
+for o in "-v" ""; do
+    runroot rpm $o \
+	--define "err %{error:bad}" \
+	--define "bar %err" \
+	--define "foo %bar zz" \
+	--eval "xxx%{foo}yyy"
+done
+],
+[1],
+[],
+[error: bad
+  3<        (%error)
+  2<      (%err)
+  1<    (%bar)
+  0<  (%foo)
+xxx
+error: bad
+])
+AT_CLEANUP


### PR DESCRIPTION
Revert commit 7f220202f20c69d6f3fd957325cdbe692bbabedd to fix #1418 and make things more consistent.
We always want the tracing output on stderr, but we might not always want the traces so conditionalize the traceback outputing to only occur on verbose levels. 

Also generate actually meaningful tracebacks by supplying the macro names where possible.