### PR TITLE
rpm package header based db backend

### DIFF
--- a/include/rpm/header.h
+++ b/include/rpm/header.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+typedef struct rpmfs_s * rpmfs;
+
 /** \ingroup header 
  * Header magic value
  */ 
@@ -386,6 +388,17 @@ typedef enum headerConvOps_e {
  * @return		1 on success, 0 on failure
  */
 int headerConvert(Header h, int op);
+
+/** \ingroup header
+ * Add header tags for installed packages
+ * @param h		header
+ * @param tid		transcation id
+ * @param installTime	installation time
+ * @param tscolor	transaction color
+ * @param fs		file states
+ * @return		1 on success, 0 on failure
+ */
+void headerAddInstallTags(Header h, rpm_tid_t tid, rpm_time_t installTime, rpm_color_t tscolor, rpmfs fs);
 
 #ifdef __cplusplus
 }

--- a/include/rpm/header.h
+++ b/include/rpm/header.h
@@ -147,6 +147,14 @@ Header headerRead(FD_t fd, int magicp);
 int headerWrite(FD_t fd, Header h, int magicp);
 
 /** \ingroup header
+ * Write lead, signature header and immutable header to file
+ * @param fd		file handle
+ * @param h		header
+ * @return		0 on success, 1 on error
+ */
+int headerWriteAsPackage(FD_t fd, Header h);
+
+/** \ingroup header
  * Check if tag is in header.
  * @param h		header
  * @param tag		tag

--- a/include/rpm/rpmdb.h
+++ b/include/rpm/rpmdb.h
@@ -251,6 +251,14 @@ int rpmdbStat(const char *prefix, struct stat *statbuf);
  */
 int rpmdbFStat(rpmdb db, struct stat *statbuf);
 
