### PR TITLE
Rewrite ordering documentation

### DIFF
--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -180,9 +180,8 @@ static int sqlite_init(rpmdb rdb, const char * dbhome)
 		int one = 1;
 		/* Annoying but necessary to support non-privileged readers */
 		sqlite3_file_control(sdb, NULL, SQLITE_FCNTL_PERSIST_WAL, &one);
-
-		if (!rpmExpandNumeric("%{?_flush_io}"))
-		    sqlexec(sdb, "PRAGMA wal_autocheckpoint = 0");
+		/* Sqlite default threshold is way too low for rpmdb */
+		sqlexec(sdb, "PRAGMA wal_autocheckpoint = 10000");
 	    }
 	}
 


### PR DESCRIPTION
News about rpm 4.0.1 ordering algorithm changes are getting a bit
long in the tooth. Rewrite the whole doc to make it reflect modern rpm
behavior.