### PR TITLE
Drop BDB era handholding on signals

### DIFF
--- a/lib/fprint.c
+++ b/lib/fprint.c
@@ -472,8 +472,6 @@ void fpCachePopulate(fingerPrintCache fpc, rpmts ts, int fileCount)
     /* also create a hash of all symlinks in the new packages */
     pi = rpmtsiInit(ts);
     while ((p = rpmtsiNext(pi, 0)) != NULL) {
-	(void) rpmsqPoll();
-
 	if ((fi = rpmteFiles(p)) == NULL)
 	    continue;
 
@@ -512,7 +510,6 @@ void fpCachePopulate(fingerPrintCache fpc, rpmts ts, int fileCount)
     pi = rpmtsiInit(ts);
     while ((p = rpmtsiNext(pi, 0)) != NULL) {
 	fingerPrint *fpList, *lastfp = NULL;
-	(void) rpmsqPoll();
 
 	if ((fi = rpmteFiles(p)) == NULL)
 	    continue;

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -62,8 +62,6 @@ RPM_GNUC_INTERNAL
 void rpmRelocationBuild(Header h, rpmRelocation *rawrelocs,
 		int *rnrelocs, rpmRelocation **rrelocs, uint8_t **rbadrelocs);
 
-RPM_GNUC_INTERNAL
-void rpmAtExit(void);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/query.c
+++ b/lib/query.c
@@ -270,7 +270,6 @@ static int rpmgiShowMatches(QVA_t qva, rpmts ts, rpmgi gi)
     while ((h = rpmgiNext(gi)) != NULL) {
 	int rc;
 
-	rpmsqPoll();
 	if ((rc = qva->qva_showPackage(qva, ts, h)) != 0)
 	    ec = rc;
 	headerFree(h);
@@ -288,7 +287,6 @@ static int rpmcliShowMatches(QVA_t qva, rpmts ts, rpmdbMatchIterator mi)
 
     while ((h = rpmdbNextIterator(mi)) != NULL) {
 	int rc;
-	rpmsqPoll();
 	if ((rc = qva->qva_showPackage(qva, ts, h)) != 0)
 	    ec = rc;
     }
@@ -313,8 +311,6 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
     const char * s;
     int i;
     rpmdbMatchIterator mi = NULL;
-
-    (void) rpmsqPoll();
 
     if (qva->qva_showPackage == NULL)
 	goto exit;

--- a/lib/rpmchecksig.c
+++ b/lib/rpmchecksig.c
@@ -299,7 +299,6 @@ int rpmcliVerifySignatures(rpmts ts, ARGV_const_t argv)
 	}
 
 	Fclose(fd);
-	rpmsqPoll();
     }
     rpmKeyringFree(keyring);
     return res;

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -982,8 +982,6 @@ rpmdbMatchIterator rpmdbFreeIterator(rpmdbMatchIterator mi)
 
     mi = _free(mi);
 
-    (void) rpmsqPoll();
-
     return NULL;
 }
 
