### PR TITLE
Shell-like escaping support in %files

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -244,7 +244,8 @@ static void FileEntryFree(FileEntry entry)
 static char *strtokWithQuotes(char *s, const char *delim)
 {
     static char *olds = NULL;
-    char *token;
+    char *token, *r;
+    int esc = 0;
 
     if (s == NULL)
 	s = olds;
@@ -263,9 +264,11 @@ static char *strtokWithQuotes(char *s, const char *delim)
     }
 
     /* Find the end of the token.  */
-    token = s;
-    while (!strchr(delim, *s))
-	s++;
+    token = r = s;
+    while (!strchr(delim, *s) || (esc && *s != '\0')) {
+	r = s++;
+	esc = (*r == '\\') && !esc;
+    }
 
     /* Terminate it */
     if (*s == '\0') {
@@ -878,13 +881,22 @@ static VFA_t const virtualAttrs[] = {
  */
 static rpmRC parseForSimple(char * buf, FileEntry cur, ARGV_t * fileNames)
 {
-    char *s, *t;
+    char *s, *t, *end;
+    char *delim = " \t\n";
     rpmRC res = RPMRC_OK;
     int allow_relative = (RPMFILE_PUBKEY|RPMFILE_DOC|RPMFILE_LICENSE);
 
     t = buf;
-    while ((s = strtokWithQuotes(t, " \t\n")) != NULL) {
+    while ((s = strtokWithQuotes(t, delim)) != NULL) {
 	t = NULL;
+	end = s + strlen(s) - 1;
+
+	if (*end == '\n') {
+	    /* Newline escaping is not supported */
+	    rpmlog(RPMLOG_ERR, _("Trailing backslash: %s\n"), s);
+	    res = RPMRC_FAIL;
+	    break;
+	}
 
     	/* Set flags for virtual file attributes */
 	if (vfaMatch(virtualAttrs, s, &(cur->attrFlags)))
@@ -901,6 +913,7 @@ static rpmRC parseForSimple(char * buf, FileEntry cur, ARGV_t * fileNames)
 	    if (cur->attrFlags & (RPMFILE_DOC | RPMFILE_LICENSE))
 		cur->attrFlags |= RPMFILE_SPECIALDIR;
 	}
+	rpmUnescape(s, delim);
 	argvAdd(fileNames, s);
     }
 
@@ -2160,18 +2173,22 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char *fn)
 {
     int quote = 1;	/* XXX permit quoted glob characters. */
     int doGlob;
-    char *fileName = xstrdup(fn);
+    char *fileName = NULL;
     char *diskPath = NULL;
     rpmRC rc = RPMRC_OK;
-    size_t fnlen = strlen(fileName);
-    int trailing_slash = (fnlen > 0 && fileName[fnlen-1] == '/');
+    size_t fnlen = strlen(fn);
+    int trailing_slash = (fnlen > 0 && fn[fnlen-1] == '/');
 
     /* XXX differentiate other directories from explicit %dir */
     if (trailing_slash && !fl->cur.isDir)
 	fl->cur.isDir = -1;
     
-    if ((doGlob = rpmIsGlob(fileName, quote)) == 0)
+    if ((doGlob = rpmIsGlob(fn, quote))) {
+	fileName = rpmEscapeSpaces(fn);
+    } else {
+	fileName = xstrdup(fn);
 	rpmUnescape(fileName, NULL);
+    }
 
     /* Check that file starts with leading "/" */
     if (*fileName != '/') {

--- a/build/files.c
+++ b/build/files.c
@@ -256,20 +256,21 @@ static char *strtokWithQuotes(char *s, const char *delim)
     if (*s == '\0')
 	return NULL;
 
-    /* Find the end of the token.  */
-    token = s;
-    if (*token == '"') {
-	token++;
-	/* Find next " char */
-	s = strchr(token, '"');
-    } else {
-	s = strpbrk(token, delim);
+    /* Leading quote escapes all of delim until next quote */
+    if (*s == '"') {
+	delim = "\"";
+	s++;
     }
 
+    /* Find the end of the token.  */
+    token = s;
+    while (!strchr(delim, *s))
+	s++;
+
     /* Terminate it */
-    if (s == NULL) {
+    if (*s == '\0') {
 	/* This token finishes the string */
-	olds = strchr(token, '\0');
+	olds = s;
     } else {
 	/* Terminate the token and make olds point past it */
 	*s = '\0';

--- a/build/files.c
+++ b/build/files.c
@@ -2199,13 +2199,14 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char *fn)
     
     /* Copy file name or glob pattern removing multiple "/" chars. */
     /*
-     * Note: rpmGetPath should guarantee a "canonical" path. That means
+     * Note: rpmCleanPath should guarantee a "canonical" path. That means
      * that the following pathologies should be weeded out:
      *		//bin//sh
      *		//usr//bin/
      *		/.././../usr/../bin//./sh
      */
-    diskPath = rpmGenPath(fl->buildRoot, NULL, fileName);
+    diskPath = rpmCleanPath(rstrscat(NULL, fl->buildRoot, "/", fileName, NULL));
+
     /* Arrange trailing slash on directories */
     if (fl->cur.isDir)
 	diskPath = rstrcat(&diskPath, "/");
@@ -2436,7 +2437,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     files = sd->files;
     fi = 0;
     while (*files != NULL) {
-	char *origfile = rpmGenPath(basepath, *files, NULL);
+	char *origfile = rpmCleanPath(rstrscat(NULL, basepath, "/", *files, NULL));
 	char *eorigfile = NULL;
 	char *newfile = NULL;
 	ARGV_t globFiles;

--- a/build/files.c
+++ b/build/files.c
@@ -2152,13 +2152,14 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
  * Add a file to a binary package.
  * @param pkg
  * @param fl		package file tree walk data
- * @param fileName	file to add
+ * @param fn		file to add
  * @return		RPMRC_OK on success
  */
-static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName)
+static rpmRC processBinaryFile(Package pkg, FileList fl, const char *fn)
 {
     int quote = 1;	/* XXX permit quoted glob characters. */
     int doGlob;
+    char *fileName = xstrdup(fn);
     char *diskPath = NULL;
     rpmRC rc = RPMRC_OK;
     size_t fnlen = strlen(fileName);
@@ -2168,7 +2169,8 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName)
     if (trailing_slash && !fl->cur.isDir)
 	fl->cur.isDir = -1;
     
-    doGlob = rpmIsGlob(fileName, quote);
+    if ((doGlob = rpmIsGlob(fileName, quote)) == 0)
+	rpmUnescape(fileName, NULL);
 
     /* Check that file starts with leading "/" */
     if (*fileName != '/') {
@@ -2220,6 +2222,7 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName)
     }
 
 exit:
+    free(fileName);
     free(diskPath);
     if (rc) {
 	fl->processingFailed = 1;
@@ -2416,17 +2419,27 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     fi = 0;
     while (*files != NULL) {
 	char *origfile = rpmGenPath(basepath, *files, NULL);
-	char *eorigfile = rpmEscapeSpaces(origfile);
+	char *eorigfile = NULL;
+	char *newfile = NULL;
 	ARGV_t globFiles;
 	int globFilesCount, i;
-	char *newfile;
 
 	FileEntryFree(&fl->cur);
 	FileEntryFree(&fl->def);
 	copyFileEntry(&sd->entries[fi].curEntry, &fl->cur);
 	copyFileEntry(&sd->entries[fi].defEntry, &fl->def);
 	fi++;
+	files++;
 
+	if (!rpmIsGlob(origfile, 1)) {
+	    rasprintf(&newfile, "%s/%s", sd->dirname, basename(origfile));
+	    processBinaryFile(pkg, fl, newfile);
+	    free(newfile);
+	    free(origfile);
+	    continue;
+	}
+
+	eorigfile = rpmEscapeSpaces(origfile);
 	if (rpmGlob(eorigfile, &globFilesCount, &globFiles) == 0) {
 	    for (i = 0; i < globFilesCount; i++) {
 		rasprintf(&newfile, "%s/%s", sd->dirname, basename(globFiles[i]));
@@ -2440,7 +2453,6 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	}
 	free(eorigfile);
 	free(origfile);
-	files++;
     }
     free(basepath);
 

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -132,6 +132,13 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr);
 char * rpmEscapeSpaces(const char * s);
 
 /** \ingroup rpmfileutil
+ * Unescape each char listed in accept by removing a backslash preceding it.
+ * @param s		string
+ * @param accept	chars to escape (NULL for all)
+ */
+void rpmUnescape(char *s, const char *accept);
+
+/** \ingroup rpmfileutil
  * Return type of compression used in file.
  * @param file		name of file
  * @param[out] compressed	address of compression type

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -131,6 +131,8 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr);
  */
 char * rpmEscapeSpaces(const char * s);
 
+char * rpmEscape(const char *s, const char *accept);
+
 /** \ingroup rpmfileutil
  * Unescape each char listed in accept by removing a backslash preceding it.
  * @param s		string

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -410,6 +410,22 @@ char * rpmEscapeSpaces(const char * s)
     return t;
 }
 
+void rpmUnescape(char *s, const char *accept)
+{
+    char *p, *q;
+    int esc = 0;
+    p = q = s;
+    while (*q != '\0') {
+	*p = *q++;
+	esc = (*p == '\\') && \
+	      (accept == NULL || ((*q != '\0') && strchr(accept, *q))) && \
+	      !esc;
+	if (!esc)
+	    p++;
+    }
+    *p = '\0';
+}
+
 int rpmFileHasSuffix(const char *path, const char *suffix)
 {
     size_t plen = strlen(path);

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -386,7 +386,7 @@ char * rpmGetPath(const char *path, ...)
     return rpmCleanPath(res);
 }
 
-char * rpmEscapeSpaces(const char * s)
+static char * rpmEscapeChars(const char *s, const char *accept, int (*fn)(int))
 {
     const char * se;
     char * t;
@@ -394,7 +394,7 @@ char * rpmEscapeSpaces(const char * s)
     size_t nb = 0;
 
     for (se = s; *se; se++) {
-	if (isspace(*se))
+	if ((accept && strchr(accept, *se)) || (fn && fn(*se)))
 	    nb++;
 	nb++;
     }
@@ -402,12 +402,22 @@ char * rpmEscapeSpaces(const char * s)
 
     t = te = xmalloc(nb);
     for (se = s; *se; se++) {
-	if (isspace(*se))
+	if ((accept && strchr(accept, *se)) || (fn && fn(*se)))
 	    *te++ = '\\';
 	*te++ = *se;
     }
     *te = '\0';
     return t;
+}
+
+char * rpmEscapeSpaces(const char *s)
+{
+    return rpmEscapeChars(s, NULL, isspace);
+}
+
+char * rpmEscape(const char *s, const char *accept)
+{
+    return rpmEscapeChars(s, accept, NULL);
 }
 
 void rpmUnescape(char *s, const char *accept)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ EXTRA_DIST += data/SPECS/hello2-suid.spec
 EXTRA_DIST += data/SPECS/hello-g3.spec
 EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
+EXTRA_DIST += data/SPECS/globesctest.spec
 EXTRA_DIST += data/SPECS/versiontest.spec
 EXTRA_DIST += data/SPECS/conflicttest.spec
 EXTRA_DIST += data/SPECS/configtest.spec
@@ -192,7 +193,7 @@ populate_testing: $(check_DATA)
 	for d in dev etc magic tmp var; do if [ ! -d testing/$${d} ]; then mkdir testing/$${d}; fi; done
 	for node in urandom stdin stderr stdout null full; do ln -s /dev/$${node} testing/dev/$${node}; done
 	for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do [ -f /etc/$${cf} ] && ln -s /etc/$${cf} testing/etc/$${cf}; done
-	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
+	for prog in gzip cat cp patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 	chmod -R u-w testing/

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -16,7 +16,7 @@ BuildArch:	noarch
 
 
 %build
-touch 'foo[bar]' bar baz 'foo bar' 'foo b' 'foo a' 'foo r'
+touch 'foo[bar]' bar baz 'foo bar' 'foo b' 'foo a' 'foo r' foo%%name
 
 %install
 mkdir -p %{buildroot}/opt
@@ -39,6 +39,9 @@ touch '%{buildroot}/opt/foo" bar"'
 touch '%{buildroot}/opt/foo b'
 touch '%{buildroot}/opt/foo a'
 touch '%{buildroot}/opt/foo r'
+
+# Macro escaping
+touch '%{buildroot}/opt/foo%%name'
 
 # Regression checks
 touch '%{buildroot}/opt/foo-bar1'
@@ -76,6 +79,10 @@ touch '%{buildroot}/opt/foobawb'
 /opt/foo\ bar
 /opt/foo"\ bar"
 /opt/foo\ [bar]
+
+# Macro escaping
+%doc foo%%name
+/opt/foo%%name
 
 # Regression checks
 %doc ba* "foo bar"

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -23,7 +23,6 @@ mkdir -p %{buildroot}/opt
 
 # Glob escaping
 touch '%{buildroot}/opt/foo[bar]'
-touch '%{buildroot}/opt/foo[bar baz]'
 touch '%{buildroot}/opt/foo\[bar\]'
 touch '%{buildroot}/opt/foo*'
 touch '%{buildroot}/opt/foo\bar'
@@ -42,6 +41,17 @@ touch '%{buildroot}/opt/foo r'
 
 # Macro escaping
 touch '%{buildroot}/opt/foo%%name'
+
+# Quoting
+touch '%{buildroot}/opt/foo bar.conf'
+touch '%{buildroot}/opt/foo [baz]'
+touch '%{buildroot}/opt/foo[bar baz]'
+touch '%{buildroot}/opt/foo\[baz\]'
+touch "%{buildroot}/opt/foo'bax'"
+touch '%{buildroot}/opt/foo"bay"'
+touch '%{buildroot}/opt/foo\baz'
+touch '%{buildroot}/opt/foo\bay'
+touch '%{buildroot}/opt/foo"baz"'
 
 # Regression checks
 touch '%{buildroot}/opt/foo-bar1'
@@ -64,7 +74,6 @@ touch '%{buildroot}/opt/foobawb'
 # Glob escaping
 %doc foo\[bar\]
 /opt/foo\[bar\]
-"/opt/foo\[bar baz\]"
 /opt/foo\\\[bar\\\]
 /opt/foo\*
 /opt/foo\\bar
@@ -83,6 +92,17 @@ touch '%{buildroot}/opt/foobawb'
 # Macro escaping
 %doc foo%%name
 /opt/foo%%name
+
+# Quoting
+%config "/opt/foo bar.conf"
+"/opt/foo [baz]"
+"/opt/foo[bar baz]"
+"/opt/foo\\[baz\\]"
+"/opt/foo'bax'"
+'/opt/foo"bay"'
+'/opt/foo\\baz'
+"/opt/foo\\bay"
+"/opt/foo\"baz\""
 
 # Regression checks
 %doc ba* "foo bar"

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -16,7 +16,7 @@ BuildArch:	noarch
 
 
 %build
-touch 'foo[bar]' bar baz 'foo bar'
+touch 'foo[bar]' bar baz 'foo bar' 'foo b' 'foo a' 'foo r'
 
 %install
 mkdir -p %{buildroot}/opt
@@ -31,6 +31,14 @@ touch %{buildroot}/opt/foo\\
 touch '%{buildroot}/opt/foo?bar'
 touch '%{buildroot}/opt/foo{bar,baz}'
 touch '%{buildroot}/opt/foo"bar"'
+
+# Space escaping
+touch '%{buildroot}/opt/foo[bax bay]'
+touch '%{buildroot}/opt/foo bar'
+touch '%{buildroot}/opt/foo" bar"'
+touch '%{buildroot}/opt/foo b'
+touch '%{buildroot}/opt/foo a'
+touch '%{buildroot}/opt/foo r'
 
 # Regression checks
 touch '%{buildroot}/opt/foo-bar1'
@@ -61,6 +69,13 @@ touch '%{buildroot}/opt/foobawb'
 /opt/foo\?bar
 /opt/foo\{bar,baz\}
 /opt/foo\"bar\"
+
+# Space escaping
+%doc foo\ [bar]
+/opt/foo\[bax\ bay\]
+/opt/foo\ bar
+/opt/foo"\ bar"
+/opt/foo\ [bar]
 
 # Regression checks
 %doc ba* "foo bar"

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -1,0 +1,72 @@
+# Override the install prefix so that absolute %%doc paths can be compared
+# against a static list using "rpm -qpl" in tests/rpmbuild.at, regardless of
+# the actual RPM installation prefix.
+%global _prefix /opt
+
+Name:           globesctest 
+Version:        1.0
+Release:        1
+Summary:        Testing file glob escape behavior
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}.
+
+
+%build
+touch 'foo[bar]' bar baz 'foo bar'
+
+%install
+mkdir -p %{buildroot}/opt
+
+# Glob escaping
+touch '%{buildroot}/opt/foo[bar]'
+touch '%{buildroot}/opt/foo[bar baz]'
+touch '%{buildroot}/opt/foo\[bar\]'
+touch '%{buildroot}/opt/foo*'
+touch '%{buildroot}/opt/foo\bar'
+touch %{buildroot}/opt/foo\\
+touch '%{buildroot}/opt/foo?bar'
+touch '%{buildroot}/opt/foo{bar,baz}'
+touch '%{buildroot}/opt/foo"bar"'
+
+# Regression checks
+touch '%{buildroot}/opt/foo-bar1'
+touch '%{buildroot}/opt/foo-bar2'
+touch '%{buildroot}/opt/fooxbarybaz'
+touch "%{buildroot}/opt/foo\"'baz\"'"
+touch '%{buildroot}/opt/foobar'
+touch '%{buildroot}/opt/foobaz'
+touch '%{buildroot}/opt/foobara'
+touch '%{buildroot}/opt/foobarb'
+touch '%{buildroot}/opt/foobaza'
+touch '%{buildroot}/opt/foobazb'
+touch '%{buildroot}/opt/foobaya'
+touch '%{buildroot}/opt/foobayb'
+touch '%{buildroot}/opt/foobawa'
+touch '%{buildroot}/opt/foobawb'
+
+%files
+
+# Glob escaping
+%doc foo\[bar\]
+/opt/foo\[bar\]
+"/opt/foo\[bar baz\]"
+/opt/foo\\\[bar\\\]
+/opt/foo\*
+/opt/foo\\bar
+/opt/foo\\
+/opt/foo\?bar
+/opt/foo\{bar,baz\}
+/opt/foo\"bar\"
+
+# Regression checks
+%doc ba* "foo bar"
+/opt/foo-bar*
+/opt/foo?bar?baz
+/opt/foo"'baz"'
+/opt/foo{bar,baz}
+/opt/foo{bar{a,b},baz{a,b}}
+/opt/foo{bay*,baw*}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -442,7 +442,12 @@ runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
 runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 ],
 [0],
-[/opt/foo"'baz"'
+[/opt/foo a
+/opt/foo b
+/opt/foo bar
+/opt/foo r
+/opt/foo" bar"
+/opt/foo"'baz"'
 /opt/foo"bar"
 /opt/foo*
 /opt/foo-bar1
@@ -450,6 +455,7 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/foo?bar
 /opt/foo[[bar baz]]
 /opt/foo[[bar]]
+/opt/foo[[bax bay]]
 /opt/foo\
 /opt/foo\[[bar\]]
 /opt/foo\bar
@@ -468,7 +474,10 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/share/doc/globesctest-1.0
 /opt/share/doc/globesctest-1.0/bar
 /opt/share/doc/globesctest-1.0/baz
+/opt/share/doc/globesctest-1.0/foo a
+/opt/share/doc/globesctest-1.0/foo b
 /opt/share/doc/globesctest-1.0/foo bar
+/opt/share/doc/globesctest-1.0/foo r
 /opt/share/doc/globesctest-1.0/foo[[bar]]
 ],
 [],

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -433,6 +433,48 @@ warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab
 ])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild glob escape])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
+runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
+],
+[0],
+[/opt/foo"'baz"'
+/opt/foo"bar"
+/opt/foo*
+/opt/foo-bar1
+/opt/foo-bar2
+/opt/foo?bar
+/opt/foo[[bar baz]]
+/opt/foo[[bar]]
+/opt/foo\
+/opt/foo\[[bar\]]
+/opt/foo\bar
+/opt/foobar
+/opt/foobara
+/opt/foobarb
+/opt/foobawa
+/opt/foobawb
+/opt/foobaya
+/opt/foobayb
+/opt/foobaz
+/opt/foobaza
+/opt/foobazb
+/opt/fooxbarybaz
+/opt/foo{bar,baz}
+/opt/share/doc/globesctest-1.0
+/opt/share/doc/globesctest-1.0/bar
+/opt/share/doc/globesctest-1.0/baz
+/opt/share/doc/globesctest-1.0/foo bar
+/opt/share/doc/globesctest-1.0/foo[[bar]]
+],
+[],
+)
+AT_CLEANUP
+
 AT_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 AT_CHECK([

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -449,6 +449,7 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/foo" bar"
 /opt/foo"'baz"'
 /opt/foo"bar"
+/opt/foo%name
 /opt/foo*
 /opt/foo-bar1
 /opt/foo-bar2
@@ -478,6 +479,7 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/share/doc/globesctest-1.0/foo b
 /opt/share/doc/globesctest-1.0/foo bar
 /opt/share/doc/globesctest-1.0/foo r
+/opt/share/doc/globesctest-1.0/foo%name
 /opt/share/doc/globesctest-1.0/foo[[bar]]
 ],
 [],

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -442,14 +442,19 @@ runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
 runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 ],
 [0],
-[/opt/foo a
+[/opt/foo [[baz]]
+/opt/foo a
 /opt/foo b
 /opt/foo bar
+/opt/foo bar.conf
 /opt/foo r
 /opt/foo" bar"
 /opt/foo"'baz"'
 /opt/foo"bar"
+/opt/foo"bay"
+/opt/foo"baz"
 /opt/foo%name
+/opt/foo'bax'
 /opt/foo*
 /opt/foo-bar1
 /opt/foo-bar2
@@ -459,7 +464,10 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/foo[[bax bay]]
 /opt/foo\
 /opt/foo\[[bar\]]
+/opt/foo\[[baz\]]
 /opt/foo\bar
+/opt/foo\bay
+/opt/foo\baz
 /opt/foobar
 /opt/foobara
 /opt/foobarb


### PR DESCRIPTION
This PR fixes the way backslashes and quotes are interpreted in `%files` entries so that they can be used to escape glob chars, like in the shell. It's also possible to escape the `%` char now.

See the attached test spec file for usage examples.

Resolves #1749