### PR TITLE
Make pgpDigParams opaque

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -33,7 +33,13 @@ typedef struct pgpDig_s * pgpDig;
  */
 typedef struct pgpDigParams_s * pgpDigParams;
 
-typedef uint8_t pgpKeyID_t[8];
+
+/** \ingroup rpmpgp
+ * The length (in bytes) of a binary (not hex encoded) key ID.
+ */
+#define PGP_KEYID_LEN 8
+
+typedef uint8_t pgpKeyID_t[PGP_KEYID_LEN];
 typedef uint8_t pgpTime_t[4];
 
 /** \ingroup rpmpgp
@@ -1112,6 +1118,71 @@ int pgpDigParamsCmp(pgpDigParams p1, pgpDigParams p2);
  * return		algorithm value, 0 on error
  */
 unsigned int pgpDigParamsAlgo(pgpDigParams digp, unsigned int algotype);
+
+/** \ingroup rpmpgp
+ * Returns the issuer or the object's Key ID.
+ *
+ * If the object is a signature, then this returns the Key ID stored
+ * in the first Issuer subpacket as a hex string.  (This is not
+ * authenticated.)
+ *
+ * If the object is a certificate or a subkey, then this returns the key's
+ * Key ID.
+ *
+ * The caller must not free the returned buffer.
+ *
+ * param digp		parameter container
+ * return		an array of PGP_KEYID_LEN bytes.  If the issuer is
+ * 			unknown, this returns an array with all zeros.
+ */
+const uint8_t *pgpDigParamsSignID(pgpDigParams digp);
+
+/** \ingroup rpmpgp
+ * Retrieve the primary User ID, if any.
+ *
+ * Returns the primary User ID, if any.
+ *
+ * If the object is a signature, then this returns NULL.
+ *
+ * If the object is a certificate or a subkey, then this returns the
+ * certificate's primary User ID, if any.
+ *
+ * This interface does not provide a way for the caller to recognize
+ * any embedded NUL characters.
+ *
+ * The caller must not free the returned buffer.
+ *
+ * param digp		parameter container
+ * return		a string or NULL, if there is no primary User ID.
+ */
+const char *pgpDigParamsUserID(pgpDigParams digp);
+
+/** \ingroup rpmpgp
+ * Retrieve the object's version.
+ *
+ * Returns the object's version.
+ *
+ * If the object is a signature, then this returns the version of the
+ * signature packet.
+ *
+ * If the object is a certificate, then this returns the version of the
+ * primary key packet.
+ *
+ * If the object is a subkey, then this returns the version of the subkey's
+ * key packet.
+ *
+ * param digp		parameter container
+ * return		the object's version
+ */
+int pgpDigParamsVersion(pgpDigParams digp);
+
+/** \ingroup rpmpgp
+ * Retrieve the object's creation time.
+ *
+ * param digp		parameter container
+ * return		seconds since the UNIX Epoch.
+ */
+uint32_t pgpDigParamsCreationTime(pgpDigParams digp);
 
 /** \ingroup rpmpgp
  * Destroy parsed OpenPGP packet parameter(s).

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -345,8 +345,8 @@ static char * pgpsigFormat(rpmtd td, char **emsg)
 	*emsg = xstrdup(_("(not an OpenPGP signature)"));
     } else {
 	char dbuf[BUFSIZ];
-	char *keyid = rpmhex(sigp->signid, sizeof(sigp->signid));
-	unsigned int dateint = sigp->time;
+	char *keyid = rpmhex(pgpDigParamsSignID(sigp), PGP_KEYID_LEN);
+	unsigned int dateint = pgpDigParamsCreationTime(sigp);
 	time_t date = dateint;
 	struct tm _tm, * tms = localtime_r(&date, &_tm);
 	unsigned int key_algo = pgpDigParamsAlgo(sigp, PGPVAL_PUBKEYALGO);

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -436,13 +436,16 @@ struct pgpdata_s {
 static void initPgpData(pgpDigParams pubp, struct pgpdata_s *pd)
 {
     memset(pd, 0, sizeof(*pd));
-    pd->signid = rpmhex(pubp->signid, sizeof(pubp->signid));
+    pd->signid = rpmhex(pgpDigParamsSignID(pubp), PGP_KEYID_LEN);
     pd->shortid = pd->signid + 8;
-    pd->userid = pubp->userid ? pubp->userid : "none";
-    pd->time = pubp->time;
+    pd->userid = pgpDigParamsUserID(pubp);
+    if (! pd->userid) {
+        pd->userid = "none";
+    }
+    pd->time = pgpDigParamsCreationTime(pubp);
 
     rasprintf(&pd->timestr, "%x", pd->time);
-    rasprintf(&pd->verid, "%d:%s-%s", pubp->version, pd->signid, pd->timestr);
+    rasprintf(&pd->verid, "%d:%s-%s", pgpDigParamsVersion(pubp), pd->signid, pd->timestr);
 }
 
 static void finiPgpData(struct pgpdata_s *pd)

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -199,7 +199,7 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
 	    goto exit;
 	}
 	sinfo->hashalgo = pgpDigParamsAlgo(sinfo->sig, PGPVAL_HASHALGO);
-	sinfo->keyid = pgpGrab(sinfo->sig->signid+4, 4);
+	sinfo->keyid = pgpGrab(pgpDigParamsSignID(sinfo->sig)+4, 4);
     } else if (sinfo->type == RPMSIG_DIGEST_TYPE) {
 	if (td->type == RPM_BIN_TYPE) {
 	    sinfo->dig = rpmhex(data, dlen);

--- a/rpmio/digest.h
+++ b/rpmio/digest.h
@@ -19,34 +19,6 @@ struct pgpDigAlg_s {
     void *data;			/*!< algorithm specific private data */
 };
 
-/** \ingroup rpmio
- * Values parsed from OpenPGP signature/pubkey packet(s).
- */
-struct pgpDigParams_s {
-    char * userid;
-    uint8_t * hash;
-    uint8_t tag;
-
-    uint8_t key_flags;		/*!< key usage flags */
-    uint8_t version;		/*!< version number. */
-    uint32_t time;		/*!< key/signature creation time. */
-    uint8_t pubkey_algo;		/*!< public key algorithm. */
-
-    uint8_t hash_algo;
-    uint8_t sigtype;
-    uint32_t hashlen;
-    uint8_t signhash16[2];
-    pgpKeyID_t signid;
-    uint8_t saved;		/*!< Various flags.  `PGPDIG_SAVED_*` are never reset.
-				 * `PGPDIG_SIG_HAS_*` are reset for each signature. */
-#define	PGPDIG_SAVED_TIME	(1 << 0)
-#define	PGPDIG_SAVED_ID		(1 << 1)
-#define	PGPDIG_SIG_HAS_CREATION_TIME	(1 << 2)
-#define	PGPDIG_SIG_HAS_KEY_FLAGS	(1 << 3)
-
-    pgpDigAlg alg;
-};
-
 pgpDigAlg pgpPubkeyNew(int algo, int curve);
 
 pgpDigAlg pgpSignatureNew(int algo);


### PR DESCRIPTION
  - Add accessor functions pgpDigParamsSignID, pgpDigParamsUserID,
    pgpDigParamsVersion, pgpDigParamsTime, pgpDigParamsHashPrefix.

  - Move the definition of `pgpDigParams_s` from `rpmio/digest.h` to
    `rpmio/rpmpgp.c`.

  - Change code to use the accessor functions.

  - Fixes #1979.