+/** \ingroup rpmdb
+ * Return next unverified package header blob from iteration.
+ * @param mi           rpm database iterator
+ * @retval size         header blob size in bytes
+ * @return             NULL on end of iteration.
+ */
+const unsigned char *rpmdbNextIteratorHeaderBlob(rpmdbMatchIterator mi, unsigned int *size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rpm/rpmlib.h
+++ b/include/rpm/rpmlib.h
@@ -145,7 +145,7 @@ rpmRC headerCheck(rpmts ts, const void * uh, size_t uc, char ** msg);
 rpmRC rpmReadHeader(rpmts ts, FD_t fd, Header *hdrp, char ** msg);
 
 /** \ingroup header
- * Return package header from file handle, verifying digests/signatures.
+ * Return package header from file handle, verifying digests/signatures of the whole file.
  * @param ts		transaction set
  * @param fd		file handle
  * @param fn		file name

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -23,6 +23,7 @@ EXTRA_PROGRAMS =
 usrlib_LTLIBRARIES = librpm.la
 librpm_la_SOURCES = \
 	backend/dbi.c backend/dbi.h backend/dummydb.c \
+	backend/filedb.c \
 	backend/dbiset.c backend/dbiset.h \
 	headerutil.c header.c headerfmt.c header_internal.h \
 	rpmdb.c rpmdb_internal.h \

--- a/lib/backend/dbi.c
+++ b/lib/backend/dbi.c
@@ -24,6 +24,7 @@ const struct rpmdbOps_s *backends[] = {
 #if defined(WITH_BDB_RO)
     &bdbro_dbops,
 #endif
+    &filedb_dbops,
     &dummydb_dbops,
     NULL
 };
@@ -130,6 +131,9 @@ dbDetectBackend(rpmdb rdb)
 		    ondisk->name, ondisk->path, ondisk->name);
 	    }
 	    rdb->db_ops = ondisk;
+	} else {
+	    rdb->db_ops = cfg;
+	    rpmlog(RPMLOG_INFO, "creating new database\n");
 	}
     }
 

--- a/lib/backend/dbi.h
+++ b/lib/backend/dbi.h
@@ -277,6 +277,9 @@ extern struct rpmdbOps_s sqlite_dbops;
 #endif
 
 RPM_GNUC_INTERNAL
+extern struct rpmdbOps_s filedb_dbops;
+
+RPM_GNUC_INTERNAL
 extern struct rpmdbOps_s dummydb_dbops;
 
 #ifdef __cplusplus

--- a/lib/backend/filedb.c
+++ b/lib/backend/filedb.c
@@ -1,0 +1,363 @@
+#include "system.h"
+
+#include <fcntl.h>
+#include <dirent.h>
+#include <errno.h>
+
+#include "rpm/rpmlib.h"
+#include "lib/rpmfs.h"
+#include "rpm/rpmts.h"
+#include "lib/rpmvs.h"
+#include "lib/rpmdb_internal.h"
+#include "lib/rpmchroot.h"
+#include "rpm/rpmlog.h"
+#include "rpm/rpmfileutil.h"
+
+#include "debug.h"
+
+#define ff(fmt, ...) rpmlog(RPMLOG_DEBUG, "%s() -- " fmt "\n", __FUNCTION__, __VA_ARGS__)
+
+struct dbiCursor_s {
+    unsigned i;
+    const void *key;
+    unsigned int keylen;
+};
+
+typedef struct filedb_s {
+    int dirfd;
+    unsigned nheaders;
+    Header* headers;
+    char** files;
+} filedb_t;
+
+static void load_headers(filedb_t* p)
+{
+    int dfd = dup(p->dirfd);
+    DIR* d = fdopendir(dfd);
+    struct dirent* entry;
+
+    while ((entry = readdir(d))) {
+        // strlen(1-3-5.rpm) == 9
+        if (strlen(entry->d_name) < 9)
+            continue;
+        if (strcmp(entry->d_name+strlen(entry->d_name)-4, ".rpm"))
+            continue;
+
+        p->files = xreallocn(p->files, sizeof(char*), p->nheaders+1);
+        p->headers = xreallocn(p->headers, sizeof(Header), p->nheaders+1);
+
+        p->files[p->nheaders] = strdup(entry->d_name);
+
+        FD_t fd = NULL;
+        struct stat sb = {0};
+        int hfd = openat(p->dirfd, entry->d_name, O_RDONLY);
+        if (hfd >= 0) {
+            fstat(hfd, &sb);
+            fd = Fdopen(fdDup(hfd), "r.ufdio");
+        } else {
+                rpmlog(RPMLOG_ERR, "failed to open %s: %m\n", entry->d_name);
+        }
+        if (fd) {
+            Header h;
+            struct rpmvs_s *vs = rpmvsCreate(0, RPMVSF_MASK_NOPAYLOAD, NULL);
+            rpmRC rc = rpmReadPackageHeader(vs, fd, NULL, &h);
+            if (rc == RPMRC_OK || rc == RPMRC_NOKEY) {
+                struct rpmtd_s basenames = {0};
+                rpmfs fs = NULL;
+
+                if (headerGet(h, RPMTAG_BASENAMES, &basenames, HEADERGET_MINMEM))
+                    fs = rpmfsNew(rpmtdCount(&basenames), 1);
+
+                headerAddInstallTags(h, sb.st_ctime, sb.st_ctime, 0, fs);
+
+                rpmtdFreeData(&basenames);
+                rpmfsFree(fs);
+
+                p->headers[p->nheaders] = h;
+            } else {
+                rpmlog(RPMLOG_ERR, "failed to read %s %d\n", entry->d_name, rc);
+            }
+            Fclose(fd);
+            rpmvsFree(vs);
+        }
+        ++p->nheaders;
+    }
+
+    closedir(d);
+    close(dfd);
+}
+
+static int filedb_Close(dbiIndex dbi, unsigned int flags)
+{
+    rpmdb rdb = dbi->dbi_rpmdb;
+
+    if (rdb->db_opens > 1) {
+        rdb->db_opens--;
+    } else {
+        filedb_t* p =  rdb->db_dbenv;
+        close(p->dirfd);
+        for (int i = 0; i < p->nheaders; ++i) {
+            free(p->files[i]);
+            headerFree(p->headers[i]);
+        }
+        free(p->files);
+        free(p->headers);
+        free(rdb->db_dbenv);
+        rdb->db_dbenv = NULL;
+    }
+
+    dbiFree(dbi);
+    return 0;
+}
+
+static int filedb_Open(rpmdb rdb, rpmDbiTagVal rpmtag, dbiIndex * dbip, int flags)
+{
+    if (rdb->db_dbenv == NULL) {
+        char fn[PATH_MAX] = {0};
+        char* c = fn;
+        if (!rpmChrootDone())
+            c = stpncpy(c, rdb->db_root, sizeof(fn)-(c-fn)-1);
+        c = stpncpy(c, filedb_dbops.path, sizeof(fn)-(c-fn)-1);
+
+        rpmioMkpath(fn, 0755, -1, -1);
+        int fd = open(fn, O_CLOEXEC|O_DIRECTORY|O_NOCTTY|O_NOFOLLOW);
+        if (fd < 0) {
+            rpmlog(RPMLOG_ERR, "failed to open %s: %m\n", fn);
+            return RPMRC_FAIL;
+        }
+        filedb_t* p =  xcalloc(1, sizeof(filedb_t));
+        p->dirfd = fd;
+
+        load_headers(p);
+
+        rdb->db_dbenv = p;
+    }
+    rdb->db_opens++;
+
+    if (dbip) {
+        dbiIndex dbi = dbiNew(rdb, rpmtag);
+        dbi->dbi_db = rdb->db_dbenv;
+        *dbip = dbi;
+    }
+    return 0;
+}
+
+static int filedb_Verify(dbiIndex dbi, unsigned int flags)
+{
+    ff("%u", flags);
+    return 0;
+}
+
+static void filedb_SetFSync(rpmdb rdb, int enable)
+{
+    ff("%d", enable);
+}
+
+static int filedb_Ctrl(rpmdb rdb, dbCtrlOp ctrl)
+{
+    ff("%d", ctrl);
+    return 0;
+}
+
+static dbiCursor filedb_CursorInit(dbiIndex dbi, unsigned int flags)
+{
+    struct dbiCursor_s* dbc = rmalloc(sizeof(struct dbiCursor_s));
+    memset(dbc, 0, sizeof(struct dbiCursor_s));
+    return dbc;
+}
+
+static dbiCursor filedb_CursorFree(dbiIndex dbi, dbiCursor dbc)
+{
+    return rfree(dbc);
+}
+
+static rpmRC filedb_pkgdbPut(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum, unsigned char *hdrBlob, unsigned int hdrLen)
+{
+    rpmdb rdb = dbi->dbi_rpmdb;
+    filedb_t* p =  rdb->db_dbenv;
+    rpmRC rc = RPMRC_FAIL;
+    char fn[PATH_MAX] = {0};
+    /* this is crappy obviously. need differnet api.
+       Copy is needed to not take ownership of the blob. */
+    Header h = headerImport(hdrBlob, hdrLen, HEADERIMPORT_COPY);
+    char *nevra = headerGetAsString(h, RPMTAG_NEVRA);
+
+    snprintf(fn, sizeof(fn), "%s.rpm", nevra);
+    nevra = rfree(nevra);
+
+    FD_t fd = NULL;
+    int hfd = openat(p->dirfd, fn, O_WRONLY|O_CREAT|O_EXCL, 0666);
+    if (hfd < 0 && errno == EEXIST) {
+        // As we don't store the hdrNum on disk, we need to move
+        // files with same name way so pkgdbDel won't remove it.
+        int i;
+        for (i = 0; i < p->nheaders; ++i) {
+            if (!strcmp(p->files[i], fn)) {
+                char* newfn = NULL;
+                rasprintf(&newfn, ".%sold", fn);
+                renameat(p->dirfd, fn, p->dirfd, newfn);
+                free(p->files[i]);
+                p->files[i] = newfn;
+                break;
+            }
+        }
+        if (i >= p->nheaders) {
+            rpmlog(RPMLOG_ERR, "%s exists but can't be found!?\n", fn);
+            return RPMRC_FAIL;
+        }
+        hfd = openat(p->dirfd, fn, O_WRONLY|O_CREAT|O_EXCL, 0666);
+    }
+    if (hfd >= 0) {
+        fd = Fdopen(fdDup(hfd), "w.ufdio");
+    }
+    if (!fd) {
+            rpmlog(RPMLOG_ERR, "failed to open %s\n", fn);
+            goto exit;
+    }
+
+    headerWriteAsPackage(fd, h);
+    Fclose(fd);
+
+    p->files = xreallocn(p->files, sizeof(char*), p->nheaders+1);
+    p->headers = xreallocn(p->headers, sizeof(Header), p->nheaders+1);
+    p->files[p->nheaders] = strdup(fn);
+    p->headers[p->nheaders] = h;
+    *hdrNum = ++p->nheaders;
+
+    rc = RPMRC_OK;
+
+exit:
+    if (rc != RPMRC_OK)
+        headerFree(h);
+    return rc;
+}
+
+static rpmRC filedb_pkgdbDel(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum)
+{
+    rpmdb rdb = dbi->dbi_rpmdb;
+    filedb_t* p =  rdb->db_dbenv;
+
+    if (hdrNum > p->nheaders)
+        return RPMRC_FAIL;
+
+    int i = hdrNum-1;
+    if (!p->headers[i])
+        return RPMRC_NOTFOUND;
+
+    if(unlinkat(p->dirfd, p->files[i], 0)) {
+        rpmlog(RPMLOG_ERR, "failed to unlink %s: %m\n", p->files[i]);
+        return RPMRC_FAIL;
+    }
+    p->files[i] = rfree(p->files[i]);
+    p->headers[i] = rfree(p->headers[i]);
+    return RPMRC_OK;
+}
+
+static rpmRC filedb_pkgdbGet(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum, unsigned char **hdrBlob, unsigned int *hdrLen)
+{
+    rpmdb rdb = dbi->dbi_rpmdb;
+    filedb_t* p =  rdb->db_dbenv;
+    if (hdrNum) {
+        if (hdrNum <= p->nheaders) {
+            *hdrBlob = headerExport(p->headers[hdrNum-1], hdrLen);
+            return RPMRC_OK;
+        }
+
+        return RPMRC_NOTFOUND;
+    } else if (dbc->i < p->nheaders) {
+        *hdrBlob = headerExport(p->headers[dbc->i], hdrLen);
+        ++dbc->i;
+        return RPMRC_OK;
+    }
+
+    return RPMRC_NOTFOUND;
+}
+
+static unsigned int filedb_pkgdbKey(dbiIndex dbi, dbiCursor dbc)
+{
+    return dbc->i;
+}
+
+static rpmRC filedb_idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexSet *set, int searchType)
+{
+    // that's weird. would make sense for dbi to contain the enum?
+    rpmTagVal tag = rpmTagGetValue(dbi->dbi_file);
+    rpmdb rdb = dbi->dbi_rpmdb;
+    filedb_t* p =  rdb->db_dbenv;
+    if (rpmTagGetTagType(tag) == RPM_STRING_TYPE) {
+        int found = 0;
+        rpmlog(RPMLOG_DEBUG, "looking for %s (%s)\n", keyp, searchType == DBC_PREFIX_SEARCH?"substr":"exact");
+        for (int i = 0; i < p->nheaders; ++i) {
+            Header h = p->headers[i];
+            if (!h) // deleted
+                continue;
+            const char *val = headerGetString(h, tag);
+            if (!val) {
+                rpmlog(RPMLOG_ERR, "failed to query %s at header %u\n", rpmTagGetName(tag), i);
+                continue;
+            }
+
+            if (keyp) {
+                if (strncmp(val, keyp, keylen))
+                    continue;
+                if (searchType == DBC_NORMAL_SEARCH && strlen(val) != keylen)
+                    continue;
+            }
+            found = 1;
+            if (*set == NULL)
+                *set = dbiIndexSetNew(0);
+            dbc->key = val;
+            dbc->keylen = strlen(val);
+            dbiIndexSetAppendOne(*set, i+1, 0, 0);
+        }
+        if (found)
+            return RPMRC_OK;
+    }
+    return RPMRC_NOTFOUND;
+}
+
+static rpmRC filedb_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
+{
+    return RPMRC_OK;
+}
+
+static rpmRC filedb_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h) {
+    return RPMRC_OK;
+}
+
+static const void * filedb_idxdbKey(dbiIndex dbi, dbiCursor dbc, unsigned int *keylen)
+{
+    const void *key = NULL;
+    if (dbc) {
+        key = dbc->key;
+        if (key && keylen)
+            *keylen = dbc->keylen;
+    }
+    return key;
+}
+
+struct rpmdbOps_s filedb_dbops = {
+    .name	= "file",
+    .path	= "/usr/lib/sysimage/rpm-headers",
+
+    .open	= filedb_Open,
+    .close	= filedb_Close,
+    .verify	= filedb_Verify,
+    .setFSync	= filedb_SetFSync,
+    .ctrl	= filedb_Ctrl,
+
+    .cursorInit	= filedb_CursorInit,
+    .cursorFree	= filedb_CursorFree,
+
+    .pkgdbPut	= filedb_pkgdbPut,
+    .pkgdbDel	= filedb_pkgdbDel,
+    .pkgdbGet	= filedb_pkgdbGet,
+    .pkgdbKey	= filedb_pkgdbKey,
+
+    .idxdbGet	= filedb_idxdbGet,
+    .idxdbPut	= filedb_idxdbPut,
+    .idxdbDel	= filedb_idxdbDel,
+    .idxdbKey	= filedb_idxdbKey
+};
+
+// vim: sw=4 et

