### PR TITLE
Add proper quotation support to %files

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -256,20 +256,21 @@ static char *strtokWithQuotes(char *s, const char *delim)
     if (*s == '\0')
 	return NULL;
 
-    /* Find the end of the token.  */
-    token = s;
-    if (*token == '"') {
-	token++;
-	/* Find next " char */
-	s = strchr(token, '"');
-    } else {
-	s = strpbrk(token, delim);
+    /* Leading quote escapes original delim until next quote */
+    if (*s == '"') {
+	delim = "\"";
+	s++;
     }
 
+    /* Find the end of the token.  */
+    token = s;
+    while (!strchr(delim, *s))
+	s++;
+
     /* Terminate it */
-    if (s == NULL) {
+    if (*s == '\0') {
 	/* This token finishes the string */
-	olds = strchr(token, '\0');
+	olds = s;
     } else {
 	/* Terminate the token and make olds point past it */
 	*s = '\0';

--- a/build/files.c
+++ b/build/files.c
@@ -926,8 +926,18 @@ static rpmRC parseForSimple(char * buf, FileEntry cur, ARGV_t * fileNames)
 	    if (cur->attrFlags & (RPMFILE_DOC | RPMFILE_LICENSE))
 		cur->attrFlags |= RPMFILE_SPECIALDIR;
 	}
-	rpmUnescape(s, delim);
+
+	if (!quotes)
+	    rpmUnescape(s, delim);
+	else {
+	    rpmUnescape(s, "\"");
+	    s = rpmEscape(s, "?*[]{}");
+	}
+
 	argvAdd(fileNames, s);
+
+	if (quotes)
+	    free(s);
     }
 
     return res;

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -653,9 +653,11 @@ Supported modifiers are:
 
 The usual rules for shell globbing apply (see `glob(7)`), including brace
 expansion.  Metacharacters can be escaped by prefixing them with a backslash
-(`\`).  A backslash or percent sign can be escaped with an extra `\` or `%`,
-respectively.  Spaces are used to separate file names and must be escaped by
-enclosing the file name in quotes.
+(`\`).  Spaces are used to separate file names and must also be escaped.
+Enclosing a file name in double quotes (`"`) preserves the literal value of all
+characters within the quotes, with the exception of `\` and the percent sign
+(`%`).  A `\` or `%` can be escaped with an extra `\` or `%`, respectively.  A
+double quote can be escaped with a `\`.
 
 For example:
 
@@ -678,7 +680,8 @@ a shell script like this:
 	rm -f filelist.txt
 	find %{buildroot} -type f -printf '/%%P\n' |	\
 	perl -pe 's/(%)/%$1/g;'				\
-	     -pe 's/([*?\[\]{}\\])/\\$1/g;'		\
+	     -pe 's/(["\\])/\\$1/g;'			\
+	     -pe 's/(^.*$)/"$1"/g;'			\
 	> filelist.txt
 
 	%files -f filelist.txt

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -145,6 +145,14 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr);
 char * rpmEscapeSpaces(const char * s);
 
 /** \ingroup rpmfileutil
+ * Escape given characters in string.
+ * @param s             string
+ * @param accept        chars to escape
+ * @return              escaped string
+ */
+char * rpmEscape(const char *s, const char *accept);
+
+/** \ingroup rpmfileutil
  * Unescape each char listed in accept by removing a backslash preceding it.
  * @param s		string
  * @param accept	chars to unescape (NULL for all)

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -145,6 +145,13 @@ int rpmGlob(const char * pattern, int * argcPtr, ARGV_t * argvPtr);
 char * rpmEscapeSpaces(const char * s);
 
 /** \ingroup rpmfileutil
+ * Unescape each char listed in accept by removing a backslash preceding it.
+ * @param s		string
+ * @param accept	chars to unescape (NULL for all)
+ */
+void rpmUnescape(char *s, const char *accept);
+
+/** \ingroup rpmfileutil
  * Return type of compression used in file.
  * @param file		name of file
  * @param[out] compressed	address of compression type

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -380,7 +380,7 @@ char * rpmGetPath(const char *path, ...)
     return rpmCleanPath(res);
 }
 
-char * rpmEscapeSpaces(const char * s)
+static char * rpmEscapeChars(const char *s, const char *accept, int (*fn)(int))
 {
     const char * se;
     char * t;
@@ -388,7 +388,7 @@ char * rpmEscapeSpaces(const char * s)
     size_t nb = 0;
 
     for (se = s; *se; se++) {
-	if (isspace(*se))
+	if ((accept && strchr(accept, *se)) || (fn && fn(*se)))
 	    nb++;
 	nb++;
     }
@@ -396,12 +396,22 @@ char * rpmEscapeSpaces(const char * s)
 
     t = te = xmalloc(nb);
     for (se = s; *se; se++) {
-	if (isspace(*se))
+	if ((accept && strchr(accept, *se)) || (fn && fn(*se)))
 	    *te++ = '\\';
 	*te++ = *se;
     }
     *te = '\0';
     return t;
+}
+
+char * rpmEscapeSpaces(const char *s)
+{
+    return rpmEscapeChars(s, NULL, isspace);
+}
+
+char * rpmEscape(const char *s, const char *accept)
+{
+    return rpmEscapeChars(s, accept, NULL);
 }
 
 void rpmUnescape(char *s, const char *accept)

--- a/rpmio/rpmfileutil.c
+++ b/rpmio/rpmfileutil.c
@@ -404,6 +404,24 @@ char * rpmEscapeSpaces(const char * s)
     return t;
 }
 
+void rpmUnescape(char *s, const char *accept)
+{
+    char *p, *q;
+    int skip = 0;
+
+    p = q = s;
+    while (*q != '\0') {
+	*p = *q++;
+	if (*p == '\\' && (!accept || strchr(accept, *q)) && !skip) {
+	    skip = 1;
+	    continue;
+	}
+	p++;
+	skip = 0;
+    }
+    *p = '\0';
+}
+
 int rpmFileHasSuffix(const char *path, const char *suffix)
 {
     size_t plen = strlen(path);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,7 @@ EXTRA_DIST += data/SPECS/hello-sources.spec
 EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
 EXTRA_DIST += data/SPECS/globesctest.spec
+EXTRA_DIST += data/SPECS/badescape.spec
 EXTRA_DIST += data/SPECS/versiontest.spec
 EXTRA_DIST += data/SPECS/conflicttest.spec
 EXTRA_DIST += data/SPECS/configtest.spec

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ EXTRA_DIST += data/SPECS/foo.spec
 EXTRA_DIST += data/SPECS/globtest.spec
 EXTRA_DIST += data/SPECS/globesctest.spec
 EXTRA_DIST += data/SPECS/badescape.spec
+EXTRA_DIST += data/SPECS/badquote.spec
 EXTRA_DIST += data/SPECS/versiontest.spec
 EXTRA_DIST += data/SPECS/conflicttest.spec
 EXTRA_DIST += data/SPECS/configtest.spec

--- a/tests/data/SPECS/badescape.spec
+++ b/tests/data/SPECS/badescape.spec
@@ -1,0 +1,19 @@
+Name:           badescape
+Version:        1.0
+Release:        1
+Summary:        Testing trailing backslash in filename
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}.
+
+
+%build
+
+%install
+
+%files
+/opt/foo\
+

--- a/tests/data/SPECS/badquote.spec
+++ b/tests/data/SPECS/badquote.spec
@@ -1,0 +1,18 @@
+Name:           badquote
+Version:        1.0
+Release:        1
+Summary:        Testing no closing quote in filename
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}.
+
+
+%build
+
+%install
+
+%files
+"/opt/foo

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -24,7 +24,6 @@ mkdir -p %{buildroot}/opt
 
 # Glob escaping
 touch '%{buildroot}/opt/foo[bar]'
-touch '%{buildroot}/opt/foo[bar baz]'
 touch '%{buildroot}/opt/foo\[bar\]'
 touch '%{buildroot}/opt/foo*'
 touch '%{buildroot}/opt/foo\bar'
@@ -46,6 +45,14 @@ touch '%{buildroot}/opt/foo" bar"'
 touch '%{buildroot}/opt/foo b'
 touch '%{buildroot}/opt/foo a'
 touch '%{buildroot}/opt/foo r'
+
+# Quoting
+touch '%{buildroot}/opt/foo bar.conf'
+touch '%{buildroot}/opt/foo [baz]'
+touch '%{buildroot}/opt/foo[bar baz]'
+touch '%{buildroot}/opt/foo\[baz\]'
+touch '%{buildroot}/opt/foo\bay'
+touch '%{buildroot}/opt/foo"baz"'
 
 # Regression checks
 touch '%{buildroot}/opt/foo-bar1'
@@ -72,7 +79,6 @@ touch '%{buildroot}/opt/foo[123]'
 %doc foo\[bar\]
 /opt/foo\[bar\]
 /opt/foo\*[bar]
-"/opt/foo\[bar baz\]"
 /opt/foo\\\[bar\\\]
 /opt/foo\*
 /opt/foo\\bar
@@ -91,6 +97,14 @@ touch '%{buildroot}/opt/foo[123]'
 /opt/foo\ bar
 /opt/foo"\ bar"
 /opt/foo\ [bar]
+
+# Quoting
+%config "/opt/foo bar.conf"
+"/opt/foo [baz]"
+"/opt/foo[bar baz]"
+"/opt/foo\\[baz\\]"
+"/opt/foo\\bay"
+"/opt/foo\"baz\""
 
 # Regression checks
 %doc ba* "foo bar"

--- a/tests/data/SPECS/globesctest.spec
+++ b/tests/data/SPECS/globesctest.spec
@@ -17,6 +17,7 @@ BuildArch:	noarch
 
 %build
 touch 'foo[bar]' bar baz 'foo bar' foo%%name 'docfb[123]' 'licfb[123]'
+touch 'foo b' 'foo a' 'foo r'
 
 %install
 mkdir -p %{buildroot}/opt
@@ -37,6 +38,14 @@ touch '%{buildroot}/opt/foo*r'
 
 # Macro escaping
 touch '%{buildroot}/opt/foo%%name'
+
+# Space escaping
+touch '%{buildroot}/opt/foo[bax bay]'
+touch '%{buildroot}/opt/foo bar'
+touch '%{buildroot}/opt/foo" bar"'
+touch '%{buildroot}/opt/foo b'
+touch '%{buildroot}/opt/foo a'
+touch '%{buildroot}/opt/foo r'
 
 # Regression checks
 touch '%{buildroot}/opt/foo-bar1'
@@ -75,6 +84,13 @@ touch '%{buildroot}/opt/foo[123]'
 # Macro escaping
 %doc foo%%name
 /opt/foo%%name
+
+# Space escaping
+%doc foo\ [bar]
+/opt/foo\[bax\ bay\]
+/opt/foo\ bar
+/opt/foo"\ bar"
+/opt/foo\ [bar]
 
 # Regression checks
 %doc ba* "foo bar"

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -542,6 +542,21 @@ runroot rpmbuild -bb --quiet /data/SPECS/badescape.spec
 )
 AT_CLEANUP
 
+AT_SETUP([rpmbuild bad quote])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/badquote.spec
+],
+[1],
+[],
+[error: Missing quote: /opt/foo
+
+],
+)
+AT_CLEANUP
+
 AT_SETUP([rpmbuild prefixpostfix])
 AT_KEYWORDS([build])
 AT_CHECK([

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -476,13 +476,16 @@ runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
 runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 ],
 [0],
-[/opt/foo a
+[/opt/foo [[baz]]
+/opt/foo a
 /opt/foo b
 /opt/foo bar
+/opt/foo bar.conf
 /opt/foo r
 /opt/foo" bar"
 /opt/foo"'baz"'
 /opt/foo"bar"
+/opt/foo"baz"
 /opt/foo%name
 /opt/foo*
 /opt/foo*a
@@ -497,7 +500,9 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/foo[[bax bay]]
 /opt/foo\
 /opt/foo\[[bar\]]
+/opt/foo\[[baz\]]
 /opt/foo\bar
+/opt/foo\bay
 /opt/foobar
 /opt/foobara
 /opt/foobarb

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -476,7 +476,12 @@ runroot rpmbuild -bb --quiet /data/SPECS/globesctest.spec
 runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 ],
 [0],
-[/opt/foo"'baz"'
+[/opt/foo a
+/opt/foo b
+/opt/foo bar
+/opt/foo r
+/opt/foo" bar"
+/opt/foo"'baz"'
 /opt/foo"bar"
 /opt/foo%name
 /opt/foo*
@@ -489,6 +494,7 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/foo[[123]]
 /opt/foo[[bar baz]]
 /opt/foo[[bar]]
+/opt/foo[[bax bay]]
 /opt/foo\
 /opt/foo\[[bar\]]
 /opt/foo\bar
@@ -508,13 +514,31 @@ runroot rpm -qpl /build/RPMS/noarch/globesctest-1.0-1.noarch.rpm
 /opt/share/doc/globesctest-1.0/bar
 /opt/share/doc/globesctest-1.0/baz
 /opt/share/doc/globesctest-1.0/docfb[[123]]
+/opt/share/doc/globesctest-1.0/foo a
+/opt/share/doc/globesctest-1.0/foo b
 /opt/share/doc/globesctest-1.0/foo bar
+/opt/share/doc/globesctest-1.0/foo r
 /opt/share/doc/globesctest-1.0/foo%name
 /opt/share/doc/globesctest-1.0/foo[[bar]]
 /opt/share/licenses/globesctest-1.0
 /opt/share/licenses/globesctest-1.0/licfb[[123]]
 ],
 [],
+)
+AT_CLEANUP
+
+AT_SETUP([rpmbuild bad escape])
+AT_KEYWORDS([build])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/badescape.spec
+],
+[1],
+[],
+[error: Trailing backslash: /opt/foo\
+
+],
 )
 AT_CLEANUP
 


### PR DESCRIPTION
Treat globs in a quoted filename as literal (not just spaces). This makes the behavior consistent with the typical shell quotation and also makes the escaping of a large file list easier to automate.

This makes the following work as expected:
```
%files
"/some/path[with spaces and square brackets]"
```

That's equivalent to:
```
%files
/some/path\[with\ spaces\ and\ square\ brackets\]
```

Only double quotes are supported for now. Adding single quotes as an alternative to mix & match isn't difficult, but would just make things needlessly more complicated to document and review.

This is the last PR in the long-running series of glob revamps that all started with #1749, which this PR, if merged, also concludes. :partying_face: 