### PR TITLE
Relicense find-lang.sh under the MIT license

### DIFF
--- a/scripts/find-lang.sh
+++ b/scripts/find-lang.sh
@@ -1,15 +1,30 @@
 #!/bin/bash
-#findlang - automagically generate list of language specific files
-#for inclusion in an rpm spec file.
-#This does assume that the *.mo files are under .../locale/...
-#Run with no arguments gets a usage message.
+# findlang - automagically generate list of language specific files
+# for inclusion in an rpm spec file.
+# This does assume that the *.mo files are under .../locale/...
+# Run with no arguments gets a usage message.
 
-#findlang is copyright (c) 1998 by W. L. Estes <wlestes@uncg.edu>
+# findlang is copyright (c) 1998 by W. L. Estes <wlestes@uncg.edu>
 
-#Redistribution and use of this software are hereby permitted for any
-#purpose as long as this notice and the above copyright notice remain
-#in tact and are included with any redistribution of this file or any
-#work based on this file.
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 usage () {
 cat <<EOF


### PR DESCRIPTION
as the previous license is ambiguous about its support for modification
and does not carry a warranty disclaimer. MIT license is close to the origial
license in intent but more legally sound.

This is done with the consent of the original author

W. L. Estes <wlestes@uncg.edu>

who was contacted by Tom Callaway <spotrh@gmail.com> by mail

and the following contributors:

Arkadiusz Miśkiewicz <arekm@pld-linux.org>
Florian Festi<ffesti@redhat.com>
Panu Matilainen<pmatilai@redhat.com>
Per Øyvind Karlsen <peroyvind@mandriva.org>
Ville Skyttä<ville.skytta@iki.fi>

who gave their permission in the GitHub ticket
(https://github.com/rpm-software-management/rpm/issues/595).

Resolves: #595