### PR TITLE
Move source/patch uncompress logic from spec parse to build time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -177,6 +177,10 @@ rpmlibexec_PROGRAMS +=	rpmdeps
 rpmdeps_SOURCES =	tools/rpmdeps.c
 rpmdeps_LDADD =		lib/librpm.la rpmio/librpmio.la build/librpmbuild.la @WITH_POPT_LIB@
 
+rpmlibexec_PROGRAMS +=	rpmuncompress
+rpmuncompress_SOURCES =	tools/rpmuncompress.c
+rpmuncompress_LDADD =	lib/librpm.la rpmio/librpmio.la @WITH_POPT_LIB@
+
 bin_PROGRAMS +=		rpmgraph
 rpmgraph_SOURCES =	tools/rpmgraph.c
 rpmgraph_LDADD =	lib/librpm.la rpmio/librpmio.la @WITH_POPT_LIB@

--- a/macros.in
+++ b/macros.in
@@ -67,6 +67,7 @@
 %__ld			@__LD@
 %__objdump		@__OBJDUMP@
 %__strip		@__STRIP@
+%__rpmuncompress	%{_rpmconfigdir}/rpmuncompress
 
 %__find_debuginfo	@__FIND_DEBUGINFO@
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -99,3 +99,4 @@ sign/rpmsignfiles.c
 tools/rpmdeps.c
 tools/rpmgraph.c
 tools/rpmlua.c
