### PR TITLE
Fix a couple of minor issues detected by the cppcheck tool.

### DIFF
--- a/build/rpmbuild.h
+++ b/build/rpmbuild.h
@@ -39,7 +39,7 @@ enum rpmBuildFlags_e {
     RPMBUILD_BUILDREQUIRES	= (1 <<  20), /*!< Execute %%buildrequires. */
     RPMBUILD_DUMPBUILDREQUIRES	= (1 <<  21), /*!< Write buildrequires.nosrc.rpm. */
 
-    RPMBUILD_NOBUILD	= (1 << 31)	/*!< Don't execute or package. */
+    RPMBUILD_NOBUILD	= (1u << 31)	/*!< Don't execute or package. */
 };
 
 typedef rpmFlags rpmBuildFlags;

--- a/build/rpmfc.h
+++ b/build/rpmfc.h
@@ -32,7 +32,7 @@ enum FCOLOR_e {
 
     RPMFC_WHITE			= (1 << 29),
     RPMFC_INCLUDE		= (1 << 30),
-    RPMFC_ERROR			= (1 << 31)
+    RPMFC_ERROR			= (1u << 31)
 };
 
 /** \ingroup rpmfc

--- a/lib/rpmfiles.h
+++ b/lib/rpmfiles.h
@@ -88,7 +88,7 @@ enum rpmVerifyAttrs_e {
     RPMVERIFY_READLINKFAIL= (1 << 28),	/*!< readlink failed */
     RPMVERIFY_READFAIL	= (1 << 29),	/*!< file read failed */
     RPMVERIFY_LSTATFAIL	= (1 << 30),	/*!< lstat failed */
-    RPMVERIFY_LGETFILECONFAIL	= (1 << 31)	/*!< lgetfilecon failed */
+    RPMVERIFY_LGETFILECONFAIL	= (1u << 31)	/*!< lgetfilecon failed */
 };
 
 typedef rpmFlags rpmVerifyAttrs;

--- a/lib/rpmplugin.h
+++ b/lib/rpmplugin.h
@@ -22,7 +22,7 @@ typedef enum rpmScriptletExecutionFlow_e {
  */
 enum rpmFileActionFlags_e {
     /* bits 0-15 reserved for actions */
-    FAF_UNOWNED		= (1 << 31)
+    FAF_UNOWNED		= (1u << 31)
 };
 typedef rpmFlags rpmFileActionFlags;
 

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -53,7 +53,7 @@ enum rpmtransFlags_e {
     /* bit 28 unused */
     RPMTRANS_FLAG_NOARTIFACTS	= (1 << 29),	/*!< from --noartifacts */
     RPMTRANS_FLAG_NOCONFIGS	= (1 << 30),	/*!< from --noconfigs */
-    RPMTRANS_FLAG_DEPLOOPS	= (1 << 31)	/*!< from --deploops */
+    RPMTRANS_FLAG_DEPLOOPS	= (1u << 31)	/*!< from --deploops */
 };
 
 typedef rpmFlags rpmtransFlags;

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -274,7 +274,7 @@ static const char *prToken(int val)
 }
 #endif	/* DEBUG_PARSER */
 
-#define RPMEXPR_DISCARD		(1 << 31)	/* internal, discard result */
+#define RPMEXPR_DISCARD		(1u << 31)	/* internal, discard result */
 
 static char *getValuebuf(ParseState state, const char *p, size_t size)
 {

--- a/sign/rpmsignfiles.h
+++ b/sign/rpmsignfiles.h
@@ -19,7 +19,7 @@ extern "C" {
 RPM_GNUC_INTERNAL
 rpmRC rpmSignFiles(Header sigh, Header h, const char *key, char *keypass);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/sign/rpmsignverity.h
+++ b/sign/rpmsignverity.h
@@ -29,7 +29,7 @@ RPM_GNUC_INTERNAL
 rpmRC rpmSignVerity(FD_t fd, Header sigh, Header h, char *key,
 		    char *keypass, char *cert, uint16_t algo);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
Hi,

Thanks a lot for developing and maintaining RPM!

What do you think about these two trivial changes caught by the cppcheck tool? It reported a lot of other false positives, as well as something strange in the lib/backend/ndb/rpmxdb.c file's moveblobstofront() function that I cannot really determine whether it is a genuine bug or a deliberate attempt to get the program to segfault in out-of-resources situations, but these two minor issues seem genuine to me.

Thanks in advance for your time, and keep up the great work!

G'luck,
Peter
