### PR TITLE
Revert "Don't brp-strip .ko files"

### DIFF
--- a/scripts/brp-strip
+++ b/scripts/brp-strip
@@ -13,5 +13,5 @@ Darwin*) exit 0 ;;
 esac
 
 # Strip ELF binaries
-find "$RPM_BUILD_ROOT" -type f \! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" \! -name "*.ko" \! -name "*.go" -print0 | \
+find "$RPM_BUILD_ROOT" -type f \! -regex "${RPM_BUILD_ROOT}/*usr/lib/debug.*" \! -name "*.go" -print0 | \
     xargs -0 -r -P$NCPUS -n32 sh -c "file \"\$@\" | sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped.*/\1/p' | grep -v 'no machine' | xargs -I\{\} $STRIP -g \{\}" ARG0


### PR DESCRIPTION
The original commit might have seemed like an easy remedy for
third-party modules affected by commit 0ab151a (such as rhbz#1967291),
but it also prevents the modules built from the kernel tree (which
employ a different signing strategy, see below) from being stripped off
of debug and symbol data, so it's not the correct solution after all.

Simply put, *.ko files *are* ELF files, so there's no good reason to
skip them.

Third-party modules should instead adopt the same hack as the in-tree
ones, i.e. overriding the %__spec_post_install macro so that the signing
occurs as a last step, after any kind of stripping has taken place.
Example from kernel.spec:

%define __modsign_install_post \\
  \# Do the signing here
[...]
%define __spec_install_post \\
  \# eu-strip(1) gets called here
  %{?__debug_package:%{__debug_install_post}}\\
  %{__arch_install_post}\\
  \# ... or strip(1) gets called here
  %{__os_install_post}\\
  %{__remove_unwanted_dbginfo_install_post}\\
  %{__modsign_install_post}

It's still a hack, but it's better than avoiding the strip altogether.

This reverts commit cfdb8300f6e3aed0abc41406a3c4737eb1192067.