### PR TITLE
Fix handling filenames with spaces in brp-compress

### DIFF
--- a/scripts/brp-compress
+++ b/scripts/brp-compress
@@ -14,29 +14,29 @@ COMPRESS=${COMPRESS:-gzip -9 -n}
 COMPRESS_EXT=${COMPRESS_EXT:-.gz}
 
 for d in .${PREFIX}/man/man* .${PREFIX}/man/*/man* .${PREFIX}/info \
-	.${PREFIX}/share/man/man* .${PREFIX}/share/man/*/man* \
-	.${PREFIX}/share/info .${PREFIX}/kerberos/man \
-	.${PREFIX}/X11R6/man/man* .${PREFIX}/lib/perl5/man/man* \
-	.${PREFIX}/share/doc/*/man/man* .${PREFIX}/lib/*/man/man* \
-	.${PREFIX}/share/fish/man/man*
+    .${PREFIX}/share/man/man* .${PREFIX}/share/man/*/man* \
+    .${PREFIX}/share/info .${PREFIX}/kerberos/man \
+    .${PREFIX}/X11R6/man/man* .${PREFIX}/lib/perl5/man/man* \
+    .${PREFIX}/share/doc/*/man/man* .${PREFIX}/lib/*/man/man* \
+    .${PREFIX}/share/fish/man/man*
 do
     [ -d $d ] || continue
-	find $d -type f ! -name dir -print0 |
+    find $d -type f ! -name dir -print0 |
     while IFS= read -r -d '' f; do
-        [ -f "$f" ] || continue
+		[ -f "$f" ] || continue
 
-	case "$f" in
-	 *.gz|*.Z)    gunzip  -f "$f"; b=`echo "$f" | sed -e 's/\.\(gz\|Z\)$//'`;;
-	 *.bz2)       bunzip2 -f "$f"; b=`echo "$f" | sed -e 's/\.bz2$//'`;;
-	 *.xz|*.lzma) unxz    -f "$f"; b=`echo "$f" | sed -e 's/\.\(xz\|lzma\)$//'`;;
-	 *.zst|*.zstd) unzstd -f --rm $f; b=`echo "$f" | sed -e 's/\.\(zst\|zstd\)$//'`;;
-	 *) b="$f";;
-	esac
+    case "$f" in
+     *.gz|*.Z)    gunzip  -f "$f"; b=`echo "$f" | sed -e 's/\.\(gz\|Z\)$//'`;;
+     *.bz2)       bunzip2 -f "$f"; b=`echo "$f" | sed -e 's/\.bz2$//'`;;
+     *.xz|*.lzma) unxz    -f "$f"; b=`echo "$f" | sed -e 's/\.\(xz\|lzma\)$//'`;;
+     *.zst|*.zstd) unzstd -f --rm $f; b=`echo "$f" | sed -e 's/\.\(zst\|zstd\)$//'`;;
+     *) b="$f";;
+    esac
 
-	$COMPRESS "$b" </dev/null 2>/dev/null || {
-	    inode=`ls -i "$b" | awk '{ print $1 }'`
-	    others="`find $d -type f -inum $inode`"
-	    if [ -n "$others" ]; then
+    $COMPRESS "$b" </dev/null 2>/dev/null || {
+		inode=`ls -i "$b" | awk '{ print $1 }'`
+		others="`find $d -type f -inum $inode`"
+		if [ -n "$others" ]; then
 		for afile in $others ; do
 		    [ "$afile" != "$b" ] && rm -f $afile
 		done
@@ -44,17 +44,17 @@ do
 		for afile in $others ; do
 		    [ "$afile" != "$b" ] && ln "$b$COMPRESS_EXT" "$afile$COMPRESS_EXT"
 		done
-	    else
+		else
 		$COMPRESS -f "$b"
-	    fi
-	}
+		fi
+    }
     done
 
     for f in "`find $d -type l`"
     do
-	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\|zst\|zstd\)$//'`
-	rm -f $f
-	b=`echo $f | sed -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\|zst\|zstd\)$//'`
-	ln -sf "$l$COMPRESS_EXT" "$b$COMPRESS_EXT"
+    l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\|zst\|zstd\)$//'`
+    rm -f $f
+    b=`echo $f | sed -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\|zst\|zstd\)$//'`
+    ln -sf "$l$COMPRESS_EXT" "$b$COMPRESS_EXT"
     done
 done

--- a/scripts/brp-compress
+++ b/scripts/brp-compress
@@ -21,40 +21,40 @@ for d in .${PREFIX}/man/man* .${PREFIX}/man/*/man* .${PREFIX}/info \
 	.${PREFIX}/share/fish/man/man*
 do
     [ -d $d ] || continue
