### PR TITLE
rpmscript: Include lib/rpmchroot.h for rpmChrootOut()

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -18,7 +18,7 @@
 #include "rpmio/rpmio_internal.h"
 
 #include "lib/rpmplugins.h"     /* rpm plugins hooks */
-
+#include "lib/rpmchroot.h" /* rpmChrootOut */
 #include "debug.h"
 
 struct scriptNextFileFunc_s {


### PR DESCRIPTION
This fixes implicit function declarations warning

Signed-off-by: Khem Raj <raj.khem@gmail.com>