### PR TITLE
cleanup rpmpgp.h includes

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -21,7 +21,6 @@
 #include <elfutils/libdwelf.h>
 #endif
 
-#include <rpm/rpmpgp.h>
 #include <rpm/argv.h>
 #include <rpm/rpmfc.h>
 #include <rpm/rpmfileutil.h>	/* rpmDoDigest() */

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -6,6 +6,7 @@
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>
 #include <rpm/rpmmacro.h>
+#include <rpm/rpmstring.h>
 #include "lib/rpmdb_internal.h"
 
 #include "debug.h"

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -10,6 +10,7 @@
 #include <rpm/rpmdb.h>
 #include <rpm/rpmds.h>
 #include <rpm/rpmfi.h>
+#include <rpm/rpmstring.h>
 
 #include "lib/rpmts_internal.h"
 #include "lib/rpmte_internal.h"

--- a/lib/fprint.c
+++ b/lib/fprint.c
@@ -5,6 +5,7 @@
 #include "system.h"
 
 #include <rpm/rpmfileutil.h>	/* for rpmCleanPath */
+#include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmsq.h>
 

--- a/lib/headerfmt.c
+++ b/lib/headerfmt.c
@@ -8,7 +8,6 @@
 #include <rpm/header.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmstring.h>
-#include <rpm/rpmpgp.h>
 #include "lib/misc.h"		/* format function protos */
 
 #include "debug.h"

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -4,9 +4,12 @@
 
 #include "system.h"
 
+#include <string.h>
+
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>
 #include <rpm/argv.h>
+#include <rpm/rpmstring.h>
 
 #include "lib/manifest.h"
 

--- a/lib/poptI.c
+++ b/lib/poptI.c
@@ -5,6 +5,8 @@
 
 #include "system.h"
 
+#include <string.h>
+
 #include <rpm/rpmcli.h>
 
 #include "debug.h"

--- a/lib/poptQV.c
+++ b/lib/poptQV.c
@@ -4,8 +4,10 @@
  */
 
 #include "system.h"
+#include <string.h>
 
 #include <rpm/rpmcli.h>
+#include <rpm/rpmstring.h>
 #include "lib/rpmgi.h"	/* XXX for giFlags */
 
 #include "debug.h"

--- a/lib/query.c
+++ b/lib/query.c
@@ -17,6 +17,7 @@
 #include <rpm/rpmsq.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>	/* rpmCleanPath */
+#include <rpm/rpmstring.h>
 
 #include "lib/rpmgi.h"
 #include "lib/manifest.h"

--- a/lib/relocation.c
+++ b/lib/relocation.c
@@ -6,6 +6,7 @@
 #include <rpm/rpmfileutil.h>
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmlog.h>
+#include <rpm/rpmstring.h>
 
 #include "lib/rpmfs.h"
 #include "lib/misc.h"

--- a/lib/rpmal.c
+++ b/lib/rpmal.c
@@ -7,6 +7,7 @@
 
 #include <rpm/rpmte.h>
 #include <rpm/rpmfi.h>
+#include <rpm/rpmstring.h>
 #include <rpm/rpmstrpool.h>
 
 #include "lib/rpmal.h"

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -19,7 +19,6 @@
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmurl.h>
 #include <rpm/rpmpgp.h>
-#include <rpm/rpmpgp.h>
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmsq.h>
 #include <rpm/rpmstring.h>

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -10,7 +10,6 @@
 #include <unistd.h>
 
 #include <rpm/rpmtypes.h>
-#include <rpm/rpmpgp.h>
 
 /** \ingroup rpmfiles
  * File types.

--- a/lib/rpmfs.c
+++ b/lib/rpmfs.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <string.h>
+
 #include "system.h"
 #include "lib/rpmfs.h"
 #include "debug.h"

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -4,6 +4,7 @@
 #include "system.h"
 
 #include <errno.h>
+#include <string.h>
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile */

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -4,6 +4,8 @@
 
 #include "system.h"
 
+#include <string.h>
+
 #include <rpm/rpmcli.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile, vercmp etc */

--- a/lib/rpmlib.h
+++ b/lib/rpmlib.h
@@ -12,7 +12,6 @@
 #include <rpm/header.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmds.h>	/* XXX move rpmlib provides to rpmds instead */
-#include <rpm/rpmpgp.h>
 #include <rpm/rpmver.h>
 
 #ifdef _RPM_4_4_COMPAT

--- a/lib/rpmlock.c
+++ b/lib/rpmlock.c
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <string.h>
 
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>

--- a/lib/rpmtd.c
+++ b/lib/rpmtd.c
@@ -2,7 +2,6 @@
 
 #include <rpm/rpmtd.h>
 #include <rpm/rpmstring.h>
-#include <rpm/rpmpgp.h>
 #include <rpm/rpmstrpool.h>
 #include "lib/misc.h"		/* format function prototypes */
 

--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -9,6 +9,7 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmds.h>
 #include <rpm/rpmfi.h>
