### PR TITLE
Add a rpm_macro() provides generator

### DIFF
--- a/fileattrs/Makefile.am
+++ b/fileattrs/Makefile.am
@@ -8,6 +8,6 @@ fattrsdir = $(rpmconfigdir)/fileattrs
 fattrs_DATA = \
 	debuginfo.attr desktop.attr elf.attr font.attr metainfo.attr \
 	perl.attr perllib.attr pkgconfig.attr ocaml.attr \
-	script.attr
+	rpm_macro.attr script.attr
 
 EXTRA_DIST = $(fattrs_DATA)

--- a/fileattrs/rpm_macro.attr
+++ b/fileattrs/rpm_macro.attr
@@ -1,0 +1,2 @@
+%__rpm_macro_provides   %{_rpmconfigdir}/rpm_macros_provides.sh
+%__rpm_macro_path       %{_rpmmacrodir}/macros\..*

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -16,6 +16,7 @@ EXTRA_DIST = \
 	perl.prov perl.req \
 	rpmdb_dump rpmdb_load \
 	rpm.daily rpm.log rpm.supp rpm2cpio.sh \
+	rpm_macros_provides.sh \
 	tgpg vpkg-provides.sh \
 	find-requires find-provides \
 	ocamldeps.sh \
@@ -34,6 +35,7 @@ rpmconfig_SCRIPTS = \
 	pkgconfigdeps.sh \
 	ocamldeps.sh \
 	fontconfig.prov script.req \
+	rpm_macros_provides.sh \
 	rpmdb_dump rpmdb_load \
 	rpm2cpio.sh tgpg
 

--- a/scripts/rpm_macros_provides.sh
+++ b/scripts/rpm_macros_provides.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+# Create a provides of the following form:
+# rpm_macro(foobar)
+# for each defined macro in a macros.* file in %_rpmmacrodir
+
+# We reuse rpm itself for this by just loading just this macro file and then use
+# the %dump macro to print all defined macros from that file. rpm gives us an
+# output of the following form:
+# ========================
+# -11: _target    x86_64-linux
+# -11= _target_cpu        x86_64
+# -11= _target_os linux
+# -13: py_build   %{expand:\
+#  ... etc
+# ===========================
+#
+# Everything starting with -11 are macros from rpmrc, those starting with -13
+# are definitions from macrofiles (i.e. those are that we want), -15 are
+# defaults and -20 are builtins (see rpmio/rpmmacro.h).
+#
+# => We grep for all lines starting with -13, as these are the macro defines
+# from the file in question.
+#
+# The actual macro name is in the second column and is extracted via awk,
+# optionally removing parameters declared in brackets. Also, we drop any macros
+# that start with __ as these are considered internal/private and should not be
+# exposed as a public API.
+
+while read filename
+do
+    for macro in $(rpm --macros="${filename}" -E "%dump" 2>&1 | grep '^-13:' | awk '{print $2}' | sed -e 's|(.*)||' -e '/^__/d'); do
+        echo "rpm_macro(${macro})"
+    done
+done


### PR DESCRIPTION
This commit adds a very simple provides generator for rpm macros as suggested on the Fedora packaging mailing list:
https://lists.fedoraproject.org/archives/list/packaging@lists.fedoraproject.org/thread/DUFER7QAFYIBYDANJQQ37FBNL5YISZQ2/

cc @hroncok @Conan-Kudo 