### PR TITLE
Add %bcond macro for defining build conditionals

### DIFF
--- a/docs/manual/conditionalbuilds.md
+++ b/docs/manual/conditionalbuilds.md
@@ -13,9 +13,38 @@ Here is an example of how to enable gnutls and disable openssl support:
 $ rpmbuild -ba newpackage.spec --with gnutls --without openssl
 ```
 
-## Enable `--with`/`--without` parameters
+## Enable build conditionals
 
-To use this feature in a spec file, add this to the beginning of the file:
+To enable a build conditional in a spec file, use the `%bcond` macro at the
+beginning of the file, specifying the name of the conditional and its default
+value:
+
+```
+# To build with "gnutls" by default:
+%bcond gnutls 1
+# To build without "gnutls" by default:
+%bcond gnutls 0
+```
+
+The default can be any numeric expression.
+To pass a complex expression as a single argument, you can enclose it in
+`%[...]` .
+
+```
+# Add `--with openssl` and `--without openssl`, with the default being the
+# inverse of the gnutls setting:
+%bcond openssl %{without gnutls}
+
+# Add `extra_tests` bcond, enabled by default if both of the other conditinals
+# are enabled:
+%bcond extra_tests %[%{with gnutls} && %{with sqlite}]
+```
+
+
+### Enabling using `%bcond_with` and `%bcond_without`
+
+Build conditionals can also be enabled using the macros `%bcond_with` and
+`%bcond_without`:
 
 ```
 # add --with gnutls option, i.e. disable gnutls by default
@@ -30,8 +59,9 @@ remainder of the spec file can be left unchanged.
 
 ## Check whether an option is enabled or disabled
 
