### PR TITLE
Handle missing closing paren in %attr rules

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -531,6 +531,11 @@ static rpmRC parseForAttr(rpmstrPool pool, char * buf, int def, FileEntry entry)
     for (p = pe; *pe && *pe != ')'; pe++)
 	{};
 
+    if (*pe == '\0') {
+	rpmlog(RPMLOG_ERR, _("Missing ')' in %s(%s\n"), name, p);
+	goto exit;
+    }
+
     if (def) {	/* %defattr */
 	char *r = pe;
 	r++;


### PR DESCRIPTION
parseForAttr is missing the check for the closing paren.  When a malformed
rule is encountered, the bounds for the end of the rule will be the NUL
terminator for the string.  When it overwrites the rule with spaces,
the entire string, including the NUL terminator, will be overwritten.

Later, in parseForSimple, the string will no longer contain a pathname and
will fail the check for files beginning with /.  Since the string is also
no longer NUL terminated, the error will contain garbage like the following:

error: File must begin with "/": nÔLó_;^?

Adding the check for the closing paren fixes the issue.

Fixes: #1648