### PR TITLE
Insert space between the "{" and "%"

### DIFF
--- a/doc/manual/queryformat.md
+++ b/doc/manual/queryformat.md
@@ -156,5 +156,5 @@ Notice that the subformats "present" and "missing" must be inside of curly
 braces.
 
 ```
-    rpm -qa --queryformat "%-30{NAME} %|PREINPROG?{%{PREINPROG}}:{no}|\n"
+    rpm -qa --queryformat "%-30{NAME} %|PREINPROG?{ %{PREINPROG\}}:{no}|\n"
 ```


### PR DESCRIPTION
to avoid gh-pages taking them as Liquid tags

See https://shopify.dev/docs/themes/liquid/reference/tags for details.