### PR TITLE
Fix python bindings

### DIFF
--- a/python/rpmts-py.h
+++ b/python/rpmts-py.h
@@ -7,7 +7,7 @@ typedef struct rpmtsObject_s rpmtsObject;
 
 extern PyTypeObject rpmts_Type;
 
-#define rpmtsObject_Check(v)	((v)->ob_type == &rpmts_Type)
+#define rpmtsObject_Check(v)	PyObject_TypeCheck(v, &rpmts_Type)
 
 int rpmtsFromPyObject(PyObject *item, rpmts *ts);
 

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -292,7 +292,7 @@ static PyObject * spec_doBuild(specObject *self, PyObject *args, PyObject *kwds)
     struct rpmBuildArguments_s ba = { 0 };
     rpmts ts;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "o&i|i:spec_doBuild",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&i|i:spec_doBuild",
 	       kwlist, rpmtsFromPyObject, &ts, &ba.buildAmount, &ba.pkgFlags))
 	return NULL;
     return PyBool_FromLong(rpmSpecBuild(ts, self->spec, &ba) == RPMRC_OK);


### PR DESCRIPTION
Change `o` to correct `O` object char format.
Update `rpmtsObject_Check` to be able check subtypes as well.