### PR TITLE
Don't brp-strip .ko files

### DIFF
--- a/scripts/brp-strip
+++ b/scripts/brp-strip
@@ -13,5 +13,5 @@ Darwin*) exit 0 ;;
 esac
 
 # Strip ELF binaries
-find "$RPM_BUILD_ROOT" -type f \! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" -print0 | \
+find "$RPM_BUILD_ROOT" -type f \! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" \! -name "*.ko" -print0 | \
     xargs -0 -r -P$NCPUS -n32 sh -c "file \"\$@\" | sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped.*/\1/p' | xargs -I\{\} $STRIP -g \{\}" ARG0


### PR DESCRIPTION
Otherwise SecureBoot signatures may be stripped too.

We used to exclude shared libraries from this strip as they were
supposed to be covered by another brp script (brp-strip-shared), however
it turned out the latter was never really used, so we removed the
exclusion in commit 0ab151ab138fd4fb6d3176fd0270d9cc6f4623f3.

As it turns out, that was a little too ambitious, since we may now
inadvertently strip SecureBoot signatures from kernel modules too,
provided that they're made during the build, prior to the invocation of
brp-strip.

Note that this regression currently does *not* affect the following two
cases on Fedora/RHEL systems with redhat-rpm-config installed:

  - in-tree modules; these are built from kernel.spec which already
    contains a hack ensuring that module signing only happens *after*
    any stripping (see %__modsign_install_post in kernel.spec)

  - out-of-tree modules built with debuginfo enabled; this is because
    brp-strip is only called when %debug_package is set to %{nil}

Any other combinations may be affected, depending on the macros and
.spec files used, so let's fix this by effectively "reverting" said
commit for .ko files only.

Fixes: rhbz#1967291