### PR TITLE
Permit secondary index open to fail for bdb_ro

### DIFF
--- a/lib/backend/bdb_ro.c
+++ b/lib/backend/bdb_ro.c
@@ -160,8 +160,7 @@ static struct bdb_db *bdb_open(const char *name)
     struct bdb_db *db;
 
     fd = open(name, O_RDONLY);
-    if (!fd) {
-	rpmlog(RPMLOG_ERR, "%s: %s\n", name, strerror(errno));
+    if (fd == -1) {
 	return NULL;
     }
     db = xcalloc(1, sizeof(*db));


### PR DESCRIPTION
The other backends would want to create the missing index, but as bdb_ro is read-only it can't do that. As the main purpose of bdb_ro is to support migrating away from BDB for which only the primary database is needed, it doesn't make sense to fail it for non-essential data. Let it fail for secondary indexes - this might affect our ability to query but that's secondary, literally, and we also do emit a warning here.
    
Fixes: #1576
