### PR TITLE
Add missing deprecation warnings to various APIs

### DIFF
--- a/include/rpm/rpmds.h
+++ b/include/rpm/rpmds.h
@@ -9,6 +9,7 @@
 #include <time.h>
 
 #include <rpm/rpmtypes.h>
+#include <rpm/rpmutil.h>
 #include <rpm/rpmps.h>
 
 #ifdef __cplusplus
@@ -303,6 +304,7 @@ int rpmdsIsReverse(rpmds ds);
  * @param ds		unused
  * @return		1 always
  */
+RPM_GNUC_DEPRECATED
 int rpmdsNoPromote(const rpmds ds);
 
 /** \ingroup rpmds
@@ -311,6 +313,7 @@ int rpmdsNoPromote(const rpmds ds);
  * @param nopromote	unused
  * @return		1 always
  */
+RPM_GNUC_DEPRECATED
 int rpmdsSetNoPromote(rpmds ds, int nopromote);
 
 /** \ingroup rpmds

--- a/include/rpm/rpmfi.h
+++ b/include/rpm/rpmfi.h
@@ -9,6 +9,7 @@
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmfiles.h>
 #include <rpm/rpmarchive.h>
+#include <rpm/rpmutil.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,6 +64,7 @@ int rpmfiDX(rpmfi fi);
  * @param dx		unused
  * @return		-1
  */
+RPM_GNUC_DEPRECATED
 int rpmfiSetDX(rpmfi fi, int dx);
 
 /** \ingroup rpmfi
@@ -339,6 +341,7 @@ rpmfi rpmfiInit(rpmfi fi, int fx);
  * @param fi		unused
  * @return		-1
  */
+RPM_GNUC_DEPRECATED
 int rpmfiNextD(rpmfi fi);
 
 /** \ingroup rpmfi
@@ -348,6 +351,7 @@ int rpmfiNextD(rpmfi fi);
  * @param dx		unused
  * @return		NULL
  */
+RPM_GNUC_DEPRECATED
 rpmfi rpmfiInitD(rpmfi fi, int dx);
 
 /** \ingroup rpmfi

--- a/include/rpm/rpmkeyring.h
+++ b/include/rpm/rpmkeyring.h
@@ -36,10 +36,13 @@ int rpmKeyringAddKey(rpmKeyring keyring, rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Perform keyring lookup for a key matching a signature
+ * @deprecated		Obsolete, do not use.
+ *
  * @param keyring	keyring handle
  * @param sig		OpenPGP packet container of signature
  * @return		RPMRC_OK if found, RPMRC_NOKEY otherwise
  */
+RPM_GNUC_DEPRECATED
 rpmRC rpmKeyringLookup(rpmKeyring keyring, pgpDig sig);
 
 /** \ingroup rpmkeyring
@@ -97,9 +100,12 @@ rpmPubkey rpmPubkeyLink(rpmPubkey key);
 
 /** \ingroup rpmkeyring
  * Parse OpenPGP pubkey parameters.
+ * @deprecated		Obsolete, do not use.
+ *
  * @param key           Pubkey
  * @return              parsed output of pubkey packet parameters
  */
+RPM_GNUC_DEPRECATED
 pgpDig rpmPubkeyDig(rpmPubkey key);
 
 /** \ingroup rpmkeyring

--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -1027,6 +1027,8 @@ int pgpPrtParamsSubkeys(const uint8_t *pkts, size_t pktlen,
 			int *subkeysCount);
 /** \ingroup rpmpgp
  * Print/parse a OpenPGP packet(s).
+ * @deprecated		Obsolete, do not use.
+ *
  * @param pkts		OpenPGP packet(s)
  * @param pktlen	OpenPGP packet(s) length (no. of bytes)
  * @param[out] dig	parsed output of signature/pubkey packet parameters
@@ -1078,18 +1080,24 @@ char * pgpArmorWrap(int atype, const unsigned char * s, size_t ns);
 
 /** \ingroup rpmpgp
  * Create a container for parsed OpenPGP packet(s).
+ * @deprecated		Obsolete, do not use.
+ *
  * @return		container
  */
 pgpDig pgpNewDig(void);
 
 /** \ingroup rpmpgp
  * Release (malloc'd) data from container.
+ * @deprecated		Obsolete, do not use.
+ *
  * @param dig		container
  */
 void pgpCleanDig(pgpDig dig);
 
 /** \ingroup rpmpgp
  * Destroy a container for parsed OpenPGP packet(s).
+ * @deprecated		Obsolete, do not use.
+ *
  * @param dig		container
  * @return		NULL always
  */

--- a/lib/psm.c
+++ b/lib/psm.c
@@ -288,7 +288,6 @@ static rpmRC handleOneTrigger(rpmts ts, rpmte te, rpmsenseFlags sense,
 	return rc;
 
     headerGet(trigH, RPMTAG_INSTPREFIXES, &pfx, HEADERGET_ALLOC|HEADERGET_ARGV);
-    (void) rpmdsSetNoPromote(trigger, 1);
 
     while ((i = rpmdsNext(trigger)) >= 0) {
 	uint32_t tix;

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -112,7 +112,7 @@ rpmds_SetNoPromote(rpmdsObject * s, PyObject * args, PyObject * kwds)
 	    &nopromote))
 	return NULL;
 
-    return Py_BuildValue("i", rpmdsSetNoPromote(s->ds, nopromote));
+    return Py_BuildValue("i", 0);
 }
 
 /* XXX rpmdsFind uses bsearch on s->ds, so a sort is needed. */
@@ -208,8 +208,7 @@ static struct PyMethodDef rpmds_methods[] = {
  {"Color",	(PyCFunction)rpmds_Color,	METH_NOARGS,
 	"ds.Color -> Color -- Return current Color.\n" },
  {"SetNoPromote",(PyCFunction)rpmds_SetNoPromote, METH_VARARGS|METH_KEYWORDS,
-  "ds.SetNoPromote(noPromote) -- Set noPromote for this instance.\n\n"
-  "If True non existing epochs are no longer equal to an epoch of 0."},
+  "ds.SetNoPromote(noPromote) -- Obsolete, do not use.\n"},
  {"Sort",	(PyCFunction)rpmds_Sort,	METH_NOARGS,
 	NULL},
  {"Find",	(PyCFunction)rpmds_Find,	METH_O,


### PR DESCRIPTION
This stuff is already mostly rendered harmless but we should make callers aware that it'll actually be going away in the next cycle.