### PR TITLE
Add shell-like escape support to %files

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2416,7 +2416,6 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     fi = 0;
     while (*files != NULL) {
 	char *origfile = rpmGenPath(basepath, *files, NULL);
-	char *eorigfile = rpmEscapeSpaces(origfile);
 	ARGV_t globFiles;
 	int globFilesCount, i;
 	char *newfile;
@@ -2427,7 +2426,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	copyFileEntry(&sd->entries[fi].defEntry, &fl->def);
 	fi++;
 
-	if (rpmGlob(eorigfile, &globFilesCount, &globFiles) == 0) {
+	if (rpmGlob(origfile, &globFilesCount, &globFiles) == 0) {
 	    for (i = 0; i < globFilesCount; i++) {
 		rasprintf(&newfile, "%s/%s", sd->dirname, basename(globFiles[i]));
 		processBinaryFile(pkg, fl, newfile);
@@ -2435,10 +2434,9 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	    }
 	    argvFree(globFiles);
 	} else {
-	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), eorigfile);
+	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), origfile);
 	    fl->processingFailed = 1;
 	}
-	free(eorigfile);
 	free(origfile);
 	files++;
     }

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -645,29 +645,35 @@ Supported modifiers are:
 
 ### Shell Globbing
 
-The usual rules for shell globbing apply.  Most special characters can
-be escaped by prefixing them with a '\'.  Spaces are used to separate
-file names and so must be escaped by enclosing the file name with quotes.
+The usual rules for shell globbing apply.  Metacharacters can be escaped by
+prefixing them with a backslash (`\`).  A backslash or percent sign can be
+escaped with an extra `\` or `%`, respectively.  Spaces are used to separate
+file names and must be escaped by enclosing the file name in quotes.
+
+The metacharacters supported are wildcards (`*` and `?`), square brackets
+(`[]`), and curly braces (`{}`).
+
 For example:
 
 ```
-	/opt/are\.you\|bob\?
-	/opt/bob\'s\*htdocs\*
-	"/opt/bob\'s htdocs"
+	/opt/are.you|bob\?
+	/opt/bob's\*htdocs\*
+	/opt/bob's%%htdocs%%
+	"/opt/bob's htdocs"
 ```
 
-Names containing "%%" will be rpm macro expanded into "%".  When
-trying to escape large number of file names, it is often best to
-create a file with the complete list of escaped file names.  This is 
-easiest to do with a shell script like this:
+When trying to escape a large number of file names, it is often best to create
+a file with a complete list of escaped file names.  This is easiest to do with
+a shell script like this:
 
 ```
-	rm -f filelist.txt 
-	find $RPM_BUILD_ROOT/%{_prefix} -type f -print | \
-	    sed "s!$RPM_BUILD_ROOT!!" |  perl -pe 's/([?|*.\'"])/\\$1/g' \
-		>> $RPM_BUILD_DIR/filelist.txt 
+	rm -f filelist.txt
+	find %{buildroot} -type f -printf '/%%P\n' |	\
+	perl -pe 's/(%)/%$1/g;'				\
+	     -pe 's/([*?\[\]{}\\])/\\$1/g;'		\
+	> filelist.txt
 
-	%files -f filelist.rpm
+	%files -f filelist.txt
 ```
 
 ## %changelog section

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -108,14 +108,6 @@ char * rpmGenPath	(const char * urlroot,
 char * rpmGetPath (const char * path, ...) RPM_GNUC_NULL_TERMINATED;
 
 /** \ingroup rpmfileutil
- * Check whether pattern contains any glob metacharacters.
- * @param pattern	glob pattern
- * @param quote		allow backslash quoting of metacharacters?
- * @return		1 if pattern contains globs, 0 otherwise
- */
-int rpmIsGlob(const char * pattern, int quote);
-
-/** \ingroup rpmfileutil
  * Return URL path(s) from a (URL prefixed) pattern glob.
  * @param pattern	glob pattern
  * @param[out] *argcPtr	no. of paths

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -117,12 +117,12 @@ int rpmIsGlob(const char * pattern, int quote);
 
 /** \ingroup rpmfileutil
  * Return URL path(s) from a (URL prefixed) pattern glob.
- * @param patterns	glob pattern
+ * @param pattern	glob pattern
  * @param[out] *argcPtr	no. of paths
  * @param[out] *argvPtr	ARGV_t array of paths
  * @return		0 on success
  */
-int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr);
+int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr);
 
 /** \ingroup rpmfileutil
  * Escape isspace(3) characters in string.

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 
+#include <popt.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfileutil.h>
 #include <rpm/argv.h>
@@ -64,7 +65,7 @@ char * rpmPermsString(int mode)
 /**@todo Infinite loops through manifest files exist, operator error for now. */
 rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
 {
-    ARGV_t sb = NULL;
+    ARGV_t p, sb = NULL;
     char * s = NULL;
     char * se;
     int ac = 0;
@@ -78,6 +79,8 @@ rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
     if (f != NULL)
     while (1) {
 	char line[BUFSIZ];
+	int pac = 0;
+	const char ** pav = NULL;
 
 	/* Read next line. */
 	s = fgets(line, sizeof(line) - 1, f);
@@ -107,19 +110,31 @@ rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
 
 	/* Concatenate next line in buffer. */
 	*se = '\0';
-	argvAdd(&sb, s);
+
+	poptParseArgvString(s, &pac, &pav);
+	for (j = 0; j < pac; j++)
+	    argvAdd(&sb, pav[j]);
+	_free(pav);
     }
 
-    s = argvJoin(sb, " ");
-
-    if (!(s && *s)) {
+    if (sb == NULL) {
 	rpmrc = RPMRC_NOTFOUND;
 	goto exit;
     }
 
     /* Glob manifest items. */
-    rpmrc = (rpmGlob(s, &ac, &av) == 0 ? RPMRC_OK : RPMRC_FAIL);
-    if (rpmrc != RPMRC_OK) goto exit;
+    for (p = sb; *p; p++) {
+	int pac = 0;
+	ARGV_t pav = NULL;
+	if (rpmGlob(*p, &pac, &pav) == 0) {
+	    argvAppend(&av, pav);
+	    ac += pac;
+	    argvFree(pav);
+	} else {
+	    rpmrc = RPMRC_FAIL;
+	    goto exit;
+	}
+    }
 
     /* Sanity check: skip dash (for stdin) */
     for (i = 0; i < ac; i++) {

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -178,14 +178,12 @@ static void rpmgiGlobArgv(rpmgi gi, ARGV_const_t argv)
     } else {
 	const char * arg;
 	while ((arg = *argv++) != NULL) {
-	    char * t = rpmEscapeSpaces(arg);
 	    char ** av = NULL;
 
-	    if (rpmGlob(t, NULL, &av) == 0) {
+	    if (rpmGlob(arg, NULL, &av) == 0) {
 		argvAppend(&gi->argv, av);
 		argvFree(av);
 	    }
-	    free(t);
 	}
     }
     gi->argc = argvCount(gi->argv);

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -459,9 +459,7 @@ int rpmInstall(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_t fileArgv)
 	if (giFlags & RPMGI_NOGLOB) {
 	    rc = rpmNoGlob(*eiu->fnp, &ac, &av);
 	} else {
-	    char * fn = rpmEscapeSpaces(*eiu->fnp);
-	    rc = rpmGlob(fn, &ac, &av);
-	    fn = _free(fn);
+	    rc = rpmGlob(*eiu->fnp, &ac, &av);
 	}
 	if (rc || ac == 0) {
 	    if (giFlags & RPMGI_NOGLOB) {

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -28,7 +28,6 @@
 #include <fnmatch.h>
 #include <glob.h>
 
-#include <popt.h>
 #include <rpm/rpmfileutil.h>
 #include <rpm/rpmurl.h>
 
@@ -85,33 +84,26 @@ static int __glob_pattern_p(const char *pattern, int quote)
 
 /* librpmio exported interfaces */
 
-int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
+int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
 {
-    int ac = 0;
-    const char ** av = NULL;
     int argc = 0;
     ARGV_t argv = NULL;
     char * globRoot = NULL;
     const char *home = getenv("HOME");
-    int gflags = 0;
+    int gflags = GLOB_NOMAGIC;
 #ifdef ENABLE_NLS
     char * old_collate = NULL;
     char * old_ctype = NULL;
     const char * t;
 #endif
     size_t maxb, nb;
-    int i, j;
-    int rc;
+    int i;
+    int rc = 0;
 
     gflags |= GLOB_BRACE;
 
     if (home != NULL && strlen(home) > 0) 
 	gflags |= GLOB_TILDE;
-
-    /* Can't use argvSplit() here, it doesn't handle whitespace etc escapes */
-    rc = poptParseArgvString(patterns, &ac, &av);
-    if (rc)
-	return rc;
 
 #ifdef ENABLE_NLS
     t = setlocale(LC_COLLATE, NULL);
@@ -124,20 +116,19 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
     (void) setlocale(LC_CTYPE, "C");
 #endif
 	
-    if (av != NULL)
-    for (j = 0; j < ac; j++) {
+    if (1) {
 	char * globURL;
 	const char * path;
-	int ut = urlPath(av[j], &path);
+	int ut = urlPath(pattern, &path);
 	int local = (ut == URL_IS_PATH) || (ut == URL_IS_UNKNOWN);
 	size_t plen = strlen(path);
 	int flags = gflags;
 	int dir_only = (plen > 0 && path[plen-1] == '/');
 	glob_t gl;
 
-	if (!local || (!rpmIsGlob(av[j], 0) && strchr(path, '~') == NULL)) {
-	    argvAdd(&argv, av[j]);
-	    continue;
+	if (!local) {
+	    argvAdd(&argv, pattern);
+	    goto exit;
 	}
 
 	if (dir_only)
@@ -146,7 +137,7 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
 	gl.gl_pathc = 0;
 	gl.gl_pathv = NULL;
 	
-	rc = glob(av[j], flags, NULL, &gl);
+	rc = glob(pattern, flags, NULL, &gl);
 	if (rc)
 	    goto exit;
 
@@ -157,7 +148,7 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
 		maxb = nb;
 	}
 	
-	nb = ((ut == URL_IS_PATH) ? (path - av[j]) : 0);
+	nb = ((ut == URL_IS_PATH) ? (path - pattern) : 0);
 	maxb += nb;
 	maxb += 1;
 	globURL = globRoot = xmalloc(maxb);
@@ -165,7 +156,7 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
 	switch (ut) {
 	case URL_IS_PATH:
 	case URL_IS_DASH:
-	    strncpy(globRoot, av[j], nb);
+	    strncpy(globRoot, pattern, nb);
 	    break;
 	case URL_IS_HTTPS:
 	case URL_IS_HTTP:
@@ -196,6 +187,7 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
 	free(globURL);
     }
 
+exit:
     argc = argvCount(argv);
     if (argc > 0) {
 	if (argvPtr)
@@ -203,11 +195,10 @@ int rpmGlob(const char * patterns, int * argcPtr, ARGV_t * argvPtr)
 	if (argcPtr)
 	    *argcPtr = argc;
 	rc = 0;
-    } else
+    } else if (rc == 0)
 	rc = 1;
 
 
-exit:
 #ifdef ENABLE_NLS	
     if (old_collate) {
 	(void) setlocale(LC_COLLATE, old_collate);
@@ -218,7 +209,6 @@ exit:
 	free(old_ctype);
     }
 #endif
-    av = _free(av);
     if (rc || argvPtr == NULL) {
 	argvFree(argv);
     }

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -51,37 +51,6 @@ static inline const char *next_brace_sub(const char *begin)
     return *cp != '\0' ? cp : NULL;
 }
 
-/* Return nonzero if PATTERN contains any metacharacters.
-   Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
-static int __glob_pattern_p(const char *pattern, int quote)
-{
-    register const char *p;
-    int openBrackets = 0;
-
-    for (p = pattern; *p != '\0'; ++p)
-	switch (*p) {
-	case '?':
-	case '*':
-	    return 1;
-
-	case '\\':
-	    if (quote && p[1] != '\0')
-		++p;
-	    break;
-
-	case '[':
-	    openBrackets = 1;
-	    break;
-
-	case ']':
-	    if (openBrackets)
-		return 1;
-	    break;
-	}
-
-    return 0;
-}
-
 /* librpmio exported interfaces */
 
 int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
@@ -209,36 +178,4 @@ exit:
 	argvFree(argv);
     }
     return rc;
-}
-
-int rpmIsGlob(const char * pattern, int quote)
-{
-    if (!__glob_pattern_p(pattern, quote)) {
-
-	const char *begin;
-	const char *next;
-	const char *rest;
-
-	begin = strchr(pattern, '{');
-	if (begin == NULL)
-	    return 0;
-	/*
-	 * Find the first sub-pattern and at the same time find the
-	 *  rest after the closing brace.
-	 */
-	next = next_brace_sub(begin + 1);
-	if (next == NULL)
-	    return 0;
-
-	/* Now find the end of the whole brace expression.  */
-	rest = next;
-	while (*rest != '}') {
-	    rest = next_brace_sub(rest + 1);
-	    if (rest == NULL)
-		return 0;
-	}
-	/* Now we can be sure that brace expression is well-foermed. */
-    }
-
-    return 1;
 }

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -89,8 +89,15 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
     int argc = 0;
     ARGV_t argv = NULL;
     char * globRoot = NULL;
+    char * globURL;
     const char *home = getenv("HOME");
-    int gflags = GLOB_NOMAGIC;
+    const char *path;
+    int ut = urlPath(pattern, &path);
+    int local = (ut == URL_IS_PATH) || (ut == URL_IS_UNKNOWN);
+    size_t plen = strlen(path);
+    int dir_only = (plen > 0 && path[plen-1] == '/');
+    glob_t gl;
+    int flags = GLOB_NOMAGIC;
 #ifdef ENABLE_NLS
     char * old_collate = NULL;
     char * old_ctype = NULL;
@@ -100,10 +107,10 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
     int i;
     int rc = 0;
 
-    gflags |= GLOB_BRACE;
+    flags |= GLOB_BRACE;
 
     if (home != NULL && strlen(home) > 0) 
-	gflags |= GLOB_TILDE;
+	flags |= GLOB_TILDE;
 
 #ifdef ENABLE_NLS
     t = setlocale(LC_COLLATE, NULL);
@@ -115,77 +122,66 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr)
     (void) setlocale(LC_COLLATE, "C");
     (void) setlocale(LC_CTYPE, "C");
 #endif
-	
-    if (1) {
-	char * globURL;
-	const char * path;
-	int ut = urlPath(pattern, &path);
-	int local = (ut == URL_IS_PATH) || (ut == URL_IS_UNKNOWN);
-	size_t plen = strlen(path);
-	int flags = gflags;
-	int dir_only = (plen > 0 && path[plen-1] == '/');
-	glob_t gl;
 
-	if (!local) {
-	    argvAdd(&argv, pattern);
-	    goto exit;
-	}
-
-	if (dir_only)
-	    flags |= GLOB_ONLYDIR;
-	
-	gl.gl_pathc = 0;
-	gl.gl_pathv = NULL;
-	
-	rc = glob(pattern, flags, NULL, &gl);
-	if (rc)
-	    goto exit;
-
-	/* XXX Prepend the URL leader for globs that have stripped it off */
-	maxb = 0;
-	for (i = 0; i < gl.gl_pathc; i++) {
-	    if ((nb = strlen(&(gl.gl_pathv[i][0]))) > maxb)
-		maxb = nb;
-	}
-	
-	nb = ((ut == URL_IS_PATH) ? (path - pattern) : 0);
-	maxb += nb;
-	maxb += 1;
-	globURL = globRoot = xmalloc(maxb);
-
-	switch (ut) {
-	case URL_IS_PATH:
-	case URL_IS_DASH:
-	    strncpy(globRoot, pattern, nb);
-	    break;
-	case URL_IS_HTTPS:
-	case URL_IS_HTTP:
-	case URL_IS_FTP:
-	case URL_IS_HKP:
-	case URL_IS_UNKNOWN:
-	default:
-	    break;
-	}
-	globRoot += nb;
-	*globRoot = '\0';
-
-	for (i = 0; i < gl.gl_pathc; i++) {
-	    const char * globFile = &(gl.gl_pathv[i][0]);
-
-	    if (dir_only) {
-		struct stat sb;
-		if (lstat(gl.gl_pathv[i], &sb) || !S_ISDIR(sb.st_mode))
-		    continue;
-	    }
-		
-	    if (globRoot > globURL && globRoot[-1] == '/')
-		while (*globFile == '/') globFile++;
-	    strcpy(globRoot, globFile);
-	    argvAdd(&argv, globURL);
-	}
-	globfree(&gl);
-	free(globURL);
+    if (!local) {
+	argvAdd(&argv, pattern);
+	goto exit;
     }
+
+    if (dir_only)
+	flags |= GLOB_ONLYDIR;
+    
+    gl.gl_pathc = 0;
+    gl.gl_pathv = NULL;
+    
+    rc = glob(pattern, flags, NULL, &gl);
+    if (rc)
+	goto exit;
+
+    /* XXX Prepend the URL leader for globs that have stripped it off */
+    maxb = 0;
+    for (i = 0; i < gl.gl_pathc; i++) {
+	if ((nb = strlen(&(gl.gl_pathv[i][0]))) > maxb)
+	    maxb = nb;
+    }
+    
+    nb = ((ut == URL_IS_PATH) ? (path - pattern) : 0);
+    maxb += nb;
+    maxb += 1;
+    globURL = globRoot = xmalloc(maxb);
+
+    switch (ut) {
+    case URL_IS_PATH:
+    case URL_IS_DASH:
+	strncpy(globRoot, pattern, nb);
+	break;
+    case URL_IS_HTTPS:
+    case URL_IS_HTTP:
+    case URL_IS_FTP:
+    case URL_IS_HKP:
+    case URL_IS_UNKNOWN:
+    default:
+	break;
+    }
+    globRoot += nb;
+    *globRoot = '\0';
+
+    for (i = 0; i < gl.gl_pathc; i++) {
+	const char * globFile = &(gl.gl_pathv[i][0]);
+
+	if (dir_only) {
+	    struct stat sb;
+	    if (lstat(gl.gl_pathv[i], &sb) || !S_ISDIR(sb.st_mode))
+		continue;
+	}
+	    
+	if (globRoot > globURL && globRoot[-1] == '/')
+	    while (*globFile == '/') globFile++;
+	strcpy(globRoot, globFile);
+	argvAdd(&argv, globURL);
+    }
+    globfree(&gl);
+    free(globURL);
 
 exit:
     argc = argvCount(argv);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ EXTRA_DIST += data/SPECS/hello2-suid.spec
 EXTRA_DIST += data/SPECS/hello-g3.spec
 EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
+EXTRA_DIST += data/SPECS/globesctest.spec
 EXTRA_DIST += data/SPECS/versiontest.spec
 EXTRA_DIST += data/SPECS/conflicttest.spec
 EXTRA_DIST += data/SPECS/configtest.spec
@@ -201,7 +202,7 @@ populate_testing: $(check_DATA)
 	for d in dev etc magic tmp var; do if [ ! -d testing/$${d} ]; then mkdir testing/$${d}; fi; done
 	for node in urandom stdin stderr stdout null full; do ln -s /dev/$${node} testing/dev/$${node}; done
 	for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do [ -f /etc/$${cf} ] && ln -s /etc/$${cf} testing/etc/$${cf}; done
-	for prog in gzip cat patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
+	for prog in gzip cat cp patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do p=`which $${prog}`; if [ "$${p}" != "" ]; then ln -s $${p} testing/$(bindir)/; fi; done
 	for d in /proc /sys /selinux /etc/selinux; do if [ -d $${d} ]; then ln -s $${d} testing/$${d}; fi; done
 	(cd testing/magic && file -C)
 	chmod -R u-w testing/

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -1,0 +1,83 @@
+# Make sure %%doc files are installed into a hard-coded prefix so that we can
+# then compare them against a static list using "rpm -qpl" in
+# tests/rpmbuild.at.
+%global _prefix /opt
+
+Name:           globesctest
+Version:        1.0
+Release:        1
+Summary:        Testing file glob escape behavior
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}.
+
+
+%build
+touch 'foo[bar]' bar baz 'foo bar' foo%%name
+
+%install
+mkdir -p %{buildroot}/opt
+
+# Glob escaping
+touch '%{buildroot}/opt/foo[bar]'
+touch '%{buildroot}/opt/foo[bar baz]'
+touch '%{buildroot}/opt/foo\[bar\]'
+touch '%{buildroot}/opt/foo*'
+touch '%{buildroot}/opt/foo\bar'
+touch %{buildroot}/opt/foo\\
+touch '%{buildroot}/opt/foo?bar'
+touch '%{buildroot}/opt/foo{bar,baz}'
+touch '%{buildroot}/opt/foo"bar"'
+touch '%{buildroot}/opt/foo*b'
+touch '%{buildroot}/opt/foo*a'
+touch '%{buildroot}/opt/foo*r'
+
+# Macro escaping
+touch '%{buildroot}/opt/foo%%name'
+
+# Regression checks
+touch '%{buildroot}/opt/foo-bar1'
+touch '%{buildroot}/opt/foo-bar2'
+touch '%{buildroot}/opt/fooxbarybaz'
+touch "%{buildroot}/opt/foo\"'baz\"'"
+touch '%{buildroot}/opt/foobar'
+touch '%{buildroot}/opt/foobaz'
+touch '%{buildroot}/opt/foobara'
+touch '%{buildroot}/opt/foobarb'
+touch '%{buildroot}/opt/foobaza'
+touch '%{buildroot}/opt/foobazb'
+touch '%{buildroot}/opt/foobaya'
+touch '%{buildroot}/opt/foobayb'
+touch '%{buildroot}/opt/foobawa'
+touch '%{buildroot}/opt/foobawb'
+
+%files
+
+# Glob escaping
+%doc foo\[bar\]
+/opt/foo\[bar\]
+/opt/foo\*[bar]
+"/opt/foo\[bar baz\]"
+/opt/foo\\\[bar\\\]
+/opt/foo\*
+/opt/foo\\bar
+/opt/foo\\
+/opt/foo\?bar
+/opt/foo\{bar,baz\}
+/opt/foo\"bar\"
+
+# Macro escaping
+%doc foo%%name
+/opt/foo%%name
+
+# Regression checks
+%doc ba* "foo bar"
+/opt/foo-bar*
+/opt/foo?bar?baz
+/opt/foo"'baz"'
+/opt/foo{bar,baz}
+/opt/foo{bar{a,b},baz{a,b}}
+/opt/foo{bay*,baw*}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -437,6 +437,53 @@ warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab
 ])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild glob escape])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
+runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
+],
+[0],
+[/opt/foo"'baz"'
+/opt/foo"bar"
+/opt/foo%name
+/opt/foo*
+/opt/foo*a
+/opt/foo*b
+/opt/foo*r
+/opt/foo-bar1
+/opt/foo-bar2
+/opt/foo?bar
+/opt/foo[[bar baz]]
+/opt/foo[[bar]]
+/opt/foo\
+/opt/foo\[[bar\]]
+/opt/foo\bar
+/opt/foobar
+/opt/foobara
+/opt/foobarb
+/opt/foobawa
+/opt/foobawb
+/opt/foobaya
+/opt/foobayb
+/opt/foobaz
+/opt/foobaza
+/opt/foobazb
+/opt/fooxbarybaz
+/opt/foo{bar,baz}
+/opt/share/doc/globesctest-1.0
+/opt/share/doc/globesctest-1.0/bar
+/opt/share/doc/globesctest-1.0/baz
+/opt/share/doc/globesctest-1.0/foo bar
+/opt/share/doc/globesctest-1.0/foo%name
+/opt/share/doc/globesctest-1.0/foo[[bar]]
+],
+[],
+)
+AT_CLEANUP
+
 AT_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 AT_CHECK([


### PR DESCRIPTION
Enable the use of backslash quotation in the `%files` section of a spec file, just like in a typical shell, for example:
```
%install
touch "%{buildroot}/file*"
touch "%{buildroot}/file%%"
touch "%{buildroot}/file[with spaces]"

%files
/file\*
/file%%
"/file\[with spaces\]"
```

This PR builds upon the recent commit 66fa46c006bae0f28d93238b8f7f1c923645eee5 which replaced our flawed `glob(3)` implementation with the one from GNU libc.

Another PR is in the works which will change the semantics of double quotes to make the following work:

```
"/file[with spaces]"
```

Fixes: #1749 