### PR TITLE
rpmspec: Support - as input for reading from stdin

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -385,7 +385,11 @@ static int readLineFromOFI(rpmSpec spec, OFI_t *ofi)
 retry:
     /* Make sure the current file is open */
     if (ofi->fp == NULL) {
-	ofi->fp = fopen(ofi->fileName, "r");
+	if (rstreq(ofi->fileName, "-")) {
+	    ofi->fp = fdopen(STDIN_FILENO, "r");
+	} else {
+	    ofi->fp = fopen(ofi->fileName, "r");
+	}
 	if (ofi->fp == NULL) {
 	    rpmlog(RPMLOG_ERR, _("Unable to open %s: %s\n"),
 		     ofi->fileName, strerror(errno));


### PR DESCRIPTION
I tried adding a test case but it fails with
```
+error: Unable to open -: Bad file descriptor
+error: query of specfile - failed, can't parse
```
while it seems to work fine on the command line. I guess the testsuite is messing with stdin but I couldn't figure out how.