### PR TITLE
Add rpmlua wrapper command for running our Lua interpreter standalone

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,11 @@ rpm2archive_SOURCES =	rpm2archive.c debug.h system.h
 rpm2archive_LDADD =	lib/librpm.la rpmio/librpmio.la
 rpm2archive_LDADD +=	@WITH_POPT_LIB@ @WITH_ARCHIVE_LIB@
 
+bin_PROGRAMS +=		rpmlua
+rpmspec_CPPFLAGS =	$(AM_CPPFLAGS)
+rpmlua_SOURCES =	tools/rpmlua.c debug.h system.h
+rpmlua_LDADD =		lib/librpm.la rpmio/librpmio.la
+rpmlua_LDADD +=		@WITH_POPT_LIB@
 
 if LIBELF
 rpmlibexec_PROGRAMS +=	elfdeps

--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -9,10 +9,11 @@ EXTRA_DIST += gendiff.1.md
 
 man_man8dir = $(mandir)/man8
 man_man8_DATA = rpm.8 rpm-misc.8 rpmbuild.8 rpmdeps.8 rpmgraph.8 rpm2cpio.8
-man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8
+man_man8_DATA += rpmdb.8 rpmkeys.8 rpmsign.8 rpmspec.8 rpmlua.8
 
 EXTRA_DIST += rpm.8.md rpm-misc.8.md rpmbuild.8.md rpmdeps.8.md rpmgraph.8.md
 EXTRA_DIST += rpm2cpio.8.md rpmdb.8.md rpmkeys.8.md rpmsign.8.md rpmspec.8.md
+EXTRA_DIST += rpmlua.8.md
 
 # Package generated man pages
 EXTRA_DIST += $(man_man1_DATA)

--- a/docs/man/rpmlua.8.md
+++ b/docs/man/rpmlua.8.md
@@ -1,0 +1,70 @@
+---
+date: 17 December 2021
+section: 8
+title: RPMLUA
+---
+
+NAME
+====
+
+rpmlua - RPM Lua interpreter
+
+SYNOPSIS
+========
+
+**rpmlua** {**-i\|\--interactive**} \[*SCRIPT_FILE* \[arg1 ...\]\]
+**rpmlua** \[**--opts=OPTSTRING**\] *SCRIPT_FILE* \[arg1 ...\]
+**rpmlua** {**-e\|\--execute**} "**STATEMENT**" \[arg1 ...\]
+
+DESCRIPTION
+===========
+
+Run RPM internal Lua interpreter.
+
+**-i\|\--interactive**
+
+: Run an interactive session after executing optional script or statement.
+
+**--opts=OPTSTRING**
+
+: Perform getopt(3) option processing on the passed arguments according
+  to OPTSTRING.
+
+**-e\|\--execute**
+
+: Execute a Lua statement.
+
+EXAMPLES
+========
+
+Execute test.lua script file:
+
+> rpmlua test.lua
+
+Execute args.lua script file with option processing:
+
+> rpmlua --opts=ab:c args.lua -- 1 2 3 -c -b5
+
+Execute single statement to compare rpm versions:
+
+> rpmlua -e "print(rpm.ver('1.0') < rpm.ver('2.0'))"
+
+Run an interactive session:
+
+> rpmlua -i
+
+SEE ALSO
+========
+
+    lua(1)
+    popt(3),
+    getopt(3),
+    rpm(8),
+
+
+**http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
+
+AUTHORS
+=======
+
+    Panu Matilainen <pmatilai@redhat.com>

--- a/docs/manual/lua.md
+++ b/docs/manual/lua.md
@@ -6,6 +6,9 @@ title: rpm.org - Embedded Lua interpreter
 
 A fairly unknown feature of RPM is that it comes with an embedded Lua interpreter. This page attempts to document the possibilities of the embedded Lua. Note that Lua-support is a compile-time option, the following assumes that your RPM is was built using --with-lua option.
 
+For testing and debugging you can run the RPM Lua interpreter in standalone
+mode with the rpmlua(8) command.
+
 ## Lua scriptlets
 
 The internal Lua can be used as the interpreter of rpm any scriptlets (%pre, %post etc):

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -98,3 +98,4 @@ sign/rpmgensig.c
 sign/rpmsignfiles.c
 tools/rpmdeps.c
 tools/rpmgraph.c
