### PR TITLE
Fix rpmtsInitDB() argument confusion

### DIFF
--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -130,13 +130,13 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 	char *path = rstrscat(NULL, dbhome, "/", rdb->db_ops->path, NULL);
 	rpmlog(RPMLOG_DEBUG, "opening  db index       %s mode=0x%x\n", path, rdb->db_mode);
 	if ((rdb->db_flags & RPMDB_FLAG_SALVAGE) == 0)
-	    rc = rpmpkgOpen(&pkgdb, path, oflags, 0666);
+	    rc = rpmpkgOpen(&pkgdb, path, oflags, rdb->db_perms);
 	else
 	    rc = rpmpkgSalvage(&pkgdb, path);
 	if (rc && errno == ENOENT && (oflags == O_RDWR) && (rdb->db_flags & RPMDB_FLAG_SALVAGE) == 0) {
 	    oflags |= O_CREAT;
 	    dbi->dbi_flags |= DBI_CREATED;
-	    rc = rpmpkgOpen(&pkgdb, path, oflags, 0666);
+	    rc = rpmpkgOpen(&pkgdb, path, oflags, rdb->db_perms);
 	}
 	if (rc) {
 	    perror("rpmpkgOpen");
@@ -161,16 +161,16 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 
 	    /* Open indexes readwrite if possible */
 	    ioflags = O_RDWR;
-	    rc = rpmxdbOpen(&ndbenv->xdb, rdb->db_pkgs->dbi_db, path, ioflags, 0666);
+	    rc = rpmxdbOpen(&ndbenv->xdb, rdb->db_pkgs->dbi_db, path, ioflags, rdb->db_perms);
 	    if (rc && (errno == EACCES || errno == EROFS)) {
 		/* If it is not asked for rw explicitly, try to open ro */
 		if (!(oflags & O_RDWR)) {
 		    ioflags = O_RDONLY;
-		    rc = rpmxdbOpen(&ndbenv->xdb, rdb->db_pkgs->dbi_db, path, ioflags, 0666);
+		    rc = rpmxdbOpen(&ndbenv->xdb, rdb->db_pkgs->dbi_db, path, ioflags, rdb->db_perms);
 		}
 	    } else if (rc && errno == ENOENT) {
 		ioflags = O_CREAT|O_RDWR;
-		rc = rpmxdbOpen(&ndbenv->xdb, rdb->db_pkgs->dbi_db, path, ioflags, 0666);
+		rc = rpmxdbOpen(&ndbenv->xdb, rdb->db_pkgs->dbi_db, path, ioflags, rdb->db_perms);
 		created = 1;
 	    }
 	    if (rc) {

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -104,12 +104,12 @@ int rpmtsOpenDB(rpmts ts, int dbmode)
     return rc;
 }
 
-int rpmtsInitDB(rpmts ts, int dbmode)
+int rpmtsInitDB(rpmts ts, int perms)
 {
     rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
     int rc = -1;
     if (txn)
-	    rc = rpmdbInit(ts->rootDir, dbmode);
+	    rc = rpmdbInit(ts->rootDir, perms);
     rpmtxnEnd(txn);
     return rc;
 }

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -272,12 +272,11 @@ int rpmtsOpenDB(rpmts ts, int dbmode);
 
 /** \ingroup rpmts
  * Initialize the database used by the transaction.
- * @deprecated An explicit rpmdbInit() is almost never needed.
  * @param ts		transaction set
- * @param dbmode	O_RDONLY or O_RDWR
+ * @param perms		database permissions (ie mode bits)
  * @return		0 on success
  */
-int rpmtsInitDB(rpmts ts, int dbmode);
+int rpmtsInitDB(rpmts ts, int perms);
 
 /** \ingroup rpmts
  * Return the transaction database mode

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -347,7 +347,7 @@ rpmts_InitDB(rpmtsObject * s)
 {
     int rc;
 
-    rc = rpmtsInitDB(s->ts, O_RDONLY);
+    rc = rpmtsInitDB(s->ts, 0644);
     if (rc == 0)
 	rc = rpmtsCloseDB(s->ts);
 


### PR DESCRIPTION
Since it's introduction, rpmtsInitDB() has passed the second argument directly to rpmdbInit() as permission bits. However commit 81fef9848051e5068694cde9b3c2be743d5a93e1 incorrectly documented this as being related to the db mode read/write *mode*, and also used it that way in the python bindings.

While looking at this, noticed that ndb passes hardcoded 0666 to open() whereas the rpm default open mode is 0644, use the API-requested mode instead. Sqlite doesn't seem to support passing a file mode request in the API (but it defaults to 0644 too).