### PR TITLE
Rip out the atexit handler

### DIFF
--- a/lib/misc.h
+++ b/lib/misc.h
@@ -61,9 +61,6 @@ int rpmRelocateSrpmFileList(Header h, const char *rootDir);
 RPM_GNUC_INTERNAL
 void rpmRelocationBuild(Header h, rpmRelocation *rawrelocs,
 		int *rnrelocs, rpmRelocation **rrelocs, uint8_t **rbadrelocs);
-
-RPM_GNUC_INTERNAL
-void rpmAtExit(void);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -307,22 +307,6 @@ static rpmdb rpmdbRock;
 static rpmdbMatchIterator rpmmiRock;
 static rpmdbIndexIterator rpmiiRock;
 
-void rpmAtExit(void)
-{
-    rpmdb db;
-    rpmdbMatchIterator mi;
-    rpmdbIndexIterator ii;
-
-    while ((mi = rpmmiRock) != NULL)
-	rpmdbFreeIterator(mi);
-
-    while ((ii = rpmiiRock) != NULL)
-	rpmdbIndexIteratorFree(ii);
-
-    while ((db = rpmdbRock) != NULL)
-	(void) rpmdbClose(db);
-}
-
 rpmop rpmdbOp(rpmdb rpmdb, rpmdbOpX opx)
 {
     rpmop op = NULL;

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1617,12 +1617,6 @@ exit:
     return rc;
 }
 
-static void register_atexit(void)
-{
-    if (atexit(rpmAtExit) != 0)
-	rpmlog(RPMLOG_WARNING, _("failed to register exit handler"));
-}
-
 /* External interfaces */
 
 int rpmReadConfigFiles(const char * file, const char * target)
@@ -1630,8 +1624,6 @@ int rpmReadConfigFiles(const char * file, const char * target)
     static pthread_once_t atexit_registered = PTHREAD_ONCE_INIT;
     int rc = -1; /* assume failure */
     rpmrcCtx ctx = rpmrcCtxAcquire(1);
-
-    pthread_once(&atexit_registered, register_atexit);
 
     if (rpmInitCrypto())
 	goto exit;


### PR DESCRIPTION
It causes undefined behavior in multithreaded programs.