### PR TITLE
Fix short circuiting of version strings in expressions

### DIFF
--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -477,7 +477,7 @@ static int rdToken(ParseState state)
       if (qtok == TOK_STRING) {
 	v = valueMakeString(temp);
       } else {
-	v = valueMakeVersion(temp);
+	v = valueMakeVersion(state->flags & RPMEXPR_DISCARD ? "0" : temp);
         free(temp); /* version doesn't take ownership of the string */
         if (v == 0) {
 	  exprErr(state, _("invalid version"), p+1);

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -533,6 +533,7 @@ runroot rpm \
     --eval '%["%{aaa}"]' \
     --eval '%[%{?ccc}]' \
     --eval '%[v"1:2.3-4"]' \
+    --eval '%[v"0" && v"0"]' \
 ]],
 [0],
 [4096
@@ -542,6 +543,7 @@ runroot rpm \
 5
 0
 1:2.3-4
+0
 ],
 [])
 AT_CLEANUP


### PR DESCRIPTION
We use an empty string when discarding a value due to short circuiting, but
an empty string is not allowed for versions. So use "0" in that case.

Fixes: #1883