### PR TITLE
Support imports to fs keyring too

### DIFF
--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -78,6 +78,7 @@ struct rpmts_s {
     rpmVSFlags vfyflags;	/*!< Package verification flags */
     int vfylevel;		/*!< Package verification level */
     rpmKeyring keyring;		/*!< Keyring in use. */
+    int keyringtype;		/*!< Keyring type */
 
     ARGV_t netsharedPaths;	/*!< From %{_netsharedpath} */
     ARGV_t installLangs;	/*!< From %{_install_langs} */

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -191,7 +191,7 @@ AT_CLEANUP
 
 # ------------------------------
 # Import a public RSA key
-AT_SETUP([rpmkeys --import rsa])
+AT_SETUP([rpmkeys --import rsa (rpmdb)])
 AT_KEYWORDS([rpmkeys import])
 AT_CHECK([
 RPMDB_INIT
@@ -249,6 +249,53 @@ gpg(1964c5fc) = 4:4344591e1964c5fc-58e63918
 gpg(4344591e1964c5fc) = 4:4344591e1964c5fc-58e63918
 gpg(f00650f8) = 4:185e6146f00650f8-58e63918
 gpg(185e6146f00650f8) = 4:185e6146f00650f8-58e63918
+],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpmkeys --import rsa (fs)])
+AT_KEYWORDS([rpmkeys import])
+AT_CHECK([
+RPMDB_INIT
+
+runroot_other mkdir -p /tmp/kr
+runroot rpmkeys \
+	--define "_keyringpath /tmp/kr" \
+	--define "_keyring fs" \
+	--import /data/keys/rpm.org-rsa-2048-test.pub
+runroot_other cat /tmp/kr/gpg-pubkey-1964c5fc-58e63918.key
+],
+[0],
+[-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: rpm-4.17.90
+
+mQENBFjmORgBCAC7TMEk6wnjSs8Dr4yqSScWdU2pjcqrkTxuzdWvowcIUPZI0w/g
+HkRqGd4apjvY2V15kjL10gk3QhFP3pZ/9p7zh8o8NHX7aGdSGDK7NOq1eFaErPRY
+91LW9RiZ0lbOjXEzIL0KHxUiTQEmdXJT43DJMFPyW9fkCWg0OltiX618FUdWWfI8
+eySdLur1utnqBvdEbCUvWK2RX3vQZQdvEBODnNk2pxqTyV0w6VPQ96W++lF/5Aas
+7rUv3HIyIXxIggc8FRrnH+y9XvvHDonhTIlGnYZN4ubm9i4y3gOkrZlGTrEw7elQ
+1QeMyG2QQEbze8YjpTm4iLABCBrRfPRaQpwrABEBAAG0IXJwbS5vcmcgUlNBIHRl
+c3RrZXkgPHJzYUBycG0ub3JnPokBNwQTAQgAIQUCWOY5GAIbAwULCQgHAgYVCAkK
+CwIEFgIDAQIeAQIXgAAKCRBDRFkeGWTF/MxxCACnjqFL+MmPh9W9JQKT2DcLbBzf
+Cqo6wcEBoCOcwgRSk8dSikhARoteoa55JRJhuMyeKhhEAogE9HRmCPFdjezFTwgB
+BDVBpO2dZ023mLXDVCYX3S8pShOgCP6Tn4wqCnYeAdLcGg106N4xcmgtcssJE+Pr
+XzTZksbZsrTVEmL/Ym+R5w5jBfFnGk7Yw7ndwfQsfNXQb5AZynClFxnX546lcyZX
+fEx3/e6ezw57WNOUK6WT+8b+EGovPkbetK/rGxNXuWaP6X4A/QUm8O98nCuHYFQq
++mvNdsCBqGf7mhaRGtpHk/JgCn5rFvArMDqLVrR9hX0LdCSsH7EGE+bR3r7wuQEN
+BFjmORgBCACk+vDZrIXQuFXEYToZVwb2attzbbJJCqD71vmZTLsW0QxuPKRgbcYY
+zp4K4lVBnHhFrF8MOUOxJ7kQWIJZMZFt+BDcptCYurbD2H4W2xvnWViiC+LzCMzz
+iMJT6165uefL4JHTDPxC2fFiM9yrc72LmylJNkM/vepT128J5Qv0gRUaQbHiQuS6
+Dm/+WRnUfx3i89SV4mnBxb/Ta93GVqoOciWwzWSnwEnWYAvOb95JL4U7c5J5f/+c
+KnQDHsW7sIiIdscsWzvgf6qs2Ra1Zrt7Fdk4+ZS2f/adagLhDO1C24sXf5XfMk5m
+L0OGwZSr9m5s17VXxfspgU5ugc8kBJfzABEBAAGJAR8EGAEIAAkFAljmORgCGwwA
+CgkQQ0RZHhlkxfzwDQf/Y5on5o+s/xD3tDyRYa6SErfT44lEArdCD7Yi+cygJFox
+3jyM8ovtJAkwRegwyxcaLN7zeG1p1Sk9ZAYWQEJT6qSU4Ppu+CVGHgxgnTcfUiu6
+EZZQE6srvua53IMY1lT50M7vx0T5VicHFRWBFV2C/Mc32p7cEE6nn45nEZgUXQNl
+ySEyvoRlsAJq6gFsfqucVz2vMJDTMVczUtq1CjvUqFbif8JVL36EoZCf1SeRw6d6
+s1Kp3AA33Rjd+Uw87HJ4EIB75zMFQX2H0ggAVdYTQcqGXHP5MZK1jJrHfxJyMi3d
+UNW2iqnN3BA7guhOv6OMiROF1+I7Q5nWT63mQC7IgQ==
+=Z6nu
+-----END PGP PUBLIC KEY BLOCK-----
 ],
 [])
 AT_CLEANUP


### PR DESCRIPTION
The fs keyring doesn't of course need the header to be created, but going through the same motions ensures consistent results, ie the key goes throught the same validation steps and we also get a "descriptive" file name for free (descriptive in that it matches the rpmdb NVR)

The first commit just paves way for this.