+tools/rpmuncompress.c

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1107,60 +1107,10 @@ static void doSP(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 
 static void doUncompress(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 {
-    rpmCompressedMagic compressed = COMPRESSED_OTHER;
-    char *b, *be, *buf = NULL;
-    int c;
-
-    if (!*argv[1])
-	goto exit;
-    buf = xstrdup(argv[1]);
-    for (b = buf; (c = *b) && isblank(c);)
-	b++;
-    for (be = b; (c = *be) && !isblank(c);)
-	be++;
-    *be = '\0';
-
-    if (*b == '\0')
-	goto exit;
-
-    if (rpmFileIsCompressed(b, &compressed))
-	mb->error = 1;
-
-    switch (compressed) {
-    default:
-    case COMPRESSED_NOT:
-	expandMacro(mb, "%__cat ", 0);
-	break;
-    case COMPRESSED_OTHER:
-	expandMacro(mb, "%__gzip -dc ", 0);
-	break;
-    case COMPRESSED_BZIP2:
-	expandMacro(mb, "%__bzip2 -dc ", 0);
-	break;
-    case COMPRESSED_ZIP:
-	expandMacro(mb, "%__unzip ", 0);
-	break;
-    case COMPRESSED_LZMA:
-    case COMPRESSED_XZ:
-	expandMacro(mb, "%__xz -dc ", 0);
-	break;
-    case COMPRESSED_LZIP:
-	expandMacro(mb, "%__lzip -dc ", 0);
-	break;
-    case COMPRESSED_LRZIP:
-	expandMacro(mb, "%__lrzip -dqo- ", 0);
-	break;
-    case COMPRESSED_7ZIP:
-	expandMacro(mb, "%__7zip x ", 0);
-	break;
-    case COMPRESSED_ZSTD:
-	expandMacro(mb, "%__zstd -dc ", 0);
-	break;
+    if (*argv[1]) {
+	expandMacro(mb, "%__rpmuncompress ", 0);
+	mbAppendStr(mb, argv[1]);
     }
-    mbAppendStr(mb, buf);
-
-exit:
-    free(buf);
 }
 
 static void doExpand(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1792,16 +1792,32 @@ AT_CLEANUP
 # Check that rpmbuild aborts with missing Source
 AT_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
-AT_CHECK_UNQUOTED([
 RPMDB_INIT
 
+runroot_other sed -i -e 's/^%patch0.*//g' /data/SPECS/hello.spec
+
+AT_CHECK_UNQUOTED([
 runroot rpmbuild \
   --define "_sourcedir /notthere" \
-  -bb /data/SPECS/hello.spec
+  --quiet -bb /data/SPECS/hello.spec 2> cmd.err
+ec=$?
+grep "^error: File" cmd.err >&2
+exit ${ec}
 ],
 [1],
 [],
-[error: Bad source: /notthere/hello-1.0.tar.gz: No such file or directory
+[error: File /notthere/hello-1.0.tar.gz: No such file or directory
+])
+
+AT_CHECK_UNQUOTED([
+runroot rpmbuild \
+  --define "_sourcedir /notthere" \
+  --quiet -bs /data/SPECS/hello.spec
+],
+[1],
+[],
+[error: Bad file: /notthere/hello-1.0-modernize.patch: No such file or directory
+error: Bad file: /notthere/hello-1.0.tar.gz: No such file or directory
 ])
 AT_CLEANUP
 

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1794,8 +1794,6 @@ AT_SETUP([rpmbuild -ba missing source])
 AT_KEYWORDS([build])
 RPMDB_INIT
 
-runroot_other sed -i -e 's/^%patch0.*//g' /data/SPECS/hello.spec
-
 AT_CHECK_UNQUOTED([
 runroot rpmbuild \
   --define "_sourcedir /notthere" \

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -216,24 +216,40 @@ AT_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 AT_CHECK([
 runroot rpm \
-    --define "__gzip /my/bin/gzip" \
+    --define "__rpmuncompress /my/bin/rpmuncompress" \
     --eval "%{uncompress:/data/SOURCES/hello-2.0.tar.gz}"
 ],
 [0],
-[/my/bin/gzip -dc /data/SOURCES/hello-2.0.tar.gz
+[/my/bin/rpmuncompress /data/SOURCES/hello-2.0.tar.gz
 ])
 AT_CLEANUP
 
-AT_SETUP([uncompress macro 2])
+AT_SETUP([uncompress 1])
+AT_KEYWORDS([macros])
+AT_CHECK([
+RPMDB_INIT
+runroot_other ${RPM_CONFIGDIR}/rpmuncompress /data/SOURCES/hello-2.0.tar.gz | tar t
+],
+[0],
+[hello-2.0/
+hello-2.0/COPYING
+hello-2.0/hello.spec
+hello-2.0/hello.c
+hello-2.0/Makefile
+hello-2.0/README
+hello-2.0/FAQ
+])
+AT_CLEANUP
+
+AT_SETUP([uncompress 2])
 AT_KEYWORDS([macros])
 AT_CHECK([
 RPMDB_INIT
 echo xxxxxxxxxxxxxxxxxxxxxxxxx > ${RPMTEST}/tmp/"some%%ath"
-runroot rpm \
-    --eval "%{uncompress:/tmp/some%%%%ath}"
+runroot_other ${RPM_CONFIGDIR}/rpmuncompress "/tmp/some%%ath"
 ],
 [0],
-[/usr/bin/cat /tmp/some%%ath
+[xxxxxxxxxxxxxxxxxxxxxxxxx
 ])
 
 AT_CLEANUP

--- a/tools/rpmuncompress.c
+++ b/tools/rpmuncompress.c
@@ -12,12 +12,15 @@
 
 static int verbose = 0;
 static int extract = 0;
+static int dryrun = 0;
 
 static struct poptOption optionsTable[] = {
     { "extract", 'x', POPT_ARG_VAL, &extract, 1,
 	N_("extract an archive"), NULL },
     { "verbose", 'v', POPT_ARG_VAL, &verbose, 1,
 	N_("provide more detailed output"), NULL },
+    { "dry-run", 'n', POPT_ARG_VAL, &dryrun, 1,
+	N_("only print what would be done"), NULL },
 
     POPT_AUTOALIAS
     POPT_AUTOHELP
@@ -135,8 +138,13 @@ int main(int argc, char *argv[])
     if (cmd) {
 	FILE *inp = NULL;
 
-	if (verbose)
+	if (verbose || dryrun)
 	    fprintf(stderr, "%s\n", cmd);
+
+	if (dryrun) {
+	    ec = EXIT_SUCCESS;
+	    goto exit;
+	}
 
 	inp = popen(cmd, "r");
 	if (inp) {

--- a/tools/rpmuncompress.c
+++ b/tools/rpmuncompress.c
@@ -1,0 +1,156 @@
+#include "system.h"
+
+#include <popt.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <rpm/rpmcli.h>
+#include <rpm/rpmstring.h>
+
+#include "debug.h"
+
+static int verbose = 0;
+static int extract = 0;
+
+static struct poptOption optionsTable[] = {
+    { "extract", 'x', POPT_ARG_VAL, &extract, 1,
+	N_("extract an archive"), NULL },
+    { "verbose", 'v', POPT_ARG_VAL, &verbose, 1,
+	N_("provide more detailed output"), NULL },
+
+    POPT_AUTOALIAS
+    POPT_AUTOHELP
+    POPT_TABLEEND
+};
+
+/* XXX this is silly, merge with the doUntar() uncompress logic */
+static char *doUncompress(const char *fn)
+{
+    return rpmExpand("%{uncompress:", fn, "}", NULL);
+}
+
+static char *doUntar(const char *fn)
+{
+    char *buf = NULL;
+    char *tar = NULL;
+    const char *taropts = verbose ? "-xvvof" : "-xof";
+    rpmCompressedMagic compressed = COMPRESSED_NOT;
+
+    /* XXX On non-build parse's, file cannot be stat'd or read */
+    if (rpmFileIsCompressed(fn, &compressed)) {
+	goto exit;
+    }
+
+    tar = rpmGetPath("%{__tar}", NULL);
+    if (compressed != COMPRESSED_NOT) {
+	char *zipper = NULL;
+	const char *t = NULL;
+	int needtar = 1;
+	int needgemspec = 0;
+
+	switch (compressed) {
+	case COMPRESSED_NOT:	/* XXX can't happen */
+	case COMPRESSED_OTHER:
+	    t = "%{__gzip} -dc";
+	    break;
+	case COMPRESSED_BZIP2:
+	    t = "%{__bzip2} -dc";
+	    break;
+	case COMPRESSED_ZIP:
+	    if (verbose)
+		t = "%{__unzip}";
+	    else
+		t = "%{__unzip} -qq";
+	    needtar = 0;
+	    break;
+	case COMPRESSED_LZMA:
+	case COMPRESSED_XZ:
+	    t = "%{__xz} -dc";
+	    break;
+	case COMPRESSED_LZIP:
+	    t = "%{__lzip} -dc";
+	    break;
+	case COMPRESSED_LRZIP:
+	    t = "%{__lrzip} -dqo-";
+	    break;
+	case COMPRESSED_7ZIP:
+	    t = "%{__7zip} x";
+	    needtar = 0;
+	    break;
+	case COMPRESSED_ZSTD:
+	    t = "%{__zstd} -dc";
+	    break;
+	case COMPRESSED_GEM:
+	    t = "%{__gem} unpack";
+	    needtar = 0;
+	    needgemspec = 1;
+	    break;
+	}
+
+	zipper = rpmGetPath(t, NULL);
+	if (needtar) {
+	    rasprintf(&buf, "%s '%s' | %s %s -", zipper, fn, tar, taropts);
+	} else if (needgemspec) {
+	    size_t nvlen = strlen(fn) - 3;
+	    char *gem = rpmGetPath("%{__gem}", NULL);
+	    char *gemspec = NULL;
+	    char gemnameversion[nvlen];
+
+	    rstrlcpy(gemnameversion, fn, nvlen);
+	    gemspec = rpmGetPath("", gemnameversion, ".gemspec", NULL);
+
+	    rasprintf(&buf, "%s '%s' && %s spec '%s' --ruby > '%s'",
+			zipper, fn, gem, fn, gemspec);
+
+	    free(gemspec);
+	    free(gem);
+	} else {
+	    rasprintf(&buf, "%s '%s'", zipper, fn);
+	}
+	free(zipper);
+    } else {
+	rasprintf(&buf, "%s %s '%s'", tar, taropts, fn);
+    }
+
+exit:
+    free(tar);
+    return buf;
+}
+
+int main(int argc, char *argv[])
+{
+    int ec = EXIT_FAILURE;
+    poptContext optCon = NULL;
+    const char *arg = NULL;
+
+    optCon = rpmcliInit(argc, argv, optionsTable);
+
+    if (optCon == NULL || ((arg = poptGetArg(optCon)) == NULL)) {
+	poptPrintUsage(optCon, stderr, 0);
+	goto exit;
+    }
+
+    char *cmd = extract ? doUntar(arg) : doUncompress(arg);
+    if (cmd) {
+	FILE *inp = NULL;
+
+	if (verbose)
+	    fprintf(stderr, "%s\n", cmd);
+
+	inp = popen(cmd, "r");
+	if (inp) {
+	    int status, c;
+	    while ((c = fgetc(inp)) != EOF)
+		fputc(c, stdout);
+	    status = pclose(inp);
+	    if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+		ec = EXIT_SUCCESS;
+	}
+	free(cmd);
+    }
+
+exit:
+    rpmcliFini(optCon);
+    return ec;
+}


### PR DESCRIPTION
See commit messages for details, but in brief this adds a new `rpmuncompress` tool which knows how to uncompress and extract what `%setup` and `%patch` can handle from the command line.

This makes it easier for packagers to extract multiple archives rather than wrestle with `%setup` for no good reason, plus it eliminates a silly dependency to sources and patches from the spec parsing step. Those are needed for building, not parsing.