### PR TITLE
Remove build tree automatically on successfull binary package creation

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -432,7 +432,7 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 		goto exit;
 
 	if ((what & RPMBUILD_RMBUILD) &&
-	    (rc = doScript(spec, RPMBUILD_RMBUILD, "--clean", NULL, test, sbp)))
+	    (rc = doScript(spec, RPMBUILD_RMBUILD, "rmbuild", NULL, test, sbp)))
 		goto exit;
     }
 

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -155,6 +155,7 @@ all the stages preceding it), and is one of:
 
 :   Build just the binary packages - executes up to and including the
     assembly stage, but without creating the source package.
+    On success, the build directory is removed (as in **\--clean**).
 
 **-bp**
 

--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -270,7 +270,7 @@ static struct poptOption rpmBuildPoptTable[] = {
 	N_("generate package header(s) compatible with (legacy) rpm v3 packaging"),
 	NULL},
 
- { "noclean", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_CLEAN,
+ { "noclean", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_CLEAN|RPMBUILD_RMBUILD,
 	N_("do not execute %clean stage of the build"), NULL },
  { "noprep", '\0', POPT_BIT_SET, &nobuildAmount, RPMBUILD_PREP,
 	N_("do not execute %prep stage of the build"), NULL },
@@ -649,6 +649,7 @@ int main(int argc, char *argv[])
 	ba->buildAmount |= RPMBUILD_CLEAN;
 	if ((buildChar == 'b') && shortCircuit)
 	    break;
+	ba->buildAmount |= RPMBUILD_RMBUILD;
 	/* fallthrough */
     case 'i':
 	ba->buildAmount |= RPMBUILD_INSTALL;

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -106,6 +106,7 @@ Executing(%build)
 Executing(%install)
 Executing(%check)
 Executing(%clean)
+Executing(rmbuild)
 ],
 [])
 
@@ -120,6 +121,7 @@ Executing(%build)
 Executing(%install)
 Executing(%check)
 Executing(%clean)
+Executing(rmbuild)
 ],
 [])
 


### PR DESCRIPTION
Traditionally rpmbuild has only cleaned up the build directory on
--rebuild mode, but by default leaving tonnes of digital waste behind in
the far more common -bb mode. Default to cleaning up build directory
in addition to buildroot on successfull binary package creation,
with the exception of short-circuit'ed builds.