### PR TITLE
Fix file descriptor leak regression on install (#1947)

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -208,7 +208,7 @@ static int fsmMkfile(int dirfd, rpmfi fi, struct filedata_s *fp, rpmfiles files,
 	if (fp->sb.st_nlink > 1) {
 	    *firstlink = fp;
 	    *firstlinkfile = fd;
-	    *firstdir = dirfd;
+	    *firstdir = dup(dirfd);
 	}
     } else {
 	/* Create hard links for others and avoid redundant metadata setting */
@@ -227,7 +227,7 @@ static int fsmMkfile(int dirfd, rpmfi fi, struct filedata_s *fp, rpmfiles files,
 	    fp->setmeta = 1;
 	    *firstlink = NULL;
 	    *firstlinkfile = -1;
-	    *firstdir = -1;
+	    fsmClose(firstdir);
 	}
     }
     *fdp = fd;
@@ -841,8 +841,7 @@ static int onChdir(rpmfi fi, void *data)
     struct diriter_s *di = data;
 
     if (di->dirfd >= 0) {
-	if (di->dirfd != di->firstdir)
-	    close(di->dirfd);
+	close(di->dirfd);
 	di->dirfd = -1;
     }
     return 0;


### PR DESCRIPTION
Commit 0e3024ca3e7450104e70ec8d213cf223e71f7c02 introduced a leak on
directory file descriptors from hardlinked sets, preventing some large
packages with many hardlinks from installing at all.

fsmMkfile() needs to close the firstdir fd when done with it because
that's the only place that knows when it's safe to do so. However, there
could be non-hardlink entries left in the same directory, so we must not
close *that* descriptor. Dup the firstdir descriptor so we're free to
close it without worrying about the other state.

Fixes: #1947