### PR TITLE
Revert branch creation in %autosetup -S git

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1165,16 +1165,13 @@ package or when debugging this package.\
 
 # Git
 %__scm_setup_git(q)\
-%{__git} init %{-q} --initial-branch=main\
+%{__git} init %{-q}\
 %{__git} config user.name "%{__scm_username}"\
 %{__git} config user.email "%{__scm_usermail}"\
 %{__git} config gc.auto 0\
 %{__git} add --force .\
 %{__git} commit %{-q} --allow-empty -a\\\
-	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"\
-%{__git} branch rpm-build \
-%{__git} checkout rpm-build \
-%{__git} branch --set-upstream-to=main
+	--author "%{__scm_author}" -m "%{NAME}-%{VERSION} base"
 
 %__scm_apply_git(qp:m:)\
 %{__git} apply --index --reject %{-p:-p%{-p*}} -\


### PR DESCRIPTION
The "master" branch is not guaranteed to exist after repo initialization
in the %__scm_setup_git macro as it can be configured differently on the
system, for example:

    git config --global init.defaultBranch main

In such a case, the macro would fail (#2120):

    %{__git} branch --set-upstream-to=master
    fatal: the requested upstream branch 'master' does not exist

At first, it seemed like the most obvious fix would be to just supply
the branch name at init time:

    %{__git} init %{-q} --initial-branch=master\

However, that won't help if the repo is manually created in the %prep
stage before the %__scm_setup_git macro runs, which is exactly the case
with e.g. the edk2 package in Fedora (#2121):

    %prep
    [...]
    git init -q
    [...]
    %autosetup -S git

Therefore, the safest fix is to just revert the original feature and the
unsuccessful fixup commit.  If we really need this feature, it can
always be revisited in the future and done differently.

This reverts commits:
3a6b1d8fbf846d3f1b139d343fdfddebe99ae42b
8b9da98e4c9e256c7c6ecca7f1e5bdbbce29e5da