### PR TITLE
Fix expected test output when using Sequoia.

### DIFF
--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -105,7 +105,8 @@ enum rpmVSFlags_e {
     RPMVSF_NOPAYLOAD	= (1 << 16),
     RPMVSF_NOMD5	= (1 << 17),
     RPMVSF_NODSA	= (1 << 18),
-    RPMVSF_NORSA	= (1 << 19)
+    RPMVSF_NORSA	= (1 << 19),
+    RPMVSF_NOLINT	= (1 << 20)
     /* bit(s) 16-31 unused */
 };
 

--- a/lib/rpmts.c
+++ b/lib/rpmts.c
@@ -616,18 +616,23 @@ rpmRC rpmtsImportPubkey(const rpmts ts, const unsigned char * pkt, size_t pktlen
     if (txn == NULL)
 	return rc;
 
-    krc = pgpPubKeyLint(pkt, pktlen, &lints);
-    if (lints) {
-        if (krc != RPMRC_OK) {
-            rpmlog(RPMLOG_ERR, "%s\n", lints);
-        } else {
-            rpmlog(RPMLOG_WARNING, "%s\n", lints);
+    if ((rpmtsVSFlags(ts) & RPMVSF_NOLINT)) {
+        // Don't show lints when --nolint is provided.
+    } else {
+        krc = pgpPubKeyLint(pkt, pktlen, &lints);
+        if (lints) {
+            if (krc != RPMRC_OK) {
+                rpmlog(RPMLOG_ERR, "%s\n", lints);
+            } else {
+                rpmlog(RPMLOG_WARNING, "%s\n", lints);
+            }
         }
         free(lints);
-    }
-    if (krc != RPMRC_OK) {
-        rc = krc;
-        goto exit;
+
+        if (krc != RPMRC_OK) {
+            rc = krc;
+            goto exit;
+        }
     }
 
     /* XXX keyring wont load if sigcheck disabled, force it temporarily */

--- a/rpmkeys.c
+++ b/rpmkeys.c
@@ -14,6 +14,7 @@ enum modes {
 
 static int mode = 0;
 static int test = 0;
+static int nolint = 0;
 
 static struct poptOption keyOptsTable[] = {
     { "checksig", 'K', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_CHECKSIG,
@@ -22,6 +23,8 @@ static struct poptOption keyOptsTable[] = {
 	N_("import an armored public key"), NULL },
     { "test", '\0', POPT_ARG_NONE, &test, 0,
 	N_("don't import, but tell if it would work or not"), NULL },
+    { "nolint", '\0', POPT_ARG_NONE, &nolint, 0,
+	N_("when importing a certificate, don't lint it"), NULL },
 #if 0
     { "delete-key", '\0', (POPT_ARG_VAL|POPT_ARGFLAG_OR), &mode, MODE_DELKEY,
 	N_("list keys from RPM keyring"), NULL },
@@ -71,6 +74,9 @@ int main(int argc, char *argv[])
     case MODE_IMPORTKEY:
 	if (test)
 	    rpmtsSetFlags(ts, (rpmtsFlags(ts)|RPMTRANS_FLAG_TEST));
+	if (nolint)
+            rpmtsSetVSFlags(ts, (rpmtsVSFlags(ts)|RPMVSF_NOLINT));
+
 	ec = rpmcliImportPubkeys(ts, args);
 	break;
     /* XXX TODO: actually implement these... */

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -323,7 +323,7 @@ RPMDB_INIT
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
 echo Importing key:
-runroot rpmkeys --import /data/keys/alice.asc; echo $?
+runroot rpmkeys --nolint --import /data/keys/alice.asc; echo $?
 echo Checking for key:
 runroot rpm -qi gpg-pubkey-eb04e625-* | grep Version | head -n1
 echo Checking package after importing key:
@@ -388,7 +388,7 @@ RPMDB_INIT
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
 echo Importing key:
-runroot rpmkeys --import /data/keys/alice-expired-subkey.asc; echo $?
+runroot rpmkeys --nolint --import /data/keys/alice-expired-subkey.asc; echo $?
 echo Checking for key:
 runroot rpm -qi gpg-pubkey-eb04e625-* | grep Version | head -n1
 echo Checking package after importing key:
@@ -455,7 +455,7 @@ RPMDB_INIT
 echo Checking package before importing key:
 runroot rpmkeys --define '_pkgverify_level all' -Kv /data/RPMS/hello-2.0-1.x86_64-signed-with-subkey.rpm; echo $?
 echo Importing key:
-runroot rpmkeys --import /data/keys/alice-revoked-subkey.asc; echo $?
+runroot rpmkeys --nolint --import /data/keys/alice-revoked-subkey.asc; echo $?
 echo Checking for key:
 runroot rpm -qi gpg-pubkey-eb04e625-* | grep Version | head -n1
 echo Checking package after importing key:
@@ -522,7 +522,7 @@ RPMDB_INIT
 # The internal OpenPGP implementation checks for validity when the key
 # is imported; other implementations should not do this.
 AT_CHECK_UNQUOTED([
-runroot rpmkeys --import /data/keys/CVE-2021-3521-badbind.asc
+runroot rpmkeys --nolint --import /data/keys/CVE-2021-3521-badbind.asc
 echo exit code: $? >&2
 ],
 [ignore],
@@ -537,7 +537,7 @@ fi`]
 )
 
 AT_CHECK_UNQUOTED([
-runroot rpmkeys --import /data/keys/CVE-2021-3521-nosubsig.asc
+runroot rpmkeys --nolint --import /data/keys/CVE-2021-3521-nosubsig.asc
 echo exit code: $? >&2
 ],
 [ignore],
@@ -552,7 +552,7 @@ fi`]
 )
 
 AT_CHECK_UNQUOTED([
-runroot rpmkeys --import /data/keys/CVE-2021-3521-nosubsig-last.asc
+runroot rpmkeys --nolint --import /data/keys/CVE-2021-3521-nosubsig-last.asc
 echo exit code: $? >&2
 ],
 [ignore],

--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -191,15 +191,22 @@ AT_CLEANUP
 
 # ------------------------------
 # Import a public RSA key
+#
+# rpm.org-rsa-2048-test.pub contains an encryption-capable subkey.  In
+# general, all subkeys should be returned whether they are valid or
+# not.  Keys should only be rejected when verifying a signature.  This
+# is because a key's validity depends on the current time.  Thus, the
+# time to check for validity is when the key is used, not when it is
+# imported.  The internal OpenPGP implementation checks for validity
+# when the key is imported; other implementations should not do this.
 AT_SETUP([rpmkeys --import rsa (rpmdb)])
 AT_KEYWORDS([rpmkeys import])
-AT_CHECK([
+AT_CHECK_UNQUOTED([
 RPMDB_INIT
 
 runroot rpmkeys --import /data/keys/rpm.org-rsa-2048-test.pub
 runroot rpm -qi gpg-pubkey-1964c5fc-58e63918|grep -v Date|grep -v Version:
-runroot rpm -q --provides gpg-pubkey-1964c5fc-58e63918
-],
+runroot rpm -q --provides gpg-pubkey-1964c5fc-58e63918],
 [0],
 [Name        : gpg-pubkey
 Version     : 1964c5fc
@@ -246,7 +253,12 @@ UNW2iqnN3BA7guhOv6OMiROF1+I7Q5nWT63mQC7IgQ==
 
 gpg(rpm.org RSA testkey <rsa@rpm.org>) = 4:4344591e1964c5fc-58e63918
 gpg(1964c5fc) = 4:4344591e1964c5fc-58e63918
-gpg(4344591e1964c5fc) = 4:4344591e1964c5fc-58e63918
+gpg(4344591e1964c5fc) = 4:4344591e1964c5fc-58e63918\
+`if test x$PGP != xinternal; then
+  echo
+  echo 'gpg(f00650f8) = 4:185e6146f00650f8-58e63918'
+  echo 'gpg(185e6146f00650f8) = 4:185e6146f00650f8-58e63918'
+fi`
 ],
 [])
 AT_CLEANUP
@@ -502,27 +514,56 @@ AT_SETUP([rpmkeys --import invalid keys])
 AT_KEYWORDS([rpmkeys import])
 RPMDB_INIT
 
-AT_CHECK([
+# The following certificates include subkeys with errors.  In general,
+# all subkeys should be returned whether they are valid or not.  Keys
+# should only be rejected when verifying a signature.  This is because
+# a key's validity depends on the current time.  Thus, the time to
+# check for validity is when the key is used, not when it is imported.
+# The internal OpenPGP implementation checks for validity when the key
+# is imported; other implementations should not do this.
+AT_CHECK_UNQUOTED([
 runroot rpmkeys --import /data/keys/CVE-2021-3521-badbind.asc
+echo exit code: $? >&2
 ],
-[1],
+[ignore],
 [],
-[error: /data/keys/CVE-2021-3521-badbind.asc: key 1 import failed.]
-)
-AT_CHECK([
-runroot rpmkeys --import /data/keys/CVE-2021-3521-nosubsig.asc
-],
-[1],
-[],
-[error: /data/keys/CVE-2021-3521-nosubsig.asc: key 1 import failed.]
+[`if test x$PGP = xinternal;
+then
+    echo 'error: /data/keys/CVE-2021-3521-badbind.asc: key 1 import failed.'
+    echo exit code: 1
+else
+    echo exit code: 0
+fi`]
 )
 
-AT_CHECK([
-runroot rpmkeys --import /data/keys/CVE-2021-3521-nosubsig-last.asc
+AT_CHECK_UNQUOTED([
+runroot rpmkeys --import /data/keys/CVE-2021-3521-nosubsig.asc
+echo exit code: $? >&2
 ],
-[1],
+[ignore],
 [],
-[error: /data/keys/CVE-2021-3521-nosubsig-last.asc: key 1 import failed.]
+[`if test x$PGP = xinternal;
+then
+    echo 'error: /data/keys/CVE-2021-3521-nosubsig.asc: key 1 import failed.'
+    echo exit code: 1
+else
+    echo exit code: 0
+fi`]
+)
+
+AT_CHECK_UNQUOTED([
+runroot rpmkeys --import /data/keys/CVE-2021-3521-nosubsig-last.asc
+echo exit code: $? >&2
+],
+[ignore],
+[],
+[`if test x$PGP = xinternal;
+then
+    echo 'error: /data/keys/CVE-2021-3521-nosubsig-last.asc: key 1 import failed.'
+    echo exit code: 1
+else
+    echo exit code: 0
+fi`]
 )
 AT_CLEANUP
 


### PR DESCRIPTION
An OpenPGP subkey shouldn't be checked for validity when imported, but
when it is used, e.g., when checking a signature's validity.  This is
because a key's validity partially depends on the current time.

The internal OpenPGP implementation checks for validity when the key
is imported; other implementations should not do this.  This means
that the output of two tests (268, 'rpmkeys --import rsa (rpmdb)' and
273, 'rpmkeys --import invalid keys') have different output depending
on whether the internal OpenPGP implementation is used or the Sequoia
backend is used.

Use AT_CHECK_UNQUOTED instead of AT_CHECK, and the selected backend to
customize the expected output.

Fixes #2062.