### PR TITLE
Bump CI Fedora version to 34

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:34
 MAINTAINER rpm-maint@lists.rpm.org
 
 WORKDIR /srv/rpm


### PR DESCRIPTION
For whatever reason, builds inside Fedora 33 container image randomly
fail due to phantom directories reported during configure/make.
This doesn't seem to happen on 34 which is closing in on a beta release
so should be stable enough for our purposes.