### PR TITLE
Make Lua a hard requirement for rpm

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,6 +5,11 @@ The popt library for option parsing, must be version 1.13 or later.
 It is available from
     http://ftp.rpm.org/popt/
 
+Lua >= 5.2 library + development environment.
+Note that only the library is needed at runtime, RPM never calls external
+Lua interpreter for anything. Lua is available from
+    http://www.lua.org
+
 The zlib library for compression support. You might also need/want
 the unzip executable for java jar dependency analysis. All available from
     http://www.gzip.org/zlib/
@@ -40,12 +45,6 @@ Additionally standalone support for read-only BDB databases is available as
 The ndb and bdb_ro backends have no external dependencies.
 SQLite >= 3.22.0 is required for the sqlite database backend.
 SQLite is available from https://www.sqlite.org/
-
-For embedded Lua scripting support (recommended and enabled by default),
-you'll need Lua >= 5.2 library + development environment installed.
-Note that only the library is needed at runtime, RPM never calls external
-Lua interpreter for anything. Lua is available from 
-    http://www.lua.org
 
 If SELinux support is desired, it can be enabled with --with-selinux option
 to configure and libselinux development environment installed. SELinux

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,6 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	--with-cap \
 	--with-acl \
 	--with-archive \
-	--with-lua \
 	--with-audit \
 	--with-selinux \
 	--with-imaevm \
@@ -27,9 +26,7 @@ EXTRA_DIST = ChangeLog CREDITS INSTALL \
 BUILT_SOURCES =
 
 SUBDIRS = po misc
-if WITH_LUA
 SUBDIRS += luaext
-endif
 SUBDIRS += rpmio lib sign build scripts fileattrs doc .
 
 if ENABLE_PYTHON

--- a/build/Makefile.am
+++ b/build/Makefile.am
@@ -17,11 +17,8 @@ librpmbuild_la_SOURCES = \
 	parseFiles.c parsePreamble.c parsePrep.c parseReqs.c parseScript.c \
 	parseSpec.c parseList.c reqprov.c rpmfc.c spec.c \
 	parsePolicies.c policies.c \
-	rpmbuild_internal.h rpmbuild_misc.h
-
-if WITH_LUA
-librpmbuild_la_SOURCES += speclua.c
-endif
+	rpmbuild_internal.h rpmbuild_misc.h \
+	speclua.c
 
 librpmbuild_la_LDFLAGS = -version-info $(rpm_version_info)
 librpmbuild_la_LIBADD = \

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -321,9 +321,7 @@ int addSource(rpmSpec spec, int specline, const char *srcname, rpmTagVal tag)
     rpmPushMacro(spec->macros, buf, NULL, p->fullSource, RMIL_SPEC);
     free(buf);
 
-#ifdef WITH_LUA
     addLuaSource(spec->lua, p);
-#endif
 
     if (!nofetch && tryDownload(p))
 	return RPMRC_FAIL;

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -360,16 +360,13 @@ int parseScript(rpmSpec spec, int parsePart)
 	p = getStringBuf(sb);
     }
 
-#ifdef WITH_LUA
     if (rstreq(progArgv[0], "<lua>")) {
 	rpmlua lua = NULL; /* Global state. */
 	if (rpmluaCheckScript(lua, p, partname) != RPMRC_OK) {
 	    goto exit;
 	}
 	(void) rpmlibNeedsFeature(pkg, "BuiltinLuaScripts", "4.2.2-1");
-    } else
-#endif
-    if (progArgv[0][0] == '<') {
+    } else if (progArgv[0][0] == '<') {
 	rpmlog(RPMLOG_ERR,
 		 _("line %d: unsupported internal script: %s\n"),
 		 spec->lineNum, progArgv[0]);

--- a/build/spec.c
+++ b/build/spec.c
@@ -249,9 +249,7 @@ rpmSpec newSpec(void)
     spec->macros = rpmGlobalMacroContext;
     spec->pool = rpmstrPoolCreate();
     
-#ifdef WITH_LUA
     spec->lua = specLuaInit(spec);
-#endif
     return spec;
 }
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -55,7 +55,6 @@ RUN ./configure \
   --with-selinux \
   --with-cap \
   --with-acl \
-  --with-lua \
   --with-audit \
   --with-fsverity \
   --enable-bdb \

