### PR TITLE
Fix 32-bit builds

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1867,13 +1867,10 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     }
 
     /*
-     * Trailer offset is negative and has a special meaning.  Be sure to negate
-     * *after* the division, so the negation cannot overflow.  The parentheses
-     * around the division are required!
-     *
-     * Thankfully, the modulus operator works fine on negative numbers.
+     * Trailer offset is negative and has a special meaning.
+     * Watch out for overflow and implicit conversions!
      */
-    blob->ril = -(einfo.offset/sizeof(*blob->pe));
+    blob->ril = einfo.offset/-(int32_t)sizeof(*blob->pe);
     /* Does the region actually fit within the header? */
     if ((einfo.offset % sizeof(*blob->pe)) || hdrchkRange(blob->il, blob->ril) ||
 					hdrchkRange(blob->dl, blob->rdl)) {


### PR DESCRIPTION
RPM has been broken on 32-bit platforms since
1efe530450b5bdbd90128327be56c87fa1b6843b, due to an integer promotion
bug: ‘einfo.offset’ gets promoted to unsigned, but promoting a negative
number produces a very large positive number.  When that number is
divided by 16, the result is still a large positive number, but the top
four bits are cleared.  Therefore, negating it produces a large negative
number with the four most significant bits set.  On 64 bit platforms,
the implicit conversion to ‘int32_t’ masks these off, but on 32-bit
platforms, the result is a negative ‘blob->ril’ that is later rejected.
The result is that no package can be installed.

This bug only affected 32-bit builds, which is why it was missed by CI.
It does not affect any release version.

Fixes: 1efe530450b5bdbd90128327be56c87fa1b6843b