### PR TITLE
Revert "Check that len is in range before using it"

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -298,9 +298,9 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	/* Verify the data actually fits */
 	len = dataLength(info.type, ds + info.offset,
 			 info.count, 1, ds + blob->dl);
-	if (hdrchkRange(blob->dl - info.offset, len))
-	    goto err;
 	end = info.offset + len;
+	if (hdrchkRange(blob->dl, end) || len <= 0)
+	    goto err;
 	if (blob->regionTag) {
 	    /*
 	     * Verify that the data does not overlap the region trailer.  The


### PR DESCRIPTION
This introduced regressions rather than fixing something, len *is*
in range because it's capped to header size already.

This reverts commit a1344cf2a5447b442af5ef68848e13114051ca63.