### PR TITLE
Make %{buildsubdir} usable without being a side effect of %setup

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -104,6 +104,7 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 {
     char *scriptName = NULL;
     char * buildDir = rpmGenPath(spec->rootDir, "%{_builddir}", "");
+    char * buildSubdir = rpmGetPath("%{?buildsubdir}", NULL);
     char * buildCmd = NULL;
     char * buildTemplate = NULL;
     char * buildPost = NULL;
@@ -182,12 +183,12 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 
     (void) fputs(buildTemplate, fp);
 
-    if (what != RPMBUILD_PREP && what != RPMBUILD_RMBUILD && spec->buildSubdir)
-	fprintf(fp, "cd '%s'\n", spec->buildSubdir);
+    if (what != RPMBUILD_PREP && what != RPMBUILD_RMBUILD && buildSubdir[0] != '\0')
+	fprintf(fp, "cd '%s'\n", buildSubdir);
 
     if (what == RPMBUILD_RMBUILD) {
-	if (spec->buildSubdir)
-	    fprintf(fp, "rm -rf '%s'\n", spec->buildSubdir);
+	if (buildSubdir[0] != '\0')
+	    fprintf(fp, "rm -rf '%s'\n", buildSubdir);
     } else if (sb != NULL)
 	fprintf(fp, "%s", sb);
 
@@ -207,8 +208,7 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
     (void) poptParseArgvString(buildCmd, &argc, &argv);
 
     rpmlog(RPMLOG_NOTICE, _("Executing(%s): %s\n"), name, buildCmd);
-    if (rpmfcExec((ARGV_const_t)argv, NULL, sb_stdoutp, 1,
-		  spec->buildSubdir)) {
+    if (rpmfcExec((ARGV_const_t)argv, NULL, sb_stdoutp, 1, buildSubdir)) {
 	rpmlog(RPMLOG_ERR, _("Bad exit status from %s (%s)\n"),
 		scriptName, name);
 	goto exit;
@@ -226,6 +226,7 @@ exit:
     free(buildCmd);
     free(buildTemplate);
     free(buildPost);
+    free(buildSubdir);
     free(buildDir);
 
     return rc;

--- a/build/files.c
+++ b/build/files.c
@@ -1625,7 +1625,6 @@ static rpmRC recurseDir(FileList fl, const char * diskPath)
 static rpmRC processMetadataFile(Package pkg, FileList fl, 
 				 const char * fileName, rpmTagVal tag)
 {
-    const char * buildDir = "%{_builddir}/%{?buildsubdir}/";
     char * fn = NULL;
     char * apkt = NULL;
     uint8_t * pkt = NULL;
@@ -1638,7 +1637,7 @@ static rpmRC processMetadataFile(Package pkg, FileList fl,
 	fn = rpmGenPath(fl->buildRoot, NULL, fileName);
 	absolute = 1;
     } else
-	fn = rpmGenPath(buildDir, NULL, fileName);
+	fn = rpmGenPath("%{_builddir}", "%{?buildsubdir}", fileName);
 
     switch (tag) {
     default:
@@ -2240,8 +2239,7 @@ int readManifest(rpmSpec spec, const char *path, const char *descr, int flags,
     if (*path == '/') {
 	fn = rpmGetPath(path, NULL);
     } else {
-	fn = rpmGetPath("%{_builddir}/",
-	    (spec->buildSubdir ? spec->buildSubdir : "") , "/", path, NULL);
+	fn = rpmGenPath("%{_builddir}", "%{?buildsubdir}", path);
     }
     fd = fopen(fn, "r");
 
@@ -2413,7 +2411,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	}
     }
 
-    basepath = rpmGenPath(spec->rootDir, "%{_builddir}", spec->buildSubdir);
+    basepath = rpmGenPath(spec->rootDir, "%{_builddir}", "%{?buildsubdir}");
     files = sd->files;
     fi = 0;
     while (*files != NULL) {

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -106,7 +106,6 @@ struct rpmSpec_s {
 
     char * specFile;	/*!< Name of the spec file. */
     char * buildRoot;
-    char * buildSubdir;
     const char * rootDir;
 
     struct OpenFileInfo * fileStack;

--- a/build/spec.c
+++ b/build/spec.c
@@ -236,7 +236,6 @@ rpmSpec newSpec(void)
     spec->sourcePackage = NULL;
     
     spec->buildRoot = NULL;
-    spec->buildSubdir = NULL;
 
     spec->buildRestrictions = headerNew();
     spec->BANames = NULL;
@@ -267,7 +266,6 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     spec->buildrequires = freeStringBuf(spec->buildrequires);
 
     spec->buildRoot = _free(spec->buildRoot);
-    spec->buildSubdir = _free(spec->buildSubdir);
     spec->specFile = _free(spec->specFile);
 
     closeSpec(spec);


### PR DESCRIPTION
This patch makes a couple of related changes:
- lets you set %{buildsubdir} as a global to expose it everywhere,
  rather than just specific parts of %prep (%setup and %patch*)
- lets you choose what path is used independently of the unpack
  options in %setup
- allows you to use a different %{buildsubdir} in different parts of
  the .spec, for instance if you have multiple builds of the same code
  with different compile options



Rebased #860 to $CURRENTYEAR

Resolves: #860