### PR TITLE
Clean up shescape macro implementation

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1147,24 +1147,15 @@ static size_t doVerbose(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 
 static size_t doShescape(MacroBuf mb, rpmMacroEntry me, ARGV_t argv)
 {
-    char *result, *dst;
-    const char *src = argv[1];
-
-    result = dst = xmalloc(strlen(src) * 4 + 3);
-    *dst++ = '\'';
-    for (; *src != '\0'; src++) {
-	if (*src == '\'') {
-	    *dst++ = '\'';
-	    *dst++ = '\\';
-	    *dst++ = '\'';
-	    *dst++ = '\'';
+    mbAppend(mb, '\'');
+    for (const char *s = argv[1]; *s != '\0'; s++) {
+	if (*s == '\'') {
+	    mbAppendStr(mb, "'\\''");
 	} else {
-	    *dst++ = *src;
+	    mbAppend(mb, *s);
 	}
     }
-    *dst++ = '\'';
-    *dst = '\0';
-    mbAppendStr(mb, result);
+    mbAppend(mb, '\'');
     return 0;
 }
 


### PR DESCRIPTION
Realizing that we have dynamic string buffer available in the macro
engine... so we don't need a dumb worst case malloc and all the other
crap in the old tag format era implementation.