### PR TITLE
Add separate build configuration (%conf) section to spec

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -129,6 +129,11 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 	mPost = "%{__spec_buildrequires_post}";
 	mCmd = "%{__spec_buildrequires_cmd}";
 	break;
+    case RPMBUILD_CONF:
+	mTemplate = "%{__spec_conf_template}";
+	mPost = "%{__spec_conf_post}";
+	mCmd = "%{__spec_conf_cmd}";
+	break;
     case RPMBUILD_BUILD:
 	mTemplate = "%{__spec_build_template}";
 	mPost = "%{__spec_build_post}";
@@ -335,9 +340,9 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	    }
 	}
     } else {
-	int didBuild = (what & (RPMBUILD_PREP|RPMBUILD_BUILD|RPMBUILD_INSTALL));
+	int didBuild = (what & (RPMBUILD_PREP|RPMBUILD_CONF|RPMBUILD_BUILD|RPMBUILD_INSTALL));
 	int sourceOnly = ((what & RPMBUILD_PACKAGESOURCE) &&
-	   !(what & (RPMBUILD_BUILD|RPMBUILD_INSTALL|RPMBUILD_PACKAGEBINARY)));
+	   !(what & (RPMBUILD_CONF|RPMBUILD_BUILD|RPMBUILD_INSTALL|RPMBUILD_PACKAGEBINARY)));
 
 	if (!spec->buildrequires && sourceOnly) {
 		/* don't run prep if not needed for source build */
@@ -377,6 +382,11 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 	} else if (rc) {
 	    goto exit;
 	}
