### PR TITLE
Add shorthand macros for some conventient Lua string operations

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -84,6 +84,15 @@ to perform useful operations. The current list is
 
 	%{macrobody:...}	literal body of a macro
 
+	%{gsub:...}	replace occurences of pattern in a string
+                        (see Lua `string.gsub()`)
+	%{len:...}	string length
+	%{lower:...}	lowercase a string
+	%{rep:...}	repeat a string (see Lua `string.rep()`)
+	%{reverse:...}	reverse a string
+	%{sub:...}	expand to substring (see Lua `string.sub()`)
+	%{upper:...}	uppercase a string
+
 	%{basename:...}	basename(1) macro analogue
 	%{dirname:...}	dirname(1) macro analogue
 	%{exists:...}	test file existence, expands to 1/0

--- a/tests/data/SPECS/configtest.spec
+++ b/tests/data/SPECS/configtest.spec
@@ -3,7 +3,7 @@
 
 %{!?filetype: %global filetype file}
 
-Name:		configtest%{?sub:-%{sub}}
+Name:		configtest%{?subpkg:-%{subpkg}}
 Version:	%{ver}
 Release:	1
 Summary:	Testing config file behavior

--- a/tests/data/SPECS/replacetest.spec
+++ b/tests/data/SPECS/replacetest.spec
@@ -3,7 +3,7 @@
 %{!?user: %global user root}
 %{!?grp: %global grp root}
 
-Name:		replacetest%{?sub:-%{sub}}
+Name:		replacetest%{?subpkg:-%{subpkg}}
 Version:	%{ver}
 Release:	1
 Summary:	Testing file replacement behavior

--- a/tests/rpmconfig.at
+++ b/tests/rpmconfig.at
@@ -402,7 +402,7 @@ RPMDB_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
+            --define "subpkg $s" \
             --define "ver $v" \
 	    --define "filedata foo" \
               /data/SPECS/configtest.spec
@@ -462,7 +462,7 @@ RPMDB_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
+            --define "subpkg $s" \
             --define "ver $v" \
 	    --define "filedata foo-$v" \
               /data/SPECS/configtest.spec
@@ -552,7 +552,7 @@ RPMDB_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
+            --define "subpkg $s" \
             --define "ver $v" \
 	    --define "filedata foo-$v" \
 	    --define "noreplace 1" \

--- a/tests/rpmconfig2.at
+++ b/tests/rpmconfig2.at
@@ -352,7 +352,7 @@ RPMDB_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
+            --define "subpkg $s" \
             --define "ver $v" \
 	    --define "filedata foo" \
 	    --define "filetype link" \
@@ -414,7 +414,7 @@ RPMDB_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
+            --define "subpkg $s" \
             --define "ver $v" \
 	    --define "filedata foo-$v" \
 	    --define "filetype link" \
@@ -504,7 +504,7 @@ RPMDB_INIT
 for s in "A" "B"; do
     for v in "1.0" "2.0"; do
         runroot rpmbuild --quiet -bb \
-            --define "sub $s" \
+            --define "subpkg $s" \
             --define "ver $v" \
 	    --define "filedata foo-$v" \
 	    --define "filetype link" \

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -387,6 +387,39 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([string functions])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --eval "%sub cd6317ba61e6c27b92d6bbdf2702094ff3c0c732 1 7" \
+    --eval "%sub cd6317ba61e6c27b92d6bbdf2702094ff3c0c732 7 -7" \
+    --eval "%sub cd6317ba61e6c27b92d6bbdf2702094ff3c0c732 -7" \
+    --eval "%len cd6317ba61e6c27b92d6bbdf2702094ff3c0c732" \
+    --eval "%upper abba" \
+    --eval "%lower Beatles" \
+    --eval "%rep ai 2" \
+    --eval "%reverse live" \
+    --eval "%reverse a'b" \
+    --eval "%reverse a\"b" \
+    --eval "%gsub aaa a b 2"
+],
+[0],
+[cd6317b
+ba61e6c27b92d6bbdf2702094ff3
+3c0c732
+40
+ABBA
+beatles
+aiai
+evil
+b'a
+b"a
+bba
+],
+[])
+AT_CLEANUP
+
+
 AT_SETUP([expr macro 1])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
Despite all the Lua magic we already do, it's annoyingly often the case that shelling out is easier (or at least shorter) than doing the same in Lua (substrings, length etc)

Add shorthand macros %gsub, %len, %lower, %rep, %reverse, %sub and %upper which simply wrap the corresponding Lua string.* functions for convenience.