### PR TITLE
Hardlink handling cleanups + fixes

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -211,6 +211,20 @@ const char * dnlNextIterator(DNLI_t dnli)
     return dn;
 }
 
+static int fsmLink(const char *opath, const char *path)
+{
+    int rc = link(opath, path);
+
+    if (_fsm_debug) {
+	rpmlog(RPMLOG_DEBUG, " %8s (%s, %s) %s\n", __func__,
+	       opath, path, (rc < 0 ? strerror(errno) : ""));
+    }
+
+    if (rc < 0)
+	rc = RPMERR_LINK_FAILED;
+    return rc;
+}
+
 static int fsmSetFCaps(const char *path, const char *captxt)
 {
     int rc = 0;
@@ -304,10 +318,7 @@ static int fsmMkfile(rpmfi fi, struct filedata_s *fp, rpmfiles files,
 	    rc = wfd_open(firstlinkfile, fp->fpath);
 	} else {
 	    /* Create hard links for others */
-	    rc = link((*firstlink)->fpath, fp->fpath);
-	    if (rc < 0) {
-		rc = RPMERR_LINK_FAILED;
-	    }
+	    rc = fsmLink((*firstlink)->fpath, fp->fpath);
 	}
     }
     /* Write normal files or fill the last hardlinked (already

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -297,6 +297,17 @@ static int fsmOpen(FD_t *wfdp, const char *dest)
     return rc;
 }
 
+static int fsmUnpack(rpmfi fi, FD_t fd, rpmpsm psm, int nodigest)
+{
+    int rc = rpmfiArchiveReadToFilePsm(fi, fd, nodigest, psm);
+    if (_fsm_debug) {
+	rpmlog(RPMLOG_DEBUG, " %8s (%s %lu bytes [%d]) %s\n", __func__,
+	       rpmfiFN(fi), rpmfiFSize(fi), Fileno(fd),
+	       (rc < 0 ? strerror(errno) : ""));
+    }
+    return rc;
+}
+
 static int fsmMkfile(rpmfi fi, struct filedata_s *fp, rpmfiles files,
 		     rpmpsm psm, int nodigest,
 		     struct filedata_s ** firstlink, FD_t *firstlinkfile)
@@ -324,7 +335,7 @@ static int fsmMkfile(rpmfi fi, struct filedata_s *fp, rpmfiles files,
     /* If the file has content, unpack it */
     if (rpmfiArchiveHasContent(fi)) {
 	if (!rc)
-	    rc = rpmfiArchiveReadToFilePsm(fi, fd, nodigest, psm);
+	    rc = fsmUnpack(fi, fd, psm, nodigest);
 	/* Last file of hardlink set, ensure metadata gets set */
 	if (*firstlink) {
 	    (*firstlink)->setmeta = 1;

--- a/lib/rpmarchive.h
+++ b/lib/rpmarchive.h
@@ -47,6 +47,7 @@ enum rpmfilesErrorCodes {
 	RPMERR_COPY_FAILED	= -32785,
 	RPMERR_LSETFCON_FAILED	= -32786,
 	RPMERR_SETCAP_FAILED	= -32787,
+	RPMERR_CLOSE_FAILED	= -32788,
 };
 
 #ifdef __cplusplus

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -812,5 +812,76 @@ runroot rpm -e hlinktest
 1
 ],
 [])
-AT_CLEANUP
 
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --excludepath=/foo/zzzz /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -Vv --nogroup --nouser hlinktest
+runroot rpm -e hlinktest
+],
+[0],
+[.........    /foo
+.........    /foo/aaaa
+.........    /foo/copyllo
+.........    /foo/hello
+.........    /foo/hello-bar
+.........    /foo/hello-foo
+.........    /foo/hello-world
+.........    /foo/zzzz (not installed)
+],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --excludepath=/foo/aaaa /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -Vv --nogroup --nouser hlinktest
+runroot rpm -e hlinktest
+],
+[0],
+[.........    /foo
+.........    /foo/aaaa (not installed)
+.........    /foo/copyllo
+.........    /foo/hello
+.........    /foo/hello-bar
+.........    /foo/hello-foo
+.........    /foo/hello-world
+.........    /foo/zzzz
+],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --excludepath=/foo/aaaa --excludepath=/foo/zzzz /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -Vv --nogroup --nouser hlinktest
+runroot rpm -e hlinktest
+],
+[0],
+[.........    /foo
+.........    /foo/aaaa (not installed)
+.........    /foo/copyllo
+.........    /foo/hello
+.........    /foo/hello-bar
+.........    /foo/hello-foo
+.........    /foo/hello-world
+.........    /foo/zzzz (not installed)
+],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i --excludepath=/foo/hello-foo /build/RPMS/noarch/hlinktest-1.0-1.noarch.rpm
+runroot rpm -Vv --nogroup --nouser hlinktest
+runroot rpm -e hlinktest
+],
+[0],
+[.........    /foo
+.........    /foo/aaaa
+.........    /foo/copyllo
+.........    /foo/hello
+.........    /foo/hello-bar
+.........    /foo/hello-foo (not installed)
+.........    /foo/hello-world
+.........    /foo/zzzz
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
Details in commit messages, but brief summary:
- add some missing diagnostics to file unpacking and hardlink handling
- always use the same code path to unpack files
- streamline the hardlink logic, consolidate to one place
- fix a case where partially skipped hardlink set will miss their metadata getting set

This deserves some specific test-cases as well. Will add, but don't let that prevent reviewing otherwise. The hardlink logic with the skipped files scenarios and all is a tricky piece of code.