### PR TITLE
Small speedup on rpm -V

### DIFF
--- a/lib/formats.c
+++ b/lib/formats.c
@@ -213,7 +213,7 @@ static char * permsFormat(rpmtd td, char **emsg)
 /* file flags formatting */
 static char * fflagsFormat(rpmtd td, char **emsg)
 {
-    return rpmFFlagsString(rpmtdGetNumber(td), "");
+    return rpmFFlagsString(rpmtdGetNumber(td));
 }
 
 /* pubkey ascii armor formatting */

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -25,7 +25,7 @@ RPM_GNUC_INTERNAL
 char * rpmVerifyString(uint32_t verifyResult, const char *pad);
 
 RPM_GNUC_INTERNAL
-char * rpmFFlagsString(uint32_t fflags, const char *pad);
+char * rpmFFlagsString(uint32_t fflags);
 
 typedef int (*headerTagTagFunction) (Header h, rpmtd td, headerGetFlags hgflags);
 

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -296,19 +296,29 @@ char * rpmVerifyString(uint32_t verifyResult, const char *pad)
 #undef aok
 #undef unknown
 
-char * rpmFFlagsString(uint32_t fflags, const char *pad)
+char * rpmFFlagsString(uint32_t fflags)
 {
-    char *fmt = NULL;
-    rasprintf(&fmt, "%s%s%s%s%s%s%s%s%s",
-		(fflags & RPMFILE_DOC) ? "d" : pad,
-		(fflags & RPMFILE_CONFIG) ? "c" : pad,
-		(fflags & RPMFILE_SPECFILE) ? "s" : pad,
-		(fflags & RPMFILE_MISSINGOK) ? "m" : pad,
-		(fflags & RPMFILE_NOREPLACE) ? "n" : pad,
-		(fflags & RPMFILE_GHOST) ? "g" : pad,
-		(fflags & RPMFILE_LICENSE) ? "l" : pad,
-		(fflags & RPMFILE_README) ? "r" : pad,
-		(fflags & RPMFILE_ARTIFACT) ? "a" : pad);
+    char *fmt, *p;
+    fmt = p = xmalloc(10);
+    if ((fflags & RPMFILE_DOC))
+        *p++ = 'd';
+    if ((fflags & RPMFILE_CONFIG))
+        *p++ = 'c';
+    if ((fflags & RPMFILE_SPECFILE))
+        *p++ = 's';
+    if ((fflags & RPMFILE_MISSINGOK))
+        *p++ = 'm';
+    if ((fflags & RPMFILE_NOREPLACE))
+        *p++ = 'n';
+    if ((fflags & RPMFILE_GHOST))
+        *p++ = 'g';
+    if ((fflags & RPMFILE_LICENSE))
+        *p++ = 'l';
+    if ((fflags & RPMFILE_README))
+        *p++ = 'r';
+    if ((fflags & RPMFILE_ARTIFACT))
+        *p++ = 'a';
+    *p++= '\0';
     return fmt;
 }
 
@@ -380,7 +390,7 @@ static int verifyHeader(rpmts ts, Header h, rpmVerifyAttrs omitMask,
 	if (headerGetInstance(h))
 	    fstate = stateStr(rpmfiFState(fi));
 
-	attrFormat = rpmFFlagsString(fileAttrs, "");
+	attrFormat = rpmFFlagsString(fileAttrs);
 	ac = rstreq(attrFormat, "") ? ' ' : attrFormat[0];
 	if (verifyResult & RPMVERIFY_LSTATFAIL) {
 	    if (!(fileAttrs & (RPMFILE_MISSINGOK|RPMFILE_GHOST)) || rpmIsVerbose()) {


### PR DESCRIPTION
This improves performance of rpm -V --nofiledigests by ~2%
by avoiding an extra parameter and a sprintf call.