### PR TITLE
Clarify %check script use-case by executing it before %install

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -379,14 +379,14 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 			   getStringBuf(spec->build), test, sbp)))
 		goto exit;
 
-	if ((what & RPMBUILD_INSTALL) &&
-	    (rc = doScript(spec, RPMBUILD_INSTALL, "%install",
-			   getStringBuf(spec->install), test, sbp)))
-		goto exit;
-
 	if ((what & RPMBUILD_CHECK) &&
 	    (rc = doScript(spec, RPMBUILD_CHECK, "%check",
 			   getStringBuf(spec->check), test, sbp)))
+		goto exit;
+
+	if ((what & RPMBUILD_INSTALL) &&
+	    (rc = doScript(spec, RPMBUILD_INSTALL, "%install",
+			   getStringBuf(spec->install), test, sbp)))
 		goto exit;
 
 	if ((what & RPMBUILD_PACKAGESOURCE) &&

--- a/doc/manual/spec.md
+++ b/doc/manual/spec.md
@@ -512,7 +512,8 @@ All files installed in the buildroot must be packaged.
 ### %check
 
 If the packaged software has accomppanying tests, this is where they
-should be executed.
+should be executed. Executes before `%install` to prevent it from
+affecting buildroot contents.
 
 ## Runtime scriptlets
 

--- a/doc/rpmbuild.8
+++ b/doc/rpmbuild.8
@@ -157,9 +157,9 @@ Compile the sources - executes up to and including the %build stage.
 This generally involves the equivalent of a "make".
 .TP
 \fB-bi\fR
-Install the binaries into the build root - executes up to and including the
-%check stage.
-This generally involves the equivalent of a "make install" and "make check".
+Install the binaries into the build root - executes up to %install stage,
+including preceding %check.
+This generally involves the equivalent of a "make check" and "make install".
 .TP
 \fB-bl\fR
 Do a "list check" - the %files section from the spec file is macro expanded,


### PR DESCRIPTION
Most packages execute their %check in the build directory, following
the spirit of autotools "make check" target. However as %check as
actually executes after %install rather than %build, it gives the
impression that you might want to run tests in the buildroot instead,
with the risk of affecting the packaged content.

Move the %check execution before %install to eliminate any ambiguosity
on the subject. This will break any packages relying on builroot
contents, but at least it's a clean break, and installation can always
be simulated by doing this in %check start to a private temporary root
in the build directory, eg ${PWD}/_check.