### PR TITLE
Reject extra packets after a signature

### DIFF
--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -1067,6 +1067,9 @@ int pgpPrtParams(const uint8_t * pkts, size_t pktlen, unsigned int pkttype,
 	    break;
 
 	p += (pkt.body - pkt.head) + pkt.blen;
+	/* If we are expecting a signature, reject multiple packets */
+	if (pkttype == PGPTAG_SIGNATURE)
+	    break;
     }
 
     rc = (digp && (p == pend)) ? 0 : -1;


### PR DESCRIPTION
Such packets are probably an attempt to exploit a bug in RPM, rather
than being useful.