### PR TITLE
treat 0 as valid file descriptor

### DIFF
--- a/lib/backend/ndb/rpmpkg.c
+++ b/lib/backend/ndb/rpmpkg.c
@@ -734,7 +734,7 @@ static int rpmpkgAddSlotPage(rpmpkgdb pkgdb)
 
 static int rpmpkgGetLock(rpmpkgdb pkgdb, int type)
 {
-    if (!pkgdb->fd)
+    if (pkgdb->fd < 0)
 	return RPMRC_FAIL;
     if (flock(pkgdb->fd, type))
 	return RPMRC_FAIL;


### PR DESCRIPTION
The descriptor is openned in rpmpkgOpen, and we treat 0 as valid file descriptor.
Here we should do the same or fail earlier.