### PR TITLE
Bump the Lua minimum version to 5.3.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ The debugedit >= 0.3 tools for producing debuginfo sub-packages.
 It is available from
    https://sourceware.org/debugedit/
 
-Lua >= 5.2 library + development environment.
+Lua >= 5.3 library + development environment.
 Note that only the library is needed at runtime, RPM never calls external
 Lua interpreter for anything. Lua is available from
     http://www.lua.org

--- a/configure.ac
+++ b/configure.ac
@@ -746,7 +746,7 @@ AC_SUBST(WITH_ACL_LIB)
 AM_CONDITIONAL(ACL,[test "$with_acl" = yes])
 
 PKG_CHECK_MODULES([LUA],
-    [lua >= 5.2],
+    [lua >= 5.3],
     [],
     [AC_MSG_ERROR([lua not present or too old)])])
 AC_SUBST(LUA_CFLAGS)


### PR DESCRIPTION
Hi,

First of all, thanks a lot for working on rpm and the related projects!

The 986be669fb037ae0e2049a2022c4fdfa05da6747 commit introduced a use of
lua_rotate(), which is not available in Lua 5.2. Hence, bump the dependency in
the configure script's pkg-config check.

Thanks in advance for your time, and keep up the great work!

G'luck,
Peter
