### PR TITLE
Ensure database creation on initial installation

### DIFF
--- a/lib/depends.c
+++ b/lib/depends.c
@@ -4,6 +4,8 @@
 
 #include "system.h"
 
+#include <fcntl.h>
+
 #include <rpm/rpmlib.h>		/* rpmVersionCompare, rpmlib provides */
 #include <rpm/rpmtag.h>
 #include <rpm/rpmlog.h>
@@ -413,6 +415,10 @@ static int addPackage(rpmts ts, Header h,
     /* Source packages are never "upgraded" */
     if (isSource)
 	op = RPMTE_INSTALL;
+
+    /* Ensure database creation on initial installs */
+    if (!isSource && rpmtsGetDBMode(ts) == O_RDONLY)
+	rpmtsSetDBMode(ts, (O_RDWR|O_CREAT));
 
     /* Do lazy (readonly?) open of rpm database for upgrades. */
     if (op != RPMTE_INSTALL && rpmtsGetRdb(ts) == NULL && rpmtsGetDBMode(ts) != -1) {


### PR DESCRIPTION
Disabling implicit database creation on read-only handles in commit
afbc2b07839c9ffe9f274f3a4bc2395c76d65472 broke number of handy
use-cases such as install to an empty chroot directory, both with
rpm itself and dnf/yum at least, probably others too.

This minimally resurrects the desired part of the behavior: if people are
asking us to install something, creating a missing database is probably
okay to create without requiring an explicit --initdb action first.
It'll still spit some ugly errors from trying to load the keyring but
at least it'll work. The harmless errors we can try to deal with
separately later on.