### PR TITLE
Add tests for 2038 readiness

### DIFF
--- a/tests/data/SPECS/hello.spec
+++ b/tests/data/SPECS/hello.spec
@@ -26,6 +26,7 @@ make
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/usr/local/bin
 make DESTDIR=$RPM_BUILD_ROOT install
+touch -t 204205042355 FAQ
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -131,6 +131,32 @@ runroot rpmbuild -bs /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [])
 AT_CLEANUP
 
+# ------------------------------
+# Check if rpmbuild -ba *.spec works after 2038
+AT_SETUP([rpmbuild -ba *.spec after 2038])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([[
+touch -t 204205042355 ${RPMTEST}/data/SPECS/hello.spec
+touch -t 204205042355 ${RPMTEST}/data/SOURCES/hello-1.0.tar.gz
+touch -t 204205042355 ${RPMTEST}/data/SOURCES/hello-1.0-modernize.patch
+
+unset SOURCE_DATE_EPOCH
+run rpmbuild --quiet \
+  -ba  "${RPMTEST}"/data/SPECS/hello.spec
+
+run rpm -qp --qf '[%{FILENAMES} %{FILEMTIMES:date}\n]' "${RPMTEST}"/build/SRPMS/hello-1.0-1.src.rpm
+run rpm -qp --qf '[%{FILENAMES} %{FILEMTIMES:date}\n]' "${RPMTEST}"/build/RPMS/*/hello-1.0-1.*.rpm | grep FAQ
+]],
+[0],
+[hello-1.0-modernize.patch Sun May  4 23:55:00 2042
+hello-1.0.tar.gz Sun May  4 23:55:00 2042
+hello.spec Sun May  4 23:55:00 2042
+/usr/share/doc/hello-1.0/FAQ Sun May  4 23:55:00 2042
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([rpmbuild -ba autosetup])
 AT_KEYWORDS([build])
 RPMDB_INIT

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -147,12 +147,17 @@ run rpmbuild --quiet \
 
 run rpm -qp --qf '[%{FILENAMES} %{FILEMTIMES:date}\n]' "${RPMTEST}"/build/SRPMS/hello-1.0-1.src.rpm
 run rpm -qp --qf '[%{FILENAMES} %{FILEMTIMES:date}\n]' "${RPMTEST}"/build/RPMS/*/hello-1.0-1.*.rpm | grep FAQ
+runroot rpm -i --quiet --nodeps /build/RPMS/*/hello-1.0-1.*.rpm
+run rpm -q --qf '[%{FILENAMES} %{FILEMTIMES:date}\n]' hello-1.0-1 | grep FAQ
+ls -l "${RPMTEST}"/usr/share/doc/hello-1.0/FAQ | cut "-d " -f6-10
 ]],
 [0],
 [hello-1.0-modernize.patch Sun May  4 23:55:00 2042
 hello-1.0.tar.gz Sun May  4 23:55:00 2042
 hello.spec Sun May  4 23:55:00 2042
 /usr/share/doc/hello-1.0/FAQ Sun May  4 23:55:00 2042
+/usr/share/doc/hello-1.0/FAQ Sun May  4 23:55:00 2042
+May  4  2042
 ],
 [])
 AT_CLEANUP


### PR DESCRIPTION
These are somewhat limited by what can be done in the vanilla test suite. One way for better coverage would be to use the `faketime` utility and either run some test with that or the whole test suite (although this is slowing down things more than is comfortable)