### PR TITLE
Really deprecate headerLoad(), headerCopyLoad() and headerUnload()

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -68,6 +68,7 @@ unsigned int headerSizeof(Header h, int magicp);
  * @param h		header (with pointers)
  * @return		on-disk header blob (i.e. with offsets)
  */
+RPM_GNUC_DEPRECATED
 void * headerUnload(Header h);
 
 /** \ingroup header
@@ -100,6 +101,7 @@ Header headerCopy(Header h);
  * @param uh		on-disk header blob (i.e. with offsets)
  * @return		header
  */
+RPM_GNUC_DEPRECATED
 Header headerLoad(void * uh);
 
 /** \ingroup header
@@ -108,6 +110,7 @@ Header headerLoad(void * uh);
  * @param uh		on-disk header blob (i.e. with offsets)
  * @return		header
  */
+RPM_GNUC_DEPRECATED
 Header headerCopyLoad(const void * uh);
 
 enum headerImportFlags_e {

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -381,7 +381,10 @@ static PyObject *hdr_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     } else if (hdrObject_Check(obj)) {
 	h = headerCopy(((hdrObject*) obj)->h);
     } else if (PyBytes_Check(obj)) {
-	h = headerCopyLoad(PyBytes_AsString(obj));
+	Py_ssize_t len = 0;
+	char *blob = NULL;
+	if (PyBytes_AsStringAndSize(obj, &blob, &len) == 0)
+	    h = headerImport(blob, len, HEADERIMPORT_COPY);
     } else if (rpmfdFromPyObject(obj, &fdo)) {
 	Py_BEGIN_ALLOW_THREADS;
 	h = headerRead(rpmfdGetFd(fdo), HEADER_MAGIC_YES);

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -414,7 +414,7 @@ static void unloadImmutableRegion(Header *hdrp, rpmTagVal tag)
     Header oh = NULL;
 
     if (headerGet(*hdrp, tag, &td, HEADERGET_DEFAULT)) {
-	oh = headerCopyLoad(td.data);
+	oh = headerImport(td.data, td.count, HEADERIMPORT_COPY);
 	rpmtdFreeData(&td);
     } else {
 	/* XXX should we warn if the immutable region is corrupt/missing? */


### PR DESCRIPTION
headerLoad(), headerCopyLoad() and headerUnload() have been deprecated as unsafe since rpm 4.10, time to start pushing them out for real. The first two are unsafe because they don't take argument for size, the last one is because it doesn't return one so it forces using the unsafe variants.

Eliminate remaining in-tree uses of the unsafe variants and issue compile-time deprecation warnings on them now that we can.