### PR TITLE
Add missing deprecation/obsoletion warnings to rpm 4.18 

### DIFF
--- a/include/rpm/rpmsq.h
+++ b/include/rpm/rpmsq.h
@@ -14,6 +14,8 @@ extern "C" {
 #endif
 
 /** \ingroup rpmsq
+ * @deprecated		Obsolete, do not use.
+ *
  * Default signal handler prototype.
  * @param signum	signal number
  * @param info		(siginfo_t) signal info
@@ -29,11 +31,14 @@ typedef void (*rpmsqAction_t) (int signum, siginfo_t * info, void * context);
 #define RPMSQ_ERR	((rpmsqAction_t)-1)
 
 /** \ingroup rpmsq
+ * @deprecated		Obsolete, do not use.
+ *
  * Test if given signal has been caught (while signals blocked).
  * Similar to sigismember() but operates on internal signal queue.
  * @param signum	signal to test for
  * @return		1 if caught, 0 if not and -1 on error
  */
+RPM_GNUC_DEPRECATED
 int rpmsqIsCaught(int signum);
 
 /** \ingroup rpmsq
@@ -41,14 +46,18 @@ int rpmsqIsCaught(int signum);
  * @param state		1 to enable, 0 to disable
  * @return		0 on success, negative on error
  */
+RPM_GNUC_DEPRECATED
 int rpmsqActivate(int state);
 
 /** \ingroup rpmsq
+ * @deprecated		Obsolete, do not use.
+ *
  * Set or delete a signal handler for a signal.
  * @param signum	signal number
  * @param handler	signal handler or NULL to delete
  * @return		previous handler, RPMSQ_ERR on error
  */
+RPM_GNUC_DEPRECATED
 rpmsqAction_t rpmsqSetAction(int signum, rpmsqAction_t handler);
 
 /** \ingroup rpmsq
@@ -61,11 +70,18 @@ rpmsqAction_t rpmsqSetAction(int signum, rpmsqAction_t handler);
 int rpmsqBlock(int op);
 
 /** \ingroup rpmsq
+ * @deprecated		Obsolete, do not use.
+ *
  * Poll for caught signals, executing their handlers.
  * @return		no. active signals found
  */
+RPM_GNUC_DEPRECATED
 int rpmsqPoll(void);
 
+/** \ingroup rpmsq
+ * @deprecated		Obsolete, do not use.
+ */
+RPM_GNUC_DEPRECATED
 void rpmsqSetInterruptSafety(int on);
 
 #ifdef __cplusplus

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -201,7 +201,7 @@ static PyObject * hdrFullFilelist(hdrObject * s)
     rpmtd fileNames = rpmtdNew();
     Header h = s->h;
 
-    DEPRECATED_METHOD("obsolete method");
+    DEPRECATED_METHOD("method is obsolete");
     if (!headerIsEntry (h, RPMTAG_BASENAMES)
 	|| !headerIsEntry (h, RPMTAG_DIRNAMES)
 	|| !headerIsEntry (h, RPMTAG_DIRINDEXES))
@@ -311,6 +311,7 @@ static PyObject * hdr_dsFromHeader(PyObject * s, PyObject * args, PyObject * kwd
 
 static PyObject * hdr_dsOfHeader(PyObject * s)
 {
+    DEPRECATED_METHOD("deprecated, use rpm.ds() instead");
     return PyObject_CallFunction((PyObject *) &rpmds_Type,
                                  "(Oi)", s, RPMTAG_NEVR);
 }
@@ -353,9 +354,9 @@ static struct PyMethodDef hdr_methods[] = {
     {"write",		(PyCFunction)hdrWrite,		METH_VARARGS|METH_KEYWORDS,
      "hdr.write(file, magic=True) -- Write header to file." },
     {"dsOfHeader",	(PyCFunction)hdr_dsOfHeader,	METH_NOARGS,
-     "hdr.dsOfHeader() -- Return dependency set with the header's NEVR."},
+     "hdr.dsOfHeader() -- Return dependency set with the header's NEVR.\n\nDEPRECATED - Use rpm.ds(hdr, 'NEVR') instead."},
     {"dsFromHeader",	(PyCFunction)hdr_dsFromHeader,	METH_VARARGS|METH_KEYWORDS,
-     "hdr.dsFromHeader(to=RPMTAG_REQUIRENAME, flags=None)\nGet dependency set from header. to must be one of the NAME tags\nbelonging to a dependency:\n'Providename', 'Requirename', 'Obsoletename', 'Conflictname',\n'Triggername', 'Recommendname', 'Suggestname', 'Supplementname',\n'Enhancename' or one of the corresponding RPMTAG_*NAME constants." },
+     "hdr.dsFromHeader(to=RPMTAG_REQUIRENAME, flags=None)\nGet dependency set from header. to must be one of the NAME tags\nbelonging to a dependency:\n'Providename', 'Requirename', 'Obsoletename', 'Conflictname',\n'Triggername', 'Recommendname', 'Suggestname', 'Supplementname',\n'Enhancename' or one of the corresponding RPMTAG_*NAME constants.\n\nDEPRECATED - Use rpm.ds(hdr, tag) instead." },
     {"fiFromHeader",	(PyCFunction)hdr_fiFromHeader,	METH_VARARGS|METH_KEYWORDS,
      "hdr.fiFromHeader() -- Return rpm.fi object containing the file\nmeta data from the header.\n\nDEPRECATED - Use rpm.files(hdr) instead."},
     {"__reduce__",	(PyCFunction)hdr_reduce,	METH_NOARGS,
@@ -860,6 +861,7 @@ rpmMergeHeadersFromFD(PyObject * self, PyObject * args, PyObject * kwds)
     int matchTag;
     char * kwlist[] = {"list", "fd", "matchTag", NULL};
 
+    DEPRECATED_METHOD("method is obsolete");
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "Oii", kwlist, &list,
 	    &fileno, &matchTag))
 	return NULL;

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -108,6 +108,7 @@ rpmds_SetNoPromote(rpmdsObject * s, PyObject * args, PyObject * kwds)
     int nopromote;
     char * kwlist[] = {"noPromote", NULL};
 
