### PR TITLE
Use explicit default branch in %autosetup -S git

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1163,7 +1163,7 @@ package or when debugging this package.\
 
 # Git
 %__scm_setup_git(q)\
-%{__git} init %{-q}\
+%{__git} init %{-q} --initial-branch=main\
 %{__git} config user.name "%{__scm_username}"\
 %{__git} config user.email "%{__scm_usermail}"\
 %{__git} config gc.auto 0\
@@ -1172,7 +1172,7 @@ package or when debugging this package.\
 	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"\
 %{__git} branch rpm-build \
 %{__git} checkout rpm-build \
-%{__git} branch --set-upstream-to=master
+%{__git} branch --set-upstream-to=main
 
 %__scm_apply_git(qp:m:)\
 %{__git} apply --index --reject %{-p:-p%{-p*}} -\


### PR DESCRIPTION
Commit 3a6b1d8fbf846d3f1b139d343fdfddebe99ae42b assumed "master" as the
default git branch to track, however the name can be changed globally,
so make it explicit.

Given the choice now, go with "main" as the general trend, e.g:
https://fedoraproject.org/wiki/Changes/GitRepos-master-to-main