### PR TITLE
Fingerprint subpacket parsing support

### DIFF
--- a/lib/formats.c
+++ b/lib/formats.c
@@ -346,7 +346,7 @@ static char * pgpsigFormat(rpmtd td, char **emsg)
     } else {
 	char dbuf[BUFSIZ];
 	char *keyid = rpmhex(sigp->signid, sizeof(sigp->signid));
-	unsigned int dateint = sigp->time;
+	unsigned int dateint = sigp->release;
 	time_t date = dateint;
 	struct tm _tm, * tms = localtime_r(&date, &_tm);
 	unsigned int key_algo = pgpDigParamsAlgo(sigp, PGPVAL_PUBKEYALGO);

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -420,7 +420,7 @@ static void initPgpData(pgpDigParams pubp, struct pgpdata_s *pd)
     pd->signid = rpmhex(pubp->signid, sizeof(pubp->signid));
     pd->shortid = pd->signid + 8;
     pd->userid = pubp->userid ? pubp->userid : "none";
-    pd->time = pubp->time;
+    pd->time = pubp->release;
 
     rasprintf(&pd->timestr, "%x", pd->time);
     rasprintf(&pd->verid, "%d:%s-%s", pubp->version, pd->signid, pd->timestr);

--- a/rpmio/digest.h
+++ b/rpmio/digest.h
@@ -36,12 +36,15 @@ struct pgpDigParams_s {
     uint8_t sigtype;
     uint32_t hashlen;
     uint8_t signhash16[2];
+    uint8_t v4_fpr[20];		/*!< fingerprint */
     pgpKeyID_t signid;
     uint8_t saved;		/*!< Various flags.  `PGPDIG_SAVED_*` are never reset.
 				 * `PGPDIG_SIG_HAS_*` are reset for each signature. */
 #define	PGPDIG_SAVED_RELEASE	(1 << 0)
 #define	PGPDIG_SAVED_ID		(1 << 1)
 #define	PGPDIG_SIG_HAS_CREATION_TIME	(1 << 2)
+#define	PGPDIG_SAVED_V4_FPR	(1 << 3)
+#define	PGPDIG_SIG_HAS_V4_FPR	(1 << 4)
 
     pgpDigAlg alg;
 };

--- a/rpmio/digest.h
+++ b/rpmio/digest.h
@@ -36,9 +36,11 @@ struct pgpDigParams_s {
     uint32_t hashlen;
     uint8_t signhash16[2];
     pgpKeyID_t signid;
-    uint8_t saved;
+    uint8_t saved;		/*!< Various flags.  `PGPDIG_SAVED_*` are never reset.
+				 * `PGPDIG_SIG_HAS_*` are reset for each signature. */
 #define	PGPDIG_SAVED_TIME	(1 << 0)
 #define	PGPDIG_SAVED_ID		(1 << 1)
+#define	PGPDIG_SIG_HAS_CREATION_TIME	(1 << 2)
 
     pgpDigAlg alg;
 };

--- a/rpmio/digest.h
+++ b/rpmio/digest.h
@@ -28,17 +28,18 @@ struct pgpDigParams_s {
     uint8_t tag;
 
     uint8_t version;		/*!< version number. */
-    uint32_t time;		/*!< key/signature creation time. */
-    uint8_t pubkey_algo;		/*!< public key algorithm. */
+    uint8_t pubkey_algo;	/*!< public key algorithm. */
+    uint8_t hash_algo;		/*!< hash algorithm. */
+    uint32_t release;		/*!< timestamp to use as the release in the RPMDB. */
+    uint32_t creation_time;	/*!< key/signature creation time. */
 
-    uint8_t hash_algo;
     uint8_t sigtype;
     uint32_t hashlen;
     uint8_t signhash16[2];
     pgpKeyID_t signid;
     uint8_t saved;		/*!< Various flags.  `PGPDIG_SAVED_*` are never reset.
 				 * `PGPDIG_SIG_HAS_*` are reset for each signature. */
-#define	PGPDIG_SAVED_TIME	(1 << 0)
+#define	PGPDIG_SAVED_RELEASE	(1 << 0)
 #define	PGPDIG_SAVED_ID		(1 << 1)
 #define	PGPDIG_SIG_HAS_CREATION_TIME	(1 << 2)
 

--- a/rpmio/rpmkeyring.c
+++ b/rpmio/rpmkeyring.c
@@ -282,7 +282,9 @@ static rpmPubkey findbySig(rpmKeyring keyring, pgpDigParams sig)
 	    pgpDigParams pub = key->pgpkey;
 	    /* Do the parameters match the signature? */
 	    if ((sig->pubkey_algo != pub->pubkey_algo) ||
-		    memcmp(sig->signid, pub->signid, sizeof(sig->signid))) {
+		memcmp(sig->signid, pub->signid, sizeof(sig->signid)) ||
+		((sig->saved & PGPDIG_SIG_HAS_V4_FPR) &&
+		 memcmp(sig->v4_fpr, pub->v4_fpr, sizeof(sig->v4_fpr)))) {
 		key = NULL;
 	    }
 	}

--- a/rpmio/rpmkeyring.c
+++ b/rpmio/rpmkeyring.c
@@ -235,7 +235,7 @@ pgpDig rpmPubkeyDig(rpmPubkey key)
     if (rc == 0) {
 	pgpDigParams pubp = pgpDigGetParams(dig, PGPTAG_PUBLIC_KEY);
 	if (!pubp || !memcmp(pubp->signid, zeros, sizeof(pubp->signid)) ||
-		pubp->time == 0 || pubp->userid == NULL) {
+		pubp->release == 0 || pubp->userid == NULL) {
 	    rc = -1;
 	}
     }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -913,7 +913,8 @@ static int getKeyID(const uint8_t *h, size_t hlen, pgpKeyID_t keyid,
 	if (digp)
 	    memcpy(digp->v4_fpr, fp, fplen);
 	free(fp);
-    }
+    } else
+	rc = 1;
     return rc;
 }
 

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -473,16 +473,16 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 	    for (i = 1; i < plen; i++)
 		pgpPrtVal(" ", pgpKeyServerPrefsTbl, p[i]);
 	    break;
