### PR TITLE
Improve the OpenSSL crypto backend

### DIFF
--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -450,7 +450,7 @@ static void pgpFreeSigRSA(pgpDigAlg pgpsig)
 static int pgpVerifySigRSA(pgpDigAlg pgpkey, pgpDigAlg pgpsig,
                            uint8_t *hash, size_t hashlen, int hash_algo)
 {
-    int rc, ret;
+    int rc = 1; /* assume failure */
     EVP_PKEY_CTX *pkey_ctx = NULL;
     struct pgpDigSigRSA_s *sig = pgpsig->data;
 
@@ -458,52 +458,31 @@ static int pgpVerifySigRSA(pgpDigAlg pgpkey, pgpDigAlg pgpsig,
 
     struct pgpDigKeyRSA_s *key = pgpkey->data;
 
-    if (!constructRSASigningKey(key)) {
-        rc = 1;
+    if (!constructRSASigningKey(key))
         goto done;
-    }
 
     pkey_ctx = EVP_PKEY_CTX_new(key->evp_pkey, NULL);
-    if (!pkey_ctx) {
-        rc = 1;
+    if (!pkey_ctx)
         goto done;
-    }
 
-    ret = EVP_PKEY_verify_init(pkey_ctx);
-    if (ret < 0) {
-        rc = 1;
+    if (EVP_PKEY_verify_init(pkey_ctx) != 1)
         goto done;
-    }
 
-    ret = EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING);
-    if (ret < 0) {
-        rc = 1;
+    if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING) <= 0)
         goto done;
-    }
 
-    ret = EVP_PKEY_CTX_set_signature_md(pkey_ctx, getEVPMD(hash_algo));
-    if (ret < 0) {
-        rc = 1;
+    if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, getEVPMD(hash_algo)) <= 0)
         goto done;
-    }
 
     int pkey_len = EVP_PKEY_size(key->evp_pkey);
     padded_sig = xcalloc(1, pkey_len);
-    if (!BN_bn2binpad(sig->bn, padded_sig, pkey_len)) {
-        rc = 1;
+    if (BN_bn2binpad(sig->bn, padded_sig, pkey_len) <= 0)
         goto done;
-    }
 
-    ret = EVP_PKEY_verify(pkey_ctx, padded_sig, pkey_len, hash, hashlen);
-    if (ret == 1)
+    if (EVP_PKEY_verify(pkey_ctx, padded_sig, pkey_len, hash, hashlen) == 1)
     {
         /* Success */
         rc = 0;
-    }
-    else
-    {
-        /* Failure */
-        rc = 1;
     }
 
 done:
@@ -735,31 +714,21 @@ static void pgpFreeSigDSA(pgpDigAlg pgpsig)
 static int pgpVerifySigDSA(pgpDigAlg pgpkey, pgpDigAlg pgpsig,
                            uint8_t *hash, size_t hashlen, int hash_algo)
 {
-    int rc, ret;
+    int rc = 1; /* assume failure */
     struct pgpDigSigDSA_s *sig = pgpsig->data;
 
     struct pgpDigKeyDSA_s *key = pgpkey->data;
 
-    if (!constructDSASigningKey(key)) {
-        rc = 1;
+    if (!constructDSASigningKey(key))
         goto done;
-    }
 
-    if (!constructDSASignature(sig)) {
-        rc = 1;
+    if (!constructDSASignature(sig))
         goto done;
-    }
 
-    ret = DSA_do_verify(hash, hashlen, sig->dsa_sig, key->dsa_key);
-    if (ret == 1)
+    if (DSA_do_verify(hash, hashlen, sig->dsa_sig, key->dsa_key) == 1)
     {
         /* Success */
         rc = 0;
-    }
-    else
-    {
-        /* Failure */
-        rc = 1;
     }
 
 done:


### PR DESCRIPTION
This fixes a double-free bug in the OpenSSL backend.  This bug is not considered exploitable as it cannot be reliably triggered by an attacker.  It also deletes a bunch of cruft.