### PR TITLE
Load plugin library symbols first

### DIFF
--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -62,7 +62,7 @@ static rpmPlugin rpmPluginNew(const char *name, const char *path,
     char *error;
     char *hooks_name = NULL;
 
-    void *handle = dlopen(path, RTLD_LAZY);
+    void *handle = dlopen(path, RTLD_LAZY|RTLD_DEEPBIND);
     if (!handle) {
 	rpmlog(RPMLOG_ERR, _("Failed to dlopen %s %s\n"), path, dlerror());
 	return NULL;


### PR DESCRIPTION
dlopen load plugins LIBRARY with RTLD_LAZY flag
it means the symbols are loaded when references are executed
so it causes issue when some references are the same than in system

append RTLD_BINDDEEP allows to first load symbols from the plugin library

Fixes: #1663