-	case PGPSUBTYPE_SIG_CREATE_TIME:
+	case PGPSUBTYPE_SIG_CREATE_TIME:  /* signature creation time */
+	    if (plen-1 != sizeof(_digp->time))
+		break; /* other lengths not understood */
+	    if (_digp->saved & PGPDIG_SIG_HAS_CREATION_TIME)
+		return 1; /* duplicate timestamps not allowed */
 	    impl = *p;
-	    if (!(_digp->saved & PGPDIG_SAVED_TIME) &&
-		(sigtype == PGPSIGTYPE_POSITIVE_CERT || sigtype == PGPSIGTYPE_BINARY || sigtype == PGPSIGTYPE_TEXT || sigtype == PGPSIGTYPE_STANDALONE))
-	    {
-		if (plen-1 != sizeof(_digp->time))
-		    break;
-		_digp->saved |= PGPDIG_SAVED_TIME;
+	    if (!(_digp->saved & PGPDIG_SAVED_TIME))
 		_digp->time = pgpGrab(p+1, sizeof(_digp->time));
-	    }
+	    _digp->saved |= PGPDIG_SAVED_TIME | PGPDIG_SIG_HAS_CREATION_TIME;
+	    break;
 	case PGPSUBTYPE_SIG_EXPIRE_TIME:
 	case PGPSUBTYPE_KEY_EXPIRE_TIME:
 	    pgpPrtTime(" ", p+1, plen-1);
