### PR TITLE
Give error message for failed PGP key import

### DIFF
--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -4,6 +4,7 @@
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
 #include <rpm/rpmcrypto.h>
+#include <rpm/rpmlog.h>
 
 #include "rpmio/rpmpgp_internal.h"
 
@@ -361,9 +362,10 @@ static int pgpVerifySigRSA(pgpDigAlg pgpkey, pgpDigAlg pgpsig,
     if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING) <= 0)
         goto done;
 
-    if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, getEVPMD(hash_algo)) <= 0)
+    if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, getEVPMD(hash_algo)) <= 0) {
+	rpmlog(RPMLOG_WARNING, "Signature not supported. Hash algorithm %s not available.\n", pgpValStr(pgpHashTbl, hash_algo));
         goto done;
-
+    }
     int pkey_len = EVP_PKEY_size(key->evp_pkey);
     padded_sig = xcalloc(1, pkey_len);
     if (BN_bn2binpad(sig->bn, padded_sig, pkey_len) <= 0)

--- a/rpmio/digest_openssl.c
+++ b/rpmio/digest_openssl.c
@@ -4,7 +4,7 @@
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
 #include <rpm/rpmcrypto.h>
-#include <rpm/rpmlog.h>
+#include <errno.h>
 
 #include "rpmio/rpmpgp_internal.h"
 
@@ -363,7 +363,7 @@ static int pgpVerifySigRSA(pgpDigAlg pgpkey, pgpDigAlg pgpsig,
         goto done;
 
     if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, getEVPMD(hash_algo)) <= 0) {
-	rpmlog(RPMLOG_WARNING, "Signature not supported. Hash algorithm %s not available.\n", pgpValStr(pgpHashTbl, hash_algo));
+	rc = ENOTSUP;
         goto done;
     }
     int pkey_len = EVP_PKEY_size(key->evp_pkey);


### PR DESCRIPTION
due to missing SHA1 support. This can happen when old keys are used on
systems that have disabled SHA1 e.g. for FIPS requirements.

See rhbz#2069877