### PR TITLE
Fix memory leak in pgpPrtParams()

### DIFF
--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -1147,12 +1147,11 @@ int pgpPrtParams(const uint8_t * pkts, size_t pktlen, unsigned int pkttype,
 
 	if (selfsig) {
 	    /* subkeys must be followed by binding signature */
-	    if (prevtag == PGPTAG_PUBLIC_SUBKEY) {
-		if (selfsig->sigtype != PGPSIGTYPE_SUBKEY_BINDING)
-		    break;
-	    }
+	    int xx = 1; /* assume failure */
 
-	    int xx = pgpVerifySelf(digp, selfsig, all, i);
+	    if (!(prevtag == PGPTAG_PUBLIC_SUBKEY &&
+		  selfsig->sigtype != PGPSIGTYPE_SUBKEY_BINDING))
+		xx = pgpVerifySelf(digp, selfsig, all, i);
 
 	    selfsig = pgpDigParamsFree(selfsig);
 	    if (xx)


### PR DESCRIPTION
Make sure selfsig is freed in case we break out of the loop in this
block.

Note that the tests added with the binding validation commit bd36c5d do
not cover this code path so valgrind won't show this.