### PR TITLE
Print that package is not installed into stderr

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -504,7 +504,7 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 	mi = matchesIterator(ts, RPMDBI_LABEL, arg, 0);
 
 	if (mi == NULL && !rpmFileHasSuffix(arg, ".rpm"))
-	    rpmlog(RPMLOG_NOTICE, _("package %s is not installed\n"), arg);
+	    rpmlog(RPMLOG_ERR, _("package %s is not installed\n"), arg);
 	break;
     }
     default:


### PR DESCRIPTION
It was printed to stdout:

$ LC_ALL=C.UTF-8 rpm -q --qf '%{version}' kernel-source-nvidia390 2>/dev/null || echo 0
package kernel-source-nvidia390 is not installed
0

But I wanted to define a version of rpm package as an rpm macro:

%define nvidia_390_n %(sh -o pipefail -c "rpm -q --qf '%%{version}' kernel-source-nvidia390 | awk -F '.' '{print $2}'" || echo 0)
<...>
Requires: (kmod-nvidia390.%{nvidia_390_n}-kabi(5.10.71-generic-1rosa2021.1-x86_64) if nvidia390)

However, when SRPM was built, kernel-source-nvidia390 was not installed, and output to stdout went into the value of the macro.