### PR TITLE
Fix build regression from 376fef14a61a9748ce004888fe19445719a5d2d5

### DIFF
--- a/build/Makefile.am
+++ b/build/Makefile.am
@@ -7,6 +7,7 @@ AM_CFLAGS += @OPENMP_CFLAGS@
 AM_CPPFLAGS =  -I$(top_builddir) -I$(top_srcdir) -I$(top_builddir)/include/
 AM_CPPFLAGS += @WITH_MAGIC_INCLUDE@
 AM_CPPFLAGS += @WITH_POPT_INCLUDE@
+AM_CPPFLAGS += @LUA_CFLAGS@
 AM_CPPFLAGS += -I$(top_srcdir)/misc
 
 usrlibdir = $(libdir)
@@ -26,6 +27,7 @@ librpmbuild_la_LIBADD = \
 	$(top_builddir)/rpmio/librpmio.la \
 	$(top_builddir)/misc/libmisc.la \
 	@LTLIBICONV@ \
+	@LUA_LIBS@ \
 	@WITH_POPT_LIB@ \
 	@WITH_MAGIC_LIB@
 

--- a/build/spec.c
+++ b/build/spec.c
@@ -296,12 +296,10 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     }
     spec->BANames = _free(spec->BANames);
 
-#ifdef WITH_LUA
     // only destroy lua tables if there are no BASpecs left
     if (spec->recursing || spec->BACount == 0) {
 	spec->lua = specLuaFini(spec);
     }
-#endif
 
     spec->sources = freeSources(spec->sources);
     spec->packages = freePackages(spec->packages);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -5,6 +5,7 @@ AM_CFLAGS = @RPMCFLAGS@
 
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_builddir)/include/
 AM_CPPFLAGS += @WITH_POPT_INCLUDE@
+AM_CPPFLAGS += @LUA_CFLAGS@
 AM_CPPFLAGS += -I$(top_srcdir)/misc
 AM_CPPFLAGS += -DLOCALEDIR="\"$(localedir)\""
 AM_CPPFLAGS += -DSYSCONFDIR="\"$(sysconfdir)\""
@@ -48,6 +49,7 @@ librpm_la_LIBADD = \
 	@WITH_POPT_LIB@ \
 	@WITH_CAP_LIB@ \
 	@WITH_ACL_LIB@ \
+	@LUA_LIBS@ \
 	@LIBINTL@
 
 if BDB_RO


### PR DESCRIPTION
Since commit 376fef14a61a9748ce004888fe19445719a5d2d5 librpmbuild is
calling Lua directly rather than through the rpmio wrapper layer, so
librpmbuild needs LUA_CFLAGS and LUA_LIBS for building. While librpm
does not currently call Lua directly, make native Lua available there
as well as it's only a matter of time.