### PR TITLE
Avoid reading out of bounds of the i18ntable

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -1311,7 +1311,7 @@ static int copyI18NEntry(Header h, indexEntry entry, rpmtd td,
 
 	/* For each entry in the header ... */
 	for (langNum = 0, t = table->data, ed = entry->data;
-	     langNum < entry->info.count;
+	     langNum < entry->info.count && langNum < table->info.count;
 	     langNum++, t += strlen(t) + 1, ed += strlen(ed) + 1) {
 
 	    int match = headerMatchLocale(t, l, le);


### PR DESCRIPTION
If the i18ntable was smaller than the i18nstring entry an out of bounds
read could result.  This should not happen in a valid package, but even
if RPM rejected such packages during load, this situation could still
result as a result of usage of the RPM API.