### PR TITLE
Revert trailer offset negation fiddling, too many regressions

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1854,6 +1854,8 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
     blob->rdl = einfo.offset + REGION_TAG_COUNT;
 
     ei2h(&trailer, &einfo);
+    /* Trailer offset is negative and has a special meaning */
+    einfo.offset = -einfo.offset;
     /* Some old packages have HEADERIMAGE in signature region trailer, fix up */
     if (regionTag == RPMTAG_HEADERSIGNATURES && einfo.tag == RPMTAG_HEADERIMAGE)
 	einfo.tag = RPMTAG_HEADERSIGNATURES;
@@ -1866,15 +1868,8 @@ static rpmRC hdrblobVerifyRegion(rpmTagVal regionTag, int exact_size,
 	goto exit;
     }
 
-    /*
-     * Trailer offset is negative and has a special meaning.  Be sure to negate
-     * *after* the division, so the negation cannot overflow.  The parentheses
-     * around the division are required!
-     *
-     * Thankfully, the modulus operator works fine on negative numbers.
-     */
-    blob->ril = -(einfo.offset/sizeof(*blob->pe));
     /* Does the region actually fit within the header? */
+    blob->ril = einfo.offset/sizeof(*blob->pe);
     if ((einfo.offset % sizeof(*blob->pe)) || hdrchkRange(blob->il, blob->ril) ||
 					hdrchkRange(blob->dl, blob->rdl)) {
 	rasprintf(buf, _("region %d size: BAD, ril %d il %d rdl %d dl %d"),


### PR DESCRIPTION
Commit c3e04c2ac91737b06ce5592e8cd8558498e566c0 tried to address
a theoretical issue with undefined behavior but cause a regression
which was fixed in commit 1efe530450b5bdbd90128327be56c87fa1b6843b
which introduced another regression: package reading on 32bit
architectures is broken. Enough is enough. Revisit some day with
an actual plan.

This reverts commits c3e04c2ac91737b06ce5592e8cd8558498e566c0 and
1efe530450b5bdbd90128327be56c87fa1b6843b.