### PR TITLE
Use lua_replace instead of lua_rotate

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ The debugedit >= 0.3 tools for producing debuginfo sub-packages.
 It is available from
    https://sourceware.org/debugedit/
 
-Lua >= 5.3 library + development environment.
+Lua >= 5.2 library + development environment.
 Note that only the library is needed at runtime, RPM never calls external
 Lua interpreter for anything. Lua is available from
     http://www.lua.org

--- a/configure.ac
+++ b/configure.ac
@@ -756,7 +756,7 @@ AC_SUBST(WITH_ACL_LIB)
 AM_CONDITIONAL(ACL,[test "$with_acl" = yes])
 
 PKG_CHECK_MODULES([LUA],
-    [lua >= 5.3],
+    [lua >= 5.2],
     [],
     [AC_MSG_ERROR([lua not present or too old)])])
 AC_SUBST(LUA_CFLAGS)

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -1063,7 +1063,7 @@ static int mc_call(lua_State *L)
     if (lua_isstring(L, 1)) {
 	lua_pushfstring(L, "%%{%s %s}", name, lua_tostring(L, 1));
 	/* throw out previous args and call expand() with our result string */
-	lua_rotate(L, 1, 1);
+	lua_replace(L, 1);
 	lua_settop(L, 1);
 	rc = rpm_expand(L);
     } else if (lua_istable(L, 1)) {
@@ -1103,7 +1103,7 @@ static int mc_index(lua_State *L)
 	    rc = 1;
 	} else {
 	    lua_pushfstring(L, "%%{%s}", a);
-	    lua_rotate(L, 1, 1);
+	    lua_replace(L, 1);
 	    lua_settop(L, 1);
 	    rc = rpm_expand(L);
 	}


### PR DESCRIPTION
lua_rotate works but is somewhat the wrong tool if we just
want to set a specific stack element. Use lua_replace instead.
This has the added advantage that the code works again with
lua version 5.2 (not that it matters much).