### PR TITLE
Fix fstat64 handling on macOS with Apple Silicon

### DIFF
--- a/misc/fts.c
+++ b/misc/fts.c
@@ -32,7 +32,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #endif /* LIBC_SCCS and not lint */
 
 /* Conditional to set up proper fstat64 implementation */
-#if defined(hpux) || defined(sun)
+#if defined(hpux) || defined(sun) || defined(__APPLE__)
 #   define FTS_FSTAT64(_fd, _sbp)   fstat((_fd), (_sbp))
 #else
 #   define FTS_FSTAT64(_fd, _sbp)   fstat64((_fd), (_sbp))
@@ -63,6 +63,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/94";
 #endif
 #if defined(__APPLE__)
 #   define __errno_location()	(__error())
+#   define stat64		stat
 #endif
 
 #include "system.h"


### PR DESCRIPTION
The Apple Silicon toolchain removes the *64 stat symbols (deprecated
since 10.6) in favour of their unprefixed form.

This change might not work properly before 10.6, but 10.5 has been out
of support for over a decade, so that hopefully shouldn't be relevant.

Fixes #1752.