### PR TITLE
Fix failing 'rpm -q' tests on non-i386-derived arches

### DIFF
--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -209,6 +209,7 @@ AT_CHECK([
 RPMDB_INIT
 runroot rpm \
   --nodeps \
+  --ignorearch \
   -i /data/RPMS/hello-1.0-1.i386.rpm
 runroot rpm \
   -qf /usr/local/bin/hello
@@ -226,6 +227,7 @@ RPMDB_INIT
 runroot rpm \
   --nodeps \
   --excludedocs \
+  --ignorearch \
   -i /data/RPMS/hello-1.0-1.i386.rpm
 runroot rpm \
   -qf /usr/share/doc/hello-1.0/FAQ
@@ -243,6 +245,7 @@ RPMDB_INIT
 runroot rpm \
   --nodeps \
   --excludedocs \
+  --ignorearch \
   -i /data/RPMS/hello-1.0-1.i386.rpm
 runroot rpm \
   -q --path /usr/share/doc/hello-1.0/FAQ


### PR DESCRIPTION
These three changed tests were failing, on at least aarch64, due to
architectural incompatibility errors on installing the
`hello-1.0-1.i386.rpm`, though the tests themselves aren't concerned
with executing the binaries, just querying the installed files. Thus, we
can just install them with `--ignorearch`.

## Testing

On a Fedora 35 EC2 `m6g.8xl` host:

```
$ uname -a
Linux ip-172-31-51-16.us-west-2.compute.internal 5.15.11-200.fc35.aarch64 #1 SMP Wed Dec 22 15:23:21 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
```

On `master`:

```
$ podman build -t rpm -f ci/Dockerfile .
$ podman run --rm rpm
...
## ------------- ##
## Test results. ##
## ------------- ##

ERROR: All 490 tests were run,
6 failed (3 expected failures).

## ------------------------ ##
## Summary of the failures. ##
## ------------------------ ##
Failed tests:
rpm 4.17.90 test suite test groups:

 NUM: FILE-NAME:LINE     TEST-GROUP-NAME
      KEYWORDS

 206: rpmquery.at:206    rpm -qf
      query
 207: rpmquery.at:222    rpm -qf on non-installed file
      query
 208: rpmquery.at:239    rpm -q --path on non-installed file
      query
...
--- /dev/null   2021-12-31 01:47:36.779999989 +0000
+++ /srv/rpm/rpm-4.17.90/_build/sub/tests/rpmtests.dir/at-groups/206/stderr     2022-01-20 23:01:35.872887882 +0000
@@ -0,0 +1,2 @@
+       package hello-1.0-1.i386 is intended for a different architecture
+error: file /usr/local/bin/hello: No such file or directory
--- -   2022-01-20 23:01:35.888910204 +0000
+++ /srv/rpm/rpm-4.17.90/_build/sub/tests/rpmtests.dir/at-groups/206/stdout     2022-01-20 23:01:35.872887882 +0000
...
```

On `pr-ignorearch-rpm-q-tests`:

```
$ podman build -t rpm -f ci/Dockerfile .
$ podman run --rm rpm
...
## ------------- ##
## Test results. ##
## ------------- ##

All 490 tests behaved as expected.
...
=============================================
rpm-4.17.90 archives ready for distribution:
rpm-4.17.90.tar.gz
rpm-4.17.90.tar.bz2
=============================================
```

This is my first PR to `rpm-software-management`; sorry if I've missed something. Happy to fix if so.