### PR TITLE
Add %{shescape:...} macro for single quoting with escapes for the shell

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -98,6 +98,7 @@ to perform useful operations. The current list is
 	%{lua:...}	expand using the [embedded Lua interpreter](lua.md)
 	%{expand:...}	like eval, expand ... to <body> and (re-)expand <body>
 	%{expr:...}	evaluate an expression
+	%{shescape:...}	single quote with escapes for use in shell
 	%{shrink:...}	trim leading and trailing whitespace, reduce
 			intermediate whitespace to a single space
 	%{quote:...}	quote a parametric macro argument, needed to pass

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -125,28 +125,13 @@ static char * dayFormat(rpmtd td, char **emsg)
 /* shell escape formatting */
 static char * shescapeFormat(rpmtd td, char **emsg)
 {
-    char * result = NULL, * dst, * src;
+    char *result = NULL;
 
     if (rpmtdClass(td) == RPM_NUMERIC_CLASS) {
 	rasprintf(&result, "%" PRIu64, rpmtdGetNumber(td));
     } else if (rpmtdClass(td) == RPM_STRING_CLASS) {
-	char *buf = xstrdup(rpmtdGetString(td));;
-
-	result = dst = xmalloc(strlen(buf) * 4 + 3);
-	*dst++ = '\'';
-	for (src = buf; *src != '\0'; src++) {
-	    if (*src == '\'') {
-		*dst++ = '\'';
-		*dst++ = '\\';
-		*dst++ = '\'';
-		*dst++ = '\'';
-	    } else {
-		*dst++ = *src;
-	    }
-	}
-	*dst++ = '\'';
-	*dst = '\0';
-	free(buf);
+	const char *args[] = { rpmtdGetString(td), NULL };
+	rpmExpandThisMacro(NULL, "shescape", (ARGV_const_t)args, &result, 0);
     } else {
 	*emsg = xstrdup(_("(invalid type)"));
     }

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1145,6 +1145,29 @@ static size_t doVerbose(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
     return 0;
 }
 
+static size_t doShescape(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
+{
+    char *result, *dst;
+    const char *src = argv[1];
+
+    result = dst = xmalloc(strlen(src) * 4 + 3);
+    *dst++ = '\'';
+    for (; *src != '\0'; src++) {
+	if (*src == '\'') {
+	    *dst++ = '\'';
+	    *dst++ = '\\';
+	    *dst++ = '\'';
+	    *dst++ = '\'';
+	} else {
+	    *dst++ = *src;
+	}
+    }
+    *dst++ = '\'';
+    *dst = '\0';
+    mbAppendStr(mb, result);
+    return 0;
+}
+
 static size_t
 doFoo(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
@@ -1279,6 +1302,7 @@ static struct builtins_s {
     { "suffix",		doFoo,		1,	ME_FUNC },
     { "trace",		doTrace,	0,	ME_FUNC },
     { "u2p",		doFoo,		1,	ME_FUNC },
+    { "shescape",	doShescape,	1,	ME_FUNC },
     { "uncompress",	doUncompress,	1,	ME_FUNC },
     { "undefine",	doUndefine,	1,	ME_FUNC },
     { "url2path",	doFoo,		1,	ME_FUNC },

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -863,6 +863,18 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([%shescape macro])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+	--eval "%{shescape:foo's}"
+],
+[0],
+['foo'\''s'
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([macro with a line starting by "{"])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
This is exactly the same as :shescape query format, hence the name.