### PR TITLE
Fix RPM_MIN_TYPE definition, RPM_NULL_TYPE is not a legit tag type

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -251,7 +251,7 @@ void rpmDisplayQueryTags(FILE * fp)
 	    rpmTagVal tag = rpmTagGetValue(sname);
 	    rpmTagType type = rpmTagGetTagType(tag);
 	    fprintf(fp, "%-20s %6d", sname, tag);
-	    if (type > RPM_NULL_TYPE && type <= RPM_MAX_TYPE)
+	    if (type > RPM_MIN_TYPE && type <= RPM_MAX_TYPE)
 		fprintf(fp, " %s", tagTypeNames[type]);
 	} else {
 	    fprintf(fp, "%s", sname);

--- a/lib/rpmtag.h
+++ b/lib/rpmtag.h
@@ -441,7 +441,7 @@ typedef enum rpmSigTag_e {
  * The basic types of data in tags from headers.
  */
 typedef enum rpmTagType_e {
-#define	RPM_MIN_TYPE		0
+#define	RPM_MIN_TYPE		1
     RPM_NULL_TYPE		=  0,
     RPM_CHAR_TYPE		=  1,
     RPM_INT8_TYPE		=  2,


### PR DESCRIPTION
RPM_NULL_TYPE is not a legit tag type, but RPM_MIN_TYPE is defined
and used as if it was. Change RPM_MIN_TYPE to 1 to make the MIN-MAX
range actually relevant, in particular for hdrchkType(). Also fix
the lone user who in query code who clearly had encountered this very
issue before but worked around locally...

Reported and initial patch by Demi Marie Obenour.