### PR TITLE
Unify glob fallback behavior

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2200,19 +2200,12 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
 	    goto exit;
 	}
 
-	if (rpmGlob(diskPath, &argc, &argv) == 0) {
+	if (rpmGlobPath(diskPath, RPMGLOB_NOCHECK,
+			&argc, &argv) == 0) {
 	    for (i = 0; i < argc; i++) {
 		rc = addFile(fl, argv[i], NULL);
 	    }
 	    argvFree(argv);
-	} else {
-	    const char *msg = (fl->cur.isDir) ?
-				_("Directory not found by glob: %s. "
-				"Trying without globbing.\n") :
-				_("File not found by glob: %s. "
-				"Trying without globbing.\n");
-	    rpmlog(RPMLOG_DEBUG, msg, diskPath);
-	    rc = addFile(fl, diskPath, NULL);
 	}
     } else {
 	rc = addFile(fl, diskPath, NULL);
@@ -2425,16 +2418,14 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
 	copyFileEntry(&sd->entries[fi].defEntry, &fl->def);
 	fi++;
 
-	if (rpmGlob(origfile, &globFilesCount, &globFiles) == 0) {
+	if (rpmGlobPath(origfile, RPMGLOB_NOCHECK,
+			&globFilesCount, &globFiles) == 0) {
 	    for (i = 0; i < globFilesCount; i++) {
 		rasprintf(&newfile, "%s/%s", sd->dirname, basename(globFiles[i]));
 		processBinaryFile(pkg, fl, newfile, 0);
 		free(newfile);
 	    }
 	    argvFree(globFiles);
-	} else {
-	    rpmlog(RPMLOG_ERR, _("File not found by glob: %s\n"), origfile);
-	    fl->processingFailed = 1;
 	}
 	free(origfile);
 	files++;

--- a/build/files.c
+++ b/build/files.c
@@ -2163,6 +2163,9 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
     rpmRC rc = RPMRC_OK;
     size_t fnlen = strlen(fileName);
     int trailing_slash = (fnlen > 0 && fileName[fnlen-1] == '/');
+    ARGV_t argv = NULL;
+    int argc = 0;
+    int i;
 
     /* XXX differentiate other directories from explicit %dir */
     if (trailing_slash && !fl->cur.isDir)
@@ -2189,27 +2192,23 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
     if (fl->cur.isDir)
 	diskPath = rstrcat(&diskPath, "/");
 
-    if (doGlob) {
-	ARGV_t argv = NULL;
-	int argc = 0;
-	int i;
-
-	if (fl->cur.devtype) {
-	    rpmlog(RPMLOG_ERR, _("%%dev glob not permitted: %s\n"), diskPath);
-	    rc = RPMRC_FAIL;
-	    goto exit;
-	}
-
-	if (rpmGlobPath(diskPath, RPMGLOB_NOCHECK,
-			&argc, &argv) == 0) {
-	    for (i = 0; i < argc; i++) {
-		rc = addFile(fl, argv[i], NULL);
-	    }
-	    argvFree(argv);
-	}
-    } else {
+    if (!doGlob) {
 	rc = addFile(fl, diskPath, NULL);
+	goto exit;
     }
+
+    if (fl->cur.devtype) {
+	rpmlog(RPMLOG_ERR, _("%%dev glob not permitted: %s\n"), diskPath);
+	rc = RPMRC_FAIL;
+	goto exit;
+    }
+
+    if (rpmGlobPath(diskPath, RPMGLOB_NOCHECK, &argc, &argv))
+	goto exit;
+
+    for (i = 0; i < argc; i++)
+	rc = addFile(fl, argv[i], NULL);
+    argvFree(argv);
 
 exit:
     free(diskPath);

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -666,6 +666,10 @@ For example:
 	"/opt/bob's htdocs"
 ```
 
+If a glob pattern has no matches, it is tried literally (as if all the
+metacharacters were escaped).  This is similar to how Bash works with the
+`failglob` option unset.
+
 When trying to escape a large number of file names, it is often best to create
 a file with a complete list of escaped file names.  This is easiest to do with
 a shell script like this:

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -31,6 +31,14 @@ typedef enum rpmCompressedMagic_e {
 } rpmCompressedMagic;
 
 /** \ingroup rpmfileutil
+ * RPM glob flags, largely modelled after glob(3) flags.
+ */
+typedef enum rpmglobFlags_e {
+    RPMGLOB_NONE		= 0,
+    RPMGLOB_NOCHECK		= (1 << 0), /*!< same as GLOB_NOCHECK */
+} rpmglobFlags;
+
+/** \ingroup rpmfileutil
  * Calculate a file digest and size.
  * @param algo		digest algorithm
  * @param fn		file name
@@ -108,7 +116,20 @@ char * rpmGenPath	(const char * urlroot,
 char * rpmGetPath (const char * path, ...) RPM_GNUC_NULL_TERMINATED;
 
 /** \ingroup rpmfileutil
- * Return URL path(s) from a (URL prefixed) pattern glob.
+ * Expand a glob pattern into matching paths.
+ * A pattern that is not a glob is returned as is.
+ * @param pattern	glob pattern
+ * @param flags		bit(s) to control glob operation
+ * @param[out] *argcPtr	no. of paths
+ * @param[out] *argvPtr	ARGV_t array of paths
+ * @return		0 on success
+ */
+int rpmGlobPath(const char * pattern, rpmglobFlags flags,
+		int * argcPtr, ARGV_t * argvPtr);
+
+/** \ingroup rpmfileutil
+ * Expand a glob pattern into matching paths, fail if nothing matches.
+ * A pattern that is not a glob is returned as is.
  * @param pattern	glob pattern
  * @param[out] *argcPtr	no. of paths
  * @param[out] *argvPtr	ARGV_t array of paths

--- a/lib/manifest.c
+++ b/lib/manifest.c
@@ -124,7 +124,7 @@ rpmRC rpmReadPackageManifest(FD_t fd, int * argcPtr, char *** argvPtr)
 
     /* Glob manifest items. */
     for (p = sb; *p; p++) {
-	if (rpmGlob(*p, &ac, &av)) {
+	if (rpmGlobPath(*p, RPMGLOB_NOCHECK, &ac, &av)) {
 	    rpmrc = RPMRC_FAIL;
 	    goto exit;
 	}

--- a/lib/rpmgi.c
+++ b/lib/rpmgi.c
@@ -180,7 +180,7 @@ static void rpmgiGlobArgv(rpmgi gi, ARGV_const_t argv)
 	while ((arg = *argv++) != NULL) {
 	    char ** av = NULL;
 
-	    if (rpmGlob(arg, NULL, &av) == 0) {
+	    if (rpmGlobPath(arg, RPMGLOB_NOCHECK, NULL, &av) == 0) {
 		argvAppend(&gi->argv, av);
 		argvFree(av);
 	    }

--- a/lib/rpminstall.c
+++ b/lib/rpminstall.c
@@ -461,7 +461,7 @@ int rpmInstall(rpmts ts, struct rpmInstallArguments_s * ia, ARGV_t fileArgv)
 	if (giFlags & RPMGI_NOGLOB) {
 	    rc = rpmNoGlob(*eiu->fnp, &ac, &av);
 	} else {
-	    rc = rpmGlob(*eiu->fnp, &ac, &av);
+	    rc = rpmGlobPath(*eiu->fnp, RPMGLOB_NOCHECK, &ac, &av);
 	}
 	if (rc || ac == 0) {
 	    if (giFlags & RPMGI_NOGLOB) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,7 @@ EXTRA_DIST += $(TESTSUITE_AT)
 EXTRA_DIST += data/SPECS/attrtest.spec
 EXTRA_DIST += data/SPECS/bcondtest.spec
 EXTRA_DIST += data/SPECS/buildrequires.spec
+EXTRA_DIST += data/SPECS/filemiss.spec
 EXTRA_DIST += data/SPECS/docmiss.spec
 EXTRA_DIST += data/SPECS/fs.spec
 EXTRA_DIST += data/SPECS/hello.spec

--- a/tests/data/SPECS/filemiss.spec
+++ b/tests/data/SPECS/filemiss.spec
@@ -1,0 +1,26 @@
+# Make sure %%doc files are installed into a hard-coded prefix so that we can
+# then compare them against a static list using "rpm -qpl" in
+# tests/rpmbuild.at.
+%global _prefix /opt
+
+Name:           filemisstest
+Version:        1.0
+Release:        1
+Summary:        Testing missing file behavior
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}.
+
+
+%build
+%install
+
+%files
+%doc /opt/share/doc/%{name}-%{version}/CREDITS
+%doc INSTALL README*
+%license LICENSE OTHERLICENSE?
+/opt/foo
+/opt/bar{a,b}

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -54,6 +54,9 @@ touch '%{buildroot}/opt/foobayb'
 touch '%{buildroot}/opt/foobawa'
 touch '%{buildroot}/opt/foobawb'
 
+# Fallback
+touch '%{buildroot}/opt/foo[123]'
+
 %files
 
 # Glob escaping
@@ -81,3 +84,6 @@ touch '%{buildroot}/opt/foobawb'
 /opt/foo{bar,baz}
 /opt/foo{bar{a,b},baz{a,b}}
 /opt/foo{bay*,baw*}
+
+# Fallback
+/opt/foo[123]

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -16,7 +16,7 @@ BuildArch:	noarch
 
 
 %build
-touch 'foo[bar]' bar baz 'foo bar' foo%%name
+touch 'foo[bar]' bar baz 'foo bar' foo%%name 'docfb[123]' 'licfb[123]'
 
 %install
 mkdir -p %{buildroot}/opt
@@ -86,4 +86,6 @@ touch '%{buildroot}/opt/foo[123]'
 /opt/foo{bay*,baw*}
 
 # Fallback
+%doc docfb[123]
+%license licfb[123]
 /opt/foo[123]

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -467,6 +467,7 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/foo-bar1
 /opt/foo-bar2
 /opt/foo?bar
+/opt/foo[[123]]
 /opt/foo[[bar baz]]
 /opt/foo[[bar]]
 /opt/foo\
@@ -1924,6 +1925,30 @@ runroot rpmbuild \
 [0],
 [],
 [])
+AT_CLEANUP
+
+AT_SETUP([rpmbuild missing files])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
+],
+[1],
+[],
+[error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/CREDITS
+error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/foo
+error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/bar{a,b}
+cp: cannot stat 'INSTALL': No such file or directory
+cp: cannot stat 'README*': No such file or directory
+error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/INSTALL
+error: File not found by glob: /build/BUILD/README*
+cp: cannot stat 'LICENSE': No such file or directory
+cp: cannot stat 'OTHERLICENSE?': No such file or directory
+error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/LICENSE
+error: File not found by glob: /build/BUILD/OTHERLICENSE?
+],
+)
 AT_CLEANUP
 
 AT_SETUP([rpmbuild missing doc])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -488,9 +488,12 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/share/doc/globesctest-1.0
 /opt/share/doc/globesctest-1.0/bar
 /opt/share/doc/globesctest-1.0/baz
+/opt/share/doc/globesctest-1.0/docfb[[123]]
 /opt/share/doc/globesctest-1.0/foo bar
 /opt/share/doc/globesctest-1.0/foo%name
 /opt/share/doc/globesctest-1.0/foo[[bar]]
+/opt/share/licenses/globesctest-1.0
+/opt/share/licenses/globesctest-1.0/licfb[[123]]
 ],
 [],
 )
@@ -1942,11 +1945,11 @@ error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/bar{a,b}
 cp: cannot stat 'INSTALL': No such file or directory
 cp: cannot stat 'README*': No such file or directory
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/INSTALL
-error: File not found by glob: /build/BUILD/README*
+error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/README*
 cp: cannot stat 'LICENSE': No such file or directory
 cp: cannot stat 'OTHERLICENSE?': No such file or directory
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/LICENSE
-error: File not found by glob: /build/BUILD/OTHERLICENSE?
+error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
 ],
 )
 AT_CLEANUP

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -59,10 +59,9 @@ echo "/tmp/fallback-[[123]].0-1.i386.rpm" > ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/tmp/test.mft
 ],
-[1],
+[0],
 [],
-[error: /tmp/test.mft: not an rpm package (or package manifest): @&t@
-])
+[])
 AT_CLEANUP
 
 AT_SETUP([rpm -U <manifest notfound 1>])
@@ -125,9 +124,11 @@ echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/tmp/test.mft
 ],
-[1],
+[3],
 [],
-[error: /tmp/test.mft: not an rpm package (or package manifest): @&t@
+[error: open of /data/RPMS/hello-not-there-*.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
 ])
 AT_CLEANUP
 
@@ -462,9 +463,11 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 	/data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
 	/data/RPMS/hello-not-there-2.0-1.x86_64.rpm
 ],
-[1],
+[3],
 [],
-[error: File not found by glob: /data/RPMS/hello-not-there-*.x86_64.rpm
+[error: open of /data/RPMS/hello-not-there-*.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
 ])
 AT_CLEANUP
 
@@ -479,10 +482,9 @@ cp "${RPMTEST}/data/RPMS/hello-1.0-1.i386.rpm" \
 runroot rpm -U --ignorearch --ignoreos --nodeps \
 	"/tmp/fallback-[[123]].0-1.i386.rpm"
 ],
-[1],
+[0],
 [],
-[error: File not found by glob: /tmp/fallback-[[123]].0-1.i386.rpm
-])
+[])
 AT_CLEANUP
 
 # ------------------------------

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -32,6 +32,39 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [])
 AT_CLEANUP
 
+AT_SETUP([rpm -U <manifest glob>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+echo "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm" > ${RPMTEST}/tmp/test.mft
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	/tmp/test.mft
+],
+[0],
+[],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpm -U <manifest glob fallback>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+cp "${RPMTEST}/data/RPMS/hello-1.0-1.i386.rpm" \
+   "${RPMTEST}/tmp/fallback-[[123]].0-1.i386.rpm"
+
+echo "/tmp/fallback-[[123]].0-1.i386.rpm" > ${RPMTEST}/tmp/test.mft
+
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	/tmp/test.mft
+],
+[1],
+[],
+[error: /tmp/test.mft: not an rpm package (or package manifest): @&t@
+])
+AT_CLEANUP
+
 AT_SETUP([rpm -U <manifest notfound 1>])
 AT_KEYWORDS([install])
 AT_CHECK([
@@ -62,6 +95,42 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 ])
 AT_CLEANUP
 
+AT_SETUP([rpm -U <manifest notfound 3>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+echo /data/RPMS/hello-not-there-1.0-1.x86_64.rpm > ${RPMTEST}/tmp/test.mft
+echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
+echo /data/RPMS/hello-not-there-3.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	/tmp/test.mft
+],
+[3],
+[],
+[error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file or directory
+])
+AT_CLEANUP
+
+AT_SETUP([rpm -U <manifest notfound 4>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+echo "/data/RPMS/hello-not-there-*.x86_64.rpm" > ${RPMTEST}/tmp/test.mft
+echo /data/RPMS/hello-not-there-1.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
+echo /data/RPMS/hello-not-there-2.0-1.x86_64.rpm >> ${RPMTEST}/tmp/test.mft
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	/tmp/test.mft
+],
+[1],
+[],
+[error: /tmp/test.mft: not an rpm package (or package manifest): @&t@
+])
+AT_CLEANUP
+
 AT_SETUP([rpm -U <notfound>])
 AT_KEYWORDS([install])
 AT_CHECK([
@@ -73,6 +142,24 @@ runroot rpm -U --ignorearch --ignoreos --nodeps \
 [1],
 [],
 [error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
+])
+AT_CLEANUP
+
+AT_SETUP([rpm -U <notfound 2>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	/data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
+	/data/RPMS/hello-not-there-2.0-1.x86_64.rpm \
+	/data/RPMS/hello-not-there-3.0-1.x86_64.rpm
+],
+[3],
+[],
+[error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file or directory
 ])
 AT_CLEANUP
 
@@ -350,6 +437,52 @@ error: unpacking of archive failed: cpio: Bad magic
 error: hello-2.0-1.x86_64: install failed
 ],
 [])
+AT_CLEANUP
+
+AT_SETUP([rpm -U <glob>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	"/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
+],
+[0],
+[],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpm -U <glob notfound>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	"/data/RPMS/hello-not-there-*.x86_64.rpm" \
+	/data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
+	/data/RPMS/hello-not-there-2.0-1.x86_64.rpm
+],
+[1],
+[],
+[error: File not found by glob: /data/RPMS/hello-not-there-*.x86_64.rpm
+])
+AT_CLEANUP
+
+AT_SETUP([rpm -U <glob fallback>])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+cp "${RPMTEST}/data/RPMS/hello-1.0-1.i386.rpm" \
+   "${RPMTEST}/tmp/fallback-[[123]].0-1.i386.rpm"
+
+runroot rpm -U --ignorearch --ignoreos --nodeps \
+	"/tmp/fallback-[[123]].0-1.i386.rpm"
+],
+[1],
+[],
+[error: File not found by glob: /tmp/fallback-[[123]].0-1.i386.rpm
+])
 AT_CLEANUP
 
 # ------------------------------

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -75,7 +75,8 @@ runroot rpm \
   -qp "/tmp/fallback-[[123]].0-1.i386.rpm"
 ],
 [0],
-[],
+[hello-1.0-1.i386
+],
 [])
 AT_CLEANUP
 
@@ -105,9 +106,10 @@ runroot rpm \
       /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
       /data/RPMS/hello-not-there-2.0-1.x86_64.rpm
 ],
-[2],
+[3],
 [],
-[error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+[error: open of /data/RPMS/hello-not-there-*.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
 error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
 ])
 AT_CLEANUP

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -49,6 +49,70 @@ runroot rpm \
 AT_CLEANUP
 
 # ------------------------------
+AT_SETUP([rpm -qp <glob>])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+runroot rpm \
+  -qp "/data/RPMS/hello-2.0-1.{i686,x86_64}.rpm"
+],
+[0],
+[hello-2.0-1.i686
+hello-2.0-1.x86_64
+],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpm -qp <glob fallback>])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+
+cp "${RPMTEST}/data/RPMS/hello-1.0-1.i386.rpm" \
+   "${RPMTEST}/tmp/fallback-[[123]].0-1.i386.rpm"
+
+runroot rpm \
+  -qp "/tmp/fallback-[[123]].0-1.i386.rpm"
+],
+[0],
+[],
+[])
+AT_CLEANUP
+
+AT_SETUP([rpm -qp <notfound>])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+runroot rpm \
+  -qp /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
+      /data/RPMS/hello-not-there-2.0-1.x86_64.rpm \
+      /data/RPMS/hello-not-there-3.0-1.x86_64.rpm
+],
+[3],
+[],
+[error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-3.0-1.x86_64.rpm failed: No such file or directory
+])
+AT_CLEANUP
+
+AT_SETUP([rpm -qp <glob notfound>])
+AT_KEYWORDS([query])
+AT_CHECK([
+RPMDB_INIT
+runroot rpm \
+  -qp "/data/RPMS/hello-not-there-*.x86_64.rpm" \
+      /data/RPMS/hello-not-there-1.0-1.x86_64.rpm \
+      /data/RPMS/hello-not-there-2.0-1.x86_64.rpm
+],
+[2],
+[],
+[error: open of /data/RPMS/hello-not-there-1.0-1.x86_64.rpm failed: No such file or directory
+error: open of /data/RPMS/hello-not-there-2.0-1.x86_64.rpm failed: No such file or directory
+])
+AT_CLEANUP
+
+# ------------------------------
 AT_SETUP([rpm -ql -p *.src.rpm])
 AT_KEYWORDS([query])
 AT_CHECK([

--- a/tools/rpmgraph.c
+++ b/tools/rpmgraph.c
@@ -48,7 +48,7 @@ rpmGraph(rpmts ts, struct rpmInstallArguments_s * ia, const char ** fileArgv)
     for (fnp = fileArgv; *fnp; fnp++) {
 	av = _free(av);
 	ac = 0;
-	rc = rpmGlob(*fnp, &ac, &av);
+	rc = rpmGlobPath(*fnp, RPMGLOB_NOCHECK, &ac, &av);
 	if (rc || ac == 0) continue;
 
 	argv = xrealloc(argv, (argc+2) * sizeof(*argv));


### PR DESCRIPTION
In the `%files` section, we currently try to match globs literally if they don't expand to any existing files. This doesn't include special (`%doc` and `%license`) files so fix that. To make this behavior consistent everywhere, also do the same kind of fallback on the CLI when reading package names.

As a side effect, error reporting for globs is now unified with that for non-glob files as we pass both through the same IO routines.