### PR TITLE
Set an extremely high sqlite3 timeout

### DIFF
--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -164,7 +164,11 @@ static int sqlite_init(rpmdb rdb, const char * dbhome)
 				(SQLITE_UTF8|SQLITE_DETERMINISTIC),
 				NULL, rpm_match3, NULL, NULL);
 
-	sqlite3_busy_timeout(sdb, sleep_ms);
+	/*
+	 * Set an extremely high timeout because we must avoid
+	 * the "database is locked" errors at every cost
+	 */
+	sqlite3_busy_timeout(sdb, 10000);
 	sqlite3_config(SQLITE_CONFIG_LOG, errCb, rdb);
 
 	sqlexec(sdb, "PRAGMA secure_delete = OFF");


### PR DESCRIPTION
We must avoid the "database is locked" errors at every cost because
otherwise the rpmdb gets corrupted and system ends up in inconsistent
state.

Resolves: rhbz#1946046