### PR TITLE
Avoid out-of-bounds pointer arithmetic in dataLength()

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -474,8 +474,8 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
     default:
 	if (typeSizes[type] == -1)
 	    return -1;
-	length = typeSizes[(type & 0xf)] * count;
-	if (length < 0 || (se && (s + length) > se))
+	length = typeSizes[type] * count;
+	if (length < 0 || (se && length > se - s))
 	    return -1;
 	break;
     }


### PR DESCRIPTION
This is undefined behavior.  Pinging @dmach @Conan-Kudo.