### PR TITLE
Do not allow extra packets to follow a signature

### DIFF
--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -1068,6 +1068,8 @@ int pgpPrtParams(const uint8_t * pkts, size_t pktlen, unsigned int pkttype,
 	    break;
 
 	p += (pkt.body - pkt.head) + pkt.blen;
+	if (pkttype == PGPTAG_SIGNATURE)
+	    break;
     }
 
     rc = (digp && (p == pend)) ? 0 : -1;


### PR DESCRIPTION
According to RFC 4880 § 11.4, a detached signature is “simply a
Signature packet”.  Therefore, extra packets following a detached
signature are not allowed.