### PR TITLE
Move backend-specific digest functionality to backend-specific files

### DIFF
--- a/lib/formats.c
+++ b/lib/formats.c
@@ -14,7 +14,7 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmbase64.h>
 
-#include "rpmio/digest.h"
+#include "rpmio/rpmpgp.h"
 #include "lib/manifest.h"
 #include "lib/misc.h"
 #include "lib/signature.h"

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -24,7 +24,7 @@
 #include <rpm/rpmsq.h>
 #include <rpm/rpmte.h>
 
-#include "rpmio/digest.h"
+#include "rpmio/rpmpgp.h"
 #include "lib/rpmal.h"
 #include "lib/rpmchroot.h"
 #include "lib/rpmplugins.h"

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -5,7 +5,7 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmlog.h>
 #include "lib/rpmvs.h"
-#include "rpmio/digest.h"
+#include "rpmio/rpmpgp.h"
 
 #include "debug.h"
 

--- a/rpmio/Makefile.am
+++ b/rpmio/Makefile.am
@@ -24,7 +24,8 @@ librpmio_la_SOURCES = \
 	rpmio_internal.h rpmhook.h rpmvercmp.c rpmver.c \
 	rpmstring.c rpmfileutil.c rpmglob.c \
 	rpmkeyring.c rpmstrpool.c rpmmacro_internal.h \
-	rpmlua.c rpmlua.h lposix.c lposix.h rpmpgp_internal.c
+	rpmlua.c rpmlua.h lposix.c lposix.h \
+	rpmpgp_internal.c rpmpgp_internal.h
 
 if WITH_OPENSSL
 librpmio_la_SOURCES += digest_openssl.c

--- a/rpmio/digest.c
+++ b/rpmio/digest.c
@@ -4,7 +4,7 @@
 
 #include "system.h"
 
-#include "rpmio/digest.h"
+#include "rpmio/rpmpgp_internal.h"
 
 #include "debug.h"
 

--- a/rpmio/digest_libgcrypt.c
+++ b/rpmio/digest_libgcrypt.c
@@ -3,7 +3,7 @@
 #include <gcrypt.h>
 
 #include <rpm/rpmcrypto.h>
-#include "rpmio/digest.h"
+#include "rpmio/rpmpgp_internal.h"
 #include "rpmio/rpmio_internal.h"
 #include "debug.h"
 

--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -5,7 +5,7 @@
 #include <openssl/dsa.h>
 #include <rpm/rpmcrypto.h>
 
-#include "rpmio/digest.h"
+#include "rpmio/rpmpgp_internal.h"
 
 
 /* Compatibility functions for OpenSSL 1.0.2 */

--- a/rpmio/rpmkeyring.c
+++ b/rpmio/rpmkeyring.c
@@ -9,8 +9,6 @@
 #include <rpm/rpmkeyring.h>
 #include <rpm/rpmbase64.h>
 
-#include "rpmio/digest.h"
-
 #include "debug.h"
 
 int _print_pkts = 0;

--- a/rpmio/rpmpgp.c
+++ b/rpmio/rpmpgp.c
@@ -10,7 +10,6 @@
 #include <rpm/rpmstring.h>
 #include <rpm/rpmlog.h>
 
-#include "rpmio/digest.h"
 #include "rpmio/rpmpgp.h"
 #include "rpmio/rpmio_internal.h"	/* XXX rpmioSlurp */
 

--- a/rpmio/rpmpgp.h
+++ b/rpmio/rpmpgp.h
@@ -1,5 +1,5 @@
-#ifndef _RPMPGP_INTERNAL_H
-#define _RPMPGP_INTERNAL_H
+#ifndef _RPMPGP_H
+#define _RPMPGP_H
 
 #include <rpm/rpmpgp.h>
 
@@ -170,4 +170,4 @@ static struct pgpValTbl_s const pgpArmorKeyTbl[] = {
     { -1,			"Unknown armor key" }
 };
 
-#endif /* _RPMPGP_INTERNAL_H */
+#endif /* _RPMPGP_H */

--- a/rpmio/rpmpgp_internal.c
+++ b/rpmio/rpmpgp_internal.c
@@ -11,8 +11,8 @@
 #include <rpm/rpmlog.h>
 #include <rpm/rpmbase64.h>
 
-#include "rpmio/digest.h"
 #include "rpmio/rpmpgp.h"
+#include "rpmio/rpmpgp_internal.h"
 #include "rpmio/rpmio_internal.h"	/* XXX rpmioSlurp */
 
 #include "debug.h"

--- a/rpmio/rpmpgp_internal.h
+++ b/rpmio/rpmpgp_internal.h
@@ -1,7 +1,7 @@
-#ifndef _RPMDIGEST_H
-#define _RPMDIGEST_H
+#ifndef _RPMPGP_INTERNAL_H
+#define _RPMPGP_INTERNAL_H
 
-#include <rpm/rpmpgp.h>
+#include "rpmio/rpmpgp.h"
 
 typedef struct pgpDigAlg_s * pgpDigAlg;
 
@@ -23,7 +23,7 @@ pgpDigAlg pgpPubkeyNew(int algo, int curve);
 
 pgpDigAlg pgpSignatureNew(int algo);
 
-pgpDigAlg pgpDigAlgFree(pgpDigAlg da);
+pgpDigAlg pgpDigAlgFree(pgpDigAlg alg);
 
 /** \ingroup rpmpgp
  * Return no. of bits in a multiprecision integer.
@@ -46,5 +46,5 @@ size_t pgpMpiLen(const uint8_t *p)
 {
     return (2 + ((pgpMpiBits(p)+7)>>3));
 }
-	
-#endif /* _RPMDIGEST_H */
+
+#endif /* _RPMPGP_INTERNAL_H */


### PR DESCRIPTION
rpmio/digest.h contains definitions that are used by the libgcrypt and
OpenSSL backends, but are not required by the future Sequoia backend.
Move those definitions into rpmio/digest-libgcrypt.h and
rpmio/digest-openssl.h, respectively, and change rpmio/digest.h to
include the correct set of definitions based on the selected backend.

Fixes #2006.