### PR TITLE
verifySignature(): package signatures must be PGPSIGTYPE_BINARY

### DIFF
--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -566,7 +566,9 @@ exit:
 static rpmRC
 verifySignature(rpmKeyring keyring, struct rpmsinfo_s *sinfo)
 {
-    rpmRC res = rpmKeyringVerifySig(keyring, sinfo->sig, sinfo->ctx);
+    rpmRC res = RPMRC_FAIL;
+    if (pgpSignatureType(sinfo->sig) == PGPSIGTYPE_BINARY)
+	res = rpmKeyringVerifySig(keyring, sinfo->sig, sinfo->ctx);
 
     return res;
 }

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -426,6 +426,13 @@ static int pgpVersion(const uint8_t *h, size_t hlen, uint8_t *version)
     return 0;
 }
 
+int pgpSignatureType(pgpDigParams _digp) {
+    if (!_digp || _digp->tag != PGPTAG_SIGNATURE)
+	return -1;
+
+    return _digp->sigtype;
+}
+
 static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype, 
 			 pgpDigParams _digp)
 {

--- a/rpmio/rpmpgp.h
+++ b/rpmio/rpmpgp.h
@@ -1161,6 +1161,15 @@ rpmRC pgpVerifySignature(pgpDigParams key, pgpDigParams sig, DIGEST_CTX hashctx)
 rpmRC pgpVerifySig(pgpDig dig, DIGEST_CTX hashctx);
 
 /** \ingroup rpmpgp
+ * Return the type of a PGP signature. If `sig` is NULL, or is not a signature,
+ * returns -1.
+ *
+ * @param sig		signature
+ * @return 		type of the signature
+ */
+int pgpSignatureType(pgpDigParams sig);
+
+/** \ingroup rpmpgp
  * Return a string identification of a PGP signature/pubkey.
  * @param digp		signature/pubkey container
  * @return		string describing the item and parameters


### PR DESCRIPTION
RPM packages are binary documents and must be signed as such.  To avoid having to access the fields of `pgpDigParams` directly, this adds a new accessor function, `pgpSignatureType()`. ` pgpSignatureType()` returns the type of a signature, or -1 if the PGP data is NULL or is not a signature.

Fixes commit b5e8bc74b2b05aa557f663fe227b94d2bc64fbd8.