### PR TITLE
Shell-like escaping support in %files, version 2

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2153,12 +2153,12 @@ static int generateBuildIDs(FileList fl, ARGV_t *files)
  * @param pkg
  * @param fl		package file tree walk data
  * @param fileName	file to add
+ * @param doGlob	perform globbing on file
  * @return		RPMRC_OK on success
  */
-static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName)
+static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
+			       int doGlob)
 {
-    int quote = 1;	/* XXX permit quoted glob characters. */
-    int doGlob;
     char *diskPath = NULL;
     rpmRC rc = RPMRC_OK;
     size_t fnlen = strlen(fileName);
@@ -2168,8 +2168,6 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName)
     if (trailing_slash && !fl->cur.isDir)
 	fl->cur.isDir = -1;
     
-    doGlob = rpmIsGlob(fileName, quote);
-
     /* Check that file starts with leading "/" */
     if (*fileName != '/') {
 	rpmlog(RPMLOG_ERR, _("File needs leading \"/\": %s\n"), fileName);
@@ -2430,7 +2428,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	if (rpmGlob(eorigfile, &globFilesCount, &globFiles) == 0) {
 	    for (i = 0; i < globFilesCount; i++) {
 		rasprintf(&newfile, "%s/%s", sd->dirname, basename(globFiles[i]));
-		processBinaryFile(pkg, fl, newfile);
+		processBinaryFile(pkg, fl, newfile, 0);
 		free(newfile);
 	    }
 	    argvFree(globFiles);
@@ -2449,7 +2447,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     copyFileEntry(&sd->entries[0].defEntry, &fl->def);
     copyFileEntry(&sd->entries[0].curEntry, &fl->cur);
     fl->cur.isDir = 1;
-    (void) processBinaryFile(pkg, fl, sd->dirname);
+    (void) processBinaryFile(pkg, fl, sd->dirname, 1);
 
     freeStringBuf(docScript);
     free(mkdocdir);
@@ -2574,7 +2572,7 @@ static void addPackageFileList (struct FileList_s *fl, Package pkg,
 	    } else {
 		if (fl->cur.attrFlags & RPMFILE_DIR)
 		    fl->cur.isDir = 1;
-		(void) processBinaryFile(pkg, fl, *fn);
+		(void) processBinaryFile(pkg, fl, *fn, 1);
 	    }
 	}
 

--- a/build/files.c
+++ b/build/files.c
@@ -5,6 +5,7 @@
  */
 
 #include "system.h"
+#include <glob.h>
 
 #define	MYALLPERMS	07777
 
@@ -2199,19 +2200,11 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
 	    goto exit;
 	}
 
-	if (rpmGlob(diskPath, &argc, &argv) == 0) {
+	if (rpmGlob(diskPath, GLOB_NOCHECK, &argc, &argv) == 0) {
 	    for (i = 0; i < argc; i++) {
 		rc = addFile(fl, argv[i], NULL);
 	    }
 	    argvFree(argv);
-	} else {
-	    const char *msg = (fl->cur.isDir) ?
-				_("Directory not found by glob: %s. "
-				"Trying without globbing.\n") :
-				_("File not found by glob: %s. "
-				"Trying without globbing.\n");
-	    rpmlog(RPMLOG_DEBUG, msg, diskPath);
-	    rc = addFile(fl, diskPath, NULL);
 	}
     } else {
 	rc = addFile(fl, diskPath, NULL);
@@ -2424,16 +2417,13 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	copyFileEntry(&sd->entries[fi].defEntry, &fl->def);
 	fi++;
 
-	if (rpmGlob(origfile, &globFilesCount, &globFiles) == 0) {
+	if (rpmGlob(origfile, GLOB_NOCHECK, &globFilesCount, &globFiles) == 0) {
 	    for (i = 0; i < globFilesCount; i++) {
 		rasprintf(&newfile, "%s/%s", sd->dirname, basename(globFiles[i]));
 		processBinaryFile(pkg, fl, newfile, 0);
 		free(newfile);
 	    }
 	    argvFree(globFiles);
-	} else {
-	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), origfile);
-	    fl->processingFailed = 1;
 	}
 	free(origfile);
 	files++;

