### PR TITLE
Fix possible NULL pointer dereference in rpmfcClassify

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1168,7 +1168,7 @@ rpmRC rpmfcClassify(rpmfc fc, ARGV_t argv, rpm_mode_t * fmode)
 
     if (fc == NULL) {
 	rpmlog(RPMLOG_ERR, _("Empty file classifier\n"));
-	goto exit;
+	return RPMRC_FAIL;
     }
 
     /* It is OK when we have no files to classify. */


### PR DESCRIPTION
Here is simplified overview of possible dereference:

```cpp
    if (fc == NULL) {
        rpmlog(RPMLOG_ERR, _("Empty file classifier\n"));
        goto exit;
    }

    // ...

exit:
    rpmstrPoolFreeze(fc->cdict, 0);
                     ~~~~~~~~~
```

This issue was found by Svace Static Analyzer.