### PR TITLE
rpmio: avoid reading past the end of the mode string

### DIFF
--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -1510,7 +1510,7 @@ static void cvtfmode (const char *m,
 
     *stdio = *other = '\0';
     if (end != NULL)
-	*end = (*m != '\0' ? m : NULL);
+	*end = (c != '\0' && *m != '\0' ? m : NULL);
     if (f != NULL)
 	*f = flags;
 }


### PR DESCRIPTION
This was found by running the testsuite under `-fsanitize=address`.