### PR TITLE
Disarm 21 year old landmine in the rpmfi API

### DIFF
--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -304,12 +304,6 @@ rpm_count_t rpmfiDC(rpmfi fi)
     return (fi != NULL ? rpmfilesDC(fi->files) : 0);
 }
 
-#ifdef	NOTYET
-int rpmfiDI(rpmfi fi)
-{
-}
-#endif
-
 int rpmfiFX(rpmfi fi)
 {
     return (fi != NULL ? fi->i : -1);
@@ -334,13 +328,7 @@ int rpmfiDX(rpmfi fi)
 
 int rpmfiSetDX(rpmfi fi, int dx)
 {
-    int j = -1;
-
-    if (fi != NULL && dx >= 0 && dx < rpmfiDC(fi)) {
-	j = fi->j;
-	fi->j = dx;
-    }
-    return j;
+    return -1;
 }
 
 int rpmfilesDI(rpmfiles fi, int ix)
@@ -894,28 +882,12 @@ rpmfi rpmfiInit(rpmfi fi, int fx)
 
 int rpmfiNextD(rpmfi fi)
 {
-    int j = -1;
-
-    if (fi != NULL && ++fi->j >= 0) {
-	if (fi->j < rpmfilesDC(fi->files))
-	    j = fi->j;
-	else
-	    fi->j = -1;
-    }
-
-    return j;
+    return -1;
 }
 
 rpmfi rpmfiInitD(rpmfi fi, int dx)
 {
-    if (fi != NULL) {
-	if (dx >= 0 && dx < rpmfilesFC(fi->files))
-	    fi->j = dx - 1;
-	else
-	    fi = NULL;
-    }
-
-    return fi;
+    return NULL;
 }
 
 rpmFileTypes rpmfiWhatis(rpm_mode_t mode)

--- a/lib/rpmfi.h
+++ b/lib/rpmfi.h
@@ -58,10 +58,10 @@ rpm_count_t rpmfiDC(rpmfi fi);
 int rpmfiDX(rpmfi fi);
 
 /** \ingroup rpmfi
- * Set current directory index in file info set iterator.
- * @param fi		file info set iterator
- * @param dx		new directory index
- * @return		current directory index
+ * Obsolete, do not use.
+ * @param fi		unused
+ * @param dx		unused
+ * @return		-1
  */
 int rpmfiSetDX(rpmfi fi, int dx);
 
@@ -335,17 +335,18 @@ int rpmfiNext(rpmfi fi);
 rpmfi rpmfiInit(rpmfi fi, int fx);
 
 /** \ingroup rpmfi
- * Return next directory iterator index.
- * @param fi		file info set iterator
- * @return		directory iterator index, -1 on termination
+ * Obsolete, do not use.
+ * @param fi		unused
+ * @return		-1
  */
 int rpmfiNextD(rpmfi fi);
 
 /** \ingroup rpmfi
  * Initialize directory iterator index.
- * @param fi		file info set iterator
- * @param dx		directory iterator index
- * @return		file info set iterator, NULL if dx is out of range
+ * Obsolete, do not use.
+ * @param fi		unused
+ * @param dx		unused
+ * @return		NULL
  */
 rpmfi rpmfiInitD(rpmfi fi, int dx);
 


### PR DESCRIPTION
The directory index must only be changed in sync with file iteration,
otherwise you get garbage out. The NOTYET'ed rpmfiDI() seems to suggest an
idea to have a separate mode of directory-only iteration in which context
rpmfiSetDX() would've perhaps made sense, but as it is this is plain
dangerous. Thankfully these APIs so broken that there can be no
legitimate users, so we can just turn them into a no-op until we have
to bump the soname next time.

The things we still have lurking in the codebase...