### PR TITLE
Skip recorded symlinks in --setperms (RhBug:1900662)

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -44,6 +44,7 @@ rpm	alias --scripts --qf '\
 	--POPTdesc=$"list install/erase scriptlets from package(s)"
 
 rpm	alias --setperms -q --qf '[\[ -L %{FILENAMES:shescape} \] || \
+        \[ -n %{FILELINKTOS:shescape} \] || \
         ( \[ $((%{FILEFLAGS} & 2#1001000)) != 0 \] && \[ ! -e %{FILENAMES:shescape} \] ) || \
         chmod %7{FILEMODES:octal} %{FILENAMES:shescape}\n]' \
 		   --pipe "grep -v \(none\) | grep '^. -L ' | sed 's/chmod .../chmod /' | sh" \


### PR DESCRIPTION
Since we record the symlink permission bits (777) in the database and
chmod(1) affects the pointed-to file (not the symlink itself), applying
these bits to anything on the file system would either be pointless (a
symlink) or an error (a ghost file present as a regular file but
recorded as a symlink in the database).

The former is already handled with the -L test, this commit handles the
latter.