### PR TITLE
Check that padding is zeroed and regions are consistent

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -304,6 +304,8 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	if (typechk && hdrchkTagType(info.tag, info.type))
 	    goto err;
 	const size_t padding = info.offset - end;
+	assert(info.type < sizeof(typeAlign)/sizeof(typeAlign[0]) &&
+	       typeAlign[info.type] <= 8);
 	/* Check that the padding is zeroed and minimum-length */
 	if (padding >= typeAlign[info.type] ||
 	    memcmp(ds + end, "\0\0\0\0\0\0\0\0", padding))

--- a/lib/header.c
+++ b/lib/header.c
@@ -275,7 +275,7 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
     int typechk = (blob->regionTag == RPMTAG_HEADERIMMUTABLE ||
 		   blob->regionTag == RPMTAG_HEADERIMAGE);
 
-    for (i = 0; i < il; i++) {
+    for (i = 0;; i++) {
 	if (i + 1 == blob->ril && blob->regionTag) {
 	    /* Bump the end past the region trailer */
 	    end += REGION_TAG_COUNT;
@@ -283,6 +283,8 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	    if (end != blob->rdl)
 		goto err;
 	}
+	if (i >= il)
+	    break;
 	ei2h(&pe[i], &info);
 
 	/* Previous data must not overlap */
@@ -314,7 +316,8 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 	if (hdrchkRange(blob->dl, end) || len <= 0)
 	    goto err;
     }
-    return 0; /* Everything ok */
+    if (end == blob->dl)
+	return 0; /* Everything ok */
 
 err:
     if (emsg) {


### PR DESCRIPTION
This adds checks that padding is zeroed and that regions are internally
consistent.  It also adds a check that the padding is of minimum length.

Fixes #1572.