### PR TITLE
Avoid a pointer overflow in dataLength()

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -475,7 +475,7 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 	if (typeSizes[type] == -1)
 	    return -1;
 	length = typeSizes[(type & 0xf)] * count;
-	if (length < 0 || (se && (s + length) > se))
+	if (length < 0 || (se && length > se - s))
 	    return -1;
 	break;
     }


### PR DESCRIPTION
This is not a problem on GCC with `-fno-strict-overflow`, at least on 64-bit systems.  However, there are several reasons I would like to get this in:

1. It makes the code easier to review.  With the code as written, I need to do additional mental work to determine that it is not exploitable.  With the modified version, it is obvious.
2. The current code does not conform to the C99 standard.  The C99 standard explicitly states that creating an out-of-bounds pointer (except one past the end) is undefined behavior.
3. It allows fuzzing with `-fsanitize-address,pointer-compare` to proceed past this section of code.  Such fuzzing already led to one long-standing bug being fixed (#580, fixed by #1606).

I have a test case, which I will be including as part of a separate PR for a fuzz harness, as it is part of the fuzz corpus.  I can split it into a separate test if desired.