### PR TITLE
Reimplement --restore as a transaction element, obsolete --setperms & co

### DIFF
--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -45,13 +45,7 @@ MISCELLANEOUS:
 
 **rpm** **\--showrc**
 
-**rpm** **\--setperms** *PACKAGE\_NAME \...*
-
-**rpm** **\--setugids** *PACKAGE\_NAME \...*
-
-**rpm** **\--setcaps** *PACKAGE\_NAME \...*
-
-**rpm** **\--restore** *PACKAGE\_NAME \...*
+**rpm** **\--restore** \[**select-options**\]
 
 select-options
 --------------
@@ -970,30 +964,14 @@ MISCELLANEOUS COMMANDS
 :   shows the values **rpm** will use for all of the options are
     currently set in *rpmrc* and *macros* configuration file(s).
 
-**rpm** **\--setperms** *PACKAGE\_NAME*
+**rpm** **\--setperms** | **\--setugids** | **\--setcaps** *PACKAGE\_NAME*
 
-:   sets permissions of files in the given package. Consider using
-    **\--restore** instead.
+:   obsolete aliases for **\--restore**
 
-**rpm** **\--setugids** *PACKAGE\_NAME*
+**rpm** **\--restore** \[**select-options**\]
 
-:   sets user/group ownership of files in the given package. This
-    command can change permissions and capabilities of files in that
-    package. In most cases it is better to use **\--restore** instead.
-
-**rpm** **\--setcaps** *PACKAGE\_NAME*
-
-:   sets capabilities of files in the given package. Consider using
-    **\--restore** instead.
-
-**rpm** **\--restore** *PACKAGE\_NAME*
-
-:   The option restores owner, group, permissions and capabilities of
-    files in the given package.
-
-Options **\--setperms**, **\--setugids**, **\--setcaps** and
-
-:   **\--restore** are mutually exclusive.
+:   The option restores file metadata such as timestamp, owner, group,
+    permissions and capabilities of files in packages.
 
 FTP/HTTP OPTIONS
 ----------------

--- a/lib/depends.c
+++ b/lib/depends.c
@@ -488,6 +488,22 @@ int rpmtsAddReinstallElement(rpmts ts, Header h, fnpyKey key)
     return addPackage(ts, h, key, RPMTE_REINSTALL, NULL);
 }
 
