### PR TITLE
Fix unrecognized bzlib regression in pack.c

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -299,7 +299,7 @@ static char *getIOFlags(Package pkg)
 	    compr = NULL;
 	} else if (rstreq(s+1, "gzdio")) {
 	    compr = "gzip";
-#ifdef have_bzlib_h
+#ifdef HAVE_BZLIB_H
 	} else if (rstreq(s+1, "bzdio")) {
 	    compr = "bzip2";
 	    /* Add prereq on rpm version that understands bzip2 payloads */


### PR DESCRIPTION
BZ2 compression type is no longer recognized during package build when used in %_binary_payload or %_source_payload.  This is caused by a typo that got in as part of commit https://github.com/rpm-software-management/rpm/commit/48d0fa954ca1629ffb0092b9c00555570241d6a0.