### PR TITLE
Fix 32bit compiler warning in recently added fsm debugging

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -5,6 +5,7 @@
 
 #include "system.h"
 
+#include <inttypes.h>
 #include <utime.h>
 #include <errno.h>
 #if WITH_CAP
@@ -301,7 +302,7 @@ static int fsmUnpack(rpmfi fi, FD_t fd, rpmpsm psm, int nodigest)
 {
     int rc = rpmfiArchiveReadToFilePsm(fi, fd, nodigest, psm);
     if (_fsm_debug) {
-	rpmlog(RPMLOG_DEBUG, " %8s (%s %lu bytes [%d]) %s\n", __func__,
+	rpmlog(RPMLOG_DEBUG, " %8s (%s %" PRIu64 " bytes [%d]) %s\n", __func__,
 	       rpmfiFN(fi), rpmfiFSize(fi), Fileno(fd),
 	       (rc < 0 ? strerror(errno) : ""));
     }


### PR DESCRIPTION
Commit f9b90179b7c80a170969d9ab4c77c0a311635e3f added debug logging for
file sizes which are 64bit in rpm, and %lu is not guaranteed to be
64bit.

Fixes: #1605