+
+	if ((what & RPMBUILD_CONF) &&
+	    (rc = doScript(spec, RPMBUILD_BUILD, "%conf",
+			   getStringBuf(spec->conf), test, sbp)))
+		goto exit;
 
 	if ((what & RPMBUILD_BUILD) &&
 	    (rc = doScript(spec, RPMBUILD_BUILD, "%build",

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -46,6 +46,7 @@ static const struct PartRec {
     { PART_PREAMBLE,      LEN_AND_STR("%package")},
     { PART_PREP,          LEN_AND_STR("%prep")},
     { PART_BUILDREQUIRES, LEN_AND_STR("%generate_buildrequires")},
+    { PART_CONF,        LEN_AND_STR("%conf")},
     { PART_BUILD,         LEN_AND_STR("%build")},
     { PART_INSTALL,       LEN_AND_STR("%install")},
     { PART_CHECK,         LEN_AND_STR("%check")},
@@ -935,6 +936,9 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 	    break;
 	case PART_PREP:
 	    parsePart = parsePrep(spec);
+	    break;
+	case PART_CONF:
+	    parsePart = parseSimpleScript(spec, "%conf", &(spec->conf));
 	    break;
 	case PART_BUILDREQUIRES:
 	    parsePart = parseSimpleScript(spec, "%generate_buildrequires",

--- a/build/rpmbuild.h
+++ b/build/rpmbuild.h
@@ -38,6 +38,7 @@ enum rpmBuildFlags_e {
     RPMBUILD_CHECKBUILDREQUIRES	= (1 <<  19),	/*!< Check %%buildrequires. */
     RPMBUILD_BUILDREQUIRES	= (1 <<  20), /*!< Execute %%buildrequires. */
     RPMBUILD_DUMPBUILDREQUIRES	= (1 <<  21), /*!< Write buildrequires.nosrc.rpm. */
+    RPMBUILD_CONF	= (1 << 22),	/*!< Execute %%conf. */
 
     RPMBUILD_NOBUILD	= (1 << 31)	/*!< Don't execute or package. */
 };

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -141,6 +141,7 @@ struct rpmSpec_s {
     rpmstrPool pool;
 
     StringBuf prep;		/*!< %prep scriptlet. */
+    StringBuf conf;		/*!< %conf scriptlet. */
     StringBuf buildrequires;	/*!< %buildrequires scriptlet. */
     StringBuf build;		/*!< %build scriptlet. */
     StringBuf install;		/*!< %install scriptlet. */
@@ -240,7 +241,8 @@ typedef enum rpmParseState_e {
     PART_PATCHLIST		= 40+PART_BASE, /*!< */
     PART_SOURCELIST		= 41+PART_BASE, /*!< */
     PART_BUILDREQUIRES		= 42+PART_BASE, /*!< */
-    PART_LAST			= 43+PART_BASE  /*!< */
+    PART_CONF			= 43+PART_BASE, /*!< */
+    PART_LAST			= 44+PART_BASE  /*!< */
 } rpmParseState; 
 
 

--- a/build/spec.c
+++ b/build/spec.c
@@ -218,6 +218,7 @@ rpmSpec newSpec(void)
 
     spec->rootDir = NULL;
     spec->prep = NULL;
+    spec->conf = NULL;
     spec->build = NULL;
     spec->install = NULL;
     spec->check = NULL;
@@ -258,6 +259,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     if (spec == NULL) return NULL;
 
     spec->prep = freeStringBuf(spec->prep);
+    spec->conf = freeStringBuf(spec->conf);
     spec->build = freeStringBuf(spec->build);
     spec->install = freeStringBuf(spec->install);
     spec->check = freeStringBuf(spec->check);
@@ -431,6 +433,7 @@ const char * rpmSpecGetSection(rpmSpec spec, int section)
 	switch (section) {
 	case RPMBUILD_NONE:	return getStringBuf(spec->parsed);
 	case RPMBUILD_PREP:	return getStringBuf(spec->prep);
+	case RPMBUILD_CONF:	return getStringBuf(spec->conf);
 	case RPMBUILD_BUILD:	return getStringBuf(spec->build);
 	case RPMBUILD_INSTALL:	return getStringBuf(spec->install);
 	case RPMBUILD_CHECK:	return getStringBuf(spec->check);

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -15,13 +15,13 @@ SYNOPSIS
 BUILDING PACKAGES:
 ------------------
 
-**rpmbuild** {**-ba\|-bb\|-bp\|-bc\|-bi\|-bl\|-bs\|-br\|-bd**}
+**rpmbuild** {**-ba\|-bb\|-bp\|-bf|\-bc\|-bi\|-bl\|-bs\|-br\|-bd**}
 \[**rpmbuild-options**\] *SPECFILE \...*
 
-**rpmbuild** {**-ra\|-rb\|-rp\|-rc\|-ri\|-rl\|-rs\|-rr\|-rd**}
+**rpmbuild** {**-ra\|-rb\|-rp\|-rf\|-rc\|-ri\|-rl\|-rs\|-rr\|-rd**}
 \[**rpmbuild-options**\] *SOURCEPACKAGE \...*
 
-**rpmbuild** {**-ta\|-tb\|-tp\|-tc\|-ti\|-tl\|-ts\|-tr\|-td**}
+**rpmbuild** {**-ta\|-tb\|-tp\|-tf\|-tc\|-ti\|-tl\|-ts\|-tr\|-td**}
 \[**rpmbuild-options**\] *TARBALL \...*
 
 **rpmbuild** {**\--rebuild\|\--recompile**} *SOURCEPKG \...*
@@ -160,6 +160,11 @@ all the stages preceding it), and is one of:
 
 :   Unpack the sources and apply any patches - executes the %prep stage
     only.
+
+**-bf**
+
+:   Configure the sources - executes up to and including the %conf stage.
+    This generally involves the equivalent of a \"./configure\".
 
 **-bc**
 

--- a/docs/manual/buildprocess.md
+++ b/docs/manual/buildprocess.md
@@ -13,6 +13,7 @@ title: rpm.org - Package Build Process
   * %prep
   * %generate_buildrequires if present
     * re-check build requires - stop build on errors
+  * %conf
   * %build
   * %install
   * %check - if present

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -485,16 +485,27 @@ package. As always they depend on the exact circumstance of the build
 and may be different when bulding based on other packages or even
 another architecture.
 
+### %conf
+
+In %conf, the unpacked sources are configured for building.
+
+Different build- and language ecosystems come with their
+own helper macros, but rpm has helpers for autotools based builds such as
+itself which typically look like this:
+
+%conf
+%configure
+
 ### %build
 
-In %build, the unpacked sources are compiled to binaries.
+In %build, the unpacked (and configured) sources are compiled to binaries.
+
 Different build- and language ecosystems come with their
 own helper macros, but rpm has helpers for autotools based builds such as
 itself which typically look like this:
 
 ```
 %build
-%configure
 %make_build
 ```
 

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -22,7 +22,7 @@ the macro with an extra percent sign (%):
 ```
 
 Another option is to use built-in macro %dnl that discards text to next
-line without expanding it.
+line without expanding it. (since rpm >= 4.15)
 
 ```
     %dnl make unversioned %__python an error unless explicitly overridden
@@ -331,12 +331,12 @@ conflicting paths or otherwise conflicting functionality.
 Packages obsoleted by this package. Used for replacing and renaming
 packages.
 
-#### Recommends
+#### Recommends (since rpm >= 4.13)
 #### Suggests
 #### Supplements
 #### Enhances
 
-#### OrderByRequires
+#### OrderWithRequires (sicne rpm >= 4.9)
 
 #### Prereq
 
@@ -465,8 +465,8 @@ In simple packages `%prep` is often just:
 %prep
 %autosetup
 ```
-
-### %generate_buildrequires
+ 
+### %generate_buildrequires (since rpm >= 4.15)
 
 This optional script can be used to determine `BuildRequires`
 dynamically. If present it is executed after %prep and can though
@@ -485,7 +485,7 @@ package. As always they depend on the exact circumstance of the build
 and may be different when bulding based on other packages or even
 another architecture.
 
-### %conf
+### %conf (since rpm >= 4.18)
 
 In %conf, the unpacked sources are configured for building.
 
@@ -555,7 +555,7 @@ for each scriptlet individually. Other supported operations include
 
 More information is available in [trigger chapter](triggers.md).
 
-### File triggers
+### File triggers (since rpm >= 4.13)
 
  * `%filetriggerin`
  * `%filetriggerun`
@@ -570,7 +570,7 @@ More information is available in [file trigger chapter](file_triggers.md).
 
 ### Virtual File Attribute(s)
 
-#### %artifact
+#### %artifact (since rpm >= 4.14.1)
 
 The %artifact attribute can be used to denote files that are more like
 side-effects of packaging than actual content the user would be interested
@@ -612,7 +612,7 @@ documentation path.
 Can also be used to filter out documentation from installations where
 space is tight.
 
-#### %license
+#### %license (since rpm >= 4.11)
 
 Used to mark and/or install files as licenses. Same as %doc, but 
 cannot be filtered out as licenses must always be present in packages.

--- a/macros.in
+++ b/macros.in
@@ -792,6 +792,15 @@ package or when debugging this package.\
 #%{__spec_buildrequires_post}\
 #%{nil}
 
+%__spec_conf_shell	%{___build_shell}
+%__spec_conf_args	%{___build_args}
+%__spec_conf_cmd	%{___build_cmd}
+%__spec_conf_pre	%{___build_pre}
+%__spec_conf_body	%{___build_body}
+%__spec_conf_post	%{___build_post}
+%__spec_conf_template	#!%{__spec_build_shell}\
+%{__spec_conf_pre}\
+%{nil}
 
 %__spec_build_shell	%{___build_shell}
 %__spec_build_args	%{___build_args}

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -626,43 +626,44 @@ int main(int argc, char *argv[])
     (void) rpmtsSetRootDir(ts, rpmcliRootDir);
     rpmtsSetFlags(ts, rpmtsFlags(ts) | RPMTRANS_FLAG_NOPLUGINS);
 
+    /* Mind the fallthrough order - it's the reverse of the build process */
     switch (buildChar) {
     case 'a':
 	ba->buildAmount |= RPMBUILD_PACKAGESOURCE;
+	/* fallthrough */
     case 'b':
 	ba->buildAmount |= RPMBUILD_PACKAGEBINARY;
 	ba->buildAmount |= RPMBUILD_CLEAN;
 	if ((buildChar == 'b') && shortCircuit)
 	    break;
+	/* fallthrough */
     case 'i':
 	ba->buildAmount |= RPMBUILD_INSTALL;
 	ba->buildAmount |= RPMBUILD_CHECK;
 	if ((buildChar == 'i') && shortCircuit)
 	    break;
+	/* fallthrough */
     case 'c':
 	ba->buildAmount |= RPMBUILD_BUILD;
-	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
-	if (!noDeps) {
-	    ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
-	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
-	}
 	if ((buildChar == 'c') && shortCircuit)
 	    break;
+	/* fallthrough */
+    case 'r':
+    case 'd':
+	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
+	ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
+	if (!noDeps)
+	    ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
+	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
+	if ((buildChar == 'r' || buildChar == 'd') && shortCircuit)
+	    break;
+	/* fallthrough */
     case 'p':
 	ba->buildAmount |= RPMBUILD_PREP;
 	break;
     case 'l':
 	ba->buildAmount |= RPMBUILD_FILECHECK;
 	break;
-    case 'r':
-    case 'd':
-	ba->buildAmount |= RPMBUILD_PREP;
-	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
-	ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
-	if (!noDeps)
-	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
-	if (buildChar == 'd')
-	    break;
     case 's':
 	ba->buildAmount |= RPMBUILD_PACKAGESOURCE;
 	break;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -76,6 +76,7 @@ EXTRA_DIST += data/SPECS/scriptfail.spec
 EXTRA_DIST += data/SPECS/scriptfile.spec
 EXTRA_DIST += data/SPECS/selfconflict.spec
 EXTRA_DIST += data/SPECS/shebang.spec
+EXTRA_DIST += data/SPECS/specstep.spec
 EXTRA_DIST += data/SPECS/suicidal.spec
 EXTRA_DIST += data/SPECS/reloc.spec
 EXTRA_DIST += data/SPECS/replacetest.spec

--- a/tests/data/SPECS/specstep.spec
+++ b/tests/data/SPECS/specstep.spec
@@ -11,6 +11,8 @@ License: GPL
 
 %generate_buildrequires
 
+%conf
+
 %build
 
 %install

--- a/tests/data/SPECS/specstep.spec
+++ b/tests/data/SPECS/specstep.spec
@@ -1,0 +1,19 @@
+Name: specstep
+Version: 1.0
+Release: 1
+Summary: Testing spec steps
+License: GPL
+
+%description
+%{summary}
+
+%prep
+
+%generate_buildrequires
+
+%build
+
+%install
+
+%check
+

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -63,11 +63,21 @@ Executing(%generate_buildrequires)
 [])
 
 AT_CHECK([
+runroot rpmbuild -bf /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+Executing(%conf)
+],
+[])
+AT_CHECK([
 runroot rpmbuild -bc /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
 [Executing(%prep)
 Executing(%generate_buildrequires)
+Executing(%conf)
 Executing(%build)
 ],
 [])
@@ -78,6 +88,7 @@ runroot rpmbuild -bi /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [0],
 [Executing(%prep)
 Executing(%generate_buildrequires)
+Executing(%conf)
 Executing(%build)
 Executing(%install)
 Executing(%check)
@@ -90,6 +101,7 @@ runroot rpmbuild -bb /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [0],
 [Executing(%prep)
 Executing(%generate_buildrequires)
+Executing(%conf)
 Executing(%build)
 Executing(%install)
 Executing(%check)
@@ -103,6 +115,7 @@ runroot rpmbuild -ba /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [0],
 [Executing(%prep)
 Executing(%generate_buildrequires)
+Executing(%conf)
 Executing(%build)
 Executing(%install)
 Executing(%check)

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -33,6 +33,91 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild -b steps])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+runroot rpmbuild -bp /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -br /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -bd /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -bc /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+Executing(%build)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -bi /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+Executing(%build)
+Executing(%install)
+Executing(%check)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -bb /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+Executing(%build)
+Executing(%install)
+Executing(%check)
+Executing(%clean)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -ba /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[Executing(%prep)
+Executing(%generate_buildrequires)
+Executing(%build)
+Executing(%install)
+Executing(%check)
+Executing(%clean)
+],
+[])
+
+AT_CHECK([
+runroot rpmbuild -bs /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
+],
+[0],
+[],
+[])
+AT_CLEANUP
+
 AT_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
 RPMDB_INIT


### PR DESCRIPTION
Configuring the sources (eg ./configure, cmake and whatnot) is really a distinct step which is very unlike the actual build, in that the actual build steps are generally equal for all projects using a given build system, but configuration differs greatly once you go beyond the default paths and the like.

This is essentially a pre-requisite for implementing build system templating  in spec files.

Fixes: #1086

Couple of preceding commits to establish tests and fixup + comment the build-letter switch-case ordering which caught me too :sweat_smile: 