### PR TITLE
Properly quote %sources and %patches

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1033,8 +1033,10 @@ package or when debugging this package.\
   install
 
 #------------------------------------------------------------------------------
-%patches %{lua: for i, p in ipairs(patches) do print(p.." ") end}
-%sources %{lua: for i, s in ipairs(sources) do print(s.." ") end}
+%patches %{lua: for i, p in ipairs(patches) do \
+  print(macros.shescape({p}).." ") end}
+%sources %{lua: for i, s in ipairs(sources) do \
+  print(macros.shescape({s}).." ") end}
 
 #------------------------------------------------------------------------------
 # arch macro for all Intel i?86 compatible processors

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,6 +59,7 @@ EXTRA_DIST += data/SPECS/hello2cp.spec
 EXTRA_DIST += data/SPECS/hello2ln.spec
 EXTRA_DIST += data/SPECS/hello2-suid.spec
 EXTRA_DIST += data/SPECS/hello-g3.spec
+EXTRA_DIST += data/SPECS/hello-sources.spec
 EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
 EXTRA_DIST += data/SPECS/globesctest.spec

--- a/tests/data/SPECS/hello-sources.spec
+++ b/tests/data/SPECS/hello-sources.spec
@@ -1,0 +1,30 @@
+Name: hello
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Simple rpm demonstration.
+
+%sourcelist
+hello-1.0 %tar.gz
+hello-addon ! tar\.gz
+
+%patchlist
+hello-1.0-m<o>dernize&renew.patch
+hello-1.0-inst(a);;.patch
+
+%description
+Simple rpm demonstration.
+
+%prep
+for f in %{sources} ; do
+    echo "$f"
+done
+for f in %{patches} ; do
+    echo "$f"
+done
+
+%files
+%doc	FAQ
+/usr/local/bin/hello
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2162,3 +2162,22 @@ foo
 ],
 [])
 AT_CLEANUP
+
+# ------------------------------
+# Check %sources and %patches with weird file names
+AT_SETUP([%sources and %patches])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+
+runroot rpmbuild \
+  -bp /data/SPECS/hello-sources.spec | grep -v Executing
+],
+[0],
+[/build/SOURCES/hello-1.0 %tar.gz
+/build/SOURCES/hello-addon ! tar\.gz
+/build/SOURCES/hello-1.0-m<o>dernize&renew.patch
+/build/SOURCES/hello-1.0-inst(a);;.patch
+],
+[ignore])
+AT_CLEANUP


### PR DESCRIPTION
by enclosing them in single quotes (').
Replace sigle quotes within with '\'' as needed for sh

Resolves: #1445