### PR TITLE
Fix Relocatable Packages manual page formatting

### DIFF
--- a/docs/manual/relocatable.md
+++ b/docs/manual/relocatable.md
@@ -24,7 +24,7 @@ All you need to do to build a relocatable package is put one or more:
   Prefix: <dir>
 ```
 
-in your spec file.  The "<dir>" will usually be something like "/usr",
+in your spec file.  The "\<dir\>" will usually be something like "/usr",
 "/usr/local", or "/opt".  Every file in your %files list must start
 with that prefix.  For example, if you have "Prefix: /usr" and your
 %files list contains "/etc/foo.conf", the build will fail. The fix for
@@ -43,7 +43,7 @@ relocated separately when this package is installed.
 
 By default, RPM will install a relocatable package in the prefix
 directory listed in the spec file.  You can override this on the
-RPM install command line with "--prefix <dir>".  For example, if
+RPM install command line with "--prefix \<dir\>".  For example, if
 the package in question were going to be installed in "/opt" but
 you don't have enough disk space there (and it is a relocatable
 package), you could install it "--prefix /usr/opt".
@@ -56,4 +56,4 @@ separately by using syntax like:
 ```
 
 If any of the Prefixes is not being relocated they can be skipped on
-the command line
+the command line.


### PR DESCRIPTION
Manual page Relocatable Packges was corrupted
due to use of unescaped angle brackets `<` and `>`.
Parser attempts to interpret these as a html tag.
Fixed by escaping the brackets with `\`.