### PR TITLE
Drag our CI to this decade

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:34
 MAINTAINER rpm-maint@lists.rpm.org
 
 WORKDIR /srv/rpm
@@ -13,6 +13,7 @@ RUN dnf -y install \
   automake \
   libtool \
   gettext-devel \
+  debugedit \
   doxygen \
   make \
   gcc \
@@ -58,7 +59,6 @@ RUN ./configure \
   --with-acl \
   --with-audit \
   --with-fsverity \
-  --enable-bdb \
   --enable-ndb \
   --enable-bdb-ro \
   --enable-sqlite \


### PR DESCRIPTION
Been stuck on Fedora 32 for too long anyhow, but for debugedit we need
at least 35. Kick out a BDB remnant while at it.