### PR TITLE
Convert %setup and %patch to actual macros

### DIFF
--- a/build/parseChangelog.c
+++ b/build/parseChangelog.c
@@ -322,7 +322,7 @@ int parseChangelog(rpmSpec spec)
 	goto exit;
     }
     
-    if ((res = parseLines(spec, STRIP_COMMENTS, &sb, NULL)) == PART_ERROR)
+    if ((res = parseLines(spec, STRIP_COMMENTS, &sb, NULL, NULL)) == PART_ERROR)
 	goto exit;
 
     if (sb && addChangelog(spec->packages->header, sb)) {

--- a/build/parseDescription.c
+++ b/build/parseDescription.c
@@ -65,7 +65,7 @@ int parseDescription(rpmSpec spec)
 	goto exit;
 
     if ((nextPart = parseLines(spec, (STRIP_TRAILINGSPACE |STRIP_COMMENTS),
-				NULL, &sb)) == PART_ERROR) {
+				NULL, &sb, NULL)) == PART_ERROR) {
 	goto exit;
     }
 

--- a/build/parseFiles.c
+++ b/build/parseFiles.c
@@ -84,7 +84,7 @@ int parseFiles(rpmSpec spec)
     }
 
     pkg->fileList = argvNew();
-    res = parseLines(spec, STRIP_COMMENTS, &(pkg->fileList), NULL);
+    res = parseLines(spec, STRIP_COMMENTS, &(pkg->fileList), NULL, NULL);
 
 exit:
     rpmPopMacro(NULL, "license");

--- a/build/parseList.c
+++ b/build/parseList.c
@@ -16,7 +16,7 @@ int parseList(rpmSpec spec, const char *name, rpmTagVal tag)
 
     /* There are no options to %patchlist and %sourcelist */
     if ((res = parseLines(spec, (STRIP_TRAILINGSPACE | STRIP_COMMENTS),
-			  &lst, NULL)) == PART_ERROR) {
+			  &lst, NULL, NULL)) == PART_ERROR) {
 	goto exit;
     }
 

--- a/build/parsePolicies.c
+++ b/build/parsePolicies.c
@@ -62,7 +62,7 @@ int parsePolicies(rpmSpec spec)
 	goto exit;
 
     res = parseLines(spec, (STRIP_TRAILINGSPACE | STRIP_COMMENTS),
-		     &(pkg->policyList), NULL);
+		     &(pkg->policyList), NULL, NULL);
 
   exit:
     free(argv);

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -504,7 +504,7 @@ int parsePrep(rpmSpec spec)
     spec->prep = newStringBuf();
 
     /* There are no options to %prep */
-    if ((res = parseLines(spec, STRIP_NOTHING, &saveLines, NULL)) == PART_ERROR)
+    if ((res = parseLines(spec, STRIP_NOTHING, &saveLines, NULL, NULL)) == PART_ERROR)
 	goto exit;
     
     for (ARGV_const_t lines = saveLines; lines && *lines; lines++) {

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -352,7 +352,7 @@ int parseScript(rpmSpec spec, int parsePart)
 	goto exit;
     }
 
-    if ((res = parseLines(spec, STRIP_NOTHING, NULL, &sb)) == PART_ERROR)
+    if ((res = parseLines(spec, STRIP_NOTHING, NULL, &sb, NULL)) == PART_ERROR)
 	goto exit;
 
     if (sb) {

--- a/build/parseSimpleScript.c
+++ b/build/parseSimpleScript.c
@@ -9,7 +9,8 @@
 #include "debug.h"
 
 
-int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp)
+int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp,
+			parseCb cb)
 {
     int res = PART_ERROR;
     
@@ -20,7 +21,7 @@ int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp)
     }
     
     /* There are no options to %build, %install, %check, or %clean */
