### PR TITLE
Drop special handling of implicit database open in Python

### DIFF
--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -320,6 +320,15 @@ rpmdbMatchIterator rpmtsInitIterator(const rpmts ts, rpmDbiTagVal rpmtag,
 			const void * keyp, size_t keylen);
 
 /** \ingroup rpmts
+ * Return transaction database index iterator.
+ * @param ts		transaction set
+ * @param tag		database index tag
+ * @param it		iterator type (0 for index values, 1 for keys)
+ * @return		NULL on failure
+ */
+rpmdbIndexIterator rpmtsInitIndexIterator(rpmts ts, rpmDbiTagVal tag, int it);
+
+/** \ingroup rpmts
  * Import a header into the rpmdb
  * @param txn		transaction handle
  * @param h		header

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -683,16 +683,6 @@ rpmts_Match(rpmtsObject * s, PyObject * args, PyObject * kwds)
 	if (PyErr_Occurred()) goto exit;
     }
 
-    /* XXX If not already opened, open the database O_RDONLY now. */
-    /* XXX FIXME: lazy default rdonly open also done by rpmtsInitIterator(). */
-    if (rpmtsGetRdb(s->ts) == NULL) {
-	int rc = rpmtsOpenDB(s->ts, O_RDONLY);
-	if (rc || rpmtsGetRdb(s->ts) == NULL) {
-	    PyErr_SetString(pyrpmError, "rpmdb open failed");
-	    goto exit;
-	}
-    }
-
     mio = rpmmi_Wrap(&rpmmi_Type, rpmtsInitIterator(s->ts, tag, key, len), (PyObject*)s);
 
 exit:
@@ -710,16 +700,7 @@ rpmts_index(rpmtsObject * s, PyObject * args, PyObject * kwds)
               tagNumFromPyObject, &tag))
 	return NULL;
 
-    /* XXX If not already opened, open the database O_RDONLY now. */
-    if (rpmtsGetRdb(s->ts) == NULL) {
-	int rc = rpmtsOpenDB(s->ts, O_RDONLY);
-	if (rc || rpmtsGetRdb(s->ts) == NULL) {
-	    PyErr_SetString(pyrpmError, "rpmdb open failed");
-	    goto exit;
-	}
-    }
-
-    rpmdbIndexIterator ii = rpmdbIndexIteratorInit(rpmtsGetRdb(s->ts), tag);
+    rpmdbIndexIterator ii = rpmtsInitIndexIterator(s->ts, tag, 0);
     if (ii == NULL) {
         PyErr_SetString(PyExc_KeyError, "No index for this tag");
         return NULL;


### PR DESCRIPTION
Let rpmtsInitIterator() and rpmtsInitIndexIterator() handle the implicit database open behind the scenes if necessary, doubling the logic up in Python side only gets in the way of improving things. As an additional side-effect, this makes the implicit open from Python bindings honor the database mode in the transaction set.

This loses the ability to differentiate between database open failure and "not found" from the iterator init, but this is intentional: if you care about database open result, open it explicitly by yourself. If you don't, then a non-existent database is for most practical purposes just a special case of "not found", which is what 99% of Python users assume and dont bother to test for exceptions anyway.
    
This is the second half of restoring yum/dnf functionality on empty chroot install since losing implicit database creation.