### PR TITLE
[rpmplugin] decouple rpmplugin return code from rpmRC

### DIFF
--- a/include/rpm/rpmtypes.h
+++ b/include/rpm/rpmtypes.h
@@ -109,6 +109,15 @@ typedef	enum rpmRC_e {
     RPMRC_NOKEY		= 4	/*!< Public key is unavailable. */
 } rpmRC;
 
+/** \ingroup rpmtypes
+ * Plugin hooks return codes.
+ */
+typedef enum rpmPluginRC_e {
+    RPMPLUGINRC_OK	    = 0,    /*!< Generic success code */
+    RPMPLUGINRC_NOTFOUND    = 1,    /*!< Generic not found code. */
+    RPMPLUGINRC_FAIL	    = 2	    /*!< Generic failure code. */
+} rpmPluginRC;
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmplugin.h
+++ b/lib/rpmplugin.h
@@ -37,26 +37,26 @@ typedef rpmFlags rpmFsmOp;
 #define XFO_FLAGS(_a)	((_a) & XFAF_MASK)	/*!< File op flags part */
 
 /* plugin hook typedefs */
-typedef rpmRC (*plugin_init_func)(rpmPlugin plugin, rpmts ts);
+typedef rpmPluginRC (*plugin_init_func)(rpmPlugin plugin, rpmts ts);
 typedef void (*plugin_cleanup_func)(rpmPlugin plugin);
