### PR TITLE
Make a bounds check easier to read

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -475,7 +475,7 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 	if (typeSizes[type] == -1)
 	    return -1;
 	length = typeSizes[(type & 0xf)] * count;
-	if (length < 0 || (se && (s + length) > se))
+	if (length < 0 || (se && se - s < length))
 	    return -1;
 	break;
     }


### PR DESCRIPTION
The undefined behavior is not an issue on modern GCC, but the new code
is easier to read.