--- a/configure.ac
+++ b/configure.ac
@@ -753,19 +753,12 @@ AS_IF([test "$with_acl" = yes],[
 AC_SUBST(WITH_ACL_LIB)
 AM_CONDITIONAL(ACL,[test "$with_acl" = yes])
 
-AC_ARG_WITH([lua], [AS_HELP_STRING([--with-lua], [build with lua support])],
-            [],
-            [with_lua=yes])
-
-AS_IF([test "$with_lua" != no],[
-  PKG_CHECK_MODULES([LUA],
+PKG_CHECK_MODULES([LUA],
     [lua >= 5.2],
-    [AC_DEFINE(WITH_LUA, 1, [Build with lua support?])],
-    [AC_MSG_ERROR([lua not present or too old (--without-lua to disable)])])
-  AC_SUBST(LUA_CFLAGS)
-  AC_SUBST(LUA_LIBS)
-])
-AM_CONDITIONAL(WITH_LUA,[test "$with_lua" = yes])
+    [],
+    [AC_MSG_ERROR([lua not present or too old)])])
+AC_SUBST(LUA_CFLAGS)
+AC_SUBST(LUA_LIBS)
 
 AC_ARG_ENABLE(plugins, [AS_HELP_STRING([--disable-plugins],[build without plugin support])],,[enable_plugins=yes])
 AS_IF([test "$enable_plugins" = yes],[

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1110,11 +1110,9 @@ static const struct rpmlibProvides_s rpmlibProvides[] = {
     { "rpmlib(ConcurrentAccess)",    "4.1-1",
 	(                RPMSENSE_EQUAL),
     N_("package scriptlets may access the rpm database while installing.") },
-#ifdef WITH_LUA
     { "rpmlib(BuiltinLuaScripts)",    "4.2.2-1",
 	(                RPMSENSE_EQUAL),
     N_("internal support for lua scripts.") },
-#endif
     { "rpmlib(FileDigests)", 		"4.6.0-1",
 	(		 RPMSENSE_EQUAL),
     N_("file digest algorithm is per package configurable") },

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1661,10 +1661,8 @@ int rpmReadConfigFiles(const char * file, const char * target)
 	free(os);
     }
 
-#ifdef WITH_LUA
     /* Force Lua state initialization */
     rpmluaGetGlobalState();
-#endif
     rc = 0;
 
 exit:
@@ -1740,10 +1738,8 @@ void rpmFreeRpmrc(void)
 
     /* XXX doesn't really belong here but... */
     rpmFreeCrypto();
-#ifdef WITH_LUA
     rpmlua lua = rpmluaGetGlobalState();
     rpmluaFree(lua);
-#endif
 
     rpmrcCtxRelease(ctx);
     return;

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -102,7 +102,6 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
 		   scriptNextFileFunc nextFileFunc)
 {
     rpmRC rc = RPMRC_FAIL;
-#ifdef WITH_LUA
     rpmlua lua = NULL; /* Global state. */
     int cwd = -1;
 
@@ -139,9 +138,6 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
 	close(cwd);
 	umask(oldmask);
     }
-#else
-    rpmlog(lvl, _("<lua> scriptlet support not built in\n"));
-#endif
 
     return rc;
 }

--- a/rpmio/Makefile.am
+++ b/rpmio/Makefile.am
@@ -8,7 +8,9 @@ AM_CPPFLAGS += @WITH_OPENSSL_INCLUDE@
 AM_CPPFLAGS += @WITH_LIBGCRYPT_INCLUDE@
 AM_CPPFLAGS += @WITH_POPT_INCLUDE@
 AM_CPPFLAGS += $(ZSTD_CFLAGS)
+AM_CPPFLAGS += @LUA_CFLAGS@
 AM_CPPFLAGS += -I$(top_srcdir)/misc
+AM_CPPFLAGS += -I$(top_srcdir)/luaext/
 AM_CPPFLAGS += -DRPMCONFIGDIR="\"@RPMCONFIGDIR@\""
 AM_CPPFLAGS += -DLOCALSTATEDIR="\"$(localstatedir)\""
 
@@ -20,7 +22,8 @@ librpmio_la_SOURCES = \
 	rpmpgp.c rpmsq.c rpmsw.c url.c \
 	rpmio_internal.h rpmhook.h rpmvercmp.c rpmver.c \
 	rpmstring.c rpmfileutil.c rpmglob.c \
-	rpmkeyring.c rpmstrpool.c rpmmacro_internal.h
+	rpmkeyring.c rpmstrpool.c rpmmacro_internal.h \
+	rpmlua.c rpmlua.h
 
 if WITH_OPENSSL
 librpmio_la_SOURCES += digest_openssl.c
@@ -39,16 +42,10 @@ librpmio_la_LIBADD = \
 	@WITH_ZLIB_LIB@ \
 	@WITH_POPT_LIB@ \
 	@WITH_LZMA_LIB@ \
+	@LUA_LIBS@ \
+	../luaext/libluaext.la \
 	$(ZSTD_LIBS) \
 	-lpthread
-
-if WITH_LUA
-AM_CPPFLAGS += -I$(top_srcdir)/luaext/
-AM_CPPFLAGS += @LUA_CFLAGS@
-librpmio_la_SOURCES += rpmlua.c rpmlua.h
-librpmio_la_LIBADD += @LUA_LIBS@
-librpmio_la_LIBADD += $(top_builddir)/luaext/libluaext.la
-endif
 
 check_PROGRAMS =
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -25,10 +25,7 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/argv.h>
 
-#ifdef	WITH_LUA
 #include "rpmio/rpmlua.h"
-#endif
-
 #include "rpmio/rpmmacro_internal.h"
 #include "debug.h"
 
@@ -1009,7 +1006,6 @@ static size_t doOutput(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
     return 0;
 }
 
-#ifdef WITH_LUA
 static size_t doLua(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
 {
     rpmlua lua = NULL; /* Global state. */
@@ -1044,7 +1040,6 @@ static size_t doLua(MacroBuf mb,  rpmMacroEntry me, ARGV_t argv)
     }
     return 0;
 }
-#endif
 
 static size_t
 doSP(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
@@ -1269,9 +1264,7 @@ static struct builtins_s {
     { "getncpus",	doFoo,		0,	ME_FUNC },
     { "global",		doGlobal,	-1,	ME_PARSE },
     { "load",		doLoad,		1,	ME_FUNC },
-#ifdef WITH_LUA
     { "lua",		doLua,		1,	ME_FUNC },
-#endif
     { "macrobody",	doBody,		1,	ME_FUNC },
     { "quote",		doFoo,		1,	ME_FUNC },
     { "shrink",		doFoo,		1,	ME_FUNC },

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -34,11 +34,6 @@ unset SOURCE_DATE_EPOCH
 TOPDIR="${HOME}/build"
 
 RPM_XFAIL=${RPM_XFAIL-1}
-if grep -q 'WITH_LUA 1' "${abs_top_builddir}/config.h"; then
-    LUA_DISABLED=false;
-else
-    LUA_DISABLED=true;
-fi
 if test "${PYTHON}"; then
     PYTHON_DISABLED=false;
 else

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -35,7 +35,6 @@ AT_CLEANUP
 
 AT_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 AT_CHECK([
 
@@ -1193,7 +1192,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debugsource debugsourcefiles.list path])
 AT_KEYWORDS([build] [debuginfo] [debugsource])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \
@@ -1218,7 +1216,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo subpackages single])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \
@@ -1257,7 +1254,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo subpackages multiple])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \
@@ -1338,7 +1334,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo subpackages multiple unique])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \
@@ -1419,7 +1414,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo subpackages multiple unique debugsource])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \
@@ -1503,7 +1497,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \
@@ -1579,7 +1572,6 @@ AT_CLEANUP
 AT_SETUP([rpmbuild debuginfo subpackages multiple excluded])
 AT_KEYWORDS([build] [debuginfo] [debugsubpackage] [debugsource])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 rundebug rpmbuild --quiet \

