### PR TITLE
Fix handling of bad IMA and fsverity signatures

### DIFF
--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1593,8 +1593,8 @@ static uint8_t *base2bin(Header h, rpmTagVal tag, rpm_count_t num, int *len)
     struct rpmtd_s td;
     uint8_t *bin = NULL, *t = NULL;
     size_t maxlen = 0;
-    int status, i= 0;
-    void **arr = xmalloc(num * sizeof(void *));
+    int status, i= 0, j;
+    void **arr = xcalloc(num, sizeof(void *));
     size_t *lengths = xcalloc(num, sizeof(size_t));
     const char *s;
 
@@ -1621,6 +1621,14 @@ static uint8_t *base2bin(Header h, rpmTagVal tag, rpm_count_t num, int *len)
     if (maxlen) {
 	rpmlog(RPMLOG_DEBUG, _("%s: base64 decode success, len %li\n"),
 	       __func__, maxlen);
+	if (MAX_HEX2BIN_MEM / maxlen < num) {
+	    rpmlog(RPMLOG_WARNING, _("%s: refusing to allocate more than %d "
+				     "bytes of memory\n"),
+		   __func__, MAX_HEX2BIN_MEM);
+	    for (j = 0; j < i; j++)
+		free(arr[j]);
+	    goto out;
+	}
 
 	t = bin = xcalloc(num, maxlen);
 

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1598,7 +1598,7 @@ static uint8_t *base2bin(Header h, rpmTagVal tag, rpm_count_t num, int *len)
     size_t *lengths = xcalloc(num, sizeof(size_t));
     const char *s;
 
-    if (headerGet(h, tag, &td, HEADERGET_MINMEM) && rpmtdCount(&td) != num)
+    if (!headerGet(h, tag, &td, HEADERGET_MINMEM) || rpmtdCount(&td) != num)
 	goto out;
 
     while ((s = rpmtdNextString(&td))) {

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1625,8 +1625,10 @@ static uint8_t *base2bin(Header h, rpmTagVal tag, rpm_count_t num, int *len)
 	t = bin = xcalloc(num, maxlen);
 
 	for (i = 0; i < num; i++) {
-	    memcpy(t, arr[i], lengths[i]);
-	    free(arr[i]);
+	    if (arr[i]) {
+		memcpy(t, arr[i], lengths[i]);
+		free(arr[i]);
+	    }
 	    t += maxlen;
 	}
 	*len = maxlen;

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1524,7 +1524,7 @@ static uint8_t *hex2bin(Header h, rpmTagVal tag, rpm_count_t num, size_t len,
 	/* Figure string sizes + max length for allocation purposes */
 	if (lengths) {
 	    int i = 0;
-	    lens = xmalloc(num * sizeof(*lens));
+	    lens = xcalloc(num, sizeof(*lens));
 
 	    while ((s = rpmtdNextString(&td))) {
 		lens[i] = strlen(s) / 2;
@@ -1542,7 +1542,7 @@ static uint8_t *hex2bin(Header h, rpmTagVal tag, rpm_count_t num, size_t len,
 	    maxl = len;
 	}
 
-	uint8_t *t = bin = xmalloc(num * maxl);
+	uint8_t *t = bin = rmallocarray(num, maxl);
 	int i = 0;
 	while ((s = rpmtdNextString(&td))) {
 	    if (*s == '\0') {

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -1613,6 +1613,8 @@ static uint8_t *base2bin(Header h, rpmTagVal tag, rpm_count_t num, int *len)
 	if (status) {
 	    rpmlog(RPMLOG_DEBUG, _("%s: base64 decode failed, len %li\n"),
 		   __func__, lengths[i]);
+	    for (j = 0; j < i; j++)
+		free(arr[j]);
 	    goto out;
 	}
 	i++;

--- a/rpmio/rpmmalloc.c
+++ b/rpmio/rpmmalloc.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "debug.h"
 
@@ -53,6 +54,18 @@ void * rcalloc (size_t nmemb, size_t size)
     if (size == 0) size++;
     if (nmemb == 0) nmemb++;
     value = calloc (nmemb, size);
+    if (value == NULL)
+	value = vmefail(size);
+    return value;
+}
+
+void * rmallocarray (size_t nmemb, size_t size)
+{
+    register void *value = NULL;
+    if (size == 0) size++;
+    if (nmemb == 0) nmemb++;
+    if (nmemb < SIZE_MAX / size)
+	value = malloc (nmemb * size);
     if (value == NULL)
 	value = vmefail(size);
     return value;

--- a/rpmio/rpmutil.h
+++ b/rpmio/rpmutil.h
@@ -124,6 +124,9 @@ void * rmalloc(size_t size);
 RPM_GNUC_MALLOC RPM_GNUC_ALLOC_SIZE2(1,2)
 void * rcalloc(size_t nmemb, size_t size);
 
+RPM_GNUC_MALLOC RPM_GNUC_ALLOC_SIZE2(1,2)
+void * rmallocarray(size_t nmemb, size_t size);
+
 RPM_GNUC_ALLOC_SIZE(2)
 void * rrealloc(void *ptr, size_t size);
 


### PR DESCRIPTION
This is based on #1900, but it includes additional protections.  #1900 just contains the security fix, whereas this PR also prevents RPM from crashing and/or leaking memory.