### PR TITLE
macros: Add %remove_installed_la_files

### DIFF
--- a/platform.in
+++ b/platform.in
@@ -94,6 +94,7 @@
 %__brp_strip_comment_note %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump}
 %__brp_strip_static_archive %{_rpmconfigdir}/brp-strip-static-archive %{__strip}
 %__brp_elfperms %{_rpmconfigdir}/brp-elfperms
+%__brp_remove_la_files %{_rpmconfigdir}/brp-remove-la-files
 
 %__os_install_post    \
     %{?__brp_compress} \
@@ -101,6 +102,7 @@
     %{?__brp_strip} \
     %{?__brp_strip_static_archive} \
     %{?__brp_strip_comment_note} \
+    %{?__brp_remove_la_files} \
 %{nil}
 
 %__spec_install_post\

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-static-archive brp-elfperms \
+	brp-remove-la-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-debuginfo.sh find-lang.sh \
@@ -26,6 +27,7 @@ rpmconfig_SCRIPTS = \
 	brp-compress brp-python-bytecompile brp-java-gcjcompile \
 	brp-strip brp-strip-comment-note brp-python-hardlink \
 	brp-strip-static-archive brp-elfperms \
+	brp-remove-la-files \
 	check-files check-prereqs \
 	check-buildroot check-rpaths check-rpaths-worker \
 	find-lang.sh find-requires find-provides \

--- a/scripts/brp-remove-la-files
+++ b/scripts/brp-remove-la-files
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
+  exit 0
+fi
+
+find "$RPM_BUILD_ROOT" -name "*.la" -type f -delete


### PR DESCRIPTION
Lots of packages remove .la files via

find $RPM_BUILD_ROOT -name "*.la" -delete

or similar. Add %remove_installed_la_files to standardize this.


I could not find tests for the macros in the rpm repository, but I testes this separately in a spec file. I went with `-delete` here and not `exec rm -f {} \;`. It might also be worthwhile to add `-print` as well.

Thoughts?
