### PR TITLE
Restore (some) compiler sanity

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ fi
 AS=${AS-as}
 AC_SUBST(AS)
 if test "$GCC" = yes; then
-    cflags_to_try="-fno-strict-aliasing -fstack-protector -Wempty-body"
+    cflags_to_try="-fno-strict-aliasing -Wempty-body"
     AC_MSG_CHECKING([supported compiler flags])
     old_cflags=$CFLAGS
     echo
@@ -50,7 +50,7 @@ if test "$GCC" = yes; then
         ],[])
         CFLAGS=$old_cflags
     done
-    RPMCFLAGS="-D_REENTRANT -Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes $RPMCFLAGS"
+    RPMCFLAGS="-Wall -Wpointer-arith -Wmissing-prototypes -Wstrict-prototypes $RPMCFLAGS"
 fi
 AC_ARG_ENABLE(werror, [AS_HELP_STRING([--enable-werror], [build with -Werror])],
 		[RPMCFLAGS="$RPMCFLAGS -Werror"], [])

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ fi
 AS=${AS-as}
 AC_SUBST(AS)
 if test "$GCC" = yes; then
-    cflags_to_try="-fno-strict-aliasing -Wempty-body"
+    cflags_to_try="-fno-strict-aliasing -fno-strict-overflow -fno-delete-null-pointer-checks -Wempty-body"
     AC_MSG_CHECKING([supported compiler flags])
     old_cflags=$CFLAGS
     echo


### PR DESCRIPTION
-fno-strict-overflow tells gcc and clang to handle signed integer and (at least on gcc) pointer arithmetic wraparound using twos-complement representation like deity intended.
    
-fno-delete-null-pointer-checks tells gcc not to "optimize" away programmer added safeguards. Really.
    
Suggested by Demi Marie Obenour.

While at it, clean up some excess flags that have no business in upstream defaults, such as -fstack-protector which has caused us various headaches over the years.

Replaces #1501