### PR TITLE
configure.ac: add linux-gnux32 variant to triplet handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -812,6 +812,10 @@ if echo "$host_os" | grep '.*-gnuabi64$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnuabi64$//'`
 	host_os_gnu=-gnuabi64
 fi
+if echo "$host_os" | grep '.*-gnux32$' > /dev/null ; then
+	host_os=`echo "${host_os}" | sed 's/-gnux32$//'`
+	host_os_gnu=-gnux32
+fi
 if echo "$host_os" | grep '.*-gnu$' > /dev/null ; then
 	host_os=`echo "${host_os}" | sed 's/-gnu$//'`
 fi


### PR DESCRIPTION
https://github.com/rpm-software-management/rpm/commit/1cdb72ae48b7ba689c5c79118f4f0c1b4ffe6b7c
introduced a change where triplets that rpm doesn't know about
are rejected, which in turn causes a regression for users like
Yocto that explicitly use them.

In particular, x32 is a 64 bit x86 ABI with 32 bit pointers and
is supported via settings in custom /etc/rpmrc:
```
arch_compat: qemux86_64: all any noarch x86_64_x32 qemux86_65
```
----
Note from Alex:
this was previously submitted here:
https://github.com/rpm-software-management/rpm/pull/2143

The pull request was closed with reverting the commit that introduced the problem in 4.17 branch, but this does not solve the issue in 4.18 or in master. This new pull request is made so that we can hopefully find a solution that satisfies everyone, and doesn't require carrying custom patches forever. I do not insist on taking the patch as it is, just would like to solve the problem some other way if needed.