+int rpmtsAddRestoreElement(rpmts ts, Header h)
+{
+    tsMembers tsmem = rpmtsMembers(ts);
+    if (rpmtsSetupTransactionPlugins(ts) == RPMRC_FAIL)
+	return 1;
+
+    rpmte p = rpmteNew(ts, h, TR_RESTORED, NULL, NULL, 0);
+    if (p == NULL)
+	return 1;
+
+    addElement(tsmem, p, tsmem->orderCount);
+    rpmtsNotifyChange(ts, RPMTS_EVENT_ADD, p, NULL);
+
+    return 0;
+}
+
 int rpmtsAddEraseElement(rpmts ts, Header h, int dboffset)
 {
     if (rpmtsSetupTransactionPlugins(ts) == RPMRC_FAIL)

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -924,7 +924,10 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
     if (rc)
 	goto exit;
 
-    fi = rpmfiNewArchiveReader(payload, files, RPMFI_ITER_READ_ARCHIVE);
+    if (rpmteType(te) == TR_ADDED)
+	fi = rpmfiNewArchiveReader(payload, files, RPMFI_ITER_READ_ARCHIVE);
+    else
+	fi = rpmfilesIter(files, RPMFI_ITER_FWD);
     if (fi == NULL) {
         rc = RPMERR_BAD_MAGIC;
         goto exit;

--- a/lib/order.c
+++ b/lib/order.c
@@ -613,6 +613,14 @@ int rpmtsOrder(rpmts ts)
 
     rpmlog(RPMLOG_DEBUG, "========== tsorting packages (order, #predecessors, #succesors, depth)\n");
 
+    /* Restored items first (doesn't matter but is simple) */
+    for (int e = 0; e < nelem; e++) {
+	tsortInfo p = &sortInfo[e];
+	if (rpmteType(p->te) == TR_RESTORED) {
+	    newOrder[newOrderCount++] = p->te;
+	}
+    }
+
     for (int i = 0; i < 2; i++) {
 	/* Do two separate runs: installs first - then erases */
 	int oType = !i ? TR_ADDED : TR_REMOVED;

--- a/lib/poptI.c
+++ b/lib/poptI.c
@@ -269,6 +269,10 @@ struct poptOption rpmInstallPoptTable[] = {
 	&rpmIArgs.installInterfaceFlags, (INSTALL_REINSTALL|INSTALL_INSTALL),
 	N_("reinstall package(s)"),
 	N_("<packagefile>+") },
+ { "restore", '\0', POPT_BIT_SET,
+	&rpmIArgs.installInterfaceFlags, (INSTALL_RESTORE),
+	N_("restore package(s)"),
+	N_("<packagefile>+") },
 
    POPT_TABLEEND
 };

--- a/lib/rpmcli.h
+++ b/lib/rpmcli.h
@@ -305,6 +305,7 @@ enum rpmInstallFlags_e {
     INSTALL_ERASE	= (1 << 8),	/*!< from --erase */
     INSTALL_ALLMATCHES	= (1 << 9),	/*!< from --allmatches */
     INSTALL_REINSTALL	= (1 << 10),	/*!< from --reinstall */
+    INSTALL_RESTORE	= (1 << 11),	/*!< from --restore */
 };
 
 typedef rpmFlags rpmInstallFlags;
@@ -384,6 +385,15 @@ int rpmInstall(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_t fileArgv);
  */
 
 int rpmErase(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_const_t argv);
+
+/** \ingroup rpmcli
+ * Restore file metadata (perms etc) of installed package(s).
+ * @param ts		transaction set
+ * @param ia		control args/bits
+ * @param argv		array of package names (NULL terminated)
+ * @return		0 on success
+ */
+int rpmRestore(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_const_t argv);
 
 /** \ingroup rpmcli
  */

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -252,10 +252,10 @@ struct rpmEIU {
     rpmRC rpmrc;
 };
 
-static int rpmcliTransaction(rpmts ts, struct rpmInstallArguments_s * ia,
-		      int numPackages)
+static int rpmcliTransaction(rpmts ts, struct rpmInstallArguments_s * ia)
 {
     rpmps ps;
+    int numPackages = rpmtsNElements(ts);
 
     int rc = 0;
     int stop = 0;
@@ -632,7 +632,7 @@ restart:
     if (eiu->numFailed) goto exit;
 
     if (eiu->numRPMS) {
-        int rc = rpmcliTransaction(ts, ia, eiu->numPkgs);
+        int rc = rpmcliTransaction(ts, ia);
         if (rc < 0)
             eiu->numFailed += eiu->numRPMS;
 	else if (rc > 0)
@@ -730,7 +730,7 @@ int rpmErase(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_const_t argv)
     free(qfmt);
 
     if (numFailed) goto exit;
-    numFailed = rpmcliTransaction(ts, ia, numPackages);
+    numFailed = rpmcliTransaction(ts, ia);
 exit:
     rpmtsEmpty(ts);
     rpmtsSetVSFlags(ts, ovsflags);

--- a/lib/rpmte.h
+++ b/lib/rpmte.h
@@ -20,6 +20,7 @@ typedef enum rpmElementType_e {
     TR_ADDED		= (1 << 0),	/*!< Package will be installed. */
     TR_REMOVED		= (1 << 1),	/*!< Package will be removed. */
     TR_RPMDB		= (1 << 2),	/*!< Package from the rpmdb. */
+    TR_RESTORED		= (1 << 3),	/*!< Package will be restored. */
 } rpmElementType;
 
 typedef rpmFlags rpmElementTypes;

--- a/lib/rpmte_internal.h
+++ b/lib/rpmte_internal.h
@@ -10,6 +10,7 @@ typedef enum pkgGoal_e {
     /* permit using rpmteType() for install + erase goals */
     PKG_INSTALL		= TR_ADDED,
     PKG_ERASE		= TR_REMOVED,
+    PKG_RESTORE		= TR_RESTORED,
     /* permit using scriptname for these for now... */
     PKG_VERIFY		= RPMTAG_VERIFYSCRIPT,
     PKG_PRETRANS	= RPMTAG_PRETRANS,
@@ -27,6 +28,7 @@ enum addOp_e {
   RPMTE_INSTALL       = 0,
   RPMTE_UPGRADE       = 1,
   RPMTE_REINSTALL     = 2,
+  RPMTE_RESTORE       = 3,
 };
 
 #ifdef __cplusplus

--- a/lib/rpmts.h
+++ b/lib/rpmts.h
@@ -669,6 +669,14 @@ int rpmtsAddInstallElement(rpmts ts, Header h,
 int rpmtsAddReinstallElement(rpmts ts, Header h, const fnpyKey key);
 
 /** \ingroup rpmts
+ * Add package to be restored to transaction set.
+ * @param ts		transaction set
+ * @param h		header
+ * @return		0 on success, 1 on error (not installed)
+ */
+int rpmtsAddRestoreElement(rpmts ts, Header h);
+
+/** \ingroup rpmts
  * Add package to be erased to transaction set.
  * @param ts		transaction set
  * @param h		header

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -703,6 +703,15 @@ assert(otherFi != NULL);
 	    /* Otherwise, we can just erase. */
 	    rpmfsSetAction(fs, i, FA_ERASE);
 	    break;
+	case TR_RESTORED:
+	    if (XFA_SKIPPING(rpmfsGetAction(fs, i)))
+		break;
+	    if (rpmfilesFState(fi, i) != RPMFILE_STATE_NORMAL) {
+		rpmfsSetAction(fs, i, FA_SKIP);
+		break;
+	    }
+	    rpmfsSetAction(fs, i, FA_TOUCH);
+	    break;
 	default:
 	    break;
 	}

--- a/python/rpm/transaction.py
+++ b/python/rpm/transaction.py
@@ -112,6 +112,13 @@ class TransactionSet(TransactionSetCore):
             if not TransactionSetCore.addErase(self, h):
                 raise rpm.error("adding erasure to transaction failed")
 
+    def addRestore(self, item):
+        hdrs = self._i2hdrs(item)
+
+        for h in hdrs:
+            if not TransactionSetCore.addErase(self, h):
+                raise rpm.error("adding restore to transaction failed")
+
     def run(self, callback, data):
         rc = TransactionSetCore.run(self, callback, data, self._probFilter)
 

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -230,6 +230,17 @@ rpmts_AddErase(rpmtsObject * s, PyObject * args)
     return PyBool_FromLong(rpmtsAddEraseElement(s->ts, h, -1) == 0);
 }
 
+static PyObject *
+rpmts_AddRestore(rpmtsObject * s, PyObject * args)
+{
+    Header h;
+
+    if (!PyArg_ParseTuple(args, "O&:AddRestore", hdrFromPyObject, &h))
+        return NULL;
+
+    return PyBool_FromLong(rpmtsAddRestoreElement(s->ts, h) == 0);
+}
+
 static int
 rpmts_SolveCallback(rpmts ts, rpmds ds, const void * data)
 {
@@ -740,6 +751,8 @@ static struct PyMethodDef rpmts_methods[] = {
   "  mode : optional argument that specifies if this package should be\n\t\tinstalled ('i'), upgraded ('u')"},
  {"addReinstall",	(PyCFunction) rpmts_AddReinstall,	METH_VARARGS,
   "ts.addReinstall(hdr, data) -- Adds transaction elements\nrepresenting a reinstall of an already installed package.\n\nSee addInstall for details."},
+ {"addRestore",	(PyCFunction) rpmts_AddRestore,			METH_VARARGS,
+  "ts.addRestore(hdr) -- Adds transaction elements\nrepresenting a restore of an already installed package."},
  {"addErase",	(PyCFunction) rpmts_AddErase,	METH_VARARGS|METH_KEYWORDS,
   "addErase(name) -- Add a transaction element representing an erase\nof an installed package.\n\n"
   "  name: the package name to be erased"},

--- a/rpm.c
+++ b/rpm.c
@@ -19,6 +19,7 @@ enum modes {
 
     MODE_INSTALL	= (1 <<  1),
     MODE_ERASE		= (1 <<  2),
+    MODE_RESTORE	= (1 <<  4),
 #define	MODES_IE (MODE_INSTALL | MODE_ERASE)
 
     MODE_UNKNOWN	= 0
@@ -114,13 +115,16 @@ int main(int argc, char *argv[])
 			(INSTALL_UPGRADE|INSTALL_FRESHEN|
 			 INSTALL_INSTALL|INSTALL_REINSTALL));
 	int eflags = (ia->installInterfaceFlags & INSTALL_ERASE);
+	int rflags = (ia->installInterfaceFlags & INSTALL_RESTORE);
 
-	if (iflags & eflags)
+	if (iflags & eflags & rflags)
 	    argerror(_("only one major mode may be specified"));
 	else if (iflags)
 	    bigMode = MODE_INSTALL;
 	else if (eflags)
 	    bigMode = MODE_ERASE;
+	else if (rflags)
+	    bigMode = MODE_RESTORE;
     }
 
     if (!( bigMode == MODE_INSTALL ) &&
@@ -265,6 +269,10 @@ int main(int argc, char *argv[])
 	    /* FIX: ia->relocations[0].newPath undefined */
 	    ec += rpmInstall(ts, ia, (ARGV_t) poptGetArgs(optCon));
 	}
+	break;
+
+    case MODE_RESTORE:
+	ec += rpmRestore(ts, ia, (ARGV_const_t) poptGetArgs(optCon));
 	break;
 
     case MODE_QUERY:

--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -43,36 +43,10 @@ rpm	alias --scripts --qf '\
 ' \
 	--POPTdesc=$"list install/erase scriptlets from package(s)"
 
-rpm	alias --setperms -q --qf '[\[ -L %{FILENAMES:shescape} \] || \
-        \[ -n %{FILELINKTOS:shescape} \] || \
-        ( \[ $((%{FILEFLAGS} & 2#1001000)) != 0 \] && \[ ! -e %{FILENAMES:shescape} \] ) || \
-        chmod %7{FILEMODES:octal} %{FILENAMES:shescape}\n]' \
-		   --pipe "grep -v \(none\) | grep '^. -L ' | sed 's/chmod .../chmod /' | sh" \
-	--POPTdesc=$"set permissions of files in a package"
-
-rpm	alias --setugids -q --qf \
-	'[ch %{FILEUSERNAME:shescape} %{FILEGROUPNAME:shescape} %{FILENAMES:shescape} %{FILEFLAGS}\n]' \
-	--pipe "(echo 'ch() { ( \[ $(($4 & 2#1001000)) != 0 \] && \[ ! -e \"$3\" \] ) || \
-		(chown -h -- \"$1\" \"$3\";chgrp -h -- \"$2\" \"$3\";) }'; \
-		grep '^ch '|grep -v \(none\))|sh" \
-	--POPTdesc=$"set user/group ownership of files in a package"
-
-rpm	alias --setcaps -q --qf \
-        "[if \[ -f %{FILENAMES:shescape} -a ! -L %{FILENAMES:shescape} \]; then\n\
-%|FILECAPS?{  if \[ -n %{FILECAPS:shescape} \]; then\n\
-    setcap %{FILECAPS:shescape} %{FILENAMES:shescape}\n\
-  el}:{  }|if \[ -n \"\$(getcap %{FILENAMES:shescape})\" \]; then\n\
-    setcap -r %{FILENAMES:shescape}\n\
-  fi\n\
-fi\n]" \
-	--pipe "sh" \
-	--POPTdesc=$"set capabilities of files in a package"
-
-rpm	alias --restore -q --qf \
-	'[  rpm --setugids %{NAME:shescape}; \
-	    rpm --setperms %{NAME:shescape}; \
-	    rpm --setcaps  %{NAME:shescape}; \n]' --pipe "sh" \
-	--POPTdesc=$"restore file/directory permissions"
+# obsolete
+rpm	alias --setperms --restore
+rpm	alias --setugids --restore
+rpm	alias --setcaps --restore
 
 rpm	alias --conflicts	--qf \
   "[%|VERBOSE?{%{CONFLICTFLAGS:deptype}: }:{}|%{CONFLICTNEVRS}\n]" \

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -286,6 +286,28 @@ package not installed
 addErase mi]
 )
 
+RPMPY_TEST([add restore to transaction],[
+ts = rpm.ts()
+for i in ['foo', 1234]:
+    myprint('addRestore %s' % i)
+    try:
+        ts.addRestore(i)
+    except rpm.error as err:
+        myprint(err)
+myprint('addRestore mi')
+mi = ts.dbMatch('name', 'foo')
+try:
+    ts.addRestore(mi)
+except rpm.error as err:
+    myprint(err)
+],
+[addRestore foo
+package not installed
+addRestore 1234
+package not installed
+addRestore mi]
+)
+
 RPMPY_TEST([add bogus package to transaction 1],[
 ts = rpm.ts()
 h = rpm.hdr()

--- a/tests/rpmverify.at
+++ b/tests/rpmverify.at
@@ -611,3 +611,23 @@ runroot rpm -Va --nouser --nogroup --nodeps | grep "/bin/hello"
 [],
 [])
 AT_CLEANUP
+
+AT_SETUP([rpm --restore])
+AT_KEYWORDS([verify restore])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -U --nodeps --noscripts --ignorearch --ignoreos \
+	/data/RPMS/hello-1.0-1.i386.rpm
+runroot_other touch /usr/share/doc/hello-1.0/FAQ
+runroot_other chmod a-x /usr/local/bin/hello
+runroot rpm -Va --nodeps --nouser --nogroup
+runroot rpm --restore hello
+runroot rpm -Va --nodeps --nouser --nogroup
+],
+[0],
+[.M.......    /usr/local/bin/hello
+.......T.  d /usr/share/doc/hello-1.0/FAQ
+],
+[])
+AT_CLEANUP


### PR DESCRIPTION
--setperms, --setugids and --setcaps were fun demos of alias capabilities
in the nineties, but they can be downright dangerous when used
separately, are blisfully unaware of all state in rpm yet try to
duplicate functionality existing in C, and thus are a constant source
of bugs that are between hard to impossible to fix in the alias space.

Add a new transaction element type for the restore operation, wire
through all the necessary places. In places (like ordering) this is
an overkill but otherwise it seems like a natural thing to be able
to process restore alongside package install/remove. The restore
operation is a cross between install and erase codepath-wise so touches
some funny places, but FA_TOUCH does just the thing, and now all the
regular disablers like --nocontext and --nocaps can be used if
necessary.

Remove the dangerous shell implementations of things and just make them
aliases to --restore.

Fixes: #965