### PR TITLE
Fix a regression from commit 22106f5d33628515d22c09c1c15dfd2217535116

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -138,7 +138,7 @@ static const size_t headerMaxbytes = (256*1024*1024);
 /**
  * Sanity check on type values.
  */
-#define hdrchkType(_type) ((_type) < RPM_MIN_TYPE || (_type) > RPM_MAX_TYPE)
+#define hdrchkType(_type) ((_type) <= RPM_MIN_TYPE || (_type) > RPM_MAX_TYPE)
 
 /**
  * Sanity check on data size and/or offset and/or count.
@@ -298,7 +298,7 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	/* Verify the data actually fits */
 	len = dataLength(info.type, ds + info.offset,
 			 info.count, 1, ds + blob->dl);
-	if (hdrchkRange(blob->dl - info.offset, len))
+	if (len <= 0 || len > blob->dl - info.offset)
 	    goto err;
 	end = info.offset + len;
 	if (blob->regionTag) {
@@ -475,7 +475,7 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 	if (typeSizes[type] == -1)
 	    return -1;
 	length = typeSizes[(type & 0xf)] * count;
-	if (length < 0 || (se && (s + length) > se))
+	if (length <= 0 || (se && (s + length) > se))
 	    return -1;
 	break;
     }

--- a/lib/header.c
+++ b/lib/header.c
@@ -475,7 +475,7 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 	if (typeSizes[type] == -1)
 	    return -1;
 	length = typeSizes[(type & 0xf)] * count;
-	if (length <= 0 || (se && (s + length) > se))
+	if (length <= 0 || (se && length > se - s))
 	    return -1;
 	break;
     }


### PR DESCRIPTION
Commit 22106f5d33628515d22c09c1c15dfd2217535116 assumed that
dataLength() would always return a nonzero number.  Unfortunately, that
isn’t the case: dataLength() returns zero for RPM_NULL_TYPE.  This meant
that hdrblobVerifyInfo() failed to reject such entries, which are
invalid.

This fixes the problem in three different ways:

1. It checks that tag data entries have length greater than zero.
2. It modifies hdrchkType() to reject RPM_NULL_TYPE.
3. It modifies dataLength() to consider zero length as an error.