### PR TITLE
rpmsign: Adopting PKCS#11 opaque keys support in libfsverity for fsverity signatures

### DIFF
--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -63,6 +63,18 @@ SIGN OPTIONS
 
 :   Used with **\--signfiles**, use file signing key *Key*.
 
+**\--pkcs11_engine ***PKCS11_ENGINE*
+
+:   Used with **\--signverity**, use pkcs#11 token with openssl pkcs#11 engine *Pkcs11Engine*.
+
+**\--pkcs11_module ***PKCS11_MODULE*
+
+:   Used with **\--signverity**, use pkcs#11 token with openssl pkcs#11 module *Pkcs11Module*.
+
+**\--pkcs11_keyid ***PKCS11_KEYID*
+
+:   Used with **\--signverity**, use pkcs#11 token with key id *Pkcs11KeyId*.
+
 **\--certpath ***CERT*
 
 :   Used with **\--signverity**, use file signing certificate *Cert*.
@@ -88,10 +100,12 @@ SIGN OPTIONS
 
 :   Sign package files with fsverity signatures. The file signing key
     (RSA private key) and the signing certificate must be set before
-    signing the package. The key can be configured on the command line
-    with **\--fskpath** or the macro %\_file\_signing\_key, and the cert
-    can be configured on the command line with **\--certpath** or the
-    macro %\_file\_signing\_cert.
+    signing the package. The key can be configured either on the command
+    line with **\--fskpath** or the macro %\_file\_signing\_key, or with
+    pkcs#11 token using **\--pkcs11_module** and **\--pkcs11_module**
+    or the macros %\_pkcs11\_engine and %\_pkcs11\_module. The cert can
+    be configured on the command line with **\--certpath** or the macro
+    %\_file\_signing\_cert.
 
 USING GPG TO SIGN PACKAGES
 --------------------------

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -461,13 +461,54 @@ static rpmRC includeVeritySignatures(FD_t fd, Header *sigp, Header *hdrp)
     rpmRC rc = RPMRC_OK;
     char *key = rpmExpand("%{?_file_signing_key}", NULL);
     char *keypass = rpmExpand("%{?_file_signing_key_password}", NULL);
+    char *pkcs11_engine = rpmExpand("%{?_pkcs11_engine}", NULL);
+    char *pkcs11_module = rpmExpand("%{?_pkcs11_module}", NULL);
+    char *pkcs11_keyid = rpmExpand("%{?_pkcs11_keyid}", NULL);
     char *cert = rpmExpand("%{?_file_signing_cert}", NULL);
     char *algorithm = rpmExpand("%{?_verity_algorithm}", NULL);
     uint16_t algo = 0;
 
+    if (rstreq(key, "")) {
+	free(key);
+	key = NULL;
+    }
+
+    if (rstreq(pkcs11_engine, "")) {
+	free(pkcs11_engine);
+	pkcs11_engine = NULL;
+    }
+
+    if (rstreq(pkcs11_module, "")) {
+	free(pkcs11_module);
+	pkcs11_module = NULL;
+    }
+
+    if (rstreq(pkcs11_keyid, "")) {
+	free(pkcs11_keyid);
+	pkcs11_keyid = NULL;
+    }
+
     if (rstreq(keypass, "")) {
 	free(keypass);
 	keypass = NULL;
+    }
+
+    if (key) {
+        if (pkcs11_engine || pkcs11_module || pkcs11_keyid) {
+            rpmlog(
+                RPMLOG_ERR,
+                _("fsverity signatures require a key specified either by file or by PKCS#11 token, not both\n"));
+            rc = RPMRC_FAIL;
+            goto out;
+        }
+    } else {
+        if (!pkcs11_engine || !pkcs11_module) {
+            rpmlog(
+                RPMLOG_ERR,
+                _("fsverity signatures require both PKCS#11 engine and module to use PKCS#11 token\n"));
+            rc = RPMRC_FAIL;
+            goto out;
+        }
     }
 
     if (algorithm && strlen(algorithm) > 0) {
@@ -481,16 +522,16 @@ static rpmRC includeVeritySignatures(FD_t fd, Header *sigp, Header *hdrp)
 		    goto out;
 	    }
     }
-    if (key && cert) {
-	    rc = rpmSignVerity(fd, *sigp, *hdrp, key, keypass, cert, algo);
-    } else {
-	rpmlog(RPMLOG_ERR, _("fsverity signatures requires a key and a cert\n"));
-	rc = RPMRC_FAIL;
-    }
+
+    rc = rpmSignVerity(fd, *sigp, *hdrp, key, keypass,
+                pkcs11_engine, pkcs11_module, pkcs11_keyid, cert, algo);
 
  out:
     free(keypass);
     free(key);
+    free(pkcs11_engine);
+    free(pkcs11_module);
+    free(pkcs11_keyid);
     free(cert);
     return rc;
 #else

--- a/sign/rpmsignverity.h
+++ b/sign/rpmsignverity.h
@@ -22,12 +22,15 @@ extern "C" {
  * @param h		package header
  * @param key		signing key
  * @param keypass	signing key password
+ * @param pkcs11_engine		PKCS#11 engine to use PKCS#11 token support for signing key
+ * @param pkcs11_module		PKCS#11 module to use PKCS#11 token support for signing key
+ * @param pkcs11_keyid		PKCS#11 key identifier
  * @param cert		signing cert
  * @return		RPMRC_OK on success
  */
-RPM_GNUC_INTERNAL
-rpmRC rpmSignVerity(FD_t fd, Header sigh, Header h, char *key,
-		    char *keypass, char *cert, uint16_t algo);
+rpmRC rpmSignVerity(FD_t fd, Header sigh, Header h, char *key, char *keypass,
+		    char *pkcs11_engine, char *pkcs11_module, char *pkcs11_keyid,
+		    char *cert, uint16_t algo);
 
 #ifdef _cplusplus
 }


### PR DESCRIPTION
We (Aleksander Adamowski) recently made a change to Kernel fsverity-utils to ["Implement PKCS#11 opaque keys support through OpenSSL pkcs11 engine"](https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/commit/?id=66b1d8a276cb3836ac275cb9f3f6517a07462737) and the change is already committed. The change is meant to allow us to use opaque keys confined in hardware security modules (HSMs) and similar hardware tokens without direct access to the
fsverity signing key material, which will then be used to generate fsverity signatures.

In this change, we basically supply "`--pkcs11_engine"`and "`--pkcs11_module`" and optionally "`--pkcs11_keyid`" in "`libfsverity_signature_params`" struct if we use PKCS#11 token for fsverity private signing key. 

With this change, we will be able to generate RPM fsverity file signatures with private signing key either from direct private key access through "`--fskpath`", or from PKCS#11 token with PKCS#11 engine and module supplied. "`--certpath`" is still required for both ways.

This requires the "`libfsverity.h`" be up-to-date with [this commit](https://git.kernel.org/pub/scm/linux/kernel/git/ebiggers/fsverity-utils.git/commit/?id=66b1d8a276cb3836ac275cb9f3f6517a07462737).

Linked issue: #1786 