### PR TITLE
Make test suite a dependency of populate_testing

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -168,8 +168,10 @@ atlocal:	atlocal.in Makefile
 DISTCLEANFILES = atlocal
 EXTRA_DIST += atlocal.in
 
+check_DATA = atconfig atlocal $(TESTSUITE)
+
 # The chmod is needed when copying from read-only sources (eg in distcheck)
-populate_testing:
+populate_testing: $(check_DATA)
 	if [ -d testing ]; then chmod -R u+w testing/; fi
 	rm -rf testing
 	mkdir -p testing/$(bindir)
@@ -186,8 +188,6 @@ populate_testing:
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 	chmod -R u-w testing/
-
-check_DATA = atconfig atlocal $(TESTSUITE)
 
 if HAVE_FAKECHROOT
 check-local: $(check_DATA) populate_testing


### PR DESCRIPTION
We are now using populate_testing as an entry point to manually calling
rpmtests (as described in the test/README.md). Right now this does not
rebuild the test suite itself. So while populate_testing itself does not
really care this makes it more user friendly for humans.