### PR TITLE
Exclude *.src.rpm from check-buildroot

### DIFF
--- a/scripts/check-buildroot
+++ b/scripts/check-buildroot
@@ -31,6 +31,7 @@ NCPUS=${RPM_BUILD_NCPUS:-1}
 export LANG=C
 find "$RPM_BUILD_ROOT" \! \( \
     -name '*.pyo' -o -name '*.pyc' -o -name '*.elc' -o -name '.packlist' \
+    -o -name '*.src.rpm' \
     \) -type f -print0 | \
     xargs -0r "-P$NCPUS" -n16 grep -lF "$RPM_BUILD_ROOT" >>"$tmp" 2>&1
 


### PR DESCRIPTION
With the SRPMs now containing the expanded spec file they are bound to
have the build root included in the header. Turns out some people
package SRPMs to rebuild them locally e.g. against the local kernel.

Resolves: rhbz#2104150