### PR TITLE
Implement %foreach builtin to iterate over arguments

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1020,3 +1020,17 @@ runroot rpm --eval 1 >/dev/full
 [Error writing to stdout: No space left on device
 ])
 AT_CLEANUP
+
+
+AT_SETUP([foreach macro])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+	--eval '%{define iter hello world %{quote:good bye}}' \
+	--eval '%{foreach iter >%1<}' \
+],
+[0],
+[
+>hello<>world<>good bye<
+])
+AT_CLEANUP


### PR DESCRIPTION
The %foreach macro expects a macro name and an iteration body.
It will split the expansion of the specified macro and then expand
the body for each element, setting %1 to the current element.