--- a/tests/rpmbuildid.at
+++ b/tests/rpmbuildid.at
@@ -1190,7 +1190,6 @@ AT_SETUP([rpmbuild buildid attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AT_SKIP_IF([$LUA_DISABLED])
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \
@@ -1221,7 +1220,6 @@ AT_SETUP([rpmbuild buildid config attrs])
 AT_KEYWORDS([build] [debuginfo] [buildid])
 AT_CHECK([
 RPMDB_INIT
-AT_SKIP_IF([$LUA_DISABLED])
 
 # Build, contains one ELF which should have a buildid.
 rundebug rpmbuild \

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -558,20 +558,9 @@ runroot rpm \
 [])
 AT_CLEANUP
 
-AT_SETUP([test lua support])
-AT_KEYWORDS([macros lua])
-AT_CHECK([[
-lua_disabled=$(runroot rpm --eval '%[%{defined lua}?"0":"1"]'|tr -d '\n')
-test $lua_disabled = $LUA_DISABLED
-]],
-[1],
-[])
-AT_CLEANUP
-
 AT_SETUP([simple lua --eval])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm --eval '%{lua:print(5*5)}'
 ],
 [0],
@@ -581,7 +570,6 @@ AT_CLEANUP
 
 AT_SETUP([lua macro arguments])
 AT_KEYWORDS([macros lua])
-AT_SKIP_IF([$LUA_DISABLED])
 AT_CHECK([[
 runroot rpm \
 	--define "foo(a:) %{lua:print(opt.a, arg[1])}" \
@@ -595,7 +583,6 @@ AT_CLEANUP
 
 AT_SETUP([lua macros table])
 AT_KEYWORDS([macros lua])
-AT_SKIP_IF([$LUA_DISABLED])
 AT_CHECK([[
 runroot rpm \
 	--define "qtst() %{lua:for i=1, #arg do print(' '..i..':'..arg[i]) end}"\
@@ -628,7 +615,6 @@ AT_CLEANUP
 
 AT_SETUP([lua macros recursion])
 AT_KEYWORDS([macros lua])
-AT_SKIP_IF([$LUA_DISABLED])
 AT_CHECK([[
 runroot rpm \
 	--define "%recurse() %{lua:io.write(' '..#arg); if #arg < 16 then table.insert(arg, #arg); macros.recurse(arg) end;}" \
@@ -642,7 +628,6 @@ AT_CLEANUP
 AT_SETUP([lua rpm extensions 1])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm --eval '%{lua: rpm.define("foo bar") print(rpm.expand("%{foo}"))}'
 ],
 [0],
@@ -653,7 +638,6 @@ AT_CLEANUP
 AT_SETUP([lua rpm extensions 2])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm --eval '%{lua: print(rpm.vercmp("1.0", "2.0"))}'
 ],
 [0],
@@ -664,7 +648,6 @@ AT_CLEANUP
 AT_SETUP([lua rpm isdefined])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm \
 	--eval '%{lua: print(rpm.isdefined("with"))}' \
 	--eval '%{lua: print(rpm.isdefined("nil"))}' \
@@ -680,7 +663,6 @@ AT_CLEANUP
 AT_SETUP([lua posix extensions])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm \
   --eval '%{lua: posix.putenv("LUATEST=ok") print(posix.getenv("LUATEST"))}'
 ],
@@ -692,7 +674,6 @@ AT_CLEANUP
 AT_SETUP([lua script exit behavior])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm \
   --eval '%{lua: os.exit()}))}'
 ],
@@ -705,7 +686,6 @@ AT_CLEANUP
 AT_SETUP([lua script redirect2null])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm \
   --eval '%{lua: posix.redirect2null()}))}'
 ],
@@ -718,7 +698,6 @@ AT_CLEANUP
 AT_SETUP([lua library path])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 f=$(run rpm --eval "%{_rpmconfigdir}/lua/foo.lua")
 echo "bar = 'graak'" > ${f}
@@ -734,7 +713,6 @@ AT_CLEANUP
 AT_SETUP([lua rpm version objects])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm \
   --eval '%{lua: v1 = rpm.ver("1:4.16-5"); print(v1, v1.e, v1.v, v1.r)}' \
   --eval '%{lua: v1 = rpm.ver("4.16-1"); print(v1, v1.e, v1.v, v1.r)}' \
@@ -752,7 +730,6 @@ AT_CLEANUP
 AT_SETUP([lua rpm io stream])
 AT_KEYWORDS([macros lua])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 runroot rpm \
   --eval '%{lua: local f = rpm.open("zzz", "w+"); f:write("gggg"); print(f:seek("cur")); f:close()}' \

--- a/tests/rpmreplace.at
+++ b/tests/rpmreplace.at
@@ -511,7 +511,6 @@ AT_CLEANUP
 AT_SETUP([upgrade empty directory to file link with pretrans])
 AT_KEYWORDS([install])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 tf="${RPMTEST}"/opt/foo
 rm -rf "${RPMTEST}"/opt/*

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -4,7 +4,6 @@ AT_BANNER([RPM scriptlets])
 
 AT_SETUP([basic script failures 1])
 AT_KEYWORDS([script])
-AT_SKIP_IF([$LUA_DISABLED])
 AT_CHECK([
 RPMDB_INIT
 
@@ -217,7 +216,6 @@ AT_CLEANUP
 AT_SETUP([basic file trigger scripts])
 AT_KEYWORDS([file trigger script])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/fakeshell.spec

--- a/tests/rpmvercmp.at
+++ b/tests/rpmvercmp.at
@@ -4,7 +4,6 @@ m4_define([RPMVERCMP],[
 AT_SETUP([rpmvercmp($1, $2) = $3])
 AT_KEYWORDS([vercmp])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 runroot rpm --eval '%{lua: print(rpm.vercmp("$1", "$2"))}'], [0], [$3
 ], [])
 AT_CLEANUP

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -223,7 +223,6 @@ AT_CLEANUP
 AT_SETUP([verifyscript failure])
 AT_KEYWORDS([verify])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/verifyscript.spec
@@ -239,7 +238,6 @@ AT_CLEANUP
 AT_SETUP([verifyscript success])
 AT_KEYWORDS([verify])
 AT_CHECK([
-AT_SKIP_IF([$LUA_DISABLED])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb /data/SPECS/verifyscript.spec


### PR DESCRIPTION
More and more macros, scriptlets and other functionality has been getting
built around Lua, to the point that it has in practise been required for
several years now.

Maintaining the pretense of being optional comes at a cost in holding
back developments and having to check for that theoretical special
case. Lets make it a hard requirement and embrace it some more!