### PR TITLE
Make pgpPubkeyFingerprint() do something meaningful again

### DIFF
--- a/rpmio/rpmpgp_internal.c
+++ b/rpmio/rpmpgp_internal.c
@@ -650,7 +650,7 @@ static int pgpPrtUserID(pgpTag tag, const uint8_t *h, size_t hlen,
     return 0;
 }
 
-int pgpPubkeyFingerprint(const uint8_t *h, size_t hlen,
+static int getPubkeyFingerprint(const uint8_t *h, size_t hlen,
 			  uint8_t **fp, size_t *fplen)
 {
     int rc = -1; /* assume failure */
@@ -717,11 +717,22 @@ int pgpPubkeyFingerprint(const uint8_t *h, size_t hlen,
     return rc;
 }
 
+int pgpPubkeyFingerprint(const uint8_t * pkt, size_t pktlen,
+                         uint8_t **fp, size_t *fplen)
+{
+    struct pgpPkt p;
+
+    if (decodePkt(pkt, pktlen, &p))
+	return -1;
+
+    return getPubkeyFingerprint(p.body, p.blen, fp, fplen);
+}
+
 static int getKeyID(const uint8_t *h, size_t hlen, pgpKeyID_t keyid)
 {
     uint8_t *fp = NULL;
     size_t fplen = 0;
-    int rc = pgpPubkeyFingerprint(h, hlen, &fp, &fplen);
+    int rc = getPubkeyFingerprint(h, hlen, &fp, &fplen);
     if (fp && fplen > 8) {
 	memcpy(keyid, (fp + (fplen-8)), 8);
 	free(fp);


### PR DESCRIPTION
Commit 4bbeec134aab33e24f960be28a7b2198359c1f67 "fixed" an old
terminology confusion about keyid vs fingerprint, but in the process
broke pgpPubkeyFingerprint() for any external callers, as it now only
feeds on decoded packets whereas before it did the decoding by itself.
Add the decoding step back to the public function to make it usable outside
rpmpgp_internal.c again, retrieving a fingerprint seems like an useful
(public) API to have.

This is kind of a regression fix in that prior to commit
4bbeec134aab33e24f960be28a7b2198359c1f67 pgpPubkeyFingerprint() returned
meaningful data to the outside caller and afterwards it didn't, however
that commit broke the API anyhow so it's kinda complicated.
Maybe we should just call it a bugfix and be done with it.

Related to #1549