### PR TITLE
Prevent readelf internet access during rpaths checking (RhBug:2079600)

### DIFF
--- a/scripts/check-rpaths-worker
+++ b/scripts/check-rpaths-worker
@@ -94,7 +94,7 @@ function msg()
 
 function check_rpath() {
     pos=0
-    rpath=$(readelf -W -d "$1" 2>/dev/null | LANG=C grep -E "\((RPATH|RUNPATH)\).*:") || return 0
+    rpath=$(DEBUGINFOD_URLS="" readelf -W -d "$1" 2>/dev/null | LANG=C grep -E "\((RPATH|RUNPATH)\).*:") || return 0
     rpath_orig="$rpath"
     rpath=$(echo "$rpath" | LANG=C sed -e "s!.*\(RPATH\|RUNPATH\).*: \[\(.*\)\]!\2!p;d")
 


### PR DESCRIPTION
Recent binutils can do debug section lookups over the internet, but this
is something we never want during rpmbuild (everything else aside, we're
just building the thing so there wont be anything on the net anyhow).
Disable the lookups by setting DEBUGINFOD_URLS to empty rather than
using the specific option as this is compatible with any old version of
readelf.