### PR TITLE
Fix possible descriptor leak in fsmOpenat

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -321,6 +321,8 @@ static int fsmOpenat(int dirfd, const char *path, int flags, int dir)
 		    close(ffd);
 		}
 	    }
+	} else {
+	    fsmClose(&ffd);
 	}
     }
 


### PR DESCRIPTION
For the very unlikely case when `openat()` succeeded but `fstatat()`
doesn't, the directory descriptor may be leaved opened. So add `fsmClose()`
as an extra precaution for this particular case.

Suggested-by: Pavel Kopylov <pkopylov@cloudlinux.com>
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>