### PR TITLE
    Add MALLOC_CHECK_ and MALLOC_PERTURB_ libc env to the test suite …

### DIFF
--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -50,6 +50,20 @@ else
     CAP_DISABLED=true;
 fi
 
+# Enable malloc-check as a cheap way to find some use-after-free and
+# uninitialized read problems when using glibc, and doesn't affect
+# normal operation or other libc.
+# Only for GLIBC >=2.34
+
+random="$(awk 'BEGIN{srand(); printf "%d\n",(rand()*255)}')"
+if _GLIBC_VERSION=$(getconf GNU_LIBC_VERSION 2>/dev/null)
+then
+	LD_PRELOAD="libc_malloc_debug.so.0"
+	GLIBC_TUNABLES="glibc.malloc.check=1:glibc.malloc.perturb=${random}"
+	export LD_PRELOAD
+	export GLIBC_TUNABLES
+fi
+
 function setup_env()
 {
     if [ -d testing ]; then


### PR DESCRIPTION
…for detecting heap corruption for glibc <2.34. For glibc >=2.34 use the new heap consistency checking environment variables

    Recent versions of Linux libc (later than 5.4.23) and glibc (2.x)
    include a malloc() implementation which is tunable via environment
    variables. When MALLOC_CHECK_ is set, a special (less efficient)
    implementation is used which is designed to be tolerant against
    simple errors, such as double calls of free() with the same argument,
    or overruns of a single byte (off-by-one bugs). When MALLOC_CHECK_
    is set to 3, a diagnostic message is printed on stderr
    and the program is aborted.

    Setting the MALLOC_PERTURB_ environment variable causes the malloc
    functions in libc to return memory which has been wiped and clear
    memory when it is returned.
    Of course this does not affect calloc which always does clear the memory.

    The reason for this exercise is, of course, to find code which uses
    memory returned by malloc without initializing it and code which uses
    code after it is freed. valgrind can do this but it's costly to run.
    The MALLOC_PERTURB_ exchanges the ability to detect problems in 100%
    of the cases with speed.

    The byte value used to initialize values returned by malloc is the byte
    value of the environment value. The value used to clear memory is the
    bitwise inverse. Setting MALLOC_PERTURB_ to zero disables the feature.

    This technique can find hard to detect bugs.
    It is therefore suggested to always use this flag (at least temporarily)
    when testing out code or a new distribution (http://udrepper.livejournal.com/11429.html).

    We have to be careful if you want to use valgrind with the test suite however.

    Memcheck wraps client calls to malloc(), and puts a "red zone" on
    each end of each block in order to detect access overruns.
    Memcheck already detects double free() (up to the limit of the buffer
    which remembers pending free()). Thus memcheck subsumes all the
    documented coverage of MALLOC_CHECK_.

    If MALLOC_CHECK_ is set non-zero when running memcheck, then the
    overruns that might be detected by MALLOC_CHECK_ would be overruns
    on the wrapped blocks which include the red zones.  Thus MALLOC_CHECK_
    would be checking memcheck, and not the client.  This is not useful,
    and actually is wasteful.  The only possible [documented] advantage
    of using MALLOC_CHECK_ and memcheck together, would be if MALLOC_CHECK_
    detected duplicate free() in more cases than memcheck because memcheck's
    buffer is too small.

    Therefore we shouldn't use use MALLOC_CHECK_ and valgrind at the
    same time.

    MALLOC_CHECK_ and MALLOC_PERTURB_ were the environment variables used until glibc 2.34.
    In glibc >= 2.34 MALLOC_CHECK_ and MALLOC_PERTURB_ environment
    variables have been replaced by GLIBC_TUNABLES.  Also the new
    glibc requires that you preload a library called libc_malloc_debug.so
    to get these features.

    This patch was inspired by a Richard W.M. Jones ndbkit patch
    (https://gitlab.com/nbdkit/nbdkit/-/commit/362e0fdcae37db876e13b944102a5c152e6bc563)