### PR TITLE
Exclude the xlateTags symbol from librpm's public API.

### DIFF
--- a/lib/package.c
+++ b/lib/package.c
@@ -31,7 +31,7 @@ struct pkgdata_s {
     rpmRC rc;
 };
 
-struct taglate_s {
+static struct taglate_s {
     rpmTagVal stag;
     rpmTagVal xtag;
     rpm_count_t count;


### PR DESCRIPTION
Hi,

First of all, thanks a lot for working on rpm and the related projects!

The d6a86b5e69e46cc283b1e06c92343319beb42e21 commit introduced
a new variable that is only used internally by headerMergeLegacySigs().
If it is not really intended to be exposed to consumers of librpm's public API,
it should not be present there or somebody may start depending on it, making it
harder to change or remove it later.

Thanks in advance for your time, and keep up the great work!

G'luck,
Peter
