### PR TITLE
Fix IMA signature lengths assumed constant (again)

### DIFF
--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1524,7 +1524,7 @@ static uint8_t *hex2bin(Header h, rpmTagVal tag, rpm_count_t num, size_t len,
 	/* Figure string sizes + max length for allocation purposes */
 	if (lengths) {
 	    int i = 0;
-	    lens = xmalloc(num * sizeof(*lens));
+	    lens = xcalloc(num, sizeof(*lens));
 
 	    while ((s = rpmtdNextString(&td))) {
 		lens[i] = strlen(s) / 2;
@@ -1542,7 +1542,7 @@ static uint8_t *hex2bin(Header h, rpmTagVal tag, rpm_count_t num, size_t len,
 	    maxl = len;
 	}
 
-	uint8_t *t = bin = xmalloc(num * maxl);
+	uint8_t *t = bin = rmallocarray(num, maxl);
 	int i = 0;
 	while ((s = rpmtdNextString(&td))) {
 	    if (*s == '\0') {

--- a/rpmio/rpmmalloc.c
+++ b/rpmio/rpmmalloc.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "debug.h"
 
@@ -53,6 +54,18 @@ void * rcalloc (size_t nmemb, size_t size)
     if (size == 0) size++;
     if (nmemb == 0) nmemb++;
     value = calloc (nmemb, size);
+    if (value == NULL)
+	value = vmefail(size);
+    return value;
+}
+
+void * rmallocarray (size_t nmemb, size_t size)
+{
+    register void *value = NULL;
+    if (size == 0) size++;
+    if (nmemb == 0) nmemb++;
+    if (nmemb < SIZE_MAX / size)
+	value = malloc (nmemb * size);
     if (value == NULL)
 	value = vmefail(size);
     return value;

--- a/rpmio/rpmutil.h
+++ b/rpmio/rpmutil.h
@@ -124,6 +124,9 @@ void * rmalloc(size_t size);
 RPM_GNUC_MALLOC RPM_GNUC_ALLOC_SIZE2(1,2)
 void * rcalloc(size_t nmemb, size_t size);
 
+RPM_GNUC_MALLOC RPM_GNUC_ALLOC_SIZE2(1,2)
+void * rmallocarray(size_t nmemb, size_t size);
+
 RPM_GNUC_ALLOC_SIZE(2)
 void * rrealloc(void *ptr, size_t size);
 


### PR DESCRIPTION
Commit 31e9daf823f7052135d1decc0802b6fa775a88c5 introduced a nasty
integer overflow, leading to a buffer overflow, if a package has one
large file signature and a bunch of smaller ones.  Since the file
signatures are from the (unsigned) signature header, this would be a
security problem if it made it into a release, but thankfully it has
not.