-    res = parseLines(spec, STRIP_NOTHING, NULL, sbp);
+    res = parseLines(spec, STRIP_NOTHING, NULL, sbp, cb);
     
 exit:
 

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -279,6 +279,8 @@ void closeSpec(rpmSpec spec);
 RPM_GNUC_INTERNAL
 int readLine(rpmSpec spec, int strip);
 
+typedef int (parseCb)(rpmSpec spec, const char *line, char **ret);
+
 /** \ingroup rpmbuild
  * Read next line from spec file.
  * @param spec		spec file control structure
@@ -288,7 +290,8 @@ int readLine(rpmSpec spec, int strip);
  * @return		next spec part or PART_ERROR on error
  */
 RPM_GNUC_INTERNAL
-int parseLines(rpmSpec spec, int strip, ARGV_t *avp, StringBuf *sbp);
+int parseLines(rpmSpec spec, int strip, ARGV_t *avp, StringBuf *sbp,
+		parseCb cb);
 
 /** \ingroup rpmbuild
  * Destroy source component chain.
@@ -313,7 +316,8 @@ int isPart(const char * line)	;
  * @return		>= 0 next rpmParseState, < 0 on error
  */
 RPM_GNUC_INTERNAL
-int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp);
+int parseSimpleScript(rpmSpec spec, const char * name, StringBuf *sbp,
+			parseCb cb);
 
 /** \ingroup rpmbuild
  * Parse %%changelog section of a spec file.

--- a/rpmio/rpmmacro_internal.h
+++ b/rpmio/rpmmacro_internal.h
@@ -7,9 +7,32 @@
  * Internal Macro API
  */
 
+#include <rpm/rpmmacro.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef struct MacroBuf_s *MacroBuf;
+typedef void (*macroFunc)(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed);
+
+/*! The structure used to store a macro. */
+struct rpmMacroEntry_s {
+    struct rpmMacroEntry_s *prev;/*!< Macro entry stack. */
+    const char *name;  	/*!< Macro name. */
+    const char *opts;  	/*!< Macro parameters (a la getopt) */
+    const char *body;	/*!< Macro body. */
+    macroFunc func;	/*!< Macro function (builtin macros) */
+    void *priv;		/*!< App private (aux macros) */
+    int nargs;		/*!< Number of required args */
+    int flags;		/*!< Macro state bits. */
+    int level;          /*!< Scoping level. */
+    char arena[];   	/*!< String arena. */
+};
+
+void mbAppend(MacroBuf mb, char c);
+void mbAppendStr(MacroBuf mb, const char *str);
+void mbErr(MacroBuf mb, int error, const char *fmt, ...);
 
 /** \ingroup rpmmacro
  * Find the end of a macro call
@@ -30,6 +53,12 @@ void splitQuoted(ARGV_t *av, const char * str, const char * seps);
 
 RPM_GNUC_INTERNAL
 char *unsplitQuoted(ARGV_const_t av, const char *sep);
+
+/* RPM_GNUC_INTERNAL omitted to allow use from librpmbuild */
+int rpmPushMacroAux(rpmMacroContext mc,
+		    const char * n, const char * o,
+		    macroFunc f, void *priv, int nargs,
+		    int level, rpmMacroFlags flags);
 
 #ifdef __cplusplus
 }

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1802,6 +1802,9 @@ runroot rpmbuild \
 [1],
 [],
 [error: Bad source: /notthere/hello-1.0.tar.gz: No such file or directory
+error: /data/SPECS/hello.spec: line 19: setup -q  0<  (%setup)
+cd '/build/BUILD'
+rm -rf 'hello-1.0'
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
In todays Friday Fun session, we do some pretty wacko stuff to convert the builtin %setup and %patch pseudo-macros into real ones.

It's a moderate success but there are some tidying up to do wrt eg error messages.
I also tried an alternative approach of predefining %patchN macros for all the patch numbers in the spec to avoid the parse callback stuff, and while it was much less code I couldn't get it to work properly, so it doesn't count.

This is *not* ready for inclusion yet so draft only.