### PR TITLE
Separate build warnings from error summary

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -431,11 +431,21 @@ exit:
     freeStringBuf(sink);
     free(cookie);
     spec->rootDir = NULL;
-    if (rc != RPMRC_OK && rc != RPMRC_MISSINGBUILDREQUIRES &&
-	    rpmlogGetNrecs() > 0) {
-	rpmlog(RPMLOG_NOTICE, _("\n\nRPM build errors:\n"));
-	rpmlogPrint(NULL);
+
+    if (rc != RPMRC_OK && rc != RPMRC_MISSINGBUILDREQUIRES) {
+	unsigned maskWarn = RPMLOG_MASK(RPMLOG_WARNING);
+	unsigned maskErrs = RPMLOG_UPTO(RPMLOG_ERR);
+
+	if (rpmlogGetNrecsByMask(maskWarn)) {
+	    rpmlog(RPMLOG_NOTICE, _("\n\nRPM build warnings:\n"));
+	    rpmlogPrintByMask(NULL, maskWarn);
+	}
+	if (rpmlogGetNrecsByMask(maskErrs)) {
+	    rpmlog(RPMLOG_NOTICE, _("\n\nRPM build errors:\n"));
+	    rpmlogPrintByMask(NULL, maskErrs);
+	}
     }
+
     rpmugFree();
     if (missing_buildreqs && !rc) {
 	rc = RPMRC_MISSINGBUILDREQUIRES;

--- a/rpmio/rpmlog.h
+++ b/rpmio/rpmlog.h
@@ -41,6 +41,7 @@ typedef enum rpmlogLvl_e {
 				/* extract priority */
 #define	RPMLOG_PRI(p)	((p) & RPMLOG_PRIMASK)
 #define	RPMLOG_MAKEPRI(fac, pri)	((((unsigned)(fac)) << 3) | (pri))
+#define	RPMLOG_NPRIS	(RPMLOG_DEBUG + 1)
 
 /** \ingroup rpmlog
  * facility codes
@@ -133,10 +134,24 @@ typedef void * rpmlogCallbackData;
 typedef int (*rpmlogCallback) (rpmlogRec rec, rpmlogCallbackData data);
 
 /** \ingroup rpmlog
+ * Return number of rpmError() messages matching a log mask.
+ * @param mask		log mask to filter by (0 is no filtering)
+ * @return		number of messages matching the mask
+ */
+int rpmlogGetNrecsByMask(unsigned mask);
+
+/** \ingroup rpmlog
  * Return number of rpmError() ressages.
  * @return		number of messages
  */
 int rpmlogGetNrecs(void)	;
+
+/** \ingroup rpmlog
+ * Print all rpmError() messages matching a log mask.
+ * @param f		file handle (NULL uses stderr)
+ * @param mask		log mask to filter by (0 is no filtering)
+ */
+void rpmlogPrintByMask(FILE *f, unsigned mask);
 
 /** \ingroup rpmlog
  * Print all rpmError() messages.


### PR DESCRIPTION
Confusingly, the "RPM build errors" section also includes messages
logged as warnings.  That gives the false impression that they somehow
contributed to the actual build failure and therefore were turned into
errors.

This appears to be a historical artifact; when a message passes through
the logging system and is of the priority RPMLOG_WARNING or higher, we
save it in a global buffer (ctx->recs), which is then simply dumped with
rpmlogPrint() in the error summary.  This was probably good enough when
the summary was introduced (commit f2efc72, year 2000), as there were
almost no warnings generated by RPM at that time, however as they became
more abundant, the summary code was never revisited.

There are 3 ways to fix this discrepancy:

 1) Change the summary's title to "RPM build problems"
 2) Remove the summary altogether
 3) Don't show warnings in it

Options #1 and #2 would be too disruptive.  The error summary needs to
stay as is, for the following reasons:

 - While it usually just repeats the last error, not all errors
   terminate a build right away, so those can get drown in the output
   that follows after.  Examples: "File not found" in rpmInstall(), or
   macro expansion errors (note: we may have these terminate a build in
   the future).

 - It makes it immediately obvious that something went wrong when
   examining build logs, and the title "RPM build errors" undoubtedly
   has become the de-facto text string to search for.

That leaves us with option #3.  To further lessen the disruption, do
keep a summary of warnings, but put them under their own heading, and
only show it on build failures.  That way, we restrict all the extra
verbosity to error time (as it is now) and don't pollute the output of
otherwise good builds.  There may be packages with long-standing
warnings that are not feasible to fix for any reason, and having an
indented block of text resembling "RPM build errors" at the end of every
build would do no good.

Effectively, this commit is just cosmetic - it splits the error summary
into two, without any functional or API changes (apart from two function
additions).

Fixes: #793