+tools/rpmlua.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -115,6 +115,7 @@ EXTRA_DIST += data/keys/CVE-2021-3521-nosubsig.asc
 EXTRA_DIST += data/keys/CVE-2021-3521-nosubsig-last.asc
 EXTRA_DIST += data/macros.testfile
 EXTRA_DIST += data/macros.debug
+EXTRA_DIST += data/t1.lua
 EXTRA_DIST += data/SOURCES/foo.c
 EXTRA_DIST += data/SOURCES/bar.c
 EXTRA_DIST += data/SOURCES/baz.c

--- a/tests/data/t1.lua
+++ b/tests/data/t1.lua
@@ -1,0 +1,10 @@
+
+print("hello world")
+print("opts:")
+for i,o in pairs(opt) do
+    print(i, o)
+end
+print("args:")
+for i = 1, #arg do
+    print(arg[i])
+end

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1077,3 +1077,39 @@ runroot rpm --eval 1 >/dev/full
 [Error writing to stdout: No space left on device
 ])
 AT_CLEANUP
+
+AT_SETUP([rpmlua])
+AT_KEYWORDS([lua])
+AT_CHECK([
+runroot_other rpmlua /data/t1.lua a b
+],
+[0],
+[hello world
+opts:
+args:
+/data/t1.lua
+a
+b
+],
+[])
+
+AT_CHECK([
+runroot_other rpmlua --opts=ot: /data/t1.lua -- -t1 a
+],
+[0],
+[hello world
+opts:
+t	1
+args:
+a
+],
+[])
+
+AT_CHECK([
+runroot_other rpmlua -e "print(macros.basename('/some/thing'))"
+],
+[0],
+[thing
+],
+[])
+AT_CLEANUP

--- a/tools/rpmlua.c
+++ b/tools/rpmlua.c
@@ -1,0 +1,73 @@
+#include "system.h"
+
+#include <popt.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <rpm/rpmcli.h>
+#include "rpmio/rpmlua.h"
+#include "rpmio/rpmio_internal.h"
+#include "debug.h"
+
+static char *opts = NULL;
+static char *execute = NULL;
+static int interactive = 0;
+
+static struct poptOption optionsTable[] = {
+
+    { "opts", 'o', POPT_ARG_STRING, &opts, 0,
+	N_("getopt string for scripts options"), NULL },
+    { "execute", 'e', POPT_ARG_STRING, &execute, 0,
+	N_("execute statement"), NULL },
+    { "interactive", 'i', POPT_ARG_VAL, &interactive, 1,
+	N_("interactive session"), NULL },
+
+    POPT_AUTOALIAS
+    POPT_AUTOHELP
+    POPT_TABLEEND
+};
+
+int main(int argc, char *argv[])
+{
+    int ec = EXIT_FAILURE;
+    poptContext optCon = NULL;
+    ARGV_t args = NULL;
+    char *buf = NULL;
+    ssize_t blen = 0;
+    const char *script = NULL;
+    const char *name = "<cli>"
+
+    xsetprogname(argv[0]);
+
+    optCon = rpmcliInit(argc, argv, optionsTable);
+
+    if (optCon == NULL) {
+	poptPrintUsage(optCon, stderr, 0);
+	goto exit;
+    }
+
+    args = (ARGV_t)poptGetArgs(optCon);
+    if (execute) {
+	script = execute;
+    } else if (argc >= 1) {
+	if (rpmioSlurp(args[0], (uint8_t **) &buf, &blen)) {
+	    fprintf(stderr, "reading %s failed: %s\n",
+		args[0], strerror(errno));
+	    goto exit;
+	}
+	script = buf;
+	name = args[0];
+    }
+
+    if (script)
+	ec = rpmluaRunScript(NULL, script, name, opts, args);
+
+    if (interactive)
+	rpmluaInteractive(NULL);
+
+exit:
+    free(buf);
+    rpmcliFini(optCon);
+    return ec;
+}


### PR DESCRIPTION
Being able to run stuff easily in rpm context helps developing and debugging
scriptlets and macros too. Supports running one-liner statements from
the cli, regular scripts and an interactive session.

This is placed into a separate executable for, well, separation and
simplicity, but it'll also give us means to link to readline without
dragging that to main rpm dependencies (but that's left for later).