### PR TITLE
Fix regression from commit 165330b7bf0757e30fa8a6de9998a564fb62796f

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -409,7 +409,8 @@ unsigned headerSizeof(Header h, int magicp)
 static inline int strtaglen(const char *str, rpm_count_t c, const char *end)
 {
     const char *start = str;
-    const char *s;
+    const char *s = NULL;
+    int len = -1; /* assume failure */
 
     if (end) {
 	while (end > start && (s = memchr(start, '\0', end-start))) {
@@ -424,7 +425,11 @@ static inline int strtaglen(const char *str, rpm_count_t c, const char *end)
 	    start = s + 1;
 	}
     }
-    return (c > 0) ? -1 : (s - str + 1);
+
+    if (s != NULL && c == 0)
+	len = s - str + 1;
+
+    return len;
 }
 
 /**


### PR DESCRIPTION
With the changed logic, the if-clause can fall through without ever
initializing s. The exit code condition is getting more complicated
now so move it to helper variable, assume failure for a safe default.

Fixes: 165330b7bf0757e30fa8a6de9998a564fb62796f