### PR TITLE
Add support for RPMDBI_BASENAMES on file queries

### DIFF
--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -57,7 +57,7 @@ select-options
 --------------
 
 \[*PACKAGE\_NAME*\] \[**-a,\--all \[***SELECTOR*\]\] \[**-f,\--file
-***FILE*\] \[**-g,\--group ***GROUP*\] \[**-p,\--package
+***FILE*\] \[**\--path ***PATH*\] \[**-g,\--group ***GROUP*\] \[**-p,\--package
 ***PACKAGE\_FILE*\] \[**\--hdrid ***SHA1*\] \[**\--pkgid ***MD5*\]
 \[**\--tid ***TID*\] \[**\--querybynumber ***HDRNUM*\]
 \[**\--triggeredby ***PACKAGE\_NAME*\] \[**\--whatprovides
@@ -620,7 +620,7 @@ name starts with \"b\".
 
 **-f, \--file ***FILE*
 
-:   Query package owning *FILE*.
+:   Query package owning installed *FILE*.
 
 **\--filecaps**
 
@@ -666,6 +666,12 @@ name starts with \"b\".
     including URL\'s, that will be expanded to paths that are
     substituted in place of the package manifest as additional
     *PACKAGE\_FILE* arguments to the query.
+
+**\--path ***PATH*
+
+:   Query package(s) owning *PATH*, whether the file is installed or not.
+    Multiple packages may own a *PATH*, but the file is only owned by the
+    package installed last.
 
 **\--pkgid ***MD5*
 

--- a/lib/poptQV.c
+++ b/lib/poptQV.c
@@ -27,6 +27,7 @@ struct rpmQVKArguments_s rpmQVKArgs;
 #define POPT_WHATENHANCES	-1014
 #define POPT_WHATOBSOLETES	-1015
 #define POPT_WHATCONFLICTS	-1016
+#define POPT_QUERYBYPATH	-1017
 
 /* ========== Query/Verify/Signature source args */
 static void rpmQVSourceArgCallback( poptContext con,
@@ -58,6 +59,7 @@ static void rpmQVSourceArgCallback( poptContext con,
     case POPT_WHATSUPPLEMENTS: qva->qva_source |= RPMQV_WHATSUPPLEMENTS; break;
     case POPT_WHATENHANCES: qva->qva_source |= RPMQV_WHATENHANCES; break;
     case POPT_TRIGGEREDBY: qva->qva_source |= RPMQV_TRIGGEREDBY; break;
+    case POPT_QUERYBYPATH: qva->qva_source |= RPMQV_PATH_ALL; break;
     case POPT_QUERYBYPKGID: qva->qva_source |= RPMQV_PKGID; break;
     case POPT_QUERYBYHDRID: qva->qva_source |= RPMQV_HDRID; break;
     case POPT_QUERYBYTID: qva->qva_source |= RPMQV_TID; break;
@@ -80,7 +82,9 @@ struct poptOption rpmQVSourcePoptTable[] = {
  { "checksig", 'K', POPT_ARGFLAG_DOC_HIDDEN, NULL, 'K',
 	N_("rpm checksig mode"), NULL },
  { "file", 'f', 0, 0, 'f',
-	N_("query/verify package(s) owning file"), "FILE" },
+	N_("query/verify package(s) owning installed file"), "FILE" },
+ { "path", '\0', 0, 0, POPT_QUERYBYPATH,
+	N_("query/verify package(s) owning path, installed or not"), "PATH" },
  { "group", 'g', 0, 0, 'g',
 	N_("query/verify package(s) in group"), "GROUP" },
  { "package", 'p', 0, 0, 'p',

--- a/lib/query.c
+++ b/lib/query.c
@@ -445,6 +445,7 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 	}
 	/* fallthrough on absolute and relative paths */
     case RPMQV_PATH:
+    case RPMQV_PATH_ALL:
     {   char * fn;
 
 	for (s = arg; *s != '\0'; s++)
@@ -463,8 +464,10 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 	    fn = xstrdup(arg);
 	(void) rpmCleanPath(fn);
 
-	/* XXX Add a switch to enable former BASENAMES behavior? */
-	mi = rpmtsInitIterator(ts, RPMDBI_INSTFILENAMES, fn, 0);
+	rpmDbiTagVal tag = RPMDBI_INSTFILENAMES;
+	if (qva->qva_source == RPMQV_PATH_ALL)
+	    tag = RPMDBI_BASENAMES;
+	mi = rpmtsInitIterator(ts, tag, fn, 0);
 	if (mi == NULL)
 	    mi = rpmtsInitIterator(ts, RPMDBI_PROVIDENAME, fn, 0);
 

--- a/lib/rpmcli.h
+++ b/lib/rpmcli.h
@@ -81,6 +81,7 @@ rpmcliFini(poptContext optCon);
 enum rpmQVSources_e {
     RPMQV_PACKAGE = 0,	/*!< ... from package name db search. */
     RPMQV_PATH,		/*!< ... from file path db search. */
+    RPMQV_PATH_ALL,	/*!< ... from file path db search (all states). */
     RPMQV_ALL,		/*!< ... from each installed package. */
     RPMQV_RPM, 		/*!< ... from reading binary rpm package. */
     RPMQV_GROUP,	/*!< ... from group db search. */

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -219,6 +219,40 @@ runroot rpm \
 [])
 AT_CLEANUP
 
+AT_SETUP([rpm -qf on non-installed file])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+runroot rpm \
+  --nodeps \
+  --excludedocs \
+  -i /data/RPMS/hello-1.0-1.i386.rpm
+runroot rpm \
+  -qf /usr/share/doc/hello-1.0/FAQ
+],
+[1],
+[],
+[error: file /usr/share/doc/hello-1.0/FAQ: No such file or directory
+])
+AT_CLEANUP
+
+AT_SETUP([rpm -q --path on non-installed file])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+runroot rpm \
+  --nodeps \
+  --excludedocs \
+  -i /data/RPMS/hello-1.0-1.i386.rpm
+runroot rpm \
+  -q --path /usr/share/doc/hello-1.0/FAQ
+],
+[0],
+[hello-1.0-1.i386
+],
+[])
+AT_CLEANUP
+
 # ------------------------------
 AT_SETUP([integer array query])
 AT_KEYWORDS([query])

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -202,6 +202,24 @@ runroot rpm \
 AT_CLEANUP
 
 # ------------------------------
+# query a package by a file
+AT_SETUP([rpm -qf])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+runroot rpm \
+  --nodeps \
+  -i /data/RPMS/hello-1.0-1.i386.rpm
+runroot rpm \
+  -qf /usr/local/bin/hello
+],
+[0],
+[hello-1.0-1.i386
+],
+[])
+AT_CLEANUP
+
+# ------------------------------
 AT_SETUP([integer array query])
 AT_KEYWORDS([query])
 AT_CHECK([


### PR DESCRIPTION
* Add the `--allfiles` switch which augments `-qf`
* Add a basic test for `-qf` while at it
* Update the list of possible file states in the man page (needed for consistency with the new `--allfiles` description)