### PR TITLE
Fix regression wrt Lua reinitialization (RhBug:1958095)

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -321,7 +321,8 @@ int addSource(rpmSpec spec, int specline, const char *srcname, rpmTagVal tag)
     rpmPushMacro(spec->macros, buf, NULL, p->fullSource, RMIL_SPEC);
     free(buf);
 
-    addLuaSource(spec->lua, p);
+    rpmlua lua = rpmluaGetGlobalState();
+    addLuaSource(lua, p);
 
     if (!nofetch && tryDownload(p))
 	return RPMRC_FAIL;

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -138,7 +138,6 @@ struct rpmSpec_s {
     Package sourcePackage;
 
     rpmMacroContext macros;
-    rpmlua lua;
     rpmstrPool pool;
 
     StringBuf prep;		/*!< %prep scriptlet. */

--- a/build/spec.c
+++ b/build/spec.c
@@ -249,7 +249,7 @@ rpmSpec newSpec(void)
     spec->macros = rpmGlobalMacroContext;
     spec->pool = rpmstrPoolCreate();
     
-    spec->lua = specLuaInit(spec);
+    specLuaInit(spec);
     return spec;
 }
 
@@ -298,7 +298,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
 
     // only destroy lua tables if there are no BASpecs left
     if (spec->recursing || spec->BACount == 0) {
-	spec->lua = specLuaFini(spec);
+	specLuaFini(spec);
     }
 
     spec->sources = freeSources(spec->sources);

--- a/build/speclua.c
+++ b/build/speclua.c
@@ -25,7 +25,7 @@ void * specLuaInit(rpmSpec spec)
 
 void * specLuaFini(rpmSpec spec)
 {
-    rpmlua lua = spec->lua;
+    rpmlua lua = rpmluaGetGlobalState();
     lua_State *L = rpmluaGetLua(lua);
     for (const char **vp = luavars; vp && *vp; vp++) {
 	lua_pushnil(L);

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -67,7 +67,7 @@ for iot in [ 'fpio', 'fdio', 'ufdio', 'gzdio' ]:
 ],
 [])
 
-RPMPY_TEST([spec parse],[
+RPMPY_TEST([spec parse 1],[
 # TODO: add a better test spec with sub-packages etc
 spec = rpm.spec('${RPMDATA}/SPECS/hello.spec')
 for (name, num, flags) in spec.sources:
@@ -80,6 +80,11 @@ myprint(spec.sourceHeader.format('%{nvr}'))
 src hello-1.0.tar.gz 0 1
 hello-1.0-1
 hello-1.0-1
+])
+
+RPMPY_TEST([spec parse 2],[
+spec = rpm.spec('${RPMDATA}/SPECS/mini.spec')
+rpm.reloadConfig()
 ])
 
 RPMPY_TEST([basic header manipulation],[


### PR DESCRIPTION
Commit 2579d3e5ad5d713f2c161b9fb4835366ea4ea291 started storing the Lua
context in the spec, but this leads to problems as what is actually a
global context is now stored in two places, and can get out of sync.
So if you parse a spec, and then reset the global context, you get a
fancy segfault when the freeing the spec because it's pointing to
la-la-lua land.

Revert back to always using the global Lua handle.