### PR TITLE
Make interactive Lua mode actually interactive

### DIFF
--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -521,6 +521,9 @@ static int rpm_load(lua_State *L)
 
 static int rpm_interactive(lua_State *L)
 {
+    if (!(isatty(STDOUT_FILENO) && isatty(STDIN_FILENO)))
+	return luaL_error(L, "not a tty");
+
     _rpmluaInteractive(L);
     return 0;
 }

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -373,6 +373,7 @@ static int rpmluaReadline(lua_State *L, const char *prompt)
 /* Based on lua.c */
 static void _rpmluaInteractive(lua_State *L)
 {
+   rpmlua lua = getdata(L, "lua");
    (void) fputs("\n", stdout);
    printf("RPM Interactive %s Interpreter\n", LUA_VERSION);
    for (;;) {
@@ -403,6 +404,12 @@ static void _rpmluaInteractive(lua_State *L)
       if (rc != 0) {
 	 fprintf(stderr, "%s\n", lua_tostring(L, -1));
 	 lua_pop(L, 1);
+      } else {
+	 char *s = rpmluaPopPrintBuffer(lua);
+	 if (s) {
+	    fprintf(stdout, "%s\n", s);
+	    free(s);
+	 }
       }
       lua_pop(L, 1); /* Remove line */
    }


### PR DESCRIPTION
Refuse to run rpm.interactive() unless running from tty as a minimal requisite.
Make the interactive loop print results immediately instead of process exit, eg:

```
$ ./rpm --eval "%{lua:rpm.interactive()}" 

RPM Interactive Lua 5.4 Interpreter
> print(macros['_libdir'])
/usr/lib64
> a=5
> =a
5
> =rpm.vercmp('1.0-1', '2.0-1')
-1
```

= being an undocumented shortcut to print()