### PR TITLE
Check for overflow in computing region length

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1846,6 +1846,7 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 	goto exit;
     }
 
+    RPM_STATIC_ASSERT(sizeof(trailer) == REGION_TAG_COUNT);
     /* Is there an immutable header region tag trailer? */
     memset(&trailer, 0, sizeof(trailer));
     regionEnd = blob->dataStart + einfo.offset;

--- a/lib/header.c
+++ b/lib/header.c
@@ -1838,8 +1838,8 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 	goto exit;
     }
 
-    /* Is the trailer within the data area? */
-    if (hdrchkRange(blob->dl, einfo.offset + REGION_TAG_COUNT)) {
+    /* Is the trailer within the data area?  Watch out for overflow! */
+    if (einfo.offset < 0 || einfo.offset + REGION_TAG_COUNT > blob->dl) {
 	rasprintf(buf,
 		_("region offset: BAD, tag %d type %d offset %d count %d"),
 		einfo.tag, einfo.type, einfo.offset, einfo.count);
@@ -1848,7 +1848,6 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 
     RPM_STATIC_ASSERT(sizeof(trailer) == REGION_TAG_COUNT);
     /* Is there an immutable header region tag trailer? */
-    memset(&trailer, 0, sizeof(trailer));
     regionEnd = blob->dataStart + einfo.offset;
     /* regionEnd is not guaranteed to be aligned */
     (void) memcpy(&trailer, regionEnd, REGION_TAG_COUNT);

--- a/system.h
+++ b/system.h
@@ -15,6 +15,16 @@
 #include <sys/param.h>
 #endif
 
+#if CHAR_BIT != 8
+#error RPM requires 8 bit bytes
+#endif
+
+#if __STDC_VERSION__ >= 201112L
+#define RPM_STATIC_ASSERT(x) do { _Static_assert(x, #x); } while (0)
+#else
+#define RPM_STATIC_ASSERT(x) do {} while (!(sizeof(struct { int j: 2 * !!(x) - 1; })))
+#endif
+
 /* <unistd.h> should be included before any preprocessor test
    of _POSIX_VERSION.  */
 #ifdef HAVE_UNISTD_H


### PR DESCRIPTION
This uses the GCC builtin `__builtin_add_overflow`, so no casts or manual checks are needed.