### PR TITLE
Properly escape %__gpg_sign_cmd

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -586,15 +586,16 @@ package or when debugging this package.\
 #==============================================================================
 # ---- GPG/PGP/PGP5 signature macros.
 #	Macro(s) to hold the arguments passed to GPG/PGP for package
-#	signing and verification.
+#	signing.  Expansion result is parsed by popt, so be sure to use
+#	%{shescape} where needed.
 #
-
-%__gpg_sign_cmd			%{__gpg} \
-	gpg --no-verbose --no-armor \
-	%{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
-	--no-secmem-warning \
-	%{?_gpg_sign_cmd_extra_args:%{_gpg_sign_cmd_extra_args}} \
-	-u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
+%__gpg_sign_cmd			%{shescape:%{__gpg}} \
+	gpg --no-verbose --no-armor --no-secmem-warning \
+	%{?_gpg_digest_algo:--digest-algo=%{_gpg_digest_algo}} \
+	%{?_gpg_sign_cmd_extra_args} \
+	%{?_gpg_name:-u %{shescape:%{_gpg_name}}} \
+	-sbo %{shescape:%{?__signature_filename}} \
+	%{?__plaintext_filename:-- %{shescape:%{__plaintext_filename}}}
 
 #==============================================================================
 # ---- Transaction macros.

--- a/macros.in
+++ b/macros.in
@@ -596,12 +596,6 @@ package or when debugging this package.\
 	%{?_gpg_sign_cmd_extra_args:%{_gpg_sign_cmd_extra_args}} \
 	-u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
 
-# XXX rpm >= 4.1 verifies signatures internally
-#%__gpg_verify_cmd		%{__gpg} \
-#	gpg --batch --no-verbose --verify --no-secmem-warning \
-#	%{__signature_filename} %{__plaintext_filename}
-#
-
 #==============================================================================
 # ---- Transaction macros.
 #	Macro(s) used to parameterize transactions.


### PR DESCRIPTION
%__gpg_sign_cmd needs to be able to cope with strange characters in e.g.
%_gpg_name.  Use the builtin shescape macro to make this
straightforward.  Also rip out the old (and commented-out)
%__gpg_verify_cmd.