### PR TITLE
Don't strip flags for OrderWithRequires in rpmds

### DIFF
--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1223,6 +1223,7 @@ rpmsenseFlags rpmSanitizeDSFlags(rpmTagVal tagN, rpmsenseFlags Flags)
     case RPMTAG_SUPPLEMENTNAME:
     case RPMTAG_ENHANCENAME:
     case RPMTAG_REQUIRENAME:
+    case RPMTAG_ORDERNAME:
 	extra = Flags & (_ALL_REQUIRES_MASK);
 	break;
     case RPMTAG_CONFLICTNAME:


### PR DESCRIPTION
As we allow dependeny flags like pre, post, ... in the spec syntax we
should not remove them when reading in the tags from a package.

Thanks to Michael Schröder for spotting this.

Resolves: #1703