### PR TITLE
Error out on --eval if stdout write fails (#1444)

### DIFF
--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -133,6 +133,10 @@ static void rpmcliAllArgCallback( poptContext con,
 	    if (rpmExpandMacros(NULL, arg, &val, 0) < 0)
 		exit(EXIT_FAILURE);
 	    fprintf(stdout, "%s\n", val);
+	    if (fflush(stdout) == EOF) {
+	        perror(_("Error writing to stdout"));
+	        exit(EXIT_FAILURE);
+	    }
 	    free(val);
 	}
 	break;

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -967,3 +967,14 @@ xxx
 error: bad
 ])
 AT_CLEANUP
+
+AT_SETUP([no space left on stdout])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm --eval 1 >/dev/full
+],
+[1],
+[],
+[Error writing to stdout: No space left on device
+])
+AT_CLEANUP


### PR DESCRIPTION
Since --eval only has one job - to actually *print* something to stdout,
we should fail completely if that's not possible due to an external
error, instead of just not printing anything.  One particular case is
redirecting stdout to a file on a file system that's full (generating
the ENOSPC error).

In order to be able to detect such errors, we need to flush the stream
buffer first; that's because normally, if stdout is not referring to an
interactive device (a terminal), it is block-buffered, as opposed to
line-buffered.