### PR TITLE
Don't fail outright when installing to filesystems without xattr support. Also fix build issue when WITH_CAP is not set.

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -94,6 +94,7 @@ static int fsmLink(int odirfd, const char *opath, int dirfd, const char *path)
     return rc;
 }
 
+#if WITH_CAP
 static int cap_set_fileat(int dirfd, const char *path, cap_t fcaps)
 {
     int rc = -1;
@@ -104,6 +105,7 @@ static int cap_set_fileat(int dirfd, const char *path, cap_t fcaps)
     }
     return rc;
 }
+#endif
 
 static int fsmSetFCaps(int fd, int dirfd, const char *path, const char *captxt)
 {

--- a/plugins/ima.c
+++ b/plugins/ima.c
@@ -74,10 +74,14 @@ static rpmRC ima_fsm_file_prepare(rpmPlugin plugin, rpmfi fi, int fd,
 	    else
 		xx = lsetxattr(path, XATTR_NAME_IMA, fsig, len, 0);
 	    if (xx < 0) {
-	        rpmlog(RPMLOG_ERR,
+		int is_err = errno != EOPNOTSUPP;
+
+	        rpmlog(is_err?RPMLOG_ERR:RPMLOG_DEBUG,
 			"ima: could not apply signature on '%s': %s\n",
 			path, strerror(errno));
-	        rc = RPMRC_FAIL;
+		if (is_err) {
+		    rc = RPMRC_FAIL;
+		}
 	    }
 	}
 


### PR DESCRIPTION
In the process of fixing one issue, in `plugins/ima.c`, I came across another build issue in `lib/fsm,c` which I've included a patch for here too.

The commit logs for each pretty much cover what they are doing.