### PR TITLE
Use root as default UID_0_USER and UID_0_GROUP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -831,6 +831,8 @@ AM_CONDITIONAL(AUDIT,[test "$with_audit" = yes])
 
 user_with_uid0=$(awk -F: '$3==0 {print $1;exit}' /etc/passwd)
 group_with_gid0=$(awk -F: '$3==0 {print $1;exit}' /etc/group)
+if [[ -z "$user_with_uid0" ]] ; then user_with_uid0=root ; fi
+if [[ -z "$group_with_uid0" ]] ; then group_with_uid0=root ; fi
 AC_DEFINE_UNQUOTED([UID_0_USER],["$user_with_uid0"],[Get the user name having userid 0])
 AC_DEFINE_UNQUOTED([GID_0_GROUP],["$group_with_gid0"],[Get the group name having groupid 0])
 


### PR DESCRIPTION
If /etc/passwd or /etc/group was not available during building rpm itself
these ended up empty. This affects builds done later on using rpmbuild.

Resolves: #1838