### PR TITLE
Fix CVE-2021-20249

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1838,8 +1838,9 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 	goto exit;
     }
 
-    /* Is the trailer within the data area? */
-    if (hdrchkRange(blob->dl, einfo.offset + REGION_TAG_COUNT)) {
+    /* Is the trailer within the data area?  Watch out for overflow! */
+    if (hdrchkData(einfo.offset) ||
+	einfo.offset + REGION_TAG_COUNT > blob->dl) {
 	rasprintf(buf,
 		_("region offset: BAD, tag %d type %d offset %d count %d"),
 		einfo.tag, einfo.type, einfo.offset, einfo.count);


### PR DESCRIPTION
In `hdrblobVerifyRegion()`, negative region offsets were not correctly
rejected, causing an integer overflow.  Use `hdrchkData()` to reject excessive and/or negative region offsets, so we can safely add `REGION_TAG_LENGTH` to them.