### PR TITLE
Fix test cases failing on systems with tape drives

### DIFF
--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -334,8 +334,8 @@ AT_CLEANUP
 AT_SETUP([rpm2archive])
 AT_KEYWORDS([basic])
 AT_CHECK([
-runroot_other rpm2archive - < "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm | tar tz
-runroot_other rpm2archive - < "${RPMTEST}"/data/SRPMS/hello-1.0-1.src.rpm | tar tz
+runroot_other rpm2archive - < "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm | tar tzf -
+runroot_other rpm2archive - < "${RPMTEST}"/data/SRPMS/hello-1.0-1.src.rpm | tar tzf -
 ],
 [0],
 [./usr/bin/hello


### PR DESCRIPTION
If $TAPE is set tar uses the tape drive instead of stdout as default.
The rpm2archive test assumed that tar will just use stdout no matter what.
Force this behaviour per command line option.

Resolves: rhbz#1902844