### PR TITLE
Fixes to PGP packet length decoding detection and calculation

### DIFF
--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -286,6 +286,7 @@ int pgpValTok(pgpValTbl vs, const char * s, const char * se)
 /** \ingroup rpmpgp
  * Decode length from 1, 2, or 5 octet body length encoding, used in
  * new format packet headers and V4 signature subpackets.
+ * Partial body lengths are (intentionally) not supported.
  * @param s		pointer to length encoding buffer
  * @param slen		buffer size
  * @param[out] *lenp	decoded length
@@ -305,10 +306,10 @@ size_t pgpLen(const uint8_t *s, size_t slen, size_t * lenp)
     if (*s < 192) {
 	lenlen = 1;
 	dlen = *s;
-    } else if (*s < 255 && slen > 2) {
+    } else if (*s < 224 && slen > 2) {
 	lenlen = 2;
 	dlen = (((s[0]) - 192) << 8) + s[1] + 192;
-    } else if (slen > 5) {
+    } else if (*s == 255 && slen > 5) {
 	lenlen = 5;
 	dlen = pgpGrab(s+1, 4);
     }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -314,6 +314,9 @@ size_t pgpLen(const uint8_t *s, size_t slen, size_t * lenp)
 	dlen = pgpGrab(s+1, 4);
     }
 
+    if (slen - lenlen < dlen)
+	lenlen = 0;
+
     if (lenlen)
 	*lenp = dlen;
 


### PR DESCRIPTION
Couple of very clear bugs in the decoding detection + additional bounds checks, based on patches from @DemiMarie spread across different PR's.

It's plain impossible to review multiple partially overlapping 10+ commit PR's of assorted changes in the GH interface, and we need to get this stuff moving forward one way or the other.