### PR TITLE
Fix a typo in doUntar that breaks verbose uncompression

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -130,7 +130,7 @@ static char *doUntar(rpmSpec spec, uint32_t c, int quietly)
     }
 
     buf = rpmExpand("%{__rpmuncompress} -x ",
-		    quietly ? "" : "-v", sp->path, NULL);
+		    quietly ? "" : "-v ", sp->path, NULL);
     rstrcat(&buf,
 	"\nSTATUS=$?\n"
 	"if [ $STATUS -ne 0 ]; then\n"


### PR DESCRIPTION
With RPM 4.18 non-quiet setup (`%setup` without `-q` or `%autosetup -v`) fails with:

    + /usr/lib/rpm/rpmuncompress -x -v/builddir/build/SOURCES/jquery-3.6.0.tar.gz
    rpmuncompress: -v/builddir/build/SOURCES/jquery-3.6.0.tar.gz: unknown option

See https://bugzilla.redhat.com/show_bug.cgi?id=2079127