### PR TITLE
Ensure negation comes *after* division

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1864,7 +1864,7 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     }
 
     /* Trailer offset is negative and has a special meaning */
-    blob->ril = -einfo.offset/sizeof(*blob->pe);
+    blob->ril = -(einfo.offset/sizeof(*blob->pe));
     /* Does the region actually fit within the header? */
     if ((einfo.offset % sizeof(*blob->pe)) || hdrchkRange(blob->il, blob->ril) ||
 					hdrchkRange(blob->dl, blob->rdl)) {

--- a/lib/header.c
+++ b/lib/header.c
@@ -1863,7 +1863,13 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 	goto exit;
     }
 
-    /* Trailer offset is negative and has a special meaning */
+    /*
+     * Trailer offset is negative and has a special meaning.  Be sure to negate
+     * *after* the division, so the negation cannot overflow.  The parentheses
+     * around the division are required!
+     *
+     * Thankfully, the modulus operator works fine on negative numbers.
+     */
     blob->ril = -(einfo.offset/sizeof(*blob->pe));
     /* Does the region actually fit within the header? */
     if ((einfo.offset % sizeof(*blob->pe)) || hdrchkRange(blob->il, blob->ril) ||


### PR DESCRIPTION
Unary `-` has a higher precedence than binary `/` in C.  Found by UBSAN
and libfuzzer.

Fixes c3e04c2ac91737b06ce5592e8cd8558498e566c0