### PR TITLE
Eliminate static rpm.next_file() from the Lua API

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -118,10 +118,12 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
 
     rpmlog(RPMLOG_DEBUG, "%s: running <lua> scriptlet.\n", sname);
 
-    lua_getglobal(L, "rpm");
-    lua_pushlightuserdata(L, nextFileFunc);
-    lua_pushcclosure(L, &next_file, 1);
-    lua_setfield(L, -2, "next_file");
+    if (nextFileFunc) {
+	lua_getglobal(L, "rpm");
+	lua_pushlightuserdata(L, nextFileFunc);
+	lua_pushcclosure(L, &next_file, 1);
+	lua_setfield(L, -2, "next_file");
+    }
 
     if (arg1 >= 0)
 	argvAddNum(argvp, arg1);
@@ -163,9 +165,11 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
     }
     free(scriptbuf);
 
-    lua_pushnil(L);
-    lua_setfield(L, -2, "next_file");
-    lua_pop(L, 1); /* "rpm" global */
+    if (nextFileFunc) {
+	lua_pushnil(L);
+	lua_setfield(L, -2, "next_file");
+	lua_pop(L, 1); /* "rpm" global */
+    }
 
     return rc;
 }

--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -61,9 +61,6 @@ struct rpmluapb_s {
 
 static rpmlua globalLuaState = NULL;
 
-static char *(*nextFileFunc)(void *) = NULL;
-static void *nextFileFuncParam = NULL;
-
 static int luaopen_rpm(lua_State *L);
 static int rpm_print(lua_State *L);
 static int rpm_exit(lua_State *L);
@@ -217,12 +214,6 @@ char *rpmluaPopPrintBuffer(rpmlua lua)
     }
 
     return ret;
-}
-
-void rpmluaSetNextFileFunc(char *(*func)(void *), void *funcParam)
-{
-    nextFileFunc = func;
-    nextFileFuncParam = funcParam;
 }
 
 int rpmluaCheckScript(rpmlua lua, const char *script, const char *name)
@@ -568,16 +559,6 @@ static int rpm_interactive(lua_State *L)
 
     _rpmluaInteractive(L);
     return 0;
-}
-
-static int rpm_next_file(lua_State *L)
-{
-    if (nextFileFunc)
-	lua_pushstring(L, nextFileFunc(nextFileFuncParam));
-    else
-	lua_pushstring(L, NULL);
-
-    return 1;
 }
 
 typedef struct rpmluaHookData_s {
@@ -1234,7 +1215,6 @@ static const luaL_Reg rpmlib[] = {
     {"unregister", rpm_unregister},
     {"call", rpm_call},
     {"interactive", rpm_interactive},
-    {"next_file", rpm_next_file},
     {"execute", rpm_execute},
     {"redirect2null", rpm_redirect2null},
     {"vercmp", rpm_vercmp},

--- a/rpmio/rpmlua.h
+++ b/rpmio/rpmlua.h
@@ -25,8 +25,6 @@ void rpmluaInteractive(rpmlua lua);
 char *rpmluaPopPrintBuffer(rpmlua lua);
 void rpmluaPushPrintBuffer(rpmlua lua);
 
-void rpmluaSetNextFileFunc(char *(*func)(void *), void *funcParam);
-
 char *rpmluaCallStringFunction(rpmlua lua, const char *function, struct rpmhookArgs_s *args);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This screams for a closure, use one. This is not supposed to change
any functionality.

If you wonder about the date, this is indeed a leftover from last years Lua campaign, forgotten for whatever reason which I've also forgotten.