+#include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlog.h>

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -12,7 +12,6 @@
 #include <rpm/rpmte.h>
 #include <rpm/rpmps.h>
 #include <rpm/rpmsw.h>
-#include <rpm/rpmpgp.h>
 #include <rpm/rpmfi.h>
 #include <rpm/rpmcallback.h>
 

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -21,6 +21,7 @@
 #include <rpm/rpmts.h>
 #include <rpm/rpmdb.h>
 #include <rpm/rpmfileutil.h>
+#include <rpm/rpmstring.h>
 
 #include "lib/misc.h"
 #include "lib/rpmchroot.h"

--- a/plugins/audit.c
+++ b/plugins/audit.c
@@ -1,7 +1,9 @@
 #include "system.h"
 
+#include <stdlib.h>
 #include <libaudit.h>
 
+#include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include "lib/rpmplugin.h"
 

--- a/plugins/dbus_announce.c
+++ b/plugins/dbus_announce.c
@@ -1,7 +1,10 @@
 #include "system.h"
 
+#include <stdlib.h>
+
 #include <dbus/dbus.h>
 #include <rpm/rpmlog.h>
+#include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmdb.h>
 #include "lib/rpmplugin.h"

--- a/plugins/fsverity.c
+++ b/plugins/fsverity.c
@@ -18,6 +18,7 @@
 #include <rpm/rpmlog.h>
 #include <rpmio/rpmstring.h>
 #include <rpmio/rpmmacro.h>
+#include <rpmio/rpmpgp.h>
 
 #include "lib/rpmfs.h"
 #include "lib/rpmplugin.h"

--- a/plugins/prioreset.c
+++ b/plugins/prioreset.c
@@ -1,5 +1,6 @@
 #include "system.h"
 
+#include <string.h>
 #include <errno.h>
 #include <sys/resource.h>
 #if defined(__linux__)

--- a/plugins/syslog.c
+++ b/plugins/syslog.c
@@ -1,7 +1,9 @@
 #include "system.h"
 
+#include <stdlib.h>
 #include <syslog.h>
 
+#include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 #include "lib/rpmplugin.h"
 

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -1,7 +1,6 @@
 #include "rpmsystem-py.h"
 
 #include <rpm/rpmtypes.h>
-#include <rpm/rpmpgp.h>
 
 #include "header-py.h"
 #include "rpmfi-py.h"

--- a/python/rpmfi-py.c
+++ b/python/rpmfi-py.c
@@ -1,7 +1,6 @@
 #include "rpmsystem-py.h"
 
 #include <rpm/rpmtypes.h>
-#include <rpm/rpmpgp.h>
 
 #include "header-py.h"
 #include "rpmfi-py.h"

--- a/rpm.c
+++ b/rpm.c
@@ -4,6 +4,7 @@
 #include <rpm/rpmlib.h>			/* RPMSIGTAG, rpmReadPackageFile .. */
 #include <rpm/rpmlog.h>
 #include <rpm/rpmps.h>
+#include <rpm/rpmstring.h>
 #include <rpm/rpmts.h>
 
 #include "cliutils.h"

--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -4,9 +4,9 @@
 
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile .. */
 #include <rpm/rpmfi.h>
+#include <rpm/rpmstring.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmio.h>
-#include <rpm/rpmpgp.h>
 #include <rpm/rpmurl.h>
 #include <rpm/rpmts.h>
 

--- a/rpm2cpio.c
+++ b/rpm2cpio.c
@@ -3,9 +3,9 @@
 #include "system.h"
 
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile .. */
+#include <rpm/rpmstring.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmio.h>
-#include <rpm/rpmpgp.h>
 
 #include <rpm/rpmts.h>
 #include <unistd.h>

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -13,8 +13,11 @@
 
 #include "system.h"
 
+#include <string.h>
+
 #include <rpm/rpmlog.h>
 #include <rpm/rpmmacro.h>
+#include <rpm/rpmstring.h>
 #include <rpm/rpmver.h>
 #include "rpmio/rpmmacro_internal.h"
 #include "debug.h"

--- a/rpmio/rpmfileutil.h
+++ b/rpmio/rpmfileutil.h
@@ -8,7 +8,6 @@
 
 #include <rpm/rpmutil.h>
 #include <rpm/rpmio.h>
-#include <rpm/rpmpgp.h>
 #include <rpm/argv.h>
 
 #ifdef __cplusplus

--- a/rpmio/rpmlog.c
+++ b/rpmio/rpmlog.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmmacro.h>
+#include <rpm/rpmstring.h>
 #include "debug.h"
 
 typedef struct rpmlogCtx_s * rpmlogCtx;

--- a/tools/rpmgraph.c
+++ b/tools/rpmgraph.c
@@ -1,5 +1,7 @@
 #include "system.h"
 
+#include <string.h>
+
 #include <rpm/rpmcli.h>
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile */
 #include <rpm/rpmdb.h>


### PR DESCRIPTION
As a first step, limit the visibility of the OpenPGP-related definitions to the code that actually uses them.