### PR TITLE
Revere Change %undefine macro to "func" style now that we can

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -784,12 +784,31 @@ exit:
 static void
 doUndefine(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 {
-    const char *n = argv[1];
-    if (!validName(mb, n, strlen(n), "%undefine")) {
+    const char *se = argv[1];
+    const char *start = se;
+    const char *s = se;
+    char *buf = xmalloc(strlen(s) + 1);
+    char * n = buf, *ne = n;
+    int c;
+
+    COPYNAME(ne, s, c);
+
+    /* Move scane over body */
+    while (iseol(*s))
+	s++;
+    se = s;
+
+    if (!validName(mb, n, ne - n, "%undefine")) {
 	mb->error = 1;
-    } else {
-	popMacro(mb->mc, n);
+	goto exit;
     }
+
+    popMacro(mb->mc, n);
+
+exit:
+    _free(buf);
+    if (parsed)
+	*parsed += se - start;
 }
 
 static void doArgvDefine(MacroBuf mb, ARGV_t argv, int level, int expand, size_t *parsed)
@@ -1285,7 +1304,7 @@ static struct builtins_s {
     { "u2p",		doFoo,		1,	0 },
     { "shescape",	doShescape,	1,	0 },
     { "uncompress",	doUncompress,	1,	0 },
-    { "undefine",	doUndefine,	1,	0 },
+    { "undefine",	doUndefine,	1,	ME_PARSE },
     { "upper",		doString,	1,	0 },
     { "url2path",	doFoo,		1,	0 },
     { "verbose",	doVerbose,	-1,	ME_PARSE },

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -934,6 +934,19 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([%define + %undefine in nested levels 5])
+AT_KEYWORDS([macros define undefine])
+AT_CHECK([
+# %define in a nested level and %undefine in --eval
+runroot rpm \
+    --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{echo:%xxx}' \
+    --eval +'%undefine xxx'- \
+],
+[0],
+[+-
+])
+AT_CLEANUP
+
 AT_SETUP([%define in conditional macro])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
https://github.com/rpm-software-management/rpm/commit/aec8bdb53a3013eabf16368e17a65ab69c2136ee introduced function changes, which cause the output of the following command is changed.
     `rpm -D '%foo() %{expand:%define xxx 1} %{echo:%xxx}' -E +'%undefine xxx'-`
The result of the command is "+-" before https://github.com/rpm-software-management/rpm/commit/aec8bdb53a3013eabf16368e17a65ab69c2136ee, now is "+".

And according to https://github.com/rpm-software-management/rpm/commit/1d1f461f80138c44556a8d87433dd39884a7d44c, the return value is saved in "parsed".