### PR TITLE
Fix %posttrans argument on upgrade

### DIFF
--- a/lib/psm.c
+++ b/lib/psm.c
@@ -435,6 +435,21 @@ static rpmpsm rpmpsmFree(rpmpsm psm)
     return NULL;
 }
 
+static int isUpdate(rpmts ts, rpmte te)
+{
+    rpmtsi pi = rpmtsiInit(ts);
+    rpmte p;
+    int update = 0;
+    while ((p = rpmtsiNext(pi, TR_REMOVED)) != NULL) {
+	if (rpmteDependsOn(p) == te) {
+	    update = 1;
+	    break;
+	}
+    }
+    rpmtsiFree(pi);
+    return update;
+}
+
 static rpmpsm rpmpsmNew(rpmts ts, rpmte te, pkgGoal goal)
 {
     rpmpsm psm = xcalloc(1, sizeof(*psm));
@@ -460,7 +475,7 @@ static rpmpsm rpmpsmNew(rpmts ts, rpmte te, pkgGoal goal)
 	    break;
 	case PKG_VERIFY:
 	case PKG_POSTTRANS:
-	    psm->scriptArg = npkgs_installed;
+	    psm->scriptArg = npkgs_installed + isUpdate(psm->ts, psm->te);
 	    psm->countCorrection = 0;
 	    break;
 	default:

--- a/tests/rpmscript.at
+++ b/tests/rpmscript.at
@@ -149,7 +149,7 @@ scripts-1.0-2 PRE 2
 scripts-1.0-2 POST 2
 scripts-1.0-1 PREUN 1
 scripts-1.0-1 POSTUN 1
-scripts-1.0-2 POSTTRANS 1
+scripts-1.0-2 POSTTRANS 2
 scripts-1.0-2 VERIFY 1
 scripts-1.0-2 PREUN 0
 scripts-1.0-2 POSTUN 0
@@ -199,7 +199,7 @@ triggers-1.0-1 TRIGGERUN 1 1
 scripts-1.0-1 PREUN 1
 scripts-1.0-1 POSTUN 1
 triggers-1.0-1 TRIGGERPOSTUN 1 1
-scripts-1.0-2 POSTTRANS 1
+scripts-1.0-2 POSTTRANS 2
 TRIGGERS 2
 triggers-1.0-2 TRIGGERPREIN 1 1
 triggers-1.0-2 TRIGGERIN 2 1


### PR DESCRIPTION
Packages need to be able to differentiate between install and upgrade scenarios, seems commit ab069ec876639d46d12dd76dad54fd8fb762e43d with half the lights out...

As %posttrans happens after all the excitement, with the erasure elements already executed, so the installed package count cannot be used to differentiate between install and upgrade. So we need to find it out the hard way: see if there's an erasure element that depends on this package.