### PR TITLE
rpm2cpio.sh: only read needed bytes of file magic

### DIFF
--- a/scripts/rpm2cpio.sh
+++ b/scripts/rpm2cpio.sh
@@ -43,7 +43,7 @@ calcsize() {
 	offset=$(($offset + $rsize))
 }
 
-case "$(_dd 0 bs=8 count=1 | tr -d '\0')" in
+case "$(_dd 0 bs=4 count=1 | tr -d '\0')" in
 	"$(printf '\355\253\356\333')"*) ;; # '\xed\xab\xee\xdb'
 	*) fatal "File doesn't look like rpm: $pkg" ;;
 esac


### PR DESCRIPTION
As we look at the first 4 bytes anyway there is no reason to read more.
Reading more also hits a bug in bash on aarch64 (rhbz#2115206).