### PR TITLE
Revert back to implicit database creation for now

### DIFF
--- a/lib/backend/ndb/glue.c
+++ b/lib/backend/ndb/glue.c
@@ -133,8 +133,8 @@ static int ndb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
 	    rc = rpmpkgOpen(&pkgdb, path, oflags, rdb->db_perms);
 	else
 	    rc = rpmpkgSalvage(&pkgdb, path);
-	if (rc && errno == ENOENT && (oflags == O_RDWR) && (rdb->db_flags & RPMDB_FLAG_SALVAGE) == 0) {
-	    oflags |= O_CREAT;
+ 	if (rc && errno == ENOENT && (rdb->db_flags & RPMDB_FLAG_SALVAGE) == 0) {
+	    oflags = O_RDWR|O_CREAT;
 	    dbi->dbi_flags |= DBI_CREATED;
 	    rc = rpmpkgOpen(&pkgdb, path, oflags, rdb->db_perms);
 	}

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -4,8 +4,6 @@
 
 #include "system.h"
 
-#include <fcntl.h>
-
 #include <rpm/rpmlib.h>		/* rpmVersionCompare, rpmlib provides */
 #include <rpm/rpmtag.h>
 #include <rpm/rpmlog.h>
@@ -415,10 +413,6 @@ static int addPackage(rpmts ts, Header h,
     /* Source packages are never "upgraded" */
     if (isSource)
 	op = RPMTE_INSTALL;
-
-    /* Ensure database creation on initial installs */
-    if (!isSource && rpmtsGetDBMode(ts) == O_RDONLY)
-	rpmtsSetDBMode(ts, (O_RDWR|O_CREAT));
 
     /* Do lazy (readonly?) open of rpm database for upgrades. */
     if (op != RPMTE_INSTALL && rpmtsGetRdb(ts) == NULL && rpmtsGetDBMode(ts) != -1) {

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -487,7 +487,7 @@ static int openDatabase(const char * prefix,
 		int mode, int perms, int flags)
 {
     rpmdb db;
-    int rc = 0;
+    int rc;
     int justCheck = flags & RPMDB_FLAG_JUSTCHECK;
 
     if (dbp)
@@ -503,8 +503,7 @@ static int openDatabase(const char * prefix,
     rpmdbRock = db;
 
     /* Try to ensure db home exists, error out if we can't even create */
-    if ((mode & O_ACCMODE) != O_RDONLY)
-	rc = rpmioMkpath(rpmdbHome(db), 0755, getuid(), getgid());
+    rc = rpmioMkpath(rpmdbHome(db), 0755, getuid(), getgid());
     if (rc == 0) {
 	/* Open just bare minimum when rebuilding a potentially damaged db */
 	int justPkgs = (db->db_flags & RPMDB_FLAG_REBUILD) &&

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -50,7 +50,7 @@ RPMTEST_SETUP
 runroot rpm \
   -qa
 ],
-[1],
+[0],
 [],
 [ignore])
 AT_CLEANUP


### PR DESCRIPTION
The implicit database creation even on read-only access is rooted so
deep in so many places that this needs more thought and saner APIs.
While creating databases on read-only access remains a crazy thing to
do, we need to have a proper solution to point people to when changing
the behavior, and right now we don't.

This effectively reverts 86f593d5135b00a9dbf7dc6d5efc8b341002aa08,
d601a7b7ae764b31ad74b2dceff1eafb5297147f and
afbc2b07839c9ffe9f274f3a4bc2395c76d65472, but adopting 4.16.x version
of the sqlite open error message to avoid accessing freed handle, and
leaving the testcase for query on non-existent db in place (just
changing the expected result) as this is a rather fundamental behavior thing.