### PR TITLE
Fix multiple regressions related to dynamic buildrequires (RhBug:2078744)

### DIFF
--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -663,16 +663,12 @@ int main(int argc, char *argv[])
 	/* fallthrough */
     case 'f':
 	ba->buildAmount |= RPMBUILD_CONF;
-	if ((buildChar == 'f') && shortCircuit)
-	    break;
-	/* fallthrough */
-    case 'r':
-    case 'd':
 	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
-	ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
-	if (!noDeps)
+	if (!noDeps) {
+	    ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
 	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
-	if ((buildChar == 'r' || buildChar == 'd') && shortCircuit)
+	}
+	if ((buildChar == 'f') && shortCircuit)
 	    break;
 	/* fallthrough */
     case 'p':
@@ -681,6 +677,18 @@ int main(int argc, char *argv[])
     case 'l':
 	ba->buildAmount |= RPMBUILD_FILECHECK;
 	break;
+    case 'r':
+	/* fallthrough */
+    case 'd':
+	if (!shortCircuit)
+	    ba->buildAmount |= RPMBUILD_PREP;
+	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
+	ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
+	if (!noDeps)
+	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
+	if (buildChar == 'd')
+	    break;
+	/* fallthrough */
     case 's':
 	ba->buildAmount |= RPMBUILD_PACKAGESOURCE;
 	break;

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -1707,6 +1707,38 @@ runroot rpmbuild \
 )
 AT_CLEANUP
 
+# Test that -br creates an src.rpm on success
+AT_SETUP([rpmbuild -br success])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild \
+  -br  /data/SPECS/mini.spec
+],
+[0],
+[Wrote: /build/SRPMS/mini-1-1.src.rpm
+],
+[],
+)
+AT_CLEANUP
+
+# Test that -br creates an src.rpm on success
+AT_SETUP([rpmbuild -br success])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild \
+  -br  /data/SPECS/mini.spec
+],
+[0],
+[Wrote: /build/SRPMS/mini-1-1.src.rpm
+],
+[],
+)
+AT_CLEANUP
+
 # ------------------------------
 # Check dynamic build requires
 AT_SETUP([rpmbuild -bd with errors])


### PR DESCRIPTION
Successful rpmbuild -br needs to produce an src.rpm, this was untested
in the testsuite and commit ad8b9bd2ca93cf4319680f056bb40bfc24661991
missed this twist in the logic. Fixing is an obvious one-liner now,
add a test to ensure it doesn't happen again.