### PR TITLE
Avoid parsing key usage flags from hashed key ID subpackets

### DIFF
--- a/rpmio/rpmpgp_internal.c
+++ b/rpmio/rpmpgp_internal.c
@@ -323,6 +323,7 @@ static int pgpPrtSubType(const uint8_t *h, size_t hlen, pgpSigType sigtype,
 		_digp->saved |= PGPDIG_SAVED_ID;
 		memcpy(_digp->signid, p+1, sizeof(_digp->signid));
 	    }
+	    break;
 	case PGPSUBTYPE_KEY_FLAGS: /* Key usage flags */
 	    /* Subpackets in the unhashed section cannot be trusted */
 	    if (!hashed)


### PR DESCRIPTION
A key ID subpacket is not a key usage flags subpacket and must not be
interpreted as such.  This caused RPM to wrongly reject a signature that
had both key ID and key usage flags subpackets in the hashed section.

@pmatilai I believe this fixes a regression in 4.18 alpha.