### PR TITLE
Fix incorrect rpmarchive_writeto argument string

### DIFF
--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -158,7 +158,7 @@ static PyObject *rpmarchive_writeto(rpmarchiveObject *s,
     int rc;
     char *kwlist[] = { "fd", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&", kwlist,
 				 rpmfdFromPyObject, &fdo)) {
 	return NULL;
     }


### PR DESCRIPTION
The current argument string mentions an optional integer argument, which does not exist.  This is probably a copy & paste from `rpmarchive_readto`.