### PR TITLE
Drop support for undocumented keyid based import over the net

### DIFF
--- a/lib/rpmchecksig.c
+++ b/lib/rpmchecksig.c
@@ -90,19 +90,6 @@ int rpmcliImportPubkeys(rpmts ts, ARGV_const_t argv)
 	char *t = NULL;
 	int iorc;
 
-	/* If arg looks like a keyid, then attempt keyserver retrieve. */
-	if (rstreqn(fn, "0x", 2)) {
-	    const char * s = fn + 2;
-	    int i;
-	    for (i = 0; *s && isxdigit(*s); s++, i++)
-		{};
-	    if (i == 8 || i == 16) {
-		t = rpmExpand("%{_hkp_keyserver_query}", fn+2, NULL);
-		if (t && *t != '%')
-		    fn = t;
-	    }
-	}
-
 	/* Read the file and try to import all contained keys */
 	iorc = rpmioSlurp(fn, &buf, &blen);
 	if (iorc || buf == NULL || blen < 64) {

--- a/macros.in
+++ b/macros.in
@@ -601,11 +601,6 @@ package or when debugging this package.\
 #	%{__signature_filename} %{__plaintext_filename}
 #
 
-# Horowitz Key Protocol server configuration
-#
-%_hkp_keyserver         http://pgp.mit.edu
-%_hkp_keyserver_query   %{_hkp_keyserver}:11371/pks/lookup?op=get&search=0x
-
 #==============================================================================
 # ---- Transaction macros.
 #	Macro(s) used to parameterize transactions.


### PR DESCRIPTION
This is insecure in so many ways I'm not going to bother trying to list
them all. It's an undocumented "feature" left over from more innocent
times, time to give it the axe.