+    DEPRECATED_METHOD("method is obsolete");
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "i:SetNoPromote", kwlist,
 	    &nopromote))
 	return NULL;

--- a/python/rpmfi-py.c
+++ b/python/rpmfi-py.c
@@ -337,6 +337,8 @@ static PyObject * rpmfi_new(PyTypeObject * subtype, PyObject *args, PyObject *kw
     rpmstrPool pool = NULL;
     char * kwlist[] = {"header", "tag", "flags", "pool", NULL};
 
+    DEPRECATED_METHOD("method is obsolete");
+
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|OiO&:rpmfi_init", kwlist,
 				hdrFromPyObject, &h, &to, &flags,
 				poolFromPyObject, &pool))

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -48,13 +48,13 @@ static PyObject * signalCaught(PyObject *self, PyObject *o)
     DEPRECATED_METHOD("method is obsolete");
     if (!PyArg_Parse(o, "i", &signo)) return NULL;
 
-    return PyBool_FromLong(rpmsqIsCaught(signo));
+    return PyBool_FromLong(0);
 }
 
 static PyObject * checkSignals(PyObject * self)
 {
     DEPRECATED_METHOD("method is obsolete");
-    return Py_BuildValue("i", rpmsqPoll());
+    return Py_BuildValue("i", 0);
 }
 
 static PyObject * blockSignals(PyObject * self, PyObject *arg)
@@ -140,16 +140,11 @@ static PyObject * reloadConfig(PyObject * self, PyObject * args, PyObject *kwds)
 
 static PyObject * setInterruptSafety(PyObject * self, PyObject * args, PyObject *kwds)
 {
-    int on = 1;
     PyObject * obj;
     char * kwlist[] = { "on", NULL };
     DEPRECATED_METHOD("method is obsolete");
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist, &obj))
 	return NULL;