--- a/build/files.c
+++ b/build/files.c
@@ -2414,7 +2414,6 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     fi = 0;
     while (*files != NULL) {
 	char *origfile = rpmGenPath(basepath, *files, NULL);
-	char *eorigfile = rpmEscapeSpaces(origfile);
 	ARGV_t globFiles = NULL;
 	int globFilesCount, i;
 	char *newfile;
@@ -2425,7 +2424,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	copyFileEntry(&sd->entries[fi].defEntry, &fl->def);
 	fi++;
 
-	if (rpmGlob(eorigfile, &globFilesCount, &globFiles) == 0) {
+	if (rpmGlob(origfile, &globFilesCount, &globFiles) == 0) {
 	    for (i = 0; i < globFilesCount; i++) {
 		rasprintf(&newfile, "%s/%s", sd->dirname, basename(globFiles[i]));
 		processBinaryFile(pkg, fl, newfile, 0);
@@ -2433,10 +2432,9 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	    }
 	    argvFree(globFiles);
 	} else {
-	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), eorigfile);
+	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), origfile);
 	    fl->processingFailed = 1;
 	}
-	free(eorigfile);
 	free(origfile);
 	files++;
     }

--- a/build/files.c
+++ b/build/files.c
@@ -2417,7 +2417,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     while (*files != NULL) {
 	char *origfile = rpmGenPath(basepath, *files, NULL);
 	char *eorigfile = rpmEscapeSpaces(origfile);
-	ARGV_t globFiles;
+	ARGV_t globFiles = NULL;
 	int globFilesCount, i;
 	char *newfile;
 

--- a/build/files.c
+++ b/build/files.c
@@ -2189,25 +2189,25 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
     if (fl->cur.isDir)
 	diskPath = rstrcat(&diskPath, "/");
 
-    if (doGlob) {
-	ARGV_t argv = NULL;
-	int argc = 0;
-	int i;
-
-	if (fl->cur.devtype) {
-	    rpmlog(RPMLOG_ERR, _("%%dev glob not permitted: %s\n"), diskPath);
-	    rc = RPMRC_FAIL;
-	    goto exit;
-	}
-
-	if (rpmGlob(diskPath, GLOB_NOCHECK, &argc, &argv) == 0) {
-	    for (i = 0; i < argc; i++) {
-		rc = addFile(fl, argv[i], NULL);
-	    }
-	    argvFree(argv);
-	}
-    } else {
+    if (!doGlob) {
 	rc = addFile(fl, diskPath, NULL);
+	goto exit;
+    }
+
+    ARGV_t argv = NULL;
+    int argc = 0;
+    int i;
+
+    if (fl->cur.devtype) {
+	rpmlog(RPMLOG_ERR, _("%%dev glob not permitted: %s\n"), diskPath);
+	rc = RPMRC_FAIL;
+	goto exit;
+    }
+
+    if (rpmGlob(diskPath, GLOB_NOCHECK, &argc, &argv) == 0) {
+	for (i = 0; i < argc; i++)
+	    rc = addFile(fl, argv[i], NULL);
+	argvFree(argv);
     }
 
 exit:

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1113,7 +1113,7 @@ static int initAttrs(rpmfc fc)
     int nattrs = 0;
 
     /* Discover known attributes from pathnames + initialize them */
-    if (rpmGlob(attrPath, NULL, &files) == 0) {
+    if (rpmGlob(attrPath, 0, NULL, &files) == 0) {
 	nattrs = argvCount(files);
 	fc->atypes = xcalloc(nattrs + 1, sizeof(*fc->atypes));
 	for (int i = 0; i < nattrs; i++) {

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -110,11 +110,12 @@ char * rpmGetPath (const char * path, ...) RPM_GNUC_NULL_TERMINATED;
 /** \ingroup rpmfileutil
  * Return URL path(s) from a (URL prefixed) pattern glob.
  * @param patterns	glob pattern
+ * @param flags		GLOB_NOMAGIC or GLOB_NOCHECK defined in glob.h
  * @param[out] *argcPtr	no. of paths
  * @param[out] *argvPtr	ARGV_t array of paths
  * @return		0 on success
  */
-int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr);
+int rpmGlob(const char * patterns, int flags, int * argcPtr, ARGV_t * argvPtr);
 
 /** \ingroup rpmfileutil
  * Escape isspace(3) characters in string.

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -108,14 +108,6 @@ char * rpmGenPath	(const char * urlroot,
 char * rpmGetPath (const char * path, ...) RPM_GNUC_NULL_TERMINATED;
 
 /** \ingroup rpmfileutil
- * Check whether pattern contains any glob metacharacters.
- * @param pattern	glob pattern
- * @param quote		allow backslash quoting of metacharacters?
- * @return		1 if pattern contains globs, 0 otherwise
- */
-int rpmIsGlob(const char * pattern, int quote);
-
-/** \ingroup rpmfileutil
  * Return URL path(s) from a (URL prefixed) pattern glob.
  * @param patterns	glob pattern
  * @param[out] *argcPtr	no. of paths

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -5,6 +5,7 @@
 #include "system.h"
 
 #include <string.h>
+#include <glob.h>
 
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>
@@ -125,7 +126,7 @@ rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
 
     /* Glob manifest items. */
     for (p = sb; *p; p++)
-	if (rpmGlob(*p, &ac, &av)) {
+	if (rpmGlob(*p, GLOB_NOMAGIC, &ac, &av)) {
 	    rpmrc = RPMRC_FAIL;
 	    goto exit;
 	}

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2280,7 +2280,7 @@ static int rpmdbRemoveFiles(char * pattern)
     int rc = 0;
     ARGV_t paths = NULL, p;
 
-    if (rpmGlob(pattern, NULL, &paths) == 0) {
+    if (rpmGlob(pattern, 0, NULL, &paths) == 0) {
 	for (p = paths; *p; p++) {
 	    rc += unlink(*p);
 	}

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <glob.h>
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile */
@@ -180,7 +181,7 @@ static void rpmgiGlobArgv(rpmgi gi, ARGV_const_t argv)
 	while ((arg = *argv++) != NULL) {
 	    char ** av = NULL;
 
-	    if (rpmGlob(arg, NULL, &av) == 0) {
+	    if (rpmGlob(arg, GLOB_NOMAGIC, NULL, &av) == 0) {
 		argvAppend(&gi->argv, av);
 		argvFree(av);
 	    }

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -178,14 +178,12 @@ static void rpmgiGlobArgv(rpmgi gi, ARGV_const_t argv)
     } else {
 	const char * arg;
 	while ((arg = *argv++) != NULL) {
-	    char * t = rpmEscapeSpaces(arg);
 	    char ** av = NULL;
 
-	    if (rpmGlob(t, NULL, &av) == 0) {
+	    if (rpmGlob(arg, NULL, &av) == 0) {
 		argvAppend(&gi->argv, av);
 		argvFree(av);
 	    }
-	    free(t);
 	}
     }
     gi->argc = argvCount(gi->argv);

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -5,6 +5,7 @@
 #include "system.h"
 
 #include <string.h>
+#include <glob.h>
 
 #include <rpm/rpmcli.h>
 #include <rpm/rpmtag.h>
@@ -459,7 +460,7 @@ int rpmInstall(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_t fileArgv)
 	if (giFlags & RPMGI_NOGLOB) {
 	    rc = rpmNoGlob(*eiu->fnp, &ac, &av);
 	} else {
-	    rc = rpmGlob(*eiu->fnp, &ac, &av);
+	    rc = rpmGlob(*eiu->fnp, GLOB_NOMAGIC, &ac, &av);
 	}
 	if (rc || ac == 0) {
 	    if (giFlags & RPMGI_NOGLOB) {

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -459,9 +459,7 @@ int rpmInstall(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_t fileArgv)
 	if (giFlags & RPMGI_NOGLOB) {
 	    rc = rpmNoGlob(*eiu->fnp, &ac, &av);
 	} else {
-	    char * fn = rpmEscapeSpaces(*eiu->fnp);
-	    rc = rpmGlob(fn, &ac, &av);
-	    fn = _free(fn);
+	    rc = rpmGlob(*eiu->fnp, &ac, &av);
 	}
 	if (rc || ac == 0) {
 	    if (giFlags & RPMGI_NOGLOB) {

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <pthread.h>
+#include <glob.h>
 
 #if defined(__linux__)
 #include <elf.h>
@@ -1595,7 +1596,7 @@ static rpmRC rpmReadRC(rpmrcCtx ctx, const char * rcfiles)
     argvSplit(&globs, rcfiles, ":");
     for (p = globs; *p; p++) {
 	ARGV_t av = NULL;
-	if (rpmGlob(*p, NULL, &av) == 0) {
+	if (rpmGlob(*p, GLOB_NOMAGIC, NULL, &av) == 0) {
 	    argvAppend(&files, av);
 	    argvFree(av);
 	}

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -281,7 +281,7 @@ static int loadKeyringFromFiles(rpmts ts)
     int nkeys = 0;
 
     rpmlog(RPMLOG_DEBUG, "loading keyring from pubkeys in %s\n", pkpath);
-    if (rpmGlob(pkpath, NULL, &files)) {
+    if (rpmGlob(pkpath, 0, NULL, &files)) {
 	rpmlog(RPMLOG_DEBUG, "couldn't find any keys in %s\n", pkpath);
 	goto exit;
     }

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1662,7 +1662,7 @@ rpmRC rpmtsSetupTransactionPlugins(rpmts ts)
 	return RPMRC_OK;
 
     dsoPath = rpmExpand("%{__plugindir}/*.so", NULL);
-    if (rpmGlob(dsoPath, &nfiles, &files) == 0) {
+    if (rpmGlob(dsoPath, 0, &nfiles, &files) == 0) {
 	rpmPlugins tsplugins = rpmtsPlugins(ts);
 	for (int i = 0; i < nfiles; i++) {
 	    char *bn = basename(files[i]);

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -6,6 +6,7 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <errno.h>
+#include <glob.h>
 #if HAVE_SCHED_GETAFFINITY
 #include <sched.h>
 #endif
@@ -1933,7 +1934,7 @@ rpmInitMacros(rpmMacroContext mc, const char * macrofiles)
 	ARGV_t path, files = NULL;
     
 	/* Glob expand the macro file path element, expanding ~ to $HOME. */
-	if (rpmGlob(*pattern, NULL, &files) != 0) {
+	if (rpmGlob(*pattern, GLOB_NOMAGIC, NULL, &files) != 0) {
 	    continue;
 	}
 

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -57,8 +57,10 @@ static inline const char *next_brace_sub(const char *begin)
 int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
 {
     char * globRoot = NULL;
+    char * globURL;
     const char *home = getenv("HOME");
-    int gflags = GLOB_NOMAGIC;
+    const char * path;
+    int flags = GLOB_NOMAGIC;
 #ifdef ENABLE_NLS
     char * old_collate = NULL;
     char * old_ctype = NULL;
@@ -67,11 +69,16 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
     size_t maxb, nb;
     int i;
     int rc = 0;
+    int ut = urlPath(pattern, &path);
+    int local = (ut == URL_IS_PATH) || (ut == URL_IS_UNKNOWN);
+    size_t plen = strlen(path);
+    int dir_only = (plen > 0 && path[plen-1] == '/');
+    glob_t gl;
 
-    gflags |= GLOB_BRACE;
+    flags |= GLOB_BRACE;
 
     if (home != NULL && strlen(home) > 0) 
-	gflags |= GLOB_TILDE;
+	flags |= GLOB_TILDE;
 
 #ifdef ENABLE_NLS
     t = setlocale(LC_COLLATE, NULL);
@@ -85,15 +92,6 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
 #endif
 	
     if (1) {
-	char * globURL;
-	const char * path;
-	int ut = urlPath(pattern, &path);
-	int local = (ut == URL_IS_PATH) || (ut == URL_IS_UNKNOWN);
-	size_t plen = strlen(path);
-	int flags = gflags;
-	int dir_only = (plen > 0 && path[plen-1] == '/');
-	glob_t gl;
-
 	if (!local) {
 	    argvAdd(argvPtr, pattern);
 	    goto exit;

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -54,13 +54,12 @@ static inline const char *next_brace_sub(const char *begin)
 
 /* librpmio exported interfaces */
 
-int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
+int rpmGlob(const char * pattern, int flags, int * argcPtr, ARGV_t * argvPtr)
 {
     char * globRoot = NULL;
     char * globURL;
     const char *home = getenv("HOME");
     const char * path;
-    int flags = GLOB_NOMAGIC;
 #ifdef ENABLE_NLS
     char * old_collate = NULL;
     char * old_ctype = NULL;
@@ -74,6 +73,9 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
     size_t plen = strlen(path);
     int dir_only = (plen > 0 && path[plen-1] == '/');
     glob_t gl;
+
+    /* Only accept these two glob(3) flags from the caller */
+    flags = (flags & (GLOB_NOMAGIC | GLOB_NOCHECK)) ? flags : 0;
 
     flags |= GLOB_BRACE;
 

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -52,44 +52,13 @@ static inline const char *next_brace_sub(const char *begin)
     return *cp != '\0' ? cp : NULL;
 }
 
-/* Return nonzero if PATTERN contains any metacharacters.
-   Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
-static int __glob_pattern_p(const char *pattern, int quote)
-{
-    register const char *p;
-    int openBrackets = 0;
-
-    for (p = pattern; *p != '\0'; ++p)
-	switch (*p) {
-	case '?':
-	case '*':
-	    return 1;
-
-	case '\\':
-	    if (quote && p[1] != '\0')
-		++p;
-	    break;
-
-	case '[':
-	    openBrackets = 1;
-	    break;
-
-	case ']':
-	    if (openBrackets)
-		return 1;
-	    break;
-	}
-
-    return 0;
-}
-
 /* librpmio exported interfaces */
 
 int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
 {
     char * globRoot = NULL;
     const char *home = getenv("HOME");
-    int gflags = 0;
+    int gflags = GLOB_NOMAGIC;
 #ifdef ENABLE_NLS
     char * old_collate = NULL;
     char * old_ctype = NULL;
@@ -125,7 +94,7 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
 	int dir_only = (plen > 0 && path[plen-1] == '/');
 	glob_t gl;
 
-	if (!local || (!rpmIsGlob(pattern, 0) && strchr(path, '~') == NULL)) {
+	if (!local) {
 	    argvAdd(argvPtr, pattern);
 	    goto exit;
 	}
@@ -201,36 +170,4 @@ exit:
     }
 #endif
     return rc;
-}
-
-int rpmIsGlob(const char * pattern, int quote)
-{
-    if (!__glob_pattern_p(pattern, quote)) {
-
-	const char *begin;
-	const char *next;
-	const char *rest;
-
-	begin = strchr(pattern, '{');
-	if (begin == NULL)
-	    return 0;
-	/*
-	 * Find the first sub-pattern and at the same time find the
-	 *  rest after the closing brace.
-	 */
-	next = next_brace_sub(begin + 1);
-	if (next == NULL)
-	    return 0;
-
-	/* Now find the end of the whole brace expression.  */
-	rest = next;
-	while (*rest != '}') {
-	    rest = next_brace_sub(rest + 1);
-	    if (rest == NULL)
-		return 0;
-	}
-	/* Now we can be sure that brace expression is well-foermed. */
-    }
-
-    return 1;
 }

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -90,68 +90,66 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
     (void) setlocale(LC_COLLATE, "C");
     (void) setlocale(LC_CTYPE, "C");
 #endif
-	
-    if (1) {
-	if (!local) {
-	    argvAdd(argvPtr, pattern);
-	    goto exit;
-	}
 
-	if (dir_only)
-	    flags |= GLOB_ONLYDIR;
-	
-	gl.gl_pathc = 0;
-	gl.gl_pathv = NULL;
-	
-	rc = glob(pattern, flags, NULL, &gl);
-	if (rc)
-	    goto exit;
-
-	/* XXX Prepend the URL leader for globs that have stripped it off */
-	maxb = 0;
-	for (i = 0; i < gl.gl_pathc; i++) {
-	    if ((nb = strlen(&(gl.gl_pathv[i][0]))) > maxb)
-		maxb = nb;
-	}
-	
-	nb = ((ut == URL_IS_PATH) ? (path - pattern) : 0);
-	maxb += nb;
-	maxb += 1;
-	globURL = globRoot = xmalloc(maxb);
-
-	switch (ut) {
-	case URL_IS_PATH:
-	case URL_IS_DASH:
-	    strncpy(globRoot, pattern, nb);
-	    break;
-	case URL_IS_HTTPS:
-	case URL_IS_HTTP:
-	case URL_IS_FTP:
-	case URL_IS_HKP:
-	case URL_IS_UNKNOWN:
-	default:
-	    break;
-	}
-	globRoot += nb;
-	*globRoot = '\0';
-
-	for (i = 0; i < gl.gl_pathc; i++) {
-	    const char * globFile = &(gl.gl_pathv[i][0]);
-
-	    if (dir_only) {
-		struct stat sb;
-		if (lstat(gl.gl_pathv[i], &sb) || !S_ISDIR(sb.st_mode))
-		    continue;
-	    }
-		
-	    if (globRoot > globURL && globRoot[-1] == '/')
-		while (*globFile == '/') globFile++;
-	    strcpy(globRoot, globFile);
-	    argvAdd(argvPtr, globURL);
-	}
-	globfree(&gl);
-	free(globURL);
+    if (!local) {
+	argvAdd(argvPtr, pattern);
+	goto exit;
     }
+
+    if (dir_only)
+	flags |= GLOB_ONLYDIR;
+    
+    gl.gl_pathc = 0;
+    gl.gl_pathv = NULL;
+    
+    rc = glob(pattern, flags, NULL, &gl);
+    if (rc)
+	goto exit;
+
+    /* XXX Prepend the URL leader for globs that have stripped it off */
+    maxb = 0;
+    for (i = 0; i < gl.gl_pathc; i++) {
+	if ((nb = strlen(&(gl.gl_pathv[i][0]))) > maxb)
+	    maxb = nb;
+    }
+    
+    nb = ((ut == URL_IS_PATH) ? (path - pattern) : 0);
+    maxb += nb;
+    maxb += 1;
+    globURL = globRoot = xmalloc(maxb);
+
+    switch (ut) {
+    case URL_IS_PATH:
+    case URL_IS_DASH:
+	strncpy(globRoot, pattern, nb);
+	break;
+    case URL_IS_HTTPS:
+    case URL_IS_HTTP:
+    case URL_IS_FTP:
+    case URL_IS_HKP:
+    case URL_IS_UNKNOWN:
+    default:
+	break;
+    }
+    globRoot += nb;
+    *globRoot = '\0';
+
+    for (i = 0; i < gl.gl_pathc; i++) {
+	const char * globFile = &(gl.gl_pathv[i][0]);
+
+	if (dir_only) {
+	    struct stat sb;
+	    if (lstat(gl.gl_pathv[i], &sb) || !S_ISDIR(sb.st_mode))
+		continue;
+	}
+	    
+	if (globRoot > globURL && globRoot[-1] == '/')
+	    while (*globFile == '/') globFile++;
+	strcpy(globRoot, globFile);
+	argvAdd(argvPtr, globURL);
+    }
+    globfree(&gl);
+    free(globURL);
 
 exit:
     if (argcPtr)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ EXTRA_DIST += data/SPECS/hello2-suid.spec
 EXTRA_DIST += data/SPECS/hello-g3.spec
 EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
+EXTRA_DIST += data/SPECS/globesctest.spec
 EXTRA_DIST += data/SPECS/versiontest.spec
 EXTRA_DIST += data/SPECS/conflicttest.spec
 EXTRA_DIST += data/SPECS/configtest.spec
@@ -200,7 +201,7 @@ populate_testing: $(check_DATA)
 	for d in dev etc magic tmp var; do if [ ! -d testing/$${d} ]; then mkdir testing/$${d}; fi; done
 	for node in urandom stdin stderr stdout null full; do ln -s /dev/$${node} testing/dev/$${node}; done
 	for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do [ -f /etc/$${cf} ] && ln -s /etc/$${cf} testing/etc/$${cf}; done
-	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
+	for prog in gzip cat cp patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 	chmod -R u-w testing/

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -1,0 +1,72 @@
+# Override the install prefix so that absolute %%doc paths can be compared
+# against a static list using "rpm -qpl" in tests/rpmbuild.at, regardless of
+# the actual RPM installation prefix.
+%global _prefix /opt
+
+Name:           globesctest
+Version:        1.0
+Release:        1
+Summary:        Testing file glob escape behavior
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}.
+
+
+%build
+touch 'foo[bar]' bar baz 'foo bar'
+
+%install
+mkdir -p %{buildroot}/opt
+
+# Glob escaping
+touch '%{buildroot}/opt/foo[bar]'
+touch '%{buildroot}/opt/foo[bar baz]'
+touch '%{buildroot}/opt/foo\[bar\]'
+touch '%{buildroot}/opt/foo*'
+touch '%{buildroot}/opt/foo\bar'
+touch %{buildroot}/opt/foo\\
+touch '%{buildroot}/opt/foo?bar'
+touch '%{buildroot}/opt/foo{bar,baz}'
+touch '%{buildroot}/opt/foo"bar"'
+
+# Regression checks
+touch '%{buildroot}/opt/foo-bar1'
+touch '%{buildroot}/opt/foo-bar2'
+touch '%{buildroot}/opt/fooxbarybaz'
+touch "%{buildroot}/opt/foo\"'baz\"'"
+touch '%{buildroot}/opt/foobar'
+touch '%{buildroot}/opt/foobaz'
+touch '%{buildroot}/opt/foobara'
+touch '%{buildroot}/opt/foobarb'
+touch '%{buildroot}/opt/foobaza'
+touch '%{buildroot}/opt/foobazb'
+touch '%{buildroot}/opt/foobaya'
+touch '%{buildroot}/opt/foobayb'
+touch '%{buildroot}/opt/foobawa'
+touch '%{buildroot}/opt/foobawb'
+
+%files
+
+# Glob escaping
+%doc foo\[bar\]
+/opt/foo\[bar\]
+"/opt/foo\[bar baz\]"
+/opt/foo\\\[bar\\\]
+/opt/foo\*
+/opt/foo\\bar
+/opt/foo\\
+/opt/foo\?bar
+/opt/foo\{bar,baz\}
+/opt/foo\"bar\"
+
+# Regression checks
+%doc ba* "foo bar"
+/opt/foo-bar*
+/opt/foo?bar?baz
+/opt/foo"'baz"'
+/opt/foo{bar,baz}
+/opt/foo{bar{a,b},baz{a,b}}
+/opt/foo{bay*,baw*}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -435,6 +435,48 @@ warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab
 ])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild glob escape])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
+runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
+],
+[0],
+[/opt/foo"'baz"'
+/opt/foo"bar"
+/opt/foo*
+/opt/foo-bar1
+/opt/foo-bar2
+/opt/foo?bar
+/opt/foo[[bar baz]]
+/opt/foo[[bar]]
+/opt/foo\
+/opt/foo\[[bar\]]
+/opt/foo\bar
+/opt/foobar
+/opt/foobara
+/opt/foobarb
+/opt/foobawa
+/opt/foobawb
+/opt/foobaya
+/opt/foobayb
+/opt/foobaz
+/opt/foobaza
+/opt/foobazb
+/opt/fooxbarybaz
+/opt/foo{bar,baz}
+/opt/share/doc/globesctest-1.0
+/opt/share/doc/globesctest-1.0/bar
+/opt/share/doc/globesctest-1.0/baz
+/opt/share/doc/globesctest-1.0/foo bar
+/opt/share/doc/globesctest-1.0/foo[[bar]]
+],
+[],
+)
+AT_CLEANUP
+
 AT_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 AT_CHECK([

--- a/tools/rpmgraph.c
+++ b/tools/rpmgraph.c
@@ -1,6 +1,7 @@
 #include "system.h"
 
 #include <string.h>
+#include <glob.h>
 
 #include <rpm/rpmcli.h>
 #include <rpm/rpmlib.h>		/* rpmReadPackageFile */
@@ -48,7 +49,7 @@ rpmGraph(rpmts ts, struct rpmInstallArguments_s * ia, const char ** fileArgv)
     for (fnp = fileArgv; *fnp; fnp++) {
 	av = _free(av);
 	ac = 0;
-	rc = rpmGlob(*fnp, &ac, &av);
+	rc = rpmGlob(*fnp, GLOB_NOMAGIC, &ac, &av);
 	if (rc || ac == 0) continue;
 
 	argv = xrealloc(argv, (argc+2) * sizeof(*argv));


### PR DESCRIPTION
Alternative implementation of #1903 based on the glibc variant of `glob(3)` that correctly handles escapes and is newly used since commit 66fa46c006bae0f28d93238b8f7f1c923645eee5.