### PR TITLE
rpmkeys: exit non-zero on I/O errors

### DIFF
--- a/rpmkeys.c
+++ b/rpmkeys.c
@@ -86,5 +86,9 @@ int main(int argc, char *argv[])
 exit:
     rpmtsFree(ts);
     rpmcliFini(optCon);
+    fflush(stderr);
+    fflush(stdout);
+    if (ferror(stdout) || ferror(stderr))
+	return 255; /* I/O error */
     return ec;
 }

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -24,6 +24,19 @@ runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i38
 [])
 AT_CLEANUP
 
+# ------------------------------
+# Test rpmkeys write errors
+AT_SETUP([[rpmkeys -K no space left on stdout]])
+AT_KEYWORDS([rpmkeys digest])
+AT_CHECK([
+RPMDB_INIT[
+
+runroot rpmkeys -Kv /data/RPMS/hello-2.0-1.x86_64.rpm /data/RPMS/hello-1.0-1.i386.rpm >/dev/full
+]],255,,[[Error writing to log: No space left on device
+]])
+AT_CLEANUP
+
+
 AT_SETUP([rpmkeys -Kv <reconstructed> 1])
 AT_KEYWORDS([rpmkeys digest])
 AT_CHECK([


### PR DESCRIPTION
If writing to stdout or stderr fails, rpmkeys should exit with a
non-zero status code.