### PR TITLE
Handle file install failures more gracefully

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -876,8 +876,8 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 	fp->action = rpmfsGetAction(fs, fx);
 	fp->skip = XFA_SKIPPING(fp->action);
 	fp->setmeta = 1;
-	if (XFA_CREATING(fp->action))
-	    fp->suffix = S_ISDIR(rpmfiFMode(fi)) ? NULL : tid;
+	if (XFA_CREATING(fp->action) && !S_ISDIR(rpmfiFMode(fi)))
+	    fp->suffix = tid;
 	fp->fpath = fsmFsPath(fi, fp->suffix);
 
 	/* Remap file perms, owner, and group. */

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -959,11 +959,9 @@ touch:
 	    /* On FA_TOUCH no hardlinks are created thus this is skipped. */
 	    /* we skip the hard linked file containing the content */
 	    /* write the content to the first used instead */
-	    char *fn = rpmfilesFN(files, firsthardlink);
 	    rc = rpmfiArchiveReadToFilePsm(fi, firstlinkfile, nodigest, psm);
 	    wfd_close(&firstlinkfile);
 	    firsthardlink = -1;
-	    free(fn);
 	}
 
         if (rc) {

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -773,14 +773,16 @@ static int fsmCommit(char **path, rpmfi fi, rpmFileAction action, const char *su
 	/* Rename temporary to final file name if needed. */
 	if (dest != *path) {
 	    rc = fsmRename(*path, dest);
-	    if (!rc && nsuffix) {
-		char * opath = fsmFsPath(fi, NULL);
-		rpmlog(RPMLOG_WARNING, _("%s created as %s\n"),
-		       opath, dest);
-		free(opath);
+	    if (!rc) {
+		if (nsuffix) {
+		    char * opath = fsmFsPath(fi, NULL);
+		    rpmlog(RPMLOG_WARNING, _("%s created as %s\n"),
+			   opath, dest);
+		    free(opath);
+		}
+		free(*path);
+		*path = dest;
 	    }
-	    free(*path);
-	    *path = dest;
 	}
     }
 

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -876,11 +876,8 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 	fp->action = rpmfsGetAction(fs, fx);
 	fp->skip = XFA_SKIPPING(fp->action);
 	fp->setmeta = 1;
-	if (fp->action != FA_TOUCH) {
+	if (XFA_CREATING(fp->action))
 	    fp->suffix = S_ISDIR(rpmfiFMode(fi)) ? NULL : tid;
-	} else {
-	    fp->suffix = NULL;
-	}
 	fp->fpath = fsmFsPath(fi, fp->suffix);
 
 	/* Remap file perms, owner, and group. */

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -121,6 +121,9 @@ typedef enum rpmFileAction_e {
 #define XFA_SKIPPING(_a)	\
     ((_a) == FA_SKIP || (_a) == FA_SKIPNSTATE || (_a) == FA_SKIPNETSHARED || (_a) == FA_SKIPCOLOR)
 
+#define XFA_CREATING(_a)	\
+    ((_a) == FA_CREATE || (_a) == FA_BACKUP || (_a) == FA_SAVE || (_a) == FA_ALTNAME)
+
 /**
  * We pass these around as an array with a sentinel.
  */

--- a/tests/data/SPECS/hlinktest.spec
+++ b/tests/data/SPECS/hlinktest.spec
@@ -1,6 +1,7 @@
 %bcond_with unpackaged_dirs
 %bcond_with unpackaged_files
 %bcond_with unpackaged_excludes
+%bcond_with owned_dir
 
 Summary:          Testing hard link behavior
 Name:             hlinktest
@@ -43,6 +44,9 @@ touch $RPM_BUILD_ROOT/teet
 
 %files
 %defattr(-,root,root)
+%if %{with owned_dir}
+%dir /foo
+%endif
 /foo/*
 %if %{with unpackaged_excludes}
 %exclude /teet

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -253,38 +253,6 @@ drwxrwxrwx zoot     zoot     /j/dir
 [])
 AT_CLEANUP
 
-# ------------------------------
-# hardlink tests
-AT_SETUP([rpmbuild hardlink])
-AT_KEYWORDS([build])
-RPMDB_INIT
-AT_CHECK([
-RPMDB_INIT
-
-runroot rpmbuild \
-  -bb --quiet /data/SPECS/hlinktest.spec
-
-runroot rpm -i /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
-
-runroot rpm -q --qf "[[%{filenlinks} %{filenames}\n]]%{longsize}\n" hlinktest
-runroot rpm -V --nouser --nogroup hlinktest
-ls -i "${RPMTEST}"/foo/hello* | awk {'print $1'} | sort -u | wc -l
-
-],
-[0],
-[2 /foo/aaaa
-1 /foo/copyllo
-4 /foo/hello
-4 /foo/hello-bar
-4 /foo/hello-foo
-4 /foo/hello-world
-2 /foo/zzzz
-87
-1
-],
-[])
-AT_CLEANUP
-
 AT_SETUP([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
 RPMDB_INIT

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -722,3 +722,95 @@ runroot rpm -V --nouser --nogroup suicidal
 [],
 [])
 AT_CLEANUP
+
+# ------------------------------
+# hardlink tests
+AT_SETUP([rpm -i hardlinks])
+AT_KEYWORDS([build install])
+RPMDB_INIT
+
+# Need a reproducable test package
+runroot rpmbuild \
+  --define "%optflags -O2 -g" \
+  --define "%_target_platform noarch-linux" \
+  --define "%_binary_payload w.ufdio" \
+  --define "%_buildhost localhost" \
+  --define "%use_source_date_epoch_as_buildtime 1" \
+  --define "%source_date_epoch_from_changelog 1" \
+  --define "%clamp_mtime_to_source_date_epoch 1" \
+  --with owned_dir \
+  -bb --quiet /data/SPECS/hlinktest.spec
+
+pkg="/build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm"
+
+cp "${RPMTEST}/${pkg}" "${RPMTEST}/tmp/1.rpm"
+dd if=/dev/zero of="${RPMTEST}/tmp/1.rpm" \
+   conv=notrunc bs=1 seek=8180 count=6 2> /dev/null
+
+cp "${RPMTEST}/${pkg}" "${RPMTEST}/tmp/2.rpm"
+dd if=/dev/zero of="${RPMTEST}/tmp/2.rpm" \
+   conv=notrunc bs=1 seek=8150 count=6 2> /dev/null
+
+cp "${RPMTEST}/${pkg}" "${RPMTEST}/tmp/3.rpm"
+dd if=/dev/zero of="${RPMTEST}/tmp/3.rpm" \
+   conv=notrunc bs=1 seek=8050 count=6 2> /dev/null
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --noverify /tmp/1.rpm
+# test that nothing of the contents remains after failure
+test -d "${RPMTEST}/foo"
+],
+[1],
+[],
+[error: unpacking of archive failed: cpio: Archive file not in header
+error: hlinktest-1.0-1.noarch: install failed
+])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --noverify /tmp/2.rpm
+# test that nothing of the contents remains after failure
+test -d "${RPMTEST}/foo"
+],
+[1],
+[],
+[error: unpacking of archive failed: cpio: Bad/unreadable  header
+error: hlinktest-1.0-1.noarch: install failed
+])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --noverify /tmp/3.rpm 2>&1| sed 's/;.*:/:/g'
+# test that nothing of the contents remains after failure
+test -d "${RPMTEST}/foo"
+],
+[1],
+[error: unpacking of archive failed on file /foo/hello-world: Digest mismatch
+error: hlinktest-1.0-1.noarch: install failed
+],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -q --qf "[[%{filenlinks} %{filenames}\n]]%{longsize}\n" hlinktest
+ls -i "${RPMTEST}"/foo/hello* | awk {'print $1'} | sort -u | wc -l
+runroot rpm -e hlinktest
+
+],
+[0],
+[1 /foo
+2 /foo/aaaa
+1 /foo/copyllo
+4 /foo/hello
+4 /foo/hello-bar
+4 /foo/hello-foo
+4 /foo/hello-world
+2 /foo/zzzz
+87
+1
+],
+[])
+AT_CLEANUP
+


### PR DESCRIPTION
Run the file installation in multiple stages:

1) gather intel
2) unpack the archive to temporary files
3) set file metadatas
4) commit files to final location
5) mop up leftovers on failure
    
This means we no longer leave behind a trail of untracked, potentially harmful junk on installation failure.
    
If commit step fails the package can still be left in an inconsistent stage, this could be further improved by first backing up old files to temporary location to allow undo on failure, but leaving that for some other day.
Also unowned directories will still be left behind.
    
And yes, this is a somewhat scary change as it's the biggest ever change to how rpm lays down files on install.
    
Fixes: #967 (+ multiple reports over the years)

Details in commit messages, there are several preparatory commits leading up to the "big switch" to this new mode of operation. This change has also been the major blocker to making the plugin API public, as this can have severe consequences on plugins which only expect to handle files one by one. Our resident plugins are not actually affected though.