-    for f in `find $d -type f ! -name dir`
-    do
+	find $d -type f ! -name dir -print0 |
+    while IFS= read -r -d '' f; do
         [ -f "$f" ] || continue
 
 	case "$f" in
-	 *.gz|*.Z)    gunzip  -f $f; b=`echo $f | sed -e 's/\.\(gz\|Z\)$//'`;;
-	 *.bz2)       bunzip2 -f $f; b=`echo $f | sed -e 's/\.bz2$//'`;;
-	 *.xz|*.lzma) unxz    -f $f; b=`echo $f | sed -e 's/\.\(xz\|lzma\)$//'`;;
-	 *.zst|*.zstd) unzstd -f --rm $f; b=`echo $f | sed -e 's/\.\(zst\|zstd\)$//'`;;
-	 *) b=$f;;
+	 *.gz|*.Z)    gunzip  -f "$f"; b=`echo "$f" | sed -e 's/\.\(gz\|Z\)$//'`;;
+	 *.bz2)       bunzip2 -f "$f"; b=`echo "$f" | sed -e 's/\.bz2$//'`;;
+	 *.xz|*.lzma) unxz    -f "$f"; b=`echo "$f" | sed -e 's/\.\(xz\|lzma\)$//'`;;
+	 *.zst|*.zstd) unzstd -f --rm $f; b=`echo "$f" | sed -e 's/\.\(zst\|zstd\)$//'`;;
+	 *) b="$f";;
 	esac
 
-	$COMPRESS $b </dev/null 2>/dev/null || {
-	    inode=`ls -i $b | awk '{ print $1 }'`
-	    others=`find $d -type f -inum $inode`
+	$COMPRESS "$b" </dev/null 2>/dev/null || {
+	    inode=`ls -i "$b" | awk '{ print $1 }'`
+	    others="`find $d -type f -inum $inode`"
 	    if [ -n "$others" ]; then
 		for afile in $others ; do
 		    [ "$afile" != "$b" ] && rm -f $afile
 		done
-		$COMPRESS -f $b
+		$COMPRESS -f "$b"
 		for afile in $others ; do
-		    [ "$afile" != "$b" ] && ln $b$COMPRESS_EXT $afile$COMPRESS_EXT
+		    [ "$afile" != "$b" ] && ln "$b$COMPRESS_EXT" "$afile$COMPRESS_EXT"
 		done
 	    else
-		$COMPRESS -f $b
+		$COMPRESS -f "$b"
 	    fi
 	}
     done
 
-    for f in `find $d -type l`
+    for f in "`find $d -type l`"
     do
 	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\|zst\|zstd\)$//'`
 	rm -f $f
 	b=`echo $f | sed -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\|zst\|zstd\)$//'`
-	ln -sf $l$COMPRESS_EXT $b$COMPRESS_EXT
+	ln -sf "$l$COMPRESS_EXT" "$b$COMPRESS_EXT"
     done
 done


### PR DESCRIPTION
Filenames with space in filename will not be handled correctly by brp-compress script. This means that variation in space and other special characters will cause problems.

Example:

```sh
$ ls /usr/share/man/man1
   'test file.1'
```

```sh
$ sh /tmp/brp-compress ; ls /usr/share/man/man1
   'test file.1'
```