### PR TITLE
Fix a tiny memory leak

### DIFF
--- a/lib/headerutil.c
+++ b/lib/headerutil.c
@@ -333,8 +333,10 @@ static void providePackageNVR(Header h)
     rpmds hds, nvrds;
 
     /* Generate provides for this package name-version-release. */
-    if (!(name && pEVR))
+    if (!(name && pEVR)) {
+	free(pEVR);
 	return;
+    }
 
     /*
      * Rpm prior to 3.0.3 does not have versioned provides.


### PR DESCRIPTION
Found by fuzzing rpmReadPackageFile() with libfuzzer under ASAN.  I didn’t include a regression test because I am not sure how best to write one for this kind of bug.  In any case, this is a minor bug.