### PR TITLE
Handle missing RPMTAG_ARCH in RPMTAG_ARCHSUFFIX

### DIFF
--- a/docs/manual/tags.md
+++ b/docs/manual/tags.md
@@ -403,7 +403,7 @@ as well however, these exceptions noted below.
 
 Tag Name      | Value| Type         | Description
 --------------|------|--------------|------------
-Archsuffix    | 5098 | string       | "src", "nosrc" or `arch`
+Archsuffix    | 5098 | string       | Package file arch suffix (".src", ".nosrc" or .`arch`)
 Dbinstance    | 1195 | int32        | Header ID of installed package, 0 otherwise.
 Epochnum      | 5019 | int32        | Package epoch as numeric value (0 if not present).
 Evr           | 5013 | string       | Formatted `epoch:version-release` string of the package

--- a/lib/tagexts.c
+++ b/lib/tagexts.c
@@ -742,17 +742,24 @@ static int headercolorTag(Header h, rpmtd td, headerGetFlags hgflags)
 
 static int archsuffixTag(Header h, rpmtd td, headerGetFlags hgflags)
 {
+    const char *a = NULL;
     char * val;
 
     if (headerIsSource(h)) {
 	if (headerIsEntry(h, RPMTAG_NOSOURCE) ||
 	    headerIsEntry(h, RPMTAG_NOPATCH))
-	    val = xstrdup("nosrc");
+	    a = xstrdup("nosrc");
 	else
-	    val = xstrdup("src");
+	    a = xstrdup("src");
     } else {
-	val = xstrdup(headerGetString(h, RPMTAG_ARCH));
+	a = headerGetString(h, RPMTAG_ARCH);
     }
+
+    if (a)
+	val = rstrscat(NULL, ".", a, NULL);
+    else
+	val = xstrdup("");
+
     td->type = RPM_STRING_TYPE;
     td->data = val;
     td->count = 1;

--- a/macros.in
+++ b/macros.in
@@ -685,7 +685,7 @@ package or when debugging this package.\
 # Default output format string for rpm -qa
 #
 # XXX	Note: escaped %% for use in headerFormat()
-%_query_all_fmt		%%{nvr}.%%{archsuffix}
+%_query_all_fmt		%%{nvr}%%{archsuffix}
 
 #
 # Default for coloring output

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -32,7 +32,7 @@ AT_CLEANUP
 
 # ------------------------------
 # Run rpm -qa on an empty rpmdb
-AT_SETUP([rpm -qa])
+AT_SETUP([rpm -qa 1])
 AT_KEYWORDS([rpmdb query])
 AT_CHECK([
 RPMDB_INIT
@@ -43,7 +43,7 @@ runroot rpm \
 AT_CLEANUP
 
 # Run rpm -qa on a non-existent rpmdb
-AT_SETUP([rpm -qa])
+AT_SETUP([rpm -qa 2])
 AT_KEYWORDS([rpmdb query])
 AT_CHECK([
 RPMTEST_SETUP
@@ -53,6 +53,34 @@ runroot rpm \
 [0],
 [],
 [ignore])
+AT_CLEANUP
+
+AT_SETUP([rpm -qa 3])
+AT_KEYWORDS([rpmdb query])
+RPMDB_INIT
+
+AT_CHECK([
+runroot rpm -U --nodeps --ignorearch --ignoreos --nosignature \
+	/data/RPMS/foo-1.0-1.noarch.rpm \
+	/data/RPMS/hello-2.0-1.x86_64-signed.rpm
+runroot rpm -qa | sort
+],
+[0],
+[foo-1.0-1.noarch
+hello-2.0-1.x86_64
+],
+[])
+
+AT_CHECK([
+runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
+runroot rpm -qa | sort
+],
+[0],
+[foo-1.0-1.noarch
+gpg-pubkey-1964c5fc-58e63918
+hello-2.0-1.x86_64
+],
+[])
 AT_CLEANUP
 
 # ------------------------------


### PR DESCRIPTION
RPMTAG_ARCHSUFFIX from commit e6a6399cb4c87f049bb75b8da83f5759522bcc58
assumes all headers have RPMTAG_ARCH, but a notable exception is gpg-pubkey
headers in rpmdb, causing segfaults on `rpm -qa` on normal systems.

Special case conditionals in queryformats get ugly and error-prone real
fast, which is why we have all the NEVRA formatter extensions. Avoid
adding yet more of those tags by handling the dot formatting in
ARCHSUFFIX instead - the "suffix" in the name seems to imply this
anyway.

Also add tests to cover the common -qa cases.