### PR TITLE
Fix use-after-free in haveSignature()

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -364,7 +364,7 @@ static int haveSignature(rpmtd sigtd, Header h)
 	pgpPrtParams(oldtd.data, oldtd.count, PGPTAG_SIGNATURE, &sig2);
 	if (pgpDigParamsCmp(sig1, sig2) == 0)
 	    rc = 1;
-	pgpDigParamsFree(sig2);
+	sig2 = pgpDigParamsFree(sig2);
     }
     pgpDigParamsFree(sig1);
     rpmtdFreeData(&oldtd);


### PR DESCRIPTION
pgpPrtParams() may leave sig2 unchanged and if we're not in the very
first iteration of the while() loop, we could pass a freed pointer to
pgpDigParamsCmp().  Fix by setting it to NULL after freeing.