### PR TITLE
Bump hash for rpmdb cookie to SHA256 to appease FIPS

### DIFF
--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2642,7 +2642,7 @@ char *rpmdbCookie(rpmdb db)
     rpmdbIndexIterator ii = rpmdbIndexIteratorInit(db, RPMDBI_NAME);
 
     if (ii) {
-	DIGEST_CTX ctx = rpmDigestInit(PGPHASHALGO_SHA1, RPMDIGEST_NONE);
+	DIGEST_CTX ctx = rpmDigestInit(PGPHASHALGO_SHA256, RPMDIGEST_NONE);
 	const void *key = 0;
 	size_t keylen = 0;
 	while ((rpmdbIndexIteratorNext(ii, &key, &keylen)) == 0) {


### PR DESCRIPTION
The rpmdb cookie is not a security feature, but as these existing
hashes are more convenient than coming up with our own... we then
run into the great big wall of FIPS which in its current incarnation
disallows use of SHA1. And so rpmdbCookie() fails under current FIPS.

Just bumping the algorithm to SHA256 seems the path of lowest
resistance, whether that algo makes sense for this purpose or not.