### PR TITLE
Fix link to the kernel coding style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ NULL arguments, don't check for it separately.
 ### Miscellaneous
 
 While many details differ and lot of it does not apply at all, the [Linux
-kernel coding style document](https://www.gnu.org/software/libtool/manual/html_node/Libtool-versioning.html)
+kernel coding style document](https://www.kernel.org/doc/html/latest/process/coding-style.html)
 contains lots of excellent guidance on good C programming practises if you
 filter out what is kernel specific.
 


### PR DESCRIPTION
It previously pointed to the documentation for libtool versioning.