### PR TITLE
Update OCaml requires/provides to ignore cmxs

### DIFF
--- a/fileattrs/ocaml.attr
+++ b/fileattrs/ocaml.attr
@@ -1,5 +1,5 @@
 %__ocaml_provides	%{_rpmconfigdir}/ocamldeps.sh --provides
 %__ocaml_requires	%{_rpmconfigdir}/ocamldeps.sh --requires
-%__ocaml_magic		^(ELF|Objective caml|OCaml) .*$
-%__ocaml_path		.(cma|cmi|cmo|cmx|cmxa|cmxs)$
+%__ocaml_magic		^(Objective caml|OCaml) .*$
+%__ocaml_path		.(cma|cmi|cmo|cmx|cmxa)$
 %__ocaml_flags		magic_and_path

--- a/scripts/ocamldeps.sh
+++ b/scripts/ocamldeps.sh
@@ -32,6 +32,10 @@
 #   Implementations imported:
 #     HASH NAME_FROM_OTHER_MODULE
 #
+# cmxs files are recoqnized, but need to be ignored.
+# They contain references of the interfaces and implementations
+# compiled into them.
+#
 # The hash may contain just '-', in which case it is ignored.
 #
 # Output:
@@ -236,7 +240,7 @@ do
   *.cmo)  parse "${filename}" ;;
   *.cmx)  parse "${filename}" ;;
   *.cmxa) parse "${filename}" ;;
-  *.cmxs) parse "${filename}" ;;
+  *.cmxs) ;;
   *) continue ;;
   esac
 done


### PR DESCRIPTION
OCaml cmxs files are static libraries, which can be loaded at runtime
via the Dynlink module. They apparently do not provide any useful
runtime dependency information to be stored into the packages
Provides/Requires list. Therefore just skip them.

Adjust attr, remove extension and ELF magic
Adjust ocamldeps, do nothing with cmxs files.

Fixes: a6fe37c39b39acbcbd014dd1e6d5653ff84254a1

Signed-off-by: Olaf Hering <olaf@aepfle.de>