### PR TITLE
Explicitly state that \0 is not supported in queryformat strings.

### DIFF
--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -477,8 +477,8 @@ in. To do this, you use the
 option, followed by the *QUERYFMT* format string. Query formats are
 modified versions of the standard **printf(3)** formatting. The format
 is made up of static strings (which may include standard C character
-escapes for newlines, tabs, and other special characters (excluding \0)) and
-**printf(3)** type formatters. As **rpm** already knows the type to
+escapes for newlines, tabs, and other special characters (not including \0))
+and **printf(3)** type formatters. As **rpm** already knows the type to
 print, the type specifier must be omitted however, and replaced by the
 name of the header tag to be printed, enclosed by **{}** characters. Tag
 names are case insensitive, and the leading **RPMTAG\_** portion of the

--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -477,7 +477,7 @@ in. To do this, you use the
 option, followed by the *QUERYFMT* format string. Query formats are
 modified versions of the standard **printf(3)** formatting. The format
 is made up of static strings (which may include standard C character
-escapes for newlines, tabs, and other special characters) and
+escapes for newlines, tabs, and other special characters (excluding \0)) and
 **printf(3)** type formatters. As **rpm** already knows the type to
 print, the type specifier must be omitted however, and replaced by the
 name of the header tag to be printed, enclosed by **{}** characters. Tag


### PR DESCRIPTION
Signed-off-by: Thomas Moschny <thomas.moschny@gmx.de>
