### PR TITLE
Close file before replacing signed

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -695,6 +695,10 @@ static int rpmSign(const char *rpm, int deleting, int flags)
 	if (copyFile(&fd, rpm, &ofd, trpm) == 0) {
 	    struct stat st;
 
+	    /* File must be closed before deletion due to different file locking in some file systems*/
+	    if (fd) (void) closeFile(&fd);
+	    if (ofd) (void) closeFile(&ofd);
+
 	    /* Move final target into place, restore file permissions. */
 	    if (stat(rpm, &st) == 0 && unlink(rpm) == 0 &&
 			rename(trpm, rpm) == 0 && chmod(rpm, st.st_mode) == 0) {


### PR DESCRIPTION
While signing an rpm package the file descriptor is not closed before replacing the signature.

For example, this could be a problem if the rpm --addsign is called in a virtual machine on Windows with a NTFS shared folder:
```
rpmsign --addsign --signfiles ... "untitled-0.1-1.i486.rpm"
untitled-0.1-1.i486.rpm:
error: replacing untitled-0.1-1.i486.rpm failed: Text file busy
```