-    if (obj) {
-	on = PyObject_IsTrue(obj);
-    }
-    rpmsqSetInterruptSafety(on);
     Py_RETURN_NONE;
 }
 

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -45,6 +45,7 @@ static PyObject * archScore(PyObject * self, PyObject * arg)
 static PyObject * signalCaught(PyObject *self, PyObject *o)
 {
     int signo;
+    DEPRECATED_METHOD("method is obsolete");
     if (!PyArg_Parse(o, "i", &signo)) return NULL;
 
     return PyBool_FromLong(rpmsqIsCaught(signo));
@@ -52,6 +53,7 @@ static PyObject * signalCaught(PyObject *self, PyObject *o)
 
 static PyObject * checkSignals(PyObject * self)
 {
+    DEPRECATED_METHOD("method is obsolete");
     return Py_BuildValue("i", rpmsqPoll());
 }
 
@@ -141,6 +143,7 @@ static PyObject * setInterruptSafety(PyObject * self, PyObject * args, PyObject 
     int on = 1;
     PyObject * obj;
     char * kwlist[] = { "on", NULL };
+    DEPRECATED_METHOD("method is obsolete");
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist, &obj))
 	return NULL;
     if (obj) {
@@ -198,14 +201,16 @@ static PyMethodDef rpmModuleMethods[] = {
       "0 for non matching arch names\n1 for best arch\nhigher numbers for less fitting arches\n(e.g. 2 for \"i586\" on an i686 machine)" },
 
     { "signalCaught", (PyCFunction) signalCaught, METH_O, 
-	"signalCaught(signo) -- Returns True if signal was caught." },
+	"signalCaught(signo) -- Returns True if signal was caught.\n" 
+      "OBSOLETE - this has no effect, do not use\n"},
     { "checkSignals", (PyCFunction) checkSignals, METH_NOARGS,
-      "checkSignals() -- Check for and exit on termination signals."},
+      "checkSignals() -- Check for and exit on termination signals.\n\n"
+      "OBSOLETE - this has no effect, do not use\n"},
     { "blockSignals", (PyCFunction) blockSignals, METH_O,
       "blocksignals(True/False) -- Block/unblock signals, refcounted."},
 
     { "mergeHeaderListFromFD", (PyCFunction) rpmMergeHeadersFromFD, METH_VARARGS|METH_KEYWORDS,
-	NULL },
+	"OBSOLETE - do not use" },
 
     { "log",		(PyCFunction) doLog, METH_VARARGS|METH_KEYWORDS,
 	"log(level, msg) -- Write msg to log if level is selected to be logged.\n\n"
@@ -237,7 +242,8 @@ static PyMethodDef rpmModuleMethods[] = {
       "a transaction is being performed.\n\n"
       "If this is not the desired behaviour it's recommended to call this\n"
       "once only at process startup because currently signal handlers will\n"
-      "not be retroactively applied if a database is open."
+      "not be retroactively applied if a database is open.\n\n"
+      "OBSOLETE - this has no effect, do not use\n"
     },
     { "addSign", (PyCFunction) addSign, METH_VARARGS|METH_KEYWORDS, NULL },
     { "delSign", (PyCFunction) delSign, METH_VARARGS|METH_KEYWORDS, NULL },

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -460,6 +460,7 @@ rpmts_PgpPrtPkts(rpmtsObject * s, PyObject * args, PyObject * kwds)
     int rc;
     char * kwlist[] = {"octets", NULL};
 
+    DEPRECATED_METHOD("obsolete method");
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "S:PgpPrtPkts", kwlist, &blob))
     	return NULL;
 

--- a/rpmio/rpmsq.c
+++ b/rpmio/rpmsq.c
@@ -192,7 +192,6 @@ int rpmsqBlock(int op)
 	blocked--;
 	if (blocked == 0) {
 	    ret = pthread_sigmask(SIG_SETMASK, &oldMask, NULL);
-	    rpmsqPoll();
 	} else if (blocked < 0) {
 	    blocked = 0;
 	    ret = -1;


### PR DESCRIPTION
We have all manner of old cruft laying around that we want to remove, but technically we need to deprecate it first...