### PR TITLE
Before importing an OpenPGP certificate, lint it

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -1055,6 +1055,32 @@ pgpArmor pgpParsePkts(const char *armor, uint8_t ** pkt, size_t * pktlen);
 int pgpPubKeyCertLen(const uint8_t *pkts, size_t pktslen, size_t *certlen);
 
 /** \ingroup rpmpgp
+ * Lints the certificate.
+ *
+ * There are four cases:
+ *
+ * The packets do not describe a certificate: returns an error and
+ * sets *explanation to NULL.
+ *
+ * The packets describe a certificate and the certificate is
+ * completely unusable: returns an error and sets *explanation to a
+ * human readable explanation.
+ *
+ * The packets describe a certificate and some components are not
+ * usable: returns success, and sets *explanation to a human readable
+ * explanation.
+ *
+ * The packets describe a certificate and there are no lints: returns
+ * success, and sets *explanation to NULL.
+ *
+ * @param pkts	OpenPGP pointer to a buffer with certificates
+ * @param pktslen	length of the buffer with certificates
+ * @param[out] explanation	An optional lint to display to the user.
+ * @return 		RPMRC_OK on success
+ */
+rpmRC pgpPubKeyLint(const uint8_t *pkts, size_t pktslen, char **explanation);
+
+/** \ingroup rpmpgp
  * Wrap a OpenPGP packets in ascii armor for transport.
  * @param atype		type of armor
  * @param s		binary pkt data

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -604,6 +604,7 @@ rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen
 {
     Header h = NULL;
     rpmRC rc = RPMRC_FAIL;		/* assume failure */
+    char *lints = NULL;
     rpmPubkey pubkey = NULL;
     rpmPubkey *subkeys = NULL;
     int subkeysCount = 0;
@@ -614,6 +615,20 @@ rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen
 
     if (txn == NULL)
 	return rc;
+
+    krc = pgpPubKeyLint(pkt, pktlen, &lints);
+    if (lints) {
+        if (krc != RPMRC_OK) {
+            rpmlog(RPMLOG_ERR, "%s\n", lints);
+        } else {
+            rpmlog(RPMLOG_WARNING, "%s\n", lints);
+        }
+        free(lints);
+    }
+    if (krc != RPMRC_OK) {
+        rc = krc;
+        goto exit;
+    }
 
     /* XXX keyring wont load if sigcheck disabled, force it temporarily */
     rpmtsSetVSFlags(ts, (oflags & ~RPMVSF_MASK_NOSIGNATURES));

--- a/rpmio/rpmpgp_internal.c
+++ b/rpmio/rpmpgp_internal.c
@@ -1345,3 +1345,9 @@ char * pgpArmorWrap(int atype, const unsigned char * s, size_t ns)
     free(buf);
     return val;
 }
+
+rpmRC pgpPubKeyLint(const uint8_t *pkts, size_t pktslen, char **explanation)
+{
+    *explanation = NULL;
+    return RPMRC_OK;
+}


### PR DESCRIPTION
When importing an OpenPGP certificate, lint the certificate to show
the user possible issues.  Fail if the certificate is completely
unusable.  Using the Sequoia backend, this yields, for instance:

  $ ./rpmkeys --import tests/data/keys/alice-revoked-subkey.asc
  Certificate B3A771BFEB04E625:
    Subkey 1F71177215217EE0 was revoked: Key material has been compromised, it was the maid
    Certificate does not have any usable signing keys

Fixes #1974.