### PR TITLE
Add quoting to literal curly brackets

### DIFF
--- a/scripts/check-rpaths-worker
+++ b/scripts/check-rpaths-worker
@@ -121,13 +121,13 @@ function check_rpath() {
 	        (/usr/libexec/*)
 		    badness=0;;
 
-		(\$ORIGIN|\${ORIGINX}|\$ORIGIN/*|\${ORIGINX}/*)
+		(\$ORIGIN|\$\{ORIGINX\}|\$ORIGIN/*|\$\{ORIGINX\}/*)
 		    test $allow_ORIGIN -eq 0 && badness=8 || {
 			badness=0
 			new_allow_ORIGIN=1
 		    }
 		    ;;
-		(/*\$PLATFORM*|/*\${PLATFORM}*|/*\$LIB*|/*\${LIB}*)
+		(/*\$PLATFORM*|/*\$\{PLATFORM\}*|/*\$LIB*|/*\$\{LIB\}*)
 		    badness=0;;
 	    	
 	        (/lib|/usr/lib|/usr/X11R6/lib)


### PR DESCRIPTION
These curly brackets are already treated as literals by the shell, so
let's make that explicit for clarity, and silence a ShellCheck warning
at the same time.

More info: https://github.com/koalaman/shellcheck/wiki/SC1083

Found by ShellCheck.