### PR TITLE
Also delete .gemspec file in BUILD/

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -193,7 +193,8 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 
     if (what == RPMBUILD_RMBUILD) {
 	if (buildSubdir[0] != '\0')
-	    fprintf(fp, "rm -rf '%s'\n", buildSubdir);
+	    fprintf(fp, "rm -rf '%s' '%s.gemspec'\n",
+		    buildSubdir, buildSubdir);
     } else if (sb != NULL)
 	fprintf(fp, "%s", sb);
 


### PR DESCRIPTION
The file is created by %setup for Ruby gems and should be deleted together
with the buildSubdir on RPMBUILD_RMBUILD (After rebuilds or when --clean
is passed).

Resolves: #1799