-typedef rpmRC (*plugin_tsm_pre_func)(rpmPlugin plugin, rpmts ts);
-typedef rpmRC (*plugin_tsm_post_func)(rpmPlugin plugin, rpmts ts, int res);
-typedef rpmRC (*plugin_psm_pre_func)(rpmPlugin plugin, rpmte te);
-typedef rpmRC (*plugin_psm_post_func)(rpmPlugin plugin, rpmte te, int res);
-typedef rpmRC (*plugin_scriptlet_pre_func)(rpmPlugin plugin,
+typedef rpmPluginRC (*plugin_tsm_pre_func)(rpmPlugin plugin, rpmts ts);
+typedef rpmPluginRC (*plugin_tsm_post_func)(rpmPlugin plugin, rpmts ts, int res);
+typedef rpmPluginRC (*plugin_psm_pre_func)(rpmPlugin plugin, rpmte te);
+typedef rpmPluginRC (*plugin_psm_post_func)(rpmPlugin plugin, rpmte te, int res);
+typedef rpmPluginRC (*plugin_scriptlet_pre_func)(rpmPlugin plugin,
 					   const char *s_name, int type);
-typedef rpmRC (*plugin_scriptlet_fork_post_func)(rpmPlugin plugin,
+typedef rpmPluginRC (*plugin_scriptlet_fork_post_func)(rpmPlugin plugin,
 					         const char *path, int type);
-typedef rpmRC (*plugin_scriptlet_post_func)(rpmPlugin plugin,
+typedef rpmPluginRC (*plugin_scriptlet_post_func)(rpmPlugin plugin,
 					    const char *s_name, int type,
 					    int res);
-typedef rpmRC (*plugin_fsm_file_pre_func)(rpmPlugin plugin, rpmfi fi,
+typedef rpmPluginRC (*plugin_fsm_file_pre_func)(rpmPlugin plugin, rpmfi fi,
 					  const char* path, mode_t file_mode,
 					  rpmFsmOp op);
-typedef rpmRC (*plugin_fsm_file_post_func)(rpmPlugin plugin, rpmfi fi,
+typedef rpmPluginRC (*plugin_fsm_file_post_func)(rpmPlugin plugin, rpmfi fi,
 					   const char* path, mode_t file_mode,
 					   rpmFsmOp op, int res);
-typedef rpmRC (*plugin_fsm_file_prepare_func)(rpmPlugin plugin, rpmfi fi,
+typedef rpmPluginRC (*plugin_fsm_file_prepare_func)(rpmPlugin plugin, rpmfi fi,
 					      int fd, const char* path,
 					      const char *dest,
 					      mode_t file_mode, rpmFsmOp op);

--- a/lib/rpmplugins.h
+++ b/lib/rpmplugins.h
@@ -31,20 +31,20 @@ rpmPlugins rpmpluginsFree(rpmPlugins plugins);
  * @param name		name to access plugin
  * @param path		path of plugin to open
  * @param opts		options to pass to the plugin
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsAdd(rpmPlugins plugins, const char *name, const char *path, const char *opts);
+rpmPluginRC rpmpluginsAdd(rpmPlugins plugins, const char *name, const char *path, const char *opts);
 
 /** \ingroup rpmplugins
  * Add and open a rpm plugin
  * @param plugins	plugins structure to add a plugin to
  * @param type     type of plugin
  * @param name		name of plugin
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsAddPlugin(rpmPlugins plugins, const char *type, const char *name);
+rpmPluginRC rpmpluginsAddPlugin(rpmPlugins plugins, const char *type, const char *name);
 
 /** \ingroup rpmplugins
  * Determine if a plugin has been added already
@@ -59,59 +59,59 @@ int rpmpluginsPluginAdded(rpmPlugins plugins, const char *name);
  * Call the pre transaction plugin hook
  * @param plugins	plugins structure
  * @param ts		processed transaction
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallTsmPre(rpmPlugins plugins, rpmts ts);
+rpmPluginRC rpmpluginsCallTsmPre(rpmPlugins plugins, rpmts ts);
 
 /** \ingroup rpmplugins
  * Call the post transaction plugin hook
  * @param plugins	plugins structure
  * @param ts		processed transaction
  * @param res		transaction result code
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallTsmPost(rpmPlugins plugins, rpmts ts, int res);
+rpmPluginRC rpmpluginsCallTsmPost(rpmPlugins plugins, rpmts ts, int res);
 
 /** \ingroup rpmplugins
  * Call the pre transaction element plugin hook
  * @param plugins	plugins structure
  * @param te		processed transaction element
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallPsmPre(rpmPlugins plugins, rpmte te);
+rpmPluginRC rpmpluginsCallPsmPre(rpmPlugins plugins, rpmte te);
 
 /** \ingroup rpmplugins
  * Call the post transaction element plugin hook
  * @param plugins	plugins structure
  * @param te		processed transaction element
  * @param res		transaction element result code
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallPsmPost(rpmPlugins plugins, rpmte te, int res);
+rpmPluginRC rpmpluginsCallPsmPost(rpmPlugins plugins, rpmte te, int res);
 
 /** \ingroup rpmplugins
  * Call the pre scriptlet execution plugin hook
  * @param plugins	plugins structure
  * @param s_name	scriptlet name
  * @param type		indicates the scriptlet execution flow, see rpmScriptletExecutionFlow
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallScriptletPre(rpmPlugins plugins, const char *s_name, int type);
+rpmPluginRC rpmpluginsCallScriptletPre(rpmPlugins plugins, const char *s_name, int type);
 
 /** \ingroup rpmplugins
  * Call the post fork scriptlet plugin hook.
  * @param plugins	plugins structure
  * @param path		scriptlet path
  * @param type		indicates the scriptlet execution flow, see rpmScriptletExecutionFlow
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallScriptletForkPost(rpmPlugins plugins, const char *path, int type);
+rpmPluginRC rpmpluginsCallScriptletForkPost(rpmPlugins plugins, const char *path, int type);
 
 /** \ingroup rpmplugins
  * Call the post scriptlet execution plugin hook
@@ -119,10 +119,10 @@ rpmRC rpmpluginsCallScriptletForkPost(rpmPlugins plugins, const char *path, int 
  * @param s_name	scriptlet name
  * @param type		indicates the scriptlet execution flow, see rpmScriptletExecutionFlow
  * @param res		scriptlet execution result code
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallScriptletPost(rpmPlugins plugins, const char *s_name, int type, int res);
+rpmPluginRC rpmpluginsCallScriptletPost(rpmPlugins plugins, const char *s_name, int type, int res);
 
 /** \ingroup rpmplugins
  * Call the fsm file pre plugin hook
@@ -131,10 +131,10 @@ rpmRC rpmpluginsCallScriptletPost(rpmPlugins plugins, const char *s_name, int ty
  * @param path		file object path
  * @param file_mode	file object mode
  * @param op		file operation + associated flags
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallFsmFilePre(rpmPlugins plugins, rpmfi fi, const char* path,
+rpmPluginRC rpmpluginsCallFsmFilePre(rpmPlugins plugins, rpmfi fi, const char* path,
                                 mode_t file_mode, rpmFsmOp op);
 
 /** \ingroup rpmplugins
@@ -145,10 +145,10 @@ rpmRC rpmpluginsCallFsmFilePre(rpmPlugins plugins, rpmfi fi, const char* path,
  * @param file_mode	file object mode
  * @param op		file operation + associated flags
  * @param res		fsm result code
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallFsmFilePost(rpmPlugins plugins, rpmfi fi, const char* path,
+rpmPluginRC rpmpluginsCallFsmFilePost(rpmPlugins plugins, rpmfi fi, const char* path,
                                 mode_t file_mode, rpmFsmOp op, int res);
 
 /** \ingroup rpmplugins
@@ -161,10 +161,10 @@ rpmRC rpmpluginsCallFsmFilePost(rpmPlugins plugins, rpmfi fi, const char* path,
  * @param dest		file object destination path
  * @param mode		file object mode
  * @param op		file operation + associated flags
- * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ * @return		RPMPLUGINRC_OK on success, RPMPLUGINRC_FAIL otherwise
  */
 RPM_GNUC_INTERNAL
-rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
+rpmPluginRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
                                    int fd, const char *path, const char *dest,
                                    mode_t mode, rpmFsmOp op);
 

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -361,7 +361,7 @@ static rpmRC runExtScript(rpmPlugins plugins, ARGV_const_t prefixes,
 	dup2(inpipe[0], STDIN_FILENO);
 
 	/* Run scriptlet post fork hook for all plugins */
-	if (rpmpluginsCallScriptletForkPost(plugins, *argvp[0], RPMSCRIPTLET_FORK | RPMSCRIPTLET_EXEC) != RPMRC_FAIL) {
+	if (rpmpluginsCallScriptletForkPost(plugins, *argvp[0], RPMSCRIPTLET_FORK | RPMSCRIPTLET_EXEC) != RPMPLUGINRC_FAIL) {
 	    doScriptExec(*argvp, prefixes, scriptFd, out);
 	} else {
 	    _exit(126); /* exit 126 for compatibility with bash(1) */

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1666,7 +1666,7 @@ rpmRC rpmtsSetupTransactionPlugins(rpmts ts)
 	for (int i = 0; i < nfiles; i++) {
 	    char *bn = basename(files[i]);
 	    bn[strlen(bn)-strlen(".so")] = '\0';
-	    if (rpmpluginsAddPlugin(tsplugins, "transaction", bn) == RPMRC_FAIL)
+	    if (rpmpluginsAddPlugin(tsplugins, "transaction", bn) == RPMPLUGINRC_FAIL)
 		rc = RPMRC_FAIL;
 	}
 	files = argvFree(files);
@@ -1803,7 +1803,7 @@ int rpmtsRun(rpmts ts, rpmps okProbs, rpmprobFilterFlags ignoreSet)
 
     /* Run pre transaction hook for all plugins */
     TsmPreDone = 1;
-    if (rpmpluginsCallTsmPre(rpmtsPlugins(ts), ts) == RPMRC_FAIL) {
+    if (rpmpluginsCallTsmPre(rpmtsPlugins(ts), ts) == RPMPLUGINRC_FAIL) {
 	goto exit;
     }
 

--- a/plugins/audit.c
+++ b/plugins/audit.c
@@ -54,7 +54,7 @@ static void getAuditOps(rpmts ts, struct teop *ops, int nelem)
  * If enabled, log audit events for the operations in this transaction.
  * In the event values, 1 means true/success and 0 false/failure. Shockingly.
  */
-static rpmRC audit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
+static rpmPluginRC audit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 {
     if (rpmtsFlags(ts) & (RPMTRANS_FLAG_TEST|RPMTRANS_FLAG_BUILD_PROBS))
 	goto exit;
@@ -94,7 +94,7 @@ static rpmRC audit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
     audit_close(auditFd);
 
 exit:
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s audit_hooks = {

--- a/plugins/fapolicyd.c
+++ b/plugins/fapolicyd.c
@@ -22,7 +22,7 @@ static struct fapolicyd_data fapolicyd_state = {
     .fifo_path = "/run/fapolicyd/fapolicyd.fifo",
 };
 
-static rpmRC open_fifo(struct fapolicyd_data* state)
+static rpmPluginRC open_fifo(struct fapolicyd_data* state)
 {
     int fd = -1;
     struct stat s;
@@ -56,15 +56,15 @@ static rpmRC open_fifo(struct fapolicyd_data* state)
 
     state->fd = fd;
     /* considering success */
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 
  bad:
     if (fd >= 0)
         close(fd);
-    return RPMRC_FAIL;
+    return RPMPLUGINRC_FAIL;
 }
 
-static rpmRC write_fifo(struct fapolicyd_data* state, const char * str)
+static rpmPluginRC write_fifo(struct fapolicyd_data* state, const char * str)
 {
     ssize_t len = strlen(str);
     ssize_t written = 0;
@@ -80,13 +80,13 @@ static rpmRC write_fifo(struct fapolicyd_data* state, const char * str)
         written += n;
     }
 
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 
  bad:
-    return RPMRC_FAIL;
+    return RPMPLUGINRC_FAIL;
 }
 
-static rpmRC fapolicyd_init(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC fapolicyd_init(rpmPlugin plugin, rpmts ts)
 {
     if (rpmtsFlags(ts) & (RPMTRANS_FLAG_TEST|RPMTRANS_FLAG_BUILD_PROBS))
         goto end;
@@ -97,7 +97,7 @@ static rpmRC fapolicyd_init(rpmPlugin plugin, rpmts ts)
     (void) open_fifo(&fapolicyd_state);
 
  end:
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 static void fapolicyd_cleanup(rpmPlugin plugin)
@@ -108,7 +108,7 @@ static void fapolicyd_cleanup(rpmPlugin plugin)
     fapolicyd_state.fd = -1;
 }
 
-static rpmRC fapolicyd_tsm_post(rpmPlugin plugin, rpmts ts, int res)
+static rpmPluginRC fapolicyd_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 {
     if (rpmtsFlags(ts) & (RPMTRANS_FLAG_TEST|RPMTRANS_FLAG_BUILD_PROBS))
         goto end;
@@ -122,10 +122,10 @@ static rpmRC fapolicyd_tsm_post(rpmPlugin plugin, rpmts ts, int res)
     }
 
  end:
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC fapolicyd_scriptlet_pre(rpmPlugin plugin, const char *s_name,
+static rpmPluginRC fapolicyd_scriptlet_pre(rpmPlugin plugin, const char *s_name,
                                      int type)
 {
     if (fapolicyd_state.fd == -1)
@@ -141,10 +141,10 @@ static rpmRC fapolicyd_scriptlet_pre(rpmPlugin plugin, const char *s_name,
     }
 
  end:
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC fapolicyd_fsm_file_prepare(rpmPlugin plugin, rpmfi fi,
+static rpmPluginRC fapolicyd_fsm_file_prepare(rpmPlugin plugin, rpmfi fi,
                                         int fd, const char *path,
 					const char *dest,
                                         mode_t file_mode, rpmFsmOp op)
@@ -181,7 +181,7 @@ static rpmRC fapolicyd_fsm_file_prepare(rpmPlugin plugin, rpmfi fi,
     free(sha);
 
  end:
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s fapolicyd_hooks = {

--- a/plugins/fsverity.c
+++ b/plugins/fsverity.c
@@ -33,7 +33,7 @@ static int sign_config_files = 0;
  * but fails gracefully if the file system doesn't support it or the
  * verity feature flag isn't enabled in the file system (ext4).
  */
-static rpmRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
+static rpmPluginRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 				       const char *path, const char *dest,
 				       mode_t file_mode, rpmFsmOp op)
 {
@@ -41,7 +41,7 @@ static rpmRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
     const unsigned char * signature = NULL;
     size_t len;
     uint16_t algo = 0;
-    int rc = RPMRC_OK;
+    int rc = RPMPLUGINRC_OK;
     rpmFileAction action = XFO_ACTION(op);
     char *buffer;
 
@@ -108,34 +108,34 @@ static rpmRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	switch(errno) {
 	case EBADMSG:
 	    rpmlog(RPMLOG_DEBUG, "invalid or malformed fsverity signature for %s\n", path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case EEXIST:
 	    rpmlog(RPMLOG_DEBUG, "fsverity signature already enabled %s\n",
 		   path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case EINVAL:
 	    rpmlog(RPMLOG_DEBUG, "invalid arguments for ioctl %s\n", path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case EKEYREJECTED:
 	    rpmlog(RPMLOG_DEBUG, "signature doesn't match file %s\n", path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case EMSGSIZE:
 	    rpmlog(RPMLOG_DEBUG, "invalid signature size for %s\n", path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case ENOPKG:
 	    rpmlog(RPMLOG_DEBUG, "unsupported signature algoritm (%i) for %s\n",
 		   arg.hash_algorithm, path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case ETXTBSY:
 	    rpmlog(RPMLOG_DEBUG, "file is open by other process %s\n",
 		   path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	case ENOTTY:
 	    rpmlog(RPMLOG_DEBUG, "fsverity not supported by file system for %s\n",
@@ -148,7 +148,7 @@ static rpmRC fsverity_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	default:
 	    rpmlog(RPMLOG_DEBUG, "failed to enable verity (errno %i) for %s\n",
 		   errno, path);
-	    rc = RPMRC_FAIL;
+	    rc = RPMPLUGINRC_FAIL;
 	    break;
 	}
     }
@@ -159,13 +159,13 @@ exit:
     return rc;
 }
 
-static rpmRC fsverity_init(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC fsverity_init(rpmPlugin plugin, rpmts ts)
 {
     sign_config_files = rpmExpandNumeric("%{?_fsverity_sign_config_files}");
 
     rpmlog(RPMLOG_DEBUG, "fsverity_init\n");
 
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s fsverity_hooks = {

--- a/plugins/ima.c
+++ b/plugins/ima.c
@@ -42,14 +42,14 @@ static int check_zero_hdr(const unsigned char *fsig, size_t siglen)
 	return (memcmp(fsig, &zero_hdr, sizeof(zero_hdr)) == 0);
 }
 
-static rpmRC ima_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
+static rpmPluginRC ima_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
                                   const char *path,
                                   const char *dest,
                                   mode_t file_mode, rpmFsmOp op)
 {
 	const unsigned char * fsig = NULL;
 	size_t len;
-	int rc = RPMRC_OK;
+	int rc = RPMPLUGINRC_OK;
 	rpmFileAction action = XFO_ACTION(op);
 
 	/* Ignore skipped files and unowned directories */
@@ -80,7 +80,7 @@ static rpmRC ima_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 			"ima: could not apply signature on '%s': %s\n",
 			path, strerror(errno));
 		if (is_err) {
-		    rc = RPMRC_FAIL;
+		    rc = RPMPLUGINRC_FAIL;
 		}
 	    }
 	}
@@ -89,12 +89,12 @@ exit:
 	return rc;
 }
 
-static rpmRC ima_init(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC ima_init(rpmPlugin plugin, rpmts ts)
 {
 	write_signatures_on_config_files =
 	    rpmExpandNumeric("%{?_ima_sign_config_files}");
 
-	return RPMRC_OK;
+	return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s ima_hooks = {

--- a/plugins/prioreset.c
+++ b/plugins/prioreset.c
@@ -22,7 +22,7 @@
  * because the it's not needed there, and the effect is counter-productive.
  */
 
-static rpmRC prioreset_scriptlet_fork_post(rpmPlugin plugin, const char *path, int type)
+static rpmPluginRC prioreset_scriptlet_fork_post(rpmPlugin plugin, const char *path, int type)
 {
         /* Call for resetting nice priority. */
         int ret = setpriority(PRIO_PROCESS, 0, 0);
@@ -43,7 +43,7 @@ static rpmRC prioreset_scriptlet_fork_post(rpmPlugin plugin, const char *path, i
         }
         #endif
 
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s prioreset_hooks = {

--- a/plugins/selinux.c
+++ b/plugins/selinux.c
@@ -29,7 +29,7 @@ static void sehandle_fini(int close_status)
     }
 }
 
-static rpmRC sehandle_init(int open_status)
+static rpmPluginRC sehandle_init(int open_status)
 {
     const char * path = selinux_file_context_path();
     struct selinux_opt opts[] = {
@@ -37,15 +37,15 @@ static rpmRC sehandle_init(int open_status)
     };
     
     if (path == NULL)
-	return RPMRC_FAIL;
+	return RPMPLUGINRC_FAIL;
 
     if (open_status) {
 	selinux_status_close();
 	if (selinux_status_open(0) < 0) {
-	    return RPMRC_FAIL;
+	    return RPMPLUGINRC_FAIL;
 	}
     } else if (!selinux_status_updated() && sehandle) {
-	return RPMRC_OK;
+	return RPMPLUGINRC_OK;
     }
 
     if (sehandle)
@@ -56,12 +56,12 @@ static rpmRC sehandle_init(int open_status)
     rpmlog(loglvl(sehandle == NULL), "selabel_open: (%s) %s\n",
 	   path, (sehandle == NULL ? strerror(errno) : ""));
 
-    return (sehandle != NULL) ? RPMRC_OK : RPMRC_FAIL;
+    return (sehandle != NULL) ? RPMPLUGINRC_OK : RPMPLUGINRC_FAIL;
 }
 
-static rpmRC selinux_tsm_pre(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC selinux_tsm_pre(rpmPlugin plugin, rpmts ts)
 {
-    rpmRC rc = RPMRC_OK;
+    rpmPluginRC rc = RPMPLUGINRC_OK;
 
     /* If SELinux isn't enabled on the system, dont mess with it */
     if (!is_selinux_enabled()) {
@@ -76,17 +76,17 @@ static rpmRC selinux_tsm_pre(rpmPlugin plugin, rpmts ts)
     return rc;
 }
 
-static rpmRC selinux_tsm_post(rpmPlugin plugin, rpmts ts, int rc)
+static rpmPluginRC selinux_tsm_post(rpmPlugin plugin, rpmts ts, int rc)
 {
     if (sehandle) {
 	sehandle_fini(1);
     }
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC selinux_psm_pre(rpmPlugin plugin, rpmte te)
+static rpmPluginRC selinux_psm_pre(rpmPlugin plugin, rpmte te)
 {
-    rpmRC rc = RPMRC_OK;
+    rpmPluginRC rc = RPMPLUGINRC_OK;
 
     if (sehandle) {
 	/* reload the labels if policy changed underneath */
@@ -132,22 +132,22 @@ exit:
 }
 #endif
 
-static rpmRC selinux_scriptlet_fork_post(rpmPlugin plugin,
+static rpmPluginRC selinux_scriptlet_fork_post(rpmPlugin plugin,
 						 const char *path, int type)
 {
     /* No default transition, use rpm_script_t for now. */
     const char *script_type  = "rpm_script_t";
-    rpmRC rc = RPMRC_FAIL;
+    rpmPluginRC rc = RPMPLUGINRC_FAIL;
 
     if (sehandle == NULL)
-	return RPMRC_OK;
+	return RPMPLUGINRC_OK;
 
     if (setexecfilecon(path, script_type) == 0)
-	rc = RPMRC_OK;
+	rc = RPMPLUGINRC_OK;
 
     /* If selinux is not enforcing, we don't care either */
     if (rc && security_getenforce() < 1)
-	rc = RPMRC_OK;
+	rc = RPMPLUGINRC_OK;
 
     rpmlog(loglvl(rc), "setexecfilecon: (%s, %s) %s\n",
 	       path, script_type, rc ? strerror(errno) : "");
@@ -155,11 +155,11 @@ static rpmRC selinux_scriptlet_fork_post(rpmPlugin plugin,
     return rc;
 }
 
-static rpmRC selinux_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
+static rpmPluginRC selinux_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 					const char *path, const char *dest,
 				        mode_t file_mode, rpmFsmOp op)
 {
-    rpmRC rc = RPMRC_FAIL; /* assume failure */
+    rpmPluginRC rc = RPMPLUGINRC_FAIL; /* assume failure */
     rpmFileAction action = XFO_ACTION(op);
 
     if (sehandle && !XFA_SKIPPING(action)) {
@@ -172,19 +172,19 @@ static rpmRC selinux_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 		conrc = lsetfilecon(path, scon);
 
 	    if (conrc == 0 || (conrc < 0 && errno == EOPNOTSUPP))
-		rc = RPMRC_OK;
+		rc = RPMPLUGINRC_OK;
 
-	    rpmlog(loglvl(rc != RPMRC_OK), "lsetfilecon: (%d %s, %s) %s\n",
+	    rpmlog(loglvl(rc != RPMPLUGINRC_OK), "lsetfilecon: (%d %s, %s) %s\n",
 		       fd, path, scon, (conrc < 0 ? strerror(errno) : ""));
 
 	    freecon(scon);
 	} else {
 	    /* No context for dest is not our headache */
 	    if (errno == ENOENT)
-		rc = RPMRC_OK;
+		rc = RPMPLUGINRC_OK;
 	}
     } else {
-	rc = RPMRC_OK;
+	rc = RPMPLUGINRC_OK;
     }
 
     return rc;

--- a/plugins/syslog.c
+++ b/plugins/syslog.c
@@ -13,7 +13,7 @@ struct logstat {
     unsigned int pkgfail;
 };
 
-static rpmRC syslog_init(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC syslog_init(rpmPlugin plugin, rpmts ts)
 {
     /* XXX make this configurable? */
     const char * log_ident = "[RPM]";
@@ -21,7 +21,7 @@ static rpmRC syslog_init(rpmPlugin plugin, rpmts ts)
 
     rpmPluginSetData(plugin, state);
     openlog(log_ident, (LOG_PID), LOG_USER);
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 static void syslog_cleanup(rpmPlugin plugin)
@@ -31,7 +31,7 @@ static void syslog_cleanup(rpmPlugin plugin)
     closelog();
 }
 
-static rpmRC syslog_tsm_pre(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC syslog_tsm_pre(rpmPlugin plugin, rpmts ts)
 {
     struct logstat * state = rpmPluginGetData(plugin);
     
@@ -54,10 +54,10 @@ static rpmRC syslog_tsm_pre(rpmPlugin plugin, rpmts ts)
 	syslog(LOG_NOTICE, "Transaction ID %x started", rpmtsGetTid(ts));
     }
 
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC syslog_tsm_post(rpmPlugin plugin, rpmts ts, int res)
+static rpmPluginRC syslog_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 {
     struct logstat * state = rpmPluginGetData(plugin);
 
@@ -71,10 +71,10 @@ static rpmRC syslog_tsm_post(rpmPlugin plugin, rpmts ts, int res)
     }
 
     state->logging = 0;
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
+static rpmPluginRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
 {
     struct logstat * state = rpmPluginGetData(plugin);
 
@@ -93,10 +93,10 @@ static rpmRC syslog_psm_post(rpmPlugin plugin, rpmte te, int res)
 
 	syslog(lvl, "%s %s: %s", op, pkg, outcome);
     }
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC syslog_scriptlet_post(rpmPlugin plugin,
+static rpmPluginRC syslog_scriptlet_post(rpmPlugin plugin,
 					const char *s_name, int type, int res)
 {
     struct logstat * state = rpmPluginGetData(plugin);
@@ -105,7 +105,7 @@ static rpmRC syslog_scriptlet_post(rpmPlugin plugin,
 	syslog(LOG_WARNING, "scriptlet %s failure: %d\n", s_name, res);
 	state->scriptfail++;
     }
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s syslog_hooks = {

--- a/plugins/systemd_inhibit.c
+++ b/plugins/systemd_inhibit.c
@@ -71,23 +71,23 @@ static int inhibit(void)
     return fd;
 }
 
-static rpmRC systemd_inhibit_init(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC systemd_inhibit_init(rpmPlugin plugin, rpmts ts)
 {
     struct stat st;
 
     if (lstat("/run/systemd/system/", &st) == 0) {
         if (S_ISDIR(st.st_mode)) {
-            return RPMRC_OK;
+            return RPMPLUGINRC_OK;
         }
     }
 
-    return RPMRC_NOTFOUND;
+    return RPMPLUGINRC_NOTFOUND;
 }
 
-static rpmRC systemd_inhibit_tsm_pre(rpmPlugin plugin, rpmts ts)
+static rpmPluginRC systemd_inhibit_tsm_pre(rpmPlugin plugin, rpmts ts)
 {
     if (rpmtsFlags(ts) & (RPMTRANS_FLAG_TEST|RPMTRANS_FLAG_BUILD_PROBS))
-	return RPMRC_OK;
+	return RPMPLUGINRC_OK;
 
     lock_fd = inhibit();
 
@@ -95,17 +95,17 @@ static rpmRC systemd_inhibit_tsm_pre(rpmPlugin plugin, rpmts ts)
 	rpmlog(RPMLOG_DEBUG, "System shutdown blocked (fd %d)\n", lock_fd);
     }
 
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
-static rpmRC systemd_inhibit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
+static rpmPluginRC systemd_inhibit_tsm_post(rpmPlugin plugin, rpmts ts, int res)
 {
     if (lock_fd >= 0) {
 	close(lock_fd);
 	lock_fd = -1;
 	rpmlog(RPMLOG_DEBUG, "System shutdown unblocked\n");
     }
-    return RPMRC_OK;
+    return RPMPLUGINRC_OK;
 }
 
 struct rpmPluginHooks_s systemd_inhibit_hooks = {


### PR DESCRIPTION
In #1470, it was mentioned that currently the plugin API is too coupled
to rpmRC code and would benefit from [getting its own return codes](https://github.com/rpm-software-management/rpm/pull/1470#discussion_r551890395) and eventually
become a [public API](https://github.com/rpm-software-management/rpm/pull/1470#issuecomment-1020165240).

This diff defines a new emum `rpmPluginRC` and its accompanying
`RPMPLUGINRC_{OK,NOTFOUND,FAIL}`, which are currently being used by
plugins, and adjust the existing plugin to use it.

CI build: https://gist.github.com/chantra/c8f61770b133b66c24cfbd5c2ed60a69