### PR TITLE
Make the rpmdb keyring type macro-configurable

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -143,6 +143,11 @@
 #	The location of the rpm database file(s) after "rpm --rebuilddb".
 %_dbpath_rebuild	%{_dbpath}
 
+# 	Keyring type to use
+# 	rpmdb		gpg-pubkey "packages" in rpmdb (default)
+# 	fs		gpg-pubkey files at %_keyringpath
+%_keyring		rpmdb
+
 %_keyringpath		%{_dbpath}/pubkeys/
 
 #


### PR DESCRIPTION
Using filesystem as keyring is an unfinished development idea from 2008
which has somehow lingered on ever after.

The fs keyring behavior has potential security problems as it allows any
package to drop in files at the keyring path, instantly becoming trusted
keys.  In some scenarios this may be a desireable feature though, and
apparently some distros (Yocto at least) actually rely on this feature.
The other issue is that the on-disk and rpmdb variants don't play well
together, in fact they don't play together at all.

The rpm keyring needs a thorough redesign but until then we don't want
to force users to adjust to something that is also destined to go away.
So in the meanwhile, let people choose with a macro which behavior they
want, using a macro seems the lowest bar to cross. Add new %_keyring
macro that accepts either `rpmdb` or `fs` values and falls back to `rpmdb`
unknown/unset values.

Fixes: #1543