### PR TITLE
Don't error git based %autosetup when master branch does not exist

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1171,8 +1171,7 @@ package or when debugging this package.\
 %{__git} commit %{-q} --allow-empty -a\\\
 	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"\
 %{__git} branch rpm-build \
-%{__git} checkout rpm-build \
-%{__git} branch --set-upstream-to=master
+%{__git} checkout rpm-build
 
 %__scm_apply_git(qp:m:)\
 %{__git} apply --index --reject %{-p:-p%{-p*}} -\


### PR DESCRIPTION
The master branch is not guaranteed to exist.
Consider this config:

    $ git config --global init.defaultBranch main

In that case, %autosetup -S git(_am) failed with:

    ...
    + /usr/bin/git checkout rpm-build
    Switched to branch 'rpm-build'
    + /usr/bin/git branch --set-upstream-to=master
    fatal: the requested upstream branch 'master' does not exist
    hint: 
    hint: If you are planning on basing your work on an upstream
    hint: branch that already exists at the remote, you may need to
    hint: run "git fetch" to retrieve it.
    hint: 
    hint: If you are planning to push out a new local branch that
    hint: will track its remote counterpart, you may want to use
    hint: "git push -u" to set the upstream config as you push.
    hint: Disable this message with "git config advice.setUpstreamFailure false"
    error: Bad exit status from /var/tmp/rpm-tmp... (%prep)

This was added in 3a6b1d8fbf846d3f1b139d343fdfddebe99ae42b,
the rationale was:

> Additionally it sets the
> "rpm-build" branch's upstream to "master", so that in the active work
> tree where the "rpm-build" is checked out, commands such as
> "git rebase -i" automatically have a default behavior that makes sense.

However, that is only useful if the master branch exists in the upstream tarball,
which is probably not very common (upstream tarballs are rarely git repos,
even when working from git archives).
Alternatively, if this feature is indeed needed,
the macro could check if it is on a git branch before calling `git init`
and use that branch here instead of master,
but I considered that too complex.