### PR TITLE
hdrchkType(): reject RPM_NULL_TYPE

### DIFF
--- a/lib/rpmtag.h
+++ b/lib/rpmtag.h
@@ -441,7 +441,7 @@ typedef enum rpmSigTag_e {
  * The basic types of data in tags from headers.
  */
 typedef enum rpmTagType_e {
-#define	RPM_MIN_TYPE		0
+#define	RPM_MIN_TYPE		1
     RPM_NULL_TYPE		=  0,
     RPM_CHAR_TYPE		=  1,
     RPM_INT8_TYPE		=  2,


### PR DESCRIPTION
`RPM_NULL_TYPE` is used to mean “unknown type”; it is not a valid type
itself.  However, `hdrchkType()` did not reject it.  Therefore,
`headerPut()` allowed adding an entry of type `RPM_NULL_TYPE` to a header,
which is wrong.