### PR TITLE
%autopatch: Fix patch number parameters

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1252,7 +1252,7 @@ for i, p in ipairs(patches) do
     bynum[patch_nums[i]] = p
 end
 for i, a in ipairs(arg) do
-    local p = bynum[a]
+    local p = bynum[tonumber(a)]
     if p then
         print(rpm.expand("%__apply_patch -m %{basename:"..p.."}  "..options..p.." "..i.."\\n"))
     else

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ EXTRA_DIST += data/SPECS/buildrequires.spec
 EXTRA_DIST += data/SPECS/docmiss.spec
 EXTRA_DIST += data/SPECS/hello.spec
 EXTRA_DIST += data/SPECS/hello-auto.spec
+EXTRA_DIST += data/SPECS/hello-autopatch.spec
 EXTRA_DIST += data/SPECS/hello-r2.spec
 EXTRA_DIST += data/SPECS/hello-script.spec
 EXTRA_DIST += data/SPECS/hello2.spec

--- a/tests/data/SPECS/hello-autopatch.spec
+++ b/tests/data/SPECS/hello-autopatch.spec
@@ -1,0 +1,32 @@
+Name: hello
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Simple rpm demonstration.
+
+%sourcelist
+hello-1.0.tar.gz
+
+%patchlist
+hello-1.0-modernize.patch
+hello-1.0-install.patch
+
+%description
+Simple rpm demonstration.
+
+%prep
+%autosetup -N
+%autopatch 1
+%autopatch -m 2
+
+%build
+%make_build CFLAGS="$RPM_OPT_FLAGS"
+
+%install
+%make_install
+
+%files
+%doc	FAQ
+/usr/local/bin/hello
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -46,6 +46,19 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild -ba autopatch])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+
+run rpmbuild \
+  -ba "${abs_srcdir}"/data/SPECS/hello-autopatch.spec
+],
+[0],
+[ignore],
+[ignore])
+AT_CLEANUP
+
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])


### PR DESCRIPTION
Those where not converted to integers for to lookup though not converted
to the actual file name.

Thanks to Vít Ondruch for pointing this out, suggesting the fix and
insisting on a test case!

Resolves: #1766