### PR TITLE
Ignore comment line contents in macro files (#1659)

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -226,6 +226,14 @@ rdcl(char * buf, size_t size, FILE *f)
 	    nb--;
 	if (*q == 0)
 	    break;			/* no newline found, EOF */
+	if (p == buf) {
+            while (*p && isblank(*p))
+                p++;
+            if (*p != '%') {		/* only parse actual macro */
+                *q = '\0';		/* trim trailing \r, \n */
+                break;
+            }
+        }
 	for (; p < q; p++) {
 	    switch (*p) {
 		case '\\':

--- a/tests/data/macros.testfile
+++ b/tests/data/macros.testfile
@@ -5,6 +5,13 @@
 }
 %second %{?def:macro_2}
 
+# empty lines inside a %{ block
+%empty0 %{expand:
+some
+
+thing
+}
+
 %comment1 %{expand:
 read
 %dnl comment

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -945,6 +945,23 @@ read
 [])
 AT_CLEANUP
 
+AT_SETUP([macro file empty lines])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+	--macros /data/macros.testfile \
+	--eval "%{empty0}"
+],
+[0],
+[
+some
+
+thing
+
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([macro traceback])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
Previously %{ and similar in macro file comment line would cause the
line continuation logic to trigger and silently eat macro definitions
up to the next empty line. Since 75275a87cff04da65d3557f2c40ea2b526528c4c
we permit empty lines inside macro definitions, which would cause the
whole remaining file to be silently skipped (RhBug:1953910)

Only ever parse macro file lines starting with %, and add a test for
the case.

Actual patch by Michael Schroeder, testcase by undersigned.

Fixes: #1659