### PR TITLE
Allow the transaction ID and installation time to be overridden

### DIFF
--- a/lib/psm.c
+++ b/lib/psm.c
@@ -536,7 +536,7 @@ static void markReplacedInstance(rpmts ts, rpmte te)
 static rpmRC dbAdd(rpmts ts, rpmte te)
 {
     Header h = rpmteHeader(te);
-    rpm_time_t installTime = (rpm_time_t) time(NULL);
+    rpm_time_t installTime = rpmtsGetTime(ts, 1);
     rpmfs fs = rpmteGetFileStates(te);
     rpm_count_t fc = rpmfsFC(fs);
     rpm_fstate_t * fileStates = rpmfsGetStates(fs);

--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -91,6 +91,8 @@ struct rpmts_s {
     rpmtriggers trigs2run;   /*!< Transaction file triggers */
 
     int min_writes;             /*!< macro minimize_writes used */
+
+    time_t overrideTime;	/*!< Time value used when overriding system clock. */
 };
 
 #ifdef __cplusplus
@@ -130,6 +132,9 @@ rpmRC runScript(rpmts ts, rpmte te, Header h, ARGV_const_t prefixes,
 
 RPM_GNUC_INTERNAL
 int rpmtsNotifyChange(rpmts ts, int event, rpmte te, rpmte other);
+
+RPM_GNUC_INTERNAL
+rpm_time_t rpmtsGetTime(rpmts ts, time_t step);
 
 #ifdef __cplusplus
 }

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1442,7 +1442,7 @@ static int runTransScripts(rpmts ts, pkgGoal goal)
 
 static int rpmtsSetup(rpmts ts, rpmprobFilterFlags ignoreSet)
 {
-    rpm_tid_t tid = (rpm_tid_t) time(NULL);
+    rpm_tid_t tid = (rpm_tid_t) rpmtsGetTime(ts, 0);
     int dbmode = (rpmtsFlags(ts) & RPMTRANS_FLAG_TEST) ?  O_RDONLY : (O_RDWR|O_CREAT);
 
     if (rpmtsFlags(ts) & RPMTRANS_FLAG_NOSCRIPTS)

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -353,6 +353,63 @@ error: hello-2.0-1.x86_64: install failed
 AT_CLEANUP
 
 # ------------------------------
+# Test tid/time overrides using SOURCE_DATE_EPOCH
+AT_SETUP([rpm -i <overridden time>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+pkg="hello-2.0-1.x86_64"
+timestamp=97445
+
+runroot rpm -i --ignorearch --ignoreos --nodeps \
+	/data/RPMS/foo-1.0-1.noarch.rpm
+export SOURCE_DATE_EPOCH=$timestamp
+runroot rpm -i --ignorearch --ignoreos --nodeps \
+	/data/RPMS/hello-2.0-1.x86_64.rpm
+unset SOURCE_DATE_EPOCH
+runroot rpm -q --tid $timestamp
+runroot rpm -qi $pkg | grep "Install Date"
+runroot rpm -qa
+
+],
+[0],
+[hello-2.0-1.x86_64
+Install Date: Fri Jan  2 03:04:05 1970
+foo-1.0-1.noarch
+hello-2.0-1.x86_64
+],
+[])
+AT_CLEANUP
+
+# ------------------------------
+# Test multiple installs using SOURCE_DATE_EPOCH
+AT_SETUP([rpm -i <overridden time keeps ticking>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+timestamp=1445412535
+
+export SOURCE_DATE_EPOCH=$timestamp
+runroot rpm -i --ignorearch --ignoreos --nodeps \
+	/data/RPMS/foo-1.0-1.noarch.rpm /data/RPMS/hello-2.0-1.x86_64.rpm
+unset SOURCE_DATE_EPOCH
+runroot rpm -q --tid $timestamp
+for pkg in `runroot rpm -q --tid $timestamp`; do
+	runroot rpm -qi $pkg | grep "Install Date"
+done
+],
+[0],
+[hello-2.0-1.x86_64
+foo-1.0-1.noarch
+Install Date: Wed Oct 21 07:28:55 2015
+Install Date: Wed Oct 21 07:28:56 2015
+],
+[])
+AT_CLEANUP
+
+# ------------------------------
 # Check if rpm -U *.src.rpm works
 AT_SETUP([rpm -U *.src.rpm])
 AT_KEYWORDS([install])


### PR DESCRIPTION
The target audience for these changes is people building OS images (or anything else RPM-derived) that desire a reproducible build. The changes are described fairly clearly but the gist is that `RPMTAG_INSTALLTID` and `RPMTAG_INSTALLTIME` contain timestamps and current mechanisms make these impossible to override. These changes add the necessary override APIs to override these values when desired.