### PR TITLE
build: warn if source_date_epoch_from_changelog set but changelog missing

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -310,6 +310,9 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	    rpmlog(RPMLOG_NOTICE, _("setting %s=%s\n"), "SOURCE_DATE_EPOCH", sdestr);
 	    setenv("SOURCE_DATE_EPOCH", sdestr, 0);
 	    rpmtdFreeData(&td);
+	} else {
+	    rpmlog(RPMLOG_WARNING, _("source_date_epoch_from_changelog set but "
+	        "%%changelog is missing\n"));
 	}
     }
 


### PR DESCRIPTION
Otherwise the user is not made aware that SOURCE_DATE_EPOCH is left
unset despite having set source_date_epoch_from_changelog.