### PR TITLE
Better detection of I/O errors

### DIFF
--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -132,9 +132,11 @@ static void rpmcliAllArgCallback( poptContext con,
 	{   char *val = NULL;
 	    if (rpmExpandMacros(NULL, arg, &val, 0) < 0)
 		exit(EXIT_FAILURE);
-	    fprintf(stdout, "%s\n", val);
-	    if (fflush(stdout) == EOF) {
+	    if (fprintf(stdout, "%s\n", val) < 0 ||
+		fflush(stdout) == EOF ||
+		ferror(stdout)) {
 	        perror(_("Error writing to stdout"));
+		free(val);
 	        exit(EXIT_FAILURE);
 	    }
 	    free(val);


### PR DESCRIPTION
It is possible for fprintf to have flushed the stream already, in which
case fflush will succeed.  Use ferror() to catch that.

Fixes 95a83332ac89e06708741e7074760981a417e64d.