### PR TITLE
Fix regression on ctrl-c during transaction killing scriptlets

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -197,8 +197,10 @@ static void doScriptExec(ARGV_const_t argv, ARGV_const_t prefixes,
     int xx;
     sigset_t set;
 
-    /* Unmask all signals, the scripts may need them */
+    /* Unmask most signals, the scripts may need them */
     sigfillset(&set);
+    sigdelset(&set, SIGINT);
+    sigdelset(&set, SIGQUIT);
     sigprocmask(SIG_UNBLOCK, &set, NULL);
 
     /* SIGPIPE is ignored in rpm, reset to default for the scriptlet */


### PR DESCRIPTION
Commit cb6aa82dbc10d554f8d234e934ae7c77e39a3ce2 unblocked all signals
from scriptlets, but turns out this is too much: SIGINT, SIGTSTP and
SIGQUIT sent from the terminal are passed to the process group, and
with unblocked signals end up killing our scriptlets while rpm itself
continues. -ENOSENSE.

Stopping (and continuing) is okay though so we don't block that.