@@ -598,6 +598,9 @@ static int pgpPrtSig(pgpTag tag, const uint8_t *h, size_t hlen,
     size_t plen;
     int rc = 1;
 
+    /* Reset the saved flags */
+    _digp->saved &= PGPDIG_SAVED_TIME | PGPDIG_SAVED_ID;
+
     if (pgpVersion(h, hlen, &version))
 	return rc;
 
@@ -625,8 +628,11 @@ static int pgpPrtSig(pgpTag tag, const uint8_t *h, size_t hlen,
 	    _digp->hashlen = v->hashlen;
 	    _digp->sigtype = v->sigtype;
 	    _digp->hash = memcpy(xmalloc(v->hashlen), &v->sigtype, v->hashlen);
-	    _digp->time = pgpGrab(v->time, sizeof(v->time));
-	    memcpy(_digp->signid, v->signid, sizeof(_digp->signid));
+	    if (!(_digp->saved & PGPDIG_SAVED_TIME))
+		_digp->time = pgpGrab(v->time, sizeof(v->time));
+	    if (!(_digp->saved & PGPDIG_SAVED_ID))
+		memcpy(_digp->signid, v->signid, sizeof(_digp->signid));
+	    _digp->saved = PGPDIG_SAVED_TIME | PGPDIG_SIG_HAS_CREATION_TIME | PGPDIG_SAVED_ID;
 	    _digp->pubkey_algo = v->pubkey_algo;
 	    _digp->hash_algo = v->hash_algo;
 	    memcpy(_digp->signhash16, v->signhash16, sizeof(_digp->signhash16));
@@ -663,6 +669,9 @@ static int pgpPrtSig(pgpTag tag, const uint8_t *h, size_t hlen,
 	if (pgpPrtSubType(p, plen, v->sigtype, _digp))
 	    return 1;
 	p += plen;
+
+	if (!(_digp->saved & PGPDIG_SIG_HAS_CREATION_TIME))
+	    return 1; /* RFC 4880 §5.2.3.4 creation time MUST be hashed */
 
 	if (pgpGet(p, 2, hend, &plen))
 	    return 1;

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -491,8 +491,7 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 
 	case PGPSUBTYPE_ISSUER_KEYID:	/* issuer key ID */
 	    impl = *p;
-	    if (!(_digp->saved & PGPDIG_SAVED_ID) &&
-		(sigtype == PGPSIGTYPE_POSITIVE_CERT || sigtype == PGPSIGTYPE_BINARY || sigtype == PGPSIGTYPE_TEXT || sigtype == PGPSIGTYPE_STANDALONE))
+	    if (!(_digp->saved & PGPDIG_SAVED_ID))
 	    {
 		if (plen-1 != sizeof(_digp->signid))
 		    break;

--- a/rpmio/rpmpgp.h
+++ b/rpmio/rpmpgp.h
@@ -437,7 +437,8 @@ typedef enum pgpSubType_e {
     PGPSUBTYPE_SIGNER_USERID	=  28, /*!< signer's user id */
     PGPSUBTYPE_REVOKE_REASON	=  29, /*!< reason for revocation */
     PGPSUBTYPE_FEATURES		=  30, /*!< feature flags (gpg) */
-    PGPSUBTYPE_EMBEDDED_SIG	=  32, /*!< embedded signature (gpg) */
+    PGPSUBTYPE_EMBEDDED_SIG	=  32, /*!< embedded signature */
+    PGPSUBTYPE_ISSUER_FPR	=  33, /*!< issuer fingerprint */
 
     PGPSUBTYPE_INTERNAL_100	= 100, /*!< internal or user-defined */
     PGPSUBTYPE_INTERNAL_101	= 101, /*!< internal or user-defined */


### PR DESCRIPTION
This PR adds support for parsing fingerprint subpackets (type 33), which are generated by GPG.  If both a fingerprint and a key ID are present, they must be consistent with each other.  Furthermore, if a fingerprint is present, it must match the fingerprint of the public key.  Finally, if more than one key ID, fingerprint, or creation time subpacket is present, the entire signature is rejected.  According to RFC 4880, having more than one subpacket with the same type (other than notation subpackets) is a syntax error.