### PR TITLE
Replace deprecated Python distutils use in test-suite setup

### DIFF
--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -7,7 +7,7 @@ export PATH
 
 PYTHON=@PYTHON@
 if test "${PYTHON}"; then
-    PYLIBDIR=$(${PYTHON} -c "from distutils.sysconfig import get_python_lib; import sys; sys.stdout.write(get_python_lib(1,0,'@execprefix@'))")
+    PYLIBDIR=$(${PYTHON} -c "import sysconfig, sys; sys.stdout.write(sysconfig.get_path('platlib', vars={'platbase':'@execprefix@'}))")
     PYTHONPATH="${abs_builddir}/testing${PYLIBDIR}"
     export PYTHONPATH
 fi


### PR DESCRIPTION
Get on with the times and use sysconfig instead of distutils for path
configuration, eliminating deprecation warnings from running the
test-suite. And in particular, on Fedora 36 distutils and sysconfig
disagree on python prefix when not in rpm-build or virtualenv (whatever
that means) causing all the python tests in our suite to fail due to
not finding the in-tree bindings.