### PR TITLE
remove-la-files: Use file to check for libtool files

### DIFF
--- a/scripts/brp-remove-la-files
+++ b/scripts/brp-remove-la-files
@@ -5,4 +5,6 @@ if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
   exit 0
 fi
 
-find "$RPM_BUILD_ROOT" -name "*.la" -type f -delete
+find "$RPM_BUILD_ROOT" -type f -name '*.la' 2>/dev/null -print0 |
+  xargs --null grep --fixed-strings '.la - a libtool library file' --files-with-matches --null |
+  xargs --null rm --force


### PR DESCRIPTION
Try to minimize accidentally removed .la files that aren't libtool .la
files.

I wasn't sure if there's a better way to do this than the manual loop, but here it is.
This is the result of  the discussion in https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/AMKKEGJZBMPE4IQHKGR65RXKF2NALSOP/