### PR TITLE
Force gpg to use SHA256 when generating signatures.

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -504,7 +504,7 @@ AT_CHECK([
 RPMDB_INIT
 
 cp "${RPMTEST}"/data/RPMS/hello-2.0-1.x86_64.rpm "${RPMTEST}"/tmp/
-run rpmsign --key-id 1964C5FC --rpmv3 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
+run rpmsign --key-id 1964C5FC --rpmv3 --digest-algo sha256 --addsign "${RPMTEST}"/tmp/hello-2.0-1.x86_64.rpm > /dev/null
 echo PRE-IMPORT
 runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm|grep -v digest
 echo POST-IMPORT


### PR DESCRIPTION
  - Some versions of gpg appear to default to using SHA512.  This
    breaks test 273's assumption that gpg generates a SHA256 hash.
    Configure gpg to use SHA256.

  - Fixes #1969.