### PR TITLE
don not skip WRONGCOLOR state file

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -690,7 +690,8 @@ assert(otherFi != NULL);
 	    if (XFA_SKIPPING(rpmfsGetAction(fs, i)))
 		break;
 	    if (rpmfilesFState(fi, i) != RPMFILE_STATE_NORMAL) {
-		rpmfsSetAction(fs, i, FA_SKIP);
+		if (rpmfilesFState(fi, i) != RPMFILE_STATE_WRONGCOLOR)
+		    rpmfsSetAction(fs, i, FA_SKIP);
 		break;
 	    }
 		


### PR DESCRIPTION
Don't skip WRONGCOLOR state file when removing packages.