--- a/lib/header_internal.h
+++ b/lib/header_internal.h
@@ -94,6 +94,11 @@ ssize_t Freadall(FD_t fd, void * buf, ssize_t size);
 
 RPM_GNUC_INTERNAL
 int headerIsSourceHeuristic(Header h);
+
+/* take signature tags from header and produce separate signature header.
+   Immutable original header needed to avoid duplicates */
+RPM_GNUC_INTERNAL
+Header headerGetSigheader(Header h, Header ih);
 #ifdef __cplusplus
 }   
 #endif

--- a/lib/headerutil.c
+++ b/lib/headerutil.c
@@ -9,6 +9,7 @@
 #include <rpm/header.h>
 #include <rpm/rpmstring.h>
 #include <rpm/rpmds.h>
+#include <lib/rpmfs.h>
 
 #include "debug.h"
 
@@ -438,4 +439,18 @@ int rpmVersionCompare(Header first, Header second)
 
     return rpmvercmp(headerGetString(first, RPMTAG_RELEASE),
 		     headerGetString(second, RPMTAG_RELEASE));
+}
+
+void headerAddInstallTags(Header h, rpm_tid_t tid, rpm_time_t installTime, rpm_color_t tscolor, rpmfs fs)
+{
+    rpm_count_t fc = rpmfsFC(fs);
+    rpm_fstate_t * fileStates = rpmfsGetStates(fs);
+
+    if (fileStates != NULL && fc > 0) {
+	headerPutChar(h, RPMTAG_FILESTATES, fileStates, fc);
+    }
+
+    headerPutUint32(h, RPMTAG_INSTALLTID, &tid, 1);
+    headerPutUint32(h, RPMTAG_INSTALLTIME, &installTime, 1);
+    headerPutUint32(h, RPMTAG_INSTALLCOLOR, &tscolor, 1);
 }