-To define `BuildRequires` depending on the command-line switch, you can use the
-`%{with foo}` macro:
+To make parts of the spec file conditional depending on the command-line
+switch, you can use the `%{with foo}` macro or its counterpart,
+`%{without foo}`:
 
 ```
 %if %{with gnutls}

--- a/docs/manual/conditionalbuilds.md
+++ b/docs/manual/conditionalbuilds.md
@@ -83,16 +83,5 @@ macros which is nicer in other situations, e.g.:
 
 Always test for the `with`-condition, not the `without`-counterpart!
 
-## Pass it to `%configure`
-
-To pass options to configure or other scripts that understand a `--with-foo` or
-`--without-foo` parameter, you can use the `%{?_with_foo}` macro:
-
-```
-%configure \
-        %{?_with_gnutls} \
-        %{?_with_openssl}
-```
-
 ## References
 * [macros](https://github.com/rpm-software-management/rpm/blob/master/macros.in)

--- a/macros.in
+++ b/macros.in
@@ -79,66 +79,16 @@
 %undefined()	%{expand:%%{?%{1}:0}%%{!?%{1}:1}}
 
 # Handle conditional builds.
+# (see 'conditionalbuilds' in the manual)
 #
 # Shorthands for %{defined with_...}:
 %with()		%{expand:%%{?with_%{1}:1}%%{!?with_%{1}:0}}
 %without()	%{expand:%%{?with_%{1}:0}%%{!?with_%{1}:1}}
 
-# When checking conditions: never use without_foo, _with_foo nor _without_foo,
-# only with_foo. This way changing default set of bconds for given spec is just
-# a matter of changing single line in it and syntax is more readable.
-
-# To define a build condition, use:
-#   %bcond <name> <default>
-# If <default> is true, %bcond defines the symbol `with_<name>` UNLESS the
-# `--without <name>` command line switch is given.
-# If <default> is false, %bcond defines the symbol `with_<name>` ONLY if the
-# `--with <name>` command line switch is given.
-#
-# For example, in the following spec file:
-# - "extra_fonts" is on, but can be deactivated by `--without extra_fonts`
-# - "static" is off, but can be activated by `--with static`
-# - "static_fonts" is on by default if both "extra_fonts" and "static" are,
-#   but can be overridden by `--with static_fonts`/`--without static_fonts`.
-#
-# (at the beginning)
-# %bcond extra_fonts 1
-# %bcond static 0
-# %bcond static_fonts %[%{with extra_fonts} && %{with static}]
-# (and later)
-# %if %{with extra_fonts}
-# ...
-# %else
-# ...
-# %endif
-# %if ! %{with static}
-# ...
-# %endif
-# %if %{with static}
-# ...
-# %endif
-# %if %{with static_fonts}
-# ...
-# %endif
-# %{?with_static: ... }
-# %{!?with_static: ... }
-# %{?with_extra_fonts: ... }
-# %{!?with_extra_fonts: ... }
-#
 %bcond()	%{expand:%[ (%2)
     ? "%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}"
     : "%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}"
 ]}
-
-# Another way to define a bcond is %bcond_with and %bcond_without.
-# %bcond_with corresponds to `%bcond ... 0`: the feature is off by default
-# and needs to be activated with --with ... command line switch.
-# %bcond_without is for the dual case.
-#
-# %bcond_with foo defines symbol with_foo if --with foo was specified on
-# command line.
-# %bcond_without foo defines symbol with_foo if --without foo was *not*
-# specified on command line.
 %bcond_with()		%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}
 %bcond_without()	%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}
 

--- a/macros.in
+++ b/macros.in
@@ -90,8 +90,8 @@
     ? "%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}"
     : "%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}"
 ]}
-%bcond_with()		%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}
-%bcond_without()	%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}
+%bcond_with()		%{expand:%%bcond %{1} 0}
+%bcond_without()	%{expand:%%bcond %{1} 1}
 
 # Shorthands for %{defined with_...}:
 %with()		%{expand:%%{?with_%{1}:1}%%{!?with_%{1}:0}}

--- a/macros.in
+++ b/macros.in
@@ -78,24 +78,33 @@
 %defined()	%{expand:%%{?%{1}:1}%%{!?%{1}:0}}
 %undefined()	%{expand:%%{?%{1}:0}%%{!?%{1}:1}}
 
-# Shorthand for %{defined with_...}
+# Handle conditional builds.
+#
+# Shorthands for %{defined with_...}:
 %with()		%{expand:%%{?with_%{1}:1}%%{!?with_%{1}:0}}
 %without()	%{expand:%%{?with_%{1}:0}%%{!?with_%{1}:1}}
 
-# Handle conditional builds. %bcond_with is for case when feature is
-# default off and needs to be activated with --with ... command line
-# switch. %bcond_without is for the dual case.
+# When checking conditions: never use without_foo, _with_foo nor _without_foo,
+# only with_foo. This way changing default set of bconds for given spec is just
+# a matter of changing single line in it and syntax is more readable.
+
+# To define a build condition, use:
+#   %bcond <name> <default>
+# If <default> is true, %bcond defines the symbol `with_<name>` UNLESS the
+# `--without <name>` command line switch is given.
+# If <default> is false, %bcond defines the symbol `with_<name>` ONLY if the
+# `--with <name>` command line switch is given.
 #
-# %bcond_with foo defines symbol with_foo if --with foo was specified on
-# command line.
-# %bcond_without foo defines symbol with_foo if --without foo was *not*
-# specified on command line.
-#
-# For example (spec file):
+# For example, in the following spec file:
+# - "extra_fonts" is on, but can be deactivated by `--without extra_fonts`
+# - "static" is off, but can be activated by `--with static`
+# - "static_fonts" is on by default if both "extra_fonts" and "static" are,
+#   but can be overridden by `--with static_fonts`/`--without static_fonts`.
 #
 # (at the beginning)
-# %bcond_with extra_fonts
-# %bcond_without static
+# %bcond extra_fonts 1
+# %bcond static 0
+# %bcond static_fonts %[%{with extra_fonts} && %{with static}]
 # (and later)
 # %if %{with extra_fonts}
 # ...
@@ -108,17 +117,31 @@
 # %if %{with static}
 # ...
 # %endif
+# %if %{with static_fonts}
+# ...
+# %endif
 # %{?with_static: ... }
 # %{!?with_static: ... }
 # %{?with_extra_fonts: ... }
 # %{!?with_extra_fonts: ... }
-
 #
-# The bottom line: never use without_foo, _with_foo nor _without_foo, only
-# with_foo. This way changing default set of bconds for given spec is just
-# a matter of changing single line in it and syntax is more readable.
+%bcond()	%{expand:%[ (%2)
+    ? "%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}"
+    : "%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}"
+]}
+
+# Another way to define a bcond is %bcond_with and %bcond_without.
+# %bcond_with corresponds to `%bcond ... 0`: the feature is off by default
+# and needs to be activated with --with ... command line switch.
+# %bcond_without is for the dual case.
+#
+# %bcond_with foo defines symbol with_foo if --with foo was specified on
+# command line.
+# %bcond_without foo defines symbol with_foo if --without foo was *not*
+# specified on command line.
 %bcond_with()		%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}
 %bcond_without()	%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}
+
 #
 #==============================================================================
 # ---- Required rpmrc macros.

--- a/macros.in
+++ b/macros.in
@@ -81,9 +81,10 @@
 # Handle conditional builds.
 # (see 'conditionalbuilds' in the manual)
 #
-# Shorthands for %{defined with_...}:
-%with()		%{expand:%%{?with_%{1}:1}%%{!?with_%{1}:0}}
-%without()	%{expand:%%{?with_%{1}:0}%%{!?with_%{1}:1}}
+# Internally, the `--with foo` option defines the macro `_with_foo` and the
+# `--without foo` option defines the macro `_without_foo`.
+# Based on those and a default (used when neither is given), bcond macros
+# define the macro `with_foo`, which should later be checked:
 
 %bcond()	%{expand:%[ (%2)
     ? "%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}"
@@ -91,6 +92,10 @@
 ]}
 %bcond_with()		%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}
 %bcond_without()	%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}
+
+# Shorthands for %{defined with_...}:
+%with()		%{expand:%%{?with_%{1}:1}%%{!?with_%{1}:0}}
+%without()	%{expand:%%{?with_%{1}:0}%%{!?with_%{1}:1}}
 
 #
 #==============================================================================

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,6 +39,7 @@ EXTRA_DIST += $(TESTSUITE_AT)
 
 ## testsuite data
 EXTRA_DIST += data/SPECS/attrtest.spec
+EXTRA_DIST += data/SPECS/bcondtest.spec
 EXTRA_DIST += data/SPECS/buildrequires.spec
 EXTRA_DIST += data/SPECS/docmiss.spec
 EXTRA_DIST += data/SPECS/hello.spec

--- a/tests/data/SPECS/bcondtest.spec
+++ b/tests/data/SPECS/bcondtest.spec
@@ -1,0 +1,33 @@
+Name:           bcondtest
+Version:        1.0
+Release:        1
+Group:          Testing
+License:        CC0
+BuildArch:      noarch
+Summary:        Test package for the bcond macro
+
+%bcond normally_on 1
+%bcond normally_off 0
+%bcond both_features %[%{with normally_on} && %{with normally_off}]
+
+%if %{with normally_on}
+Provides:       has_bcond(normally_on)
+%endif
+%if %{with normally_off}
+Provides:       has_bcond(normally_off)
+%endif
+%if %{with both_features}
+Provides:       has_bcond(both_features)
+%endif
+
+%description
+%{summary}
+
+%install
+mkdir -p %{buildroot}/opt
+touch %{buildroot}/opt/file
+
+%files
+/opt/file
+
+%changelog

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1791,3 +1791,76 @@ runroot rpmbuild -ba --quiet      \
 [],
 [])
 AT_CLEANUP
+
+AT_SETUP([bcond macro])
+AT_KEYWORDS([bcond build])
+RPMDB_INIT
+
+# basic bcond behavior with --eval
+AT_CHECK([
+runroot rpm \
+	--eval "%bcond normally_on 1" \
+	--eval "%bcond normally_off 0" \
+	--eval "%bcond both_features %[[%{with normally_on} && %{with normally_off}]]" \
+	--eval "%{with normally_on}" \
+	--eval "%{with normally_off}" \
+	--eval "%{with both_features}"
+],
+[0],
+[
+
+
+1
+0
+0
+],
+[])
+
+# bcond behavior, without CLI options
+AT_CHECK([
+runroot rpmbuild -bb --quiet /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[has_bcond(normally_on)
+],
+[])
+
+# bcond behavior, --with
+AT_CHECK([
+runroot rpmbuild -bb --quiet --with normally_on --with normally_off \
+    /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[has_bcond(both_features)
+has_bcond(normally_off)
+has_bcond(normally_on)
+],
+[])
+
+# bcond behavior, --without
+AT_CHECK([
+runroot rpmbuild -bb --quiet --without normally_on --without normally_off \
+    /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[],
+[])
+
+# bcond behavior, CLI overriding a complex defailt
+AT_CHECK([
+runroot rpmbuild -bb --quiet --with both_features /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[has_bcond(both_features)
+has_bcond(normally_on)
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
The names `%bcond_with` and `%bcond_without` are based on the inner workings of the macros. They describe the inverse of their default; anecdotal evidence sugests that this is quite confusing in practice. I personally always have to stop and think when using/reviewing them.

This PR adds the macro `%bcond`, which does the same thing as either `%bcond_with` or `%bcond_without`, based on a numeric "default" value:

```
# To build with "gnutls" by default (equivalent to %bcond_without gnutls):
%bcond gnutls 1
# To build without "gnutls" default (equivalent to %bcond_with gnutls):
%bcond gnutls 0
```
It allows more complex defaults, simplifying a common if-elif pattern (see https://github.com/rpm-software-management/rpm/issues/941):
```
# By default, build with openssl iff not building with gnutls (but allow building with none or both)
%bcond openssl %{without gnutls}

# Enable some new feature that only works on Fedora 30+ with the gnutls crypto
%bcond new_feature %[ 0%fedora > 30 && %{with gnutls} ]
```
Documentation is changed to mention `%bcond` first – the only disadvantage I can see vs. the existing macros is that old RPM versions won't have it.

---

This is my first contribution to RPM. Please tell me all the things I'm doing wrong!
(e.g. should this be discussed somewhere first?)