@@ -1704,8 +1702,6 @@ rpmdbMatchIterator rpmdbInitIterator(rpmdb db, rpmDbiTagVal rpmtag,
     rpmdbMatchIterator mi = NULL;
 
     if (db != NULL) {
-	(void) rpmsqPoll();
-
 	if (rpmtag == RPMDBI_PACKAGES)
 	    mi = pkgdbIterInit(db, keyp, keylen);
 	else
@@ -1727,8 +1723,6 @@ rpmdbMatchIterator rpmdbInitPrefixIterator(rpmdb db, rpmDbiTagVal rpmtag,
 	return NULL;
 
     if (db != NULL && rpmtag != RPMDBI_PACKAGES) {
-	(void) rpmsqPoll();
-
 
 	if (indexOpen(db, dbtag, 0, &dbi) == 0) {
 	    int rc = 0;
@@ -1812,8 +1806,6 @@ rpmdbIndexIterator rpmdbIndexIteratorInit(rpmdb db, rpmDbiTag rpmtag)
 
     if (db == NULL)
 	return NULL;
-
-    (void) rpmsqPoll();
 
     if (indexOpen(db, rpmtag, 0, &dbi))
 	return NULL;

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -423,9 +423,6 @@ int rpmdbClose(rpmdb db)
 
     db = _free(db);
 
-    if (rpmdbRock == NULL) {
-	rpmsqActivate(0);
-    }
 exit:
     return rc;
 }
@@ -507,11 +504,6 @@ static int openDatabase(const char * prefix,
 	/* Open just bare minimum when rebuilding a potentially damaged db */
 	int justPkgs = (db->db_flags & RPMDB_FLAG_REBUILD) &&
 		       ((db->db_mode & O_ACCMODE) == O_RDONLY);
-	/* Enable signal queue on the first db open */
-	if (db->db_next == NULL) {
-	    rpmsqActivate(1);
-	}
-
 	rc = doOpen(db, justPkgs);
 
 	if (!db->db_descr)

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -651,7 +651,6 @@ restart:
 	rpmcliProgressTotal = 0;
 	rpmcliProgressCurrent = 0;
 	for (i = 0; i < eiu->numSRPMS; i++) {
-	    rpmsqPoll();
 	    if (eiu->sourceURL[i] != NULL) {
 	        rc = RPMRC_OK;
 		if (!(rpmtsFlags(ts) & RPMTRANS_FLAG_TEST))

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1622,21 +1622,12 @@ exit:
     return rc;
 }
 
-static void register_atexit(void)
-{
-    if (atexit(rpmAtExit) != 0)
-	rpmlog(RPMLOG_WARNING, _("failed to register exit handler"));
-}
-
 /* External interfaces */
 
 int rpmReadConfigFiles(const char * file, const char * target)
 {
-    static pthread_once_t atexit_registered = PTHREAD_ONCE_INIT;
     int rc = -1; /* assume failure */
     rpmrcCtx ctx = rpmrcCtxAcquire(1);
-
-    pthread_once(&atexit_registered, register_atexit);
 
     if (rpmInitCrypto())
 	goto exit;

--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -195,6 +195,7 @@ static void doScriptExec(ARGV_const_t argv, ARGV_const_t prefixes,
 			FD_t scriptFd, FD_t out)
 {
     int xx;
+    struct sigaction act;
     sigset_t set;
 
     /* Unmask all signals, the scripts may need them */
@@ -202,7 +203,9 @@ static void doScriptExec(ARGV_const_t argv, ARGV_const_t prefixes,
     sigprocmask(SIG_UNBLOCK, &set, NULL);
 
     /* SIGPIPE is ignored in rpm, reset to default for the scriptlet */
-    (void) signal(SIGPIPE, SIG_DFL);
+    memset(&act, 0, sizeof(act));
+    act.sa_handler = SIG_DFL;
+    sigaction(SIGPIPE, &act, NULL);
 
     rpmSetCloseOnExec();
 

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1774,7 +1774,10 @@ int rpmtsRun(rpmts ts, rpmps okProbs, rpmprobFilterFlags ignoreSet)
     int TsmPreDone = 0; /* TsmPre hook hasn't been called */
     int nelem = rpmtsNElements(ts);
     /* Ignore SIGPIPE for the duration of transaction */
-    rpmsqAction_t oact = rpmsqSetAction(SIGPIPE, RPMSQ_IGN);
+    struct sigaction act, oact;
+    memset(&act, 0, sizeof(act));
+    act.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &act, &oact);
     
     /* Force default 022 umask during transaction for consistent results */
     mode_t oldmask = umask(022);
@@ -1887,6 +1890,6 @@ exit:
     rpmpsFree(tsprobs);
     rpmtxnEnd(txn);
     /* Restore SIGPIPE *after* unblocking signals in rpmtxnEnd() */
-    rpmsqSetAction(SIGPIPE, oact);
+    sigaction(SIGPIPE, &oact, NULL);
     return rc;
 }

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1046,8 +1046,6 @@ rpmdbMatchIterator rpmFindBaseNamesInDB(rpmts ts, uint64_t fileCount)
 
     pi = rpmtsiInit(ts);
     while ((p = rpmtsiNext(pi, 0)) != NULL) {
-	(void) rpmsqPoll();
-
 	rpmtsNotify(ts, NULL, RPMCALLBACK_TRANS_PROGRESS, oc++, tsmem->orderCount);
 
 	/* Gather all installed headers with matching basename's. */

--- a/rpmio/rpmsq.h
+++ b/rpmio/rpmsq.h
@@ -4,7 +4,7 @@
 /** \ingroup rpmio
  * \file rpmio/rpmsq.h
  *
- * Signal Queue API
+ * Signal Queue API (obsolete, do not use)
  */
 #include <rpm/rpmsw.h>
 #include <signal.h>


### PR DESCRIPTION
Details in commit messages, but in short, this drops the dreaded "block signals on rpmdb on" behavior that every librpm user comes to loathe. As a bonus, it also improves thread-safety by eliminating global structures.

This is a pretty drastic change to a very long-standing behavior so some fallout would not be unexpected, despite being a positive change.