### PR TITLE
Allow file namesakes on symlink->dir replacement

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -633,7 +633,17 @@ assert(otherFi != NULL);
 		rConflicts = handleColorConflict(ts, fs, fi, i,
 						otherFs, otherFi, otherFileNum);
 
-		if (rConflicts && reportConflicts) {
+		/*
+		 * This may be a false positive (two separate files) if a
+		 * symlink is being replaced by a directory in one of these two
+		 * paths.  This check extends the one for removal conflicts in
+		 * handleInstInstalledFile().
+		 */
+		int reportThis = !(p == otherTe &&
+				   rpmtsFlags(ts) & RPMTRANS_FLAG_TEST &&
+				   rpmteHaveTransScript(p, RPMTAG_PRETRANS));
+
+		if (rConflicts && reportConflicts && reportThis) {
 		    char *fn = rpmfilesFN(fi, i);
 		    rpmteAddProblem(p, RPMPROB_NEW_FILE_CONFLICT,
 				    rpmteNEVRA(otherTe), fn, 0);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ EXTRA_DIST += data/SPECS/iftest.spec
 EXTRA_DIST += data/SPECS/ifmultiline.spec
 EXTRA_DIST += data/SPECS/eliftest.spec
 EXTRA_DIST += data/SPECS/symlinktest.spec
+EXTRA_DIST += data/SPECS/symlinktest-pretrans.spec
 EXTRA_DIST += data/SPECS/deptest.spec
 EXTRA_DIST += data/SPECS/verifyscript.spec
 EXTRA_DIST += data/SPECS/fakeshell.spec

--- a/tests/data/SPECS/symlinktest-pretrans.spec
+++ b/tests/data/SPECS/symlinktest-pretrans.spec
@@ -1,0 +1,48 @@
+%bcond_with symlink
+%bcond_with file
+
+Name:		symlinktest-pretrans
+Version:	1.0
+Release:	%{rel}
+Summary:	Testing symlink behavior with pretrans scriptlet
+Group:		Testing
+License:	GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+# Details: https://docs.fedoraproject.org/en-US/packaging-guidelines/
+#          Directory_Replacement/
+%if %{without symlink}
+%pretrans -p <lua>
+path = "/usr/share/%{name}"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end
+%endif
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/usr/share
+mkdir -p $RPM_BUILD_ROOT/usr/lib/%{name}
+%if %{with file}
+echo foo > $RPM_BUILD_ROOT/usr/lib/%{name}/README
+%endif
+%if %{with symlink}
+ln -s ../lib/%{name} $RPM_BUILD_ROOT/usr/share/%{name}
+%else
+mkdir -p $RPM_BUILD_ROOT/usr/share/%{name}
+%if %{with file}
+echo bar > $RPM_BUILD_ROOT/usr/share/%{name}/README
+%endif
+%endif
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+/usr/lib/%{name}
+/usr/share/%{name}

--- a/tests/rpmconflict.at
+++ b/tests/rpmconflict.at
@@ -366,6 +366,59 @@ runroot rpm -U /build/RPMS/noarch/symlinktest-1.0-2.noarch.rpm
 AT_CLEANUP
 
 # ------------------------------
+# Replace symlink with a directory using a %pretrans scriptlet
+AT_SETUP([replacing symlink with directory with pretrans])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest-pretrans*
+
+runroot rpmbuild --quiet -bb \
+    --define "rel 1" \
+    --with symlink \
+    /data/SPECS/symlinktest-pretrans.spec
+runroot rpmbuild --quiet -bb \
+    --define "rel 2" \
+    --without symlink \
+    /data/SPECS/symlinktest-pretrans.spec
+
+runroot rpm -U /build/RPMS/noarch/symlinktest-pretrans-1.0-1.noarch.rpm
+runroot rpm -U --test /build/RPMS/noarch/symlinktest-pretrans-1.0-2.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/symlinktest-pretrans-1.0-2.noarch.rpm
+],
+[0],
+[],
+[])
+AT_CLEANUP
+
+# ------------------------------
+# Replace symlink with a populated directory using a %pretrans scriptlet
+AT_SETUP([replacing symlink with populated directory with pretrans])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+rm -rf "${RPMTEST}"/usr/{share,lib}/symlinktest-pretrans*
+
+runroot rpmbuild --quiet -bb \
+    --define "rel 1" \
+    --with symlink \
+    --with file \
+    /data/SPECS/symlinktest-pretrans.spec
+runroot rpmbuild --quiet -bb \
+    --define "rel 2" \
+    --without symlink \
+    --with file \
+    /data/SPECS/symlinktest-pretrans.spec
+
+runroot rpm -U /build/RPMS/noarch/symlinktest-pretrans-1.0-1.noarch.rpm
+runroot rpm -U --test /build/RPMS/noarch/symlinktest-pretrans-1.0-2.noarch.rpm
+runroot rpm -U /build/RPMS/noarch/symlinktest-pretrans-1.0-2.noarch.rpm
+],
+[0],
+[],
+[])
+AT_CLEANUP
+# ------------------------------
 # Regular file shared with a ghost, does not conflict
 # Regular file should be created and not removed when the ghost is removed
 AT_SETUP([real file with shared ghost])


### PR DESCRIPTION
Spurious file conflicts may appear when a package update replaces a
directory symlink with a plain directory *and* also installs the same
file name(s) in it, but with different contents, as is the case with
RhBug 1936422:

$ rpm -i /path/to/squid-4.rpm
$ rpm -ql squid-4:
...
/usr/share/squid/errors/es      # directory
/usr/share/squid/errors/es-mx   # symlink to "es"
...
$ stat -c '%i' /usr/share/squid/errors/es{,-mx}/ERR_ACCESS_DENIED
2680891
2680891

$ rpm -U --test /path/to/squid-5.rpm  # this fails
$ rpm -U /path/to/squid-5.rpm
$ rpm -ql squid-5:
...
/usr/share/squid/errors/es      # directory
/usr/share/squid/errors/es-mx   # directory
...
$ stat -c '%i' /usr/share/squid/errors/es{,-mx}/ERR_ACCESS_DENIED
2696662
2696619

When we compute file fingerprints during transaction preparation, we use
stat(2) to obtain input data (such as the inode number) from the
existing files on disk.  Since stat(2) follows symlinks, any file in the
original directory (pointed to by the symlink) for which we're about to
install a namesake in the new directory, including the symlink itself,
gets a hash collision with its counterpart and appears as "overlapped"
to us.

A %pretrans scriptlet may be defined [1] which removes the symlink
beforehand to avoid the collision, however that still won't let DNF
through since it runs a test transaction first, during which we don't
run scriptlets, to avoid file system modification.

Therefore, for the symlink replacement itself, we already have a simple
heuristic that ignores the conflict in a test transaction if a %pretrans
scriptlet also is defined, in the hope that it fixes the conflict in a
real transaction (or we abort gracefully).  This runs when checking the
transaction files against the rpmdb in handleInstInstalledFile().  Also
see commits 00d82f1 and a7a06ec.

This commit extends that heuristic also to files installed in the new
directory, to allow namesakes as described above.  This needs to run a
bit later, when checking the transaction files against each other in
handleOverlappedFiles().

We really should look into proper support for symlink replacements in
the future, but for the time being (and to address this bug), this
should be good enough.

Note that, while at it, this commit also adds a test case for the first
heuristic (i.e. simple symlink replacement without additional files).

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/
    Directory_Replacement/