### PR TITLE
Be much more careful about copying data from the signature header

### DIFF
--- a/lib/package.c
+++ b/lib/package.c
@@ -67,11 +67,14 @@ rpmTagVal headerMergeLegacySigs(Header h, Header sigh, char **msg)
     const struct taglate_s *xl;
     struct rpmtd_s td;
 
-    rpmtdReset(&td);
     for (xl = xlateTags; xl->stag; xl++) {
 	/* There mustn't be one in the main header */
 	if (headerIsEntry(h, xl->xtag))
-	    break;
+	    goto exit;
+    }
+
+    rpmtdReset(&td);
+    for (xl = xlateTags; xl->stag; xl++) {
 	if (headerGet(sigh, xl->stag, &td, HEADERGET_RAW|HEADERGET_MINMEM)) {
 	    /* Translate legacy tags */
 	    if (xl->stag != xl->xtag)
@@ -90,6 +93,7 @@ rpmTagVal headerMergeLegacySigs(Header h, Header sigh, char **msg)
     }
     rpmtdFreeData(&td);
 
+exit:
     if (xl->stag) {
 	rasprintf(msg, "invalid signature tag %s (%d)",
 			rpmTagGetName(xl->xtag), xl->xtag);


### PR DESCRIPTION
Only look for known tags, and ensure correct type and size where known
before copying over. Bump the old arbitrary 16k count limit to 16M limit
though, it's not inconceivable that a package could have that many files.
While at it, ensure none of these tags exist in the main header,
which would confuse us greatly.

This is optimized for backporting ease, upstream can remove redundancies
and further improve checking later.

Fixes: RhBug:1935049, RhBug:1933867, RhBug:1935035, RhBug:1934125, ...

Fixes: CVE-2021-3421, CVE-2021-20271