### PR TITLE
Add SourceLicense tag to spec syntax

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -824,6 +824,11 @@ static rpmRC handlePreambleTag(rpmSpec spec, Package pkg, rpmTagVal tag,
 	if (addLangTag(spec, pkg->header, tag, field, lang))
 	    goto exit;
 	break;
+    case RPMTAG_SOURCELICENSE:
+	if (addLangTag(spec, spec->sourcePackage->header,
+		       RPMTAG_LICENSE, field, lang))
+	    goto exit;
+	break;
     case RPMTAG_BUILDROOT:
 	/* just silently ignore BuildRoot */
 	break;
@@ -1005,6 +1010,7 @@ static struct PreambleRec_s const preambleList[] = {
     {RPMTAG_EPOCH,		0, 0, 1, LEN_AND_STR("epoch")},
     {RPMTAG_SUMMARY,		1, 0, 1, LEN_AND_STR("summary")},
     {RPMTAG_LICENSE,		0, 0, 1, LEN_AND_STR("license")},
+    {RPMTAG_SOURCELICENSE,	0, 0, 1, LEN_AND_STR("sourcelicense")},
     {RPMTAG_DISTRIBUTION,	0, 0, 1, LEN_AND_STR("distribution")},
     {RPMTAG_DISTURL,		0, 0, 1, LEN_AND_STR("disturl")},
     {RPMTAG_VENDOR,		0, 0, 1, LEN_AND_STR("vendor")},

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -125,6 +125,12 @@ Short (< 70 characters) summary of the package license. For example:
 	License: GPLv3
 ```
 
+#### SourceLicense
+
+If license of the sources differ from the main package the license tag
+of the source package can be set with this. If not given the license
+tag of the source and the main package are the same.
+
 #### Group
 
 Optional, short (< 70 characters) group of the package.

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -380,6 +380,7 @@ typedef enum rpmTag_e {
     RPMTAG_SPEC			= 5099, /* s */
     RPMTAG_TRANSLATIONURL	= 5100, /* s */
     RPMTAG_UPSTREAMRELEASES	= 5101, /* s */
+    RPMTAG_SOURCELICENSE	= 5102, /* internal */
 
     RPMTAG_FIRSTFREE_TAG	/*!< internal */
 } rpmTag;

--- a/tests/data/SPECS/hello.spec
+++ b/tests/data/SPECS/hello.spec
@@ -4,6 +4,7 @@ Version: 1.0
 Release: 1
 Group: Utilities
 License: GPL
+SourceLicense: GPL, ASL 1.0
 Distribution: RPM test suite.
 URL: http://rpm.org
 Source0: hello-1.0.tar.gz

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -31,6 +31,17 @@ run rpmbuild \
 [0],
 [ignore],
 [ignore])
+
+AT_CHECK([
+
+runroot rpm -qp --qf "%{license}\n" /build/SRPMS/hello-1.0-1.src.rpm
+runroot rpm -qp --qf "%{license}\n" /build/RPMS/*/hello-1.0-1.*.rpm
+],
+[0],
+[GPL, ASL 1.0
+GPL
+],
+[])
 AT_CLEANUP
 
 AT_SETUP([rpmbuild -b steps])

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -308,6 +308,7 @@ Version: 1.0
 Release: 1
 Group: Utilities
 License: GPL
+SourceLicense: GPL, ASL 1.0
 Distribution: RPM test suite.
 URL: http://rpm.org
 Source0: hello-1.0.tar.gz


### PR DESCRIPTION
to set a separate license to the source RPM. This can be useful if the
sources have code under additional licenses that do not end up in the
binary packeges.

Resolves: #2079