### PR TITLE
Fix rpm lua rpm_vercmp error message if second argument is broken

### DIFF
--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -491,7 +491,7 @@ static int rpm_vercmp(lua_State *L)
 	} else {
 	    if (v1 == NULL)
 		luaL_argerror(L, 1, "invalid version ");
-	    if (v1 == NULL)
+	    if (v2 == NULL)
 		luaL_argerror(L, 2, "invalid version ");
 	}
 	rpmverFree(v1);


### PR DESCRIPTION
This is a fix for small issue I encounter while was playing with lua in rpm spec:
```
➜  rpm --eval "%{lua:rpm.interactive()}"

RPM Interactive Lua 5.4 Interpreter
> print(rpm.vercmp('1', '1'))
0
> print(rpm.vercmp('', '1'))         
[string "<lua>"]:1: bad argument #1 to 'vercmp' (invalid version )
> print(rpm.vercmp('1', '')) 

> 
```
If first argument is wrong in `rpm.vercmp()` - meaningful error message as expected
if second argument is wrong - nothing happens and `nil` returned