--- a/lib/psm.c
+++ b/lib/psm.c
@@ -538,19 +538,11 @@ static rpmRC dbAdd(rpmts ts, rpmte te)
     Header h = rpmteHeader(te);
     rpm_time_t installTime = rpmtsGetTime(ts, 1);
     rpmfs fs = rpmteGetFileStates(te);
-    rpm_count_t fc = rpmfsFC(fs);
-    rpm_fstate_t * fileStates = rpmfsGetStates(fs);
     rpm_color_t tscolor = rpmtsColor(ts);
     rpm_tid_t tid = rpmtsGetTid(ts);
     rpmRC rc;
 
-    if (fileStates != NULL && fc > 0) {
-	headerPutChar(h, RPMTAG_FILESTATES, fileStates, fc);
-    }
-
-    headerPutUint32(h, RPMTAG_INSTALLTID, &tid, 1);
-    headerPutUint32(h, RPMTAG_INSTALLTIME, &installTime, 1);
-    headerPutUint32(h, RPMTAG_INSTALLCOLOR, &tscolor, 1);
+    headerAddInstallTags(h, tid, installTime, tscolor, fs);
 
     (void) rpmswEnter(rpmtsOp(ts, RPMTS_OP_DBADD), 0);
     rc = (rpmdbAdd(rpmtsGetRdb(ts), h) == 0) ? RPMRC_OK : RPMRC_FAIL;

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2556,6 +2556,48 @@ int rpmdbCtrl(rpmdb db, rpmdbCtrlOp ctrl)
     return dbctrl ? dbCtrl(db, dbctrl) : 1;
 }
 
+const unsigned char *rpmdbNextIteratorHeaderBlob(rpmdbMatchIterator mi, unsigned int *size)
+{
+    dbiIndex dbi = NULL;
+    unsigned char * uh;
+    unsigned int uhlen;
+    int rc;
+    if (mi == NULL || mi->mi_re != NULL)
+	return NULL;
+    if (pkgdbOpen(mi->mi_db, 0, &dbi))
+	return NULL;
+    if (mi->mi_dbc == NULL)
+	mi->mi_dbc = dbiCursorInit(dbi, mi->mi_cflags);
+    miFreeHeader(mi, dbi);
+    uh = NULL;
+    uhlen = 0;
+    do {
+	if (mi->mi_set) {
+	    if (!(mi->mi_setx < mi->mi_set->count))
+		return NULL;
+	    mi->mi_offset = dbiIndexRecordOffset(mi->mi_set, mi->mi_setx);
+	    mi->mi_filenum = dbiIndexRecordFileNumber(mi->mi_set, mi->mi_setx);
+	} else {
+	    rc = pkgdbGet(dbi, mi->mi_dbc, 0, &uh, &uhlen);
+	    if (rc == 0)
+		mi->mi_offset = pkgdbKey(dbi, mi->mi_dbc);
+
+	    /* Terminate on error or end of keys */
+	    if (rc || (mi->mi_setx && mi->mi_offset == 0))
+		return NULL;
+	}
+	mi->mi_setx++;
+    } while (mi->mi_offset == 0);
+    if (uh == NULL) {
+	rc = pkgdbGet(dbi, mi->mi_dbc, mi->mi_offset, &uh, &uhlen);
+	if (rc || uh == NULL)
+	    return NULL;
+    }
+    if (size)
+	*size = uhlen;
+    return uh;
+}
+
 char *rpmdbCookie(rpmdb db)
 {
     void *cookie = NULL;

--- a/lib/rpmfs.c
+++ b/lib/rpmfs.c
@@ -98,7 +98,7 @@ rpmfileState rpmfsGetState(rpmfs fs, unsigned int ix)
 
 rpm_fstate_t * rpmfsGetStates(rpmfs fs)
 {
-    return fs->states;
+    return (fs != NULL) ? fs->states : NULL;
 }
 
 rpmFileAction rpmfsGetAction(rpmfs fs, unsigned int ix)

--- a/lib/rpmplugin.h
+++ b/lib/rpmplugin.h
@@ -22,7 +22,7 @@ typedef enum rpmScriptletExecutionFlow_e {
  */
 enum rpmFileActionFlags_e {
     /* bits 0-15 reserved for actions */
-    FAF_UNOWNED		= (1 << 31)
+    FAF_UNOWNED		= (1 << 31) /* an intermediate directory not owned by a package */
 };
 typedef rpmFlags rpmFileActionFlags;
 

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -270,9 +270,14 @@ int rpmtsSetKeyring(rpmts ts, rpmKeyring keyring)
 static int loadKeyringFromFiles(rpmts ts)
 {
     ARGV_t files = NULL;
-    /* XXX TODO: deal with chroot path issues */
-    char *pkpath = rpmGetPath(ts->rootDir, "%{_keyringpath}/*.key", NULL);
+    char *pkpath = NULL;
     int nkeys = 0;
+    const char *rootDir = rpmtsRootDir(ts);
+
+    if (!rootDir || rpmChrootDone())
+	rootDir = "/";
+
+    pkpath = rpmGetPath(rootDir, "%{_keyringpath}/*.key", NULL);
 
     rpmlog(RPMLOG_DEBUG, "loading keyring from pubkeys in %s\n", pkpath);
     if (rpmGlob(pkpath, NULL, &files)) {

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -566,9 +566,17 @@ rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen
     int subkeysCount = 0;
     rpmVSFlags oflags = rpmtsVSFlags(ts);
     rpmKeyring keyring;
-    rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
     int krc, i;
 
+    char *krtype = rpmExpand("%{?_keyring}", NULL);
+    if (rstreq(krtype, "fs")) {
+	rpmlog(RPMLOG_DEBUG, "%%_keyring fs does not support importing\n");
+	free(krtype);
+	return RPMRC_FAIL;
+    }
+    free(krtype);
+
+    rpmtxn txn = rpmtxnBegin(ts, RPMTXN_WRITE);
     if (txn == NULL)
 	return rc;
 

--- a/lib/rpmvs.h
+++ b/lib/rpmvs.h
@@ -75,6 +75,17 @@ int rpmvsVerify(struct rpmvs_s *sis, int type,
 rpmRC rpmpkgRead(struct rpmvs_s *vs, FD_t fd,
 		hdrblob *sigblobp, hdrblob *blobp, char **emsg);
 
+/** \ingroup header
+ * Return package header from file handle.
+ * @param vs		verify flags
+ * @param fd		file handle
+ * @param fn		file name
+ * @param[out] hdrp	address of header (or NULL)
+ * @return		RPMRC_OK on success
+ */
+rpmRC rpmReadPackageHeader(struct rpmvs_s * vs, FD_t fd,
+		const char * fn, Header * hdrp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmvs.h
+++ b/lib/rpmvs.h
@@ -3,6 +3,7 @@
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmts.h> /* for rpmVSFlags */
+#include <rpm/rpmpgp.h> /* DIGEST_CTX */
 #include "lib/header_internal.h"
 
 /* siginfo range bits */


### PR DESCRIPTION
Following up on the idea in #1151 this submission uses rpm package(!) headers in /usr to determine what's installed. That way it is possible to query and verify(!) installed packages even when there is no real database. Filing as draft for the world to look at it. I don't expect this to go in this way :laughing: 

The mode is sufficient for eg containers or appliances that do not
use rpm at runtime. Nevertheless one can still inspect and check the
content of such images. Also, diffing fs trees of revisions of a
container/os tree shows changed packages rather than only individual files.

Even though installation using this backend is actually possible and
implemented for the fun of it, it's not really the intended use
case. Due to lack of indexes there is no dependency checking nor
execution of triggers. To build a container one would use a real
backend like sqlite, then dump the headers to /usr and drop the
database in /var.

Nevertheless even the primitive install feature could be useful
in a way similar to systemd-sysext
(https://www.freedesktop.org/software/systemd/man/systemd-sysext.html).
Ie have /usr read-only and install temporary extensions as overlay
eg for debugging. cf https://github.com/kubic-project/microos-tools/pull/5/files

By storing package headers, certain information is not available
though. File states cannot be stored. The code reading headers just
assumes all files are installed. For the intended use case some
files may actually be skipped though. This could be fixed by
factoring out the code in the install path that determines the
intended state of files and call it when reading the header. Ie
evaluate eg. %_install_langs there.