### PR TITLE
Reject unimplemented critical PGP packets as per RFC-4880

### DIFF
--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -407,6 +407,7 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
     int rc = 0;
 
     while (hlen > 0 && rc == 0) {
+	int impl = 0;
 	i = pgpLen(p, hlen, &plen);
 	if (i == 0 || plen < 1 || i + plen > hlen)
 	    break;
@@ -436,6 +437,7 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 		pgpPrtVal(" ", pgpKeyServerPrefsTbl, p[i]);
 	    break;
 	case PGPSUBTYPE_SIG_CREATE_TIME:
+	    impl = *p;
 	    if (!(_digp->saved & PGPDIG_SAVED_TIME) &&
 		(sigtype == PGPSIGTYPE_POSITIVE_CERT || sigtype == PGPSIGTYPE_BINARY || sigtype == PGPSIGTYPE_TEXT || sigtype == PGPSIGTYPE_STANDALONE))
 	    {
@@ -450,6 +452,7 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 	    break;
 
 	case PGPSUBTYPE_ISSUER_KEYID:	/* issuer key ID */
+	    impl = *p;
 	    if (!(_digp->saved & PGPDIG_SAVED_ID) &&
 		(sigtype == PGPSIGTYPE_POSITIVE_CERT || sigtype == PGPSIGTYPE_BINARY || sigtype == PGPSIGTYPE_TEXT || sigtype == PGPSIGTYPE_STANDALONE))
 	    {
@@ -489,6 +492,10 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 	    break;
 	}
 	pgpPrtNL();
+
+	if (!impl && (p[0] & PGPSUBTYPE_CRITICAL))
+	    rc = 1;
+
 	p += plen;
 	hlen -= plen;
     }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -404,8 +404,9 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 {
     const uint8_t *p = h;
     size_t plen = 0, i;
+    int rc = 0;
 
-    while (hlen > 0) {
+    while (hlen > 0 && rc == 0) {
 	i = pgpLen(p, hlen, &plen);
 	if (i == 0 || plen < 1 || i + plen > hlen)
 	    break;
@@ -491,7 +492,11 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 	p += plen;
 	hlen -= plen;
     }
-    return (hlen != 0); /* non-zero hlen is an error */
+
+    if (hlen != 0)
+	rc = 1;
+
+    return rc;
 }
 
 pgpDigAlg pgpDigAlgFree(pgpDigAlg alg)


### PR DESCRIPTION
    Reject unimplemented critical PGP packets as per RFC-4880
    
        Bit 7 of the subpacket type is the "critical" bit.  If set, it
        denotes that the subpacket is one that is critical for the evaluator
        of the signature to recognize.  If a subpacket is encountered that is
        marked critical but is unknown to the evaluating software, the
        evaluator SHOULD consider the signature to be in error.
    
    We only implement creation time and issuer keyid, everything else is
    unimplemented and should be flagged as an error if critical as per above.
    
    Initial patch by Demi Marie Obenour.
