### PR TITLE
Fix minimize_writes not minimizing writes since 4.15 regression

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -945,7 +945,12 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 	    }
 	    /* Assume file does't exist when tmp suffix is in use */
 	    if (!fp->suffix) {
-		rc = fsmVerify(fp->fpath, fi);
+		if (fp->action == FA_TOUCH) {
+		    struct stat sb;
+		    rc = fsmStat(fp->fpath, 1, &sb);
+		} else {
+		    rc = fsmVerify(fp->fpath, fi);
+		}
 	    } else {
 		rc = RPMERR_ENOENT;
 	    }


### PR DESCRIPTION
Commit 13f70e3710b2df49a923cc6450ff4a8f86e65666 caused minimize_writes
to actually not minimize anything since fsmVerify() only "verifies"
the thing does NOT exist anymore when it exist. Sigh.

FA_TOUCH needs different kind of verification, stat the file instead
to see if it needs creating afterall. This is all soooo broken...

Fixes: #1881