### PR TITLE
Avoid undefined shifts

### DIFF
--- a/build/rpmbuild.h
+++ b/build/rpmbuild.h
@@ -39,7 +39,7 @@ enum rpmBuildFlags_e {
     RPMBUILD_BUILDREQUIRES	= (1 <<  20), /*!< Execute %%buildrequires. */
     RPMBUILD_DUMPBUILDREQUIRES	= (1 <<  21), /*!< Write buildrequires.nosrc.rpm. */
 
-    RPMBUILD_NOBUILD	= (1 << 31)	/*!< Don't execute or package. */
+    RPMBUILD_NOBUILD	= (1UL << 31)	/*!< Don't execute or package. */
 };
 
 typedef rpmFlags rpmBuildFlags;

--- a/build/rpmfc.h
+++ b/build/rpmfc.h
@@ -32,7 +32,7 @@ enum FCOLOR_e {
 
     RPMFC_WHITE			= (1 << 29),
     RPMFC_INCLUDE		= (1 << 30),
-    RPMFC_ERROR			= (1 << 31)
+    RPMFC_ERROR			= (1UL << 31)
 };
 
 /** \ingroup rpmfc

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -89,7 +89,7 @@ enum rpmVerifyAttrs_e {
     RPMVERIFY_READLINKFAIL= (1 << 28),	/*!< readlink failed */
     RPMVERIFY_READFAIL	= (1 << 29),	/*!< file read failed */
     RPMVERIFY_LSTATFAIL	= (1 << 30),	/*!< lstat failed */
-    RPMVERIFY_LGETFILECONFAIL	= (1 << 31)	/*!< lgetfilecon failed */
+    RPMVERIFY_LGETFILECONFAIL	= (1UL << 31)	/*!< lgetfilecon failed */
 };
 
 typedef rpmFlags rpmVerifyAttrs;

--- a/lib/rpmplugin.h
+++ b/lib/rpmplugin.h
@@ -22,7 +22,7 @@ typedef enum rpmScriptletExecutionFlow_e {
  */
 enum rpmFileActionFlags_e {
     /* bits 0-15 reserved for actions */
-    FAF_UNOWNED		= (1 << 31)
+    FAF_UNOWNED		= (1UL << 31)
 };
 typedef rpmFlags rpmFileActionFlags;
 

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -54,7 +54,7 @@ enum rpmtransFlags_e {
     /* bit 28 unused */
     RPMTRANS_FLAG_NOARTIFACTS	= (1 << 29),	/*!< from --noartifacts */
     RPMTRANS_FLAG_NOCONFIGS	= (1 << 30),	/*!< from --noconfigs */
-    RPMTRANS_FLAG_DEPLOOPS	= (1 << 31)	/*!< from --deploops */
+    RPMTRANS_FLAG_DEPLOOPS	= (1UL << 31)	/*!< from --deploops */
 };
 
 typedef rpmFlags rpmtransFlags;

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -265,7 +265,7 @@ static const char *prToken(int val)
 }
 #endif	/* DEBUG_PARSER */
 
-#define RPMEXPR_DISCARD		(1 << 31)	/* internal, discard result */
+#define RPMEXPR_DISCARD		(1UL << 31)	/* internal, discard result */
 
 static char *getValuebuf(ParseState state, const char *p, size_t size)
 {


### PR DESCRIPTION
This allows running the testsuite under UBsan.