### PR TITLE
Fix a couple of issues with removing the GNU suffixes from the target triplets.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -838,23 +838,26 @@ AC_DEFINE_UNQUOTED([GID_0_GROUP],["$group_with_gid0"],[Get the group name having
 # get rid of the 4-th tuple, if config.guess returned "linux-gnu" for host_os
 #
 host_os_gnu=-gnu
-if echo "$host_os" | grep '.*-gnulibc1' > /dev/null ; then
+if echo "$host_os" | grep '.*-gnulibc1$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnulibc1$//'`
 fi
-if echo "$host_os" | grep '.*-gnueabihf' > /dev/null ; then
+if echo "$host_os" | grep '.*-gnueabihf$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnueabihf$//'`
 	host_os_gnu=-gnueabihf
 fi
-if echo "$host_os" | grep '.*-gnueabi' > /dev/null ; then
+if echo "$host_os" | grep '.*-gnueabi$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnueabi$//'`
 	host_os_gnu=-gnueabi
 fi
-if echo "$host_os" | grep '.*-gnuabi64' > /dev/null ; then
+if echo "$host_os" | grep '.*-gnuabi64$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnuabi64$//'`
 	host_os_gnu=-gnuabi64
 fi
-if echo "$host_os" | grep '.*-gnu' > /dev/null ; then
+if echo "$host_os" | grep '.*-gnu$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnu$//'`
+fi
+if echo "$host_os" | grep '.*-gnu[[^-]]*$' > /dev/null ; then
+	AC_MSG_ERROR([unrecognized GNU build triplet $host_os])
 fi
 
 changequote(<, >)

--- a/configure.ac
+++ b/configure.ac
@@ -841,9 +841,17 @@ host_os_gnu=-gnu
 if echo "$host_os" | grep '.*-gnulibc1' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnulibc1$//'`
 fi
+if echo "$host_os" | grep '.*-gnueabihf' > /dev/null ; then
+	host_os=`echo "${host_os}" | sed 's/-gnueabihf$//'`
+	host_os_gnu=-gnueabihf
+fi
 if echo "$host_os" | grep '.*-gnueabi' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnueabi$//'`
 	host_os_gnu=-gnueabi
+fi
+if echo "$host_os" | grep '.*-gnuabi64' > /dev/null ; then
+	host_os=`echo "${host_os}" | sed 's/-gnuabi64$//'`
+	host_os_gnu=-gnuabi64
 fi
 if echo "$host_os" | grep '.*-gnu' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnu$//'`


### PR DESCRIPTION
Hi,

Thanks a lot for developing and maintaining RPM and the related tools and libraries!

The Debian package of rpm was found to build incorrectly on the armhf (arm7hl-linux) architecture. It turns out the cause is that the configure script does not recognize the -gnueabihf (not -gnueabi) suffix and does not strip it correctly.

What do you think about these two changes? The first one teaches configure about the -gnueabihf suffix, and the second one attempts to make it easier to catch future occurrences of this issue early.

Thanks in advance for your time, and keep up the great work!

G'luck,
Peter