### PR TITLE
Implement simple macro objects

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1020,3 +1020,19 @@ runroot rpm --eval 1 >/dev/full
 [Error writing to stdout: No space left on device
 ])
 AT_CLEANUP
+
+AT_SETUP([macro objects])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+	--eval "%define _strbuf__init(-) %nil" \
+	--eval "%define _strbuf_add(-) %{setobjectbody %1 %{quote:%{getobjectbody %1}%2}}" \
+	--eval "%{defineobject buf(strbuf)}%{buf add hello}%{buf add world}%buf"
+],
+[0],
+[
+
+helloworld
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
A macro object is a special macro that stores its type in the
'opts' element and delegates the expansion to other macros.
The first argument in the expansion is used as the method name.
E.g. the expansion of %{myarray push bar} will delegate to the
%_array_push macro if %myarray is of type "array".

There are two special methods:
_init is used to set up the object and must always be present.
_expand is used if the macro is expanded without arguments and
defaults to just using the literal macro body.

There are two new builtins to get/set the macro body of a macro
object: getobjectbody and setobjectbody. They can be used to store
a string in the macro object without delegation.