### PR TITLE
docs/queryformat: fix query expressions example

### DIFF
--- a/docs/manual/queryformat.md
+++ b/docs/manual/queryformat.md
@@ -160,5 +160,5 @@ Notice that the subformats "present" and "missing" must be inside of curly
 braces.
 
 ```
-    rpm -qa --queryformat "%-30{NAME} %|PREINPROG?{ %{PREINPROG\}}:{no}|\n"
+    rpm -qa --queryformat "%-30{NAME} %|PREINPROG?{ %{PREINPROG}}:{ no}|\n"
 ```


### PR DESCRIPTION
The example command in the "Query Expressions" section fails because of
the backslash added in a9678c2dc (Insert space between the "{" and "%",
2021-05-06):

    $ # rpm -qa --queryformat "%-30{NAME} %|PREINPROG?{ %{PREINPROG\}}:{no}|\n"
    error: incorrect format: unknown tag: "PREINPROG\"
    ...

While this is relatively easy to spot and fix, it is better to avoid
non-working examples in the documentation.

Fortunately, there is no need to escape the closing `}}` as there is no
opening `{{` tag.  The dependency_generators and macros pages both
contain un-escaped `}}` strings which are displayed correctly.

Add a space to the else condition as well, to align the output.