### PR TITLE
Make rpmfiSetFX() return code meaningful

### DIFF
--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -867,15 +867,8 @@ int rpmfiNext(rpmfi fi)
 	    next = fi->next(fi);
 	} while (next == RPMERR_ITER_SKIP);
 
-	if (next >= 0 && next < rpmfilesFC(fi->files)) {
-	    fi->i = next;
-	    fi->j = rpmfilesDI(fi->files, fi->i);
-	} else {
-	    fi->i = -1;
-	    if (next >= 0) {
-		next = -1;
-	    }
-	}
+	if (next >= 0)
+	    next = rpmfiSetFX(fi, next);
     }
     return next;
 }

--- a/lib/rpmfi.c
+++ b/lib/rpmfi.c
@@ -320,9 +320,9 @@ int rpmfiSetFX(rpmfi fi, int fx)
     int i = -1;
 
     if (fi != NULL && fx >= 0 && fx < rpmfilesFC(fi->files)) {
-	i = fi->i;
 	fi->i = fx;
 	fi->j = rpmfilesDI(fi->files, fi->i);
+	i = fi->i;
     }
     return i;
 }

--- a/lib/rpmfi.h
+++ b/lib/rpmfi.h
@@ -39,7 +39,7 @@ int rpmfiFX(rpmfi fi);
  * Set current file index in file info set iterator.
  * @param fi		file info set iterator
  * @param fx		new file index
- * @return		current file index
+ * @return		new file index, -1 on error
  */
 int rpmfiSetFX(rpmfi fi, int fx);
 


### PR DESCRIPTION
Up to now, rpmfiSetFX() has returned the previous file index on success,
and -1 on error. Which seems okay on the outset, but on a just
initialized iterator the file index is at -1 which means the returned
-1 sometimes indicates an error and sometimes success. This is so broken
that none of the callers even try to use it (grep for it). Which is
lucky in the sense that it means we can change it.

Simply return the newly set index on success and -1 on error, it may
not be the greatest return code on earth but at least it's
non-ambiguous.