### PR TITLE
Handle downgrade within V-R when epoch goes away (RhBug:1845069)

### DIFF
--- a/lib/depends.c
+++ b/lib/depends.c
@@ -161,6 +161,19 @@ rpmdbMatchIterator rpmtsPrunedIterator(rpmts ts, rpmDbiTagVal tag,
     return mi;
 }
 
+rpmdbMatchIterator rpmtsTeIterator(rpmts ts, rpmte te, int prune)
+{
+    rpmdbMatchIterator mi = rpmtsPrunedIterator(ts, RPMDBI_NAME, rpmteN(te), prune);
+    rpmdbSetIteratorRE(mi, RPMTAG_EPOCH, RPMMIRE_STRCMP, rpmteE(te));
+    rpmdbSetIteratorRE(mi, RPMTAG_VERSION, RPMMIRE_STRCMP, rpmteV(te));
+    rpmdbSetIteratorRE(mi, RPMTAG_RELEASE, RPMMIRE_STRCMP, rpmteR(te));
+    if (rpmtsColor(ts)) {
+	rpmdbSetIteratorRE(mi, RPMTAG_ARCH, RPMMIRE_STRCMP, rpmteA(te));
+	rpmdbSetIteratorRE(mi, RPMTAG_OS, RPMMIRE_STRCMP, rpmteO(te));
+    }
+    return mi;
+}
+
 /**
  * Decides whether to skip a package upgrade/obsoletion on TE color.
  *

--- a/lib/psm.c
+++ b/lib/psm.c
@@ -540,16 +540,7 @@ void rpmpsmNotify(rpmpsm psm, int what, rpm_loff_t amount)
  */
 static void markReplacedInstance(rpmts ts, rpmte te)
 {
-    rpmdbMatchIterator mi = rpmtsPrunedIterator(ts, RPMDBI_NAME, rpmteN(te), 1);
-    rpmdbSetIteratorRE(mi, RPMTAG_EPOCH, RPMMIRE_STRCMP, rpmteE(te));
-    rpmdbSetIteratorRE(mi, RPMTAG_VERSION, RPMMIRE_STRCMP, rpmteV(te));
-    rpmdbSetIteratorRE(mi, RPMTAG_RELEASE, RPMMIRE_STRCMP, rpmteR(te));
-    /* XXX shouldn't we also do this on colorless transactions? */
-    if (rpmtsColor(ts)) {
-	rpmdbSetIteratorRE(mi, RPMTAG_ARCH, RPMMIRE_STRCMP, rpmteA(te));
-	rpmdbSetIteratorRE(mi, RPMTAG_OS, RPMMIRE_STRCMP, rpmteO(te));
-    }
-
+    rpmdbMatchIterator mi = rpmtsTeIterator(ts, te, 1);
     while (rpmdbNextIterator(mi) != NULL) {
 	rpmteSetDBInstance(te, rpmdbGetIteratorOffset(mi));
 	break;

--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -1196,6 +1196,10 @@ int rpmdbSetIteratorRE(rpmdbMatchIterator mi, rpmTagVal tag,
 	free(t);
      }
 
+    /* Handle missing epoch, see mireSkip() */
+    if (tag == RPMTAG_EPOCH && pattern == NULL)
+	pattern = "0";
+
     if (mi == NULL || pattern == NULL)
 	return rc;
 

--- a/lib/rpmts_internal.h
+++ b/lib/rpmts_internal.h
@@ -116,6 +116,10 @@ RPM_GNUC_INTERNAL
 rpmdbMatchIterator rpmtsPrunedIterator(rpmts ts, rpmDbiTagVal tag,
 					      const char * key, int prune);
 
+/* Return rpmdb iterator locked to a single rpmte */
+RPM_GNUC_INTERNAL
+rpmdbMatchIterator rpmtsTeIterator(rpmts ts, rpmte te, int prune);
+
 RPM_GNUC_INTERNAL
 rpmal rpmtsCreateAl(rpmts ts, rpmElementTypes types);
 

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1344,15 +1344,7 @@ static void checkAdded(rpmts ts, rpmprobFilterFlags probFilter, rpmte p)
 
     if (!(probFilter & RPMPROB_FILTER_REPLACEPKG) && rpmteAddOp(p) != RPMTE_REINSTALL) {
 	Header h;
-	rpmdbMatchIterator mi;
-	mi = rpmtsInitIterator(ts, RPMDBI_NAME, rpmteN(p), 0);
-	rpmdbSetIteratorRE(mi, RPMTAG_EPOCH, RPMMIRE_STRCMP, rpmteE(p));
-	rpmdbSetIteratorRE(mi, RPMTAG_VERSION, RPMMIRE_STRCMP, rpmteV(p));
-	rpmdbSetIteratorRE(mi, RPMTAG_RELEASE, RPMMIRE_STRCMP, rpmteR(p));
-	if (rpmtsColor(ts)) {
-	    rpmdbSetIteratorRE(mi, RPMTAG_ARCH, RPMMIRE_STRCMP, rpmteA(p));
-	    rpmdbSetIteratorRE(mi, RPMTAG_OS, RPMMIRE_STRCMP, rpmteO(p));
-	}
+	rpmdbMatchIterator mi = rpmtsTeIterator(ts, p, 0);
 
 	if ((h = rpmdbNextIterator(mi)) != NULL) {
 	    rpmteAddProblem(p, RPMPROB_PKG_INSTALLED, NULL, NULL,

--- a/tests/data/SPECS/versiontest.spec
+++ b/tests/data/SPECS/versiontest.spec
@@ -1,6 +1,9 @@
 Name:		versiontest
 Version:	%{ver}
 Release:	1
+%if %{defined:epoch}
+Epoch:		%{epoch}
+%endif
 Summary:	Testing version behavior
 
 Group:		Testing

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -891,7 +891,6 @@ runroot rpm -U /tmp/noepoch.rpm
 [2],
 [],
 [	package versiontest-1:1.0-1.noarch (which is newer than versiontest-1.0-1.noarch) is already installed
-	package versiontest-1.0-1.noarch is already installed
 ])
 
 AT_CHECK([
@@ -923,10 +922,9 @@ runroot rpm -U --oldpackage /tmp/noepoch.rpm
 runroot rpm -q versiontest
 ],
 [0],
-[versiontest-1:1.0-1.noarch
+[versiontest-1.0-1.noarch
 ],
-[	package versiontest-1.0-1.noarch is already installed
-])
+[])
 
 AT_CHECK([
 RPMDB_INIT

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -786,7 +786,6 @@ runroot rpm -q versiontest
 [versiontest-1.0-1.noarch
 ],
 [])
-# TODO: the same with epoch vs no epoch
 
 # Test freshen
 AT_CHECK([
@@ -847,6 +846,145 @@ runroot rpm -q versiontest
 ],
 [])
 
+AT_CLEANUP
+
+AT_SETUP([rpm upgrade/downgrade epoch])
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb --define "ver 1.0" /data/SPECS/versiontest.spec
+runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/noepoch.rpm
+for e in 1 2; do
+    runroot rpmbuild --quiet -bb --define "ver 1.0" --define "epoch ${e}" /data/SPECS/versiontest.spec
+    runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/epoch${e}.rpm
+done
+# for testing sanity
+runroot_other echo '%_query_all_fmt %%{nevra}' > ${HOME}/.rpmmacros
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/noepoch.rpm
+runroot rpm -U /tmp/epoch1.rpm
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-1:1.0-1.noarch
+],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch1.rpm
+runroot rpm -U /tmp/epoch2.rpm
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-2:1.0-1.noarch
+],
+[])
+
+# XXX this should be FAIL, but don't want to fail all the test just because...
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch1.rpm
+runroot rpm -U /tmp/noepoch.rpm
+],
+[2],
+[],
+[	package versiontest-1:1.0-1.noarch (which is newer than versiontest-1.0-1.noarch) is already installed
+	package versiontest-1.0-1.noarch is already installed
+])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch2.rpm
+runroot rpm -U /tmp/epoch1.rpm
+],
+[2],
+[],
+[	package versiontest-2:1.0-1.noarch (which is newer than versiontest-1:1.0-1.noarch) is already installed
+])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch2.rpm
+runroot rpm -U --oldpackage /tmp/epoch1.rpm
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-1:1.0-1.noarch
+],
+[])
+
+# XXX this should be FAIL, but don't want to fail all the test just because...
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch1.rpm
+runroot rpm -U --oldpackage /tmp/noepoch.rpm
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-1:1.0-1.noarch
+],
+[	package versiontest-1.0-1.noarch is already installed
+])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/noepoch.rpm
+runroot rpm -e versiontest-1.0-1
+],
+[0],
+[],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch1.rpm
+runroot rpm -e versiontest-1.0-1
+],
+[0],
+[],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -i /tmp/noepoch.rpm
+runroot rpm -i /tmp/epoch1.rpm
+
+# gah, versions listed on stdout but error message on stderr
+runroot rpm -e versiontest 1>&2
+runroot rpm -e versiontest-1.0-1 1>&2
+runroot rpm -e versiontest-1:1.0-1 1>&2
+runroot rpm -q versiontest
+],
+[0],
+[versiontest-1.0-1.noarch
+],
+[error: "versiontest" specifies multiple packages:
+  versiontest-1.0-1.noarch
+  versiontest-1:1.0-1.noarch
+error: "versiontest-1.0-1" specifies multiple packages:
+  versiontest-1.0-1.noarch
+  versiontest-1:1.0-1.noarch
+])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/noepoch.rpm
+runroot rpm -U --replacepkgs /tmp/noepoch.rpm
+],
+[0],
+[],
+[])
+
+AT_CHECK([
+RPMDB_INIT
+runroot rpm -U /tmp/epoch1.rpm
+runroot rpm -U --replacepkgs /tmp/epoch1.rpm
+],
+[0],
+[],
+[])
 AT_CLEANUP
 
 AT_SETUP([rpm -U obsoleted packages])


### PR DESCRIPTION
A missing epoch is returned as NULL from rpmteE(), but the rpmdb matching code can't handle NULL in any meaningful way currently. Arguably it should, but that's a bigger topic...
    
Specifically convert a missing epoch to a "0" which matches the behavior in mireSkip() to handle, adjust testcases as appropriate. 

Add a whole bunch of epoch related tests, and refactor related copy-paste code to a helper function while at it.
