### PR TITLE
Implement test-suite execution in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,12 @@ foreach(f macros rpmrc rpmpopt-${PROJECT_VERSION})
 	install(FILES ${CMAKE_BINARY_DIR}/${f} DESTINATION ${RPMCONFIGDIR})
 endforeach()
 
+find_program(AUTOM4TE autom4te)
+find_program(FAKECHROOT fakechroot)
+if (DEFINED AUTOM4TE AND DEFINED FAKECHROOT)
+	add_subdirectory(tests)
+endif()
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rpm.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 install(DIRECTORY DESTINATION ${RPMCONFIGDIR}/lua)
 install(DIRECTORY DESTINATION ${RPMCONFIGDIR}/macros.d)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -11,8 +11,7 @@ RUN sed -i -e "s:^gpgcheck=.$:gpgcheck=1:g" /etc/yum.repos.d/*.repo
 RUN dnf -y update
 RUN dnf -y install \
   autoconf \
-  automake \
-  libtool \
+  cmake \
   gettext-devel \
   debugedit \
   doxygen \
@@ -53,22 +52,12 @@ RUN dnf -y install \
 
 COPY . .
 
-RUN autoreconf -vfi
-RUN ./configure \
-  --with-crypto=libgcrypt \
-  --with-selinux \
-  --with-cap \
-  --with-acl \
-  --with-audit \
-  --with-fsverity \
-  --enable-ndb \
-  --enable-bdb-ro \
-  --enable-sqlite \
-  --enable-python \
-  --enable-silent-rules \
-  --enable-werror
+WORKDIR /srv/rpm/_build
+RUN cmake \
+	-DENABLE_WERROR=ON \
+	-DENABLE_BDB_RO=ON \
+	-DWITH_FSVERITY=ON \
+	-DWITH_IMAEVM=ON \
+	..
 
-# --enable-werror equivalent for Doxygen
-RUN sed -i -e "/^WARN_AS_ERROR/s/ NO/ YES/g" docs/librpm.doxy.in
-
-CMD make -j$(nproc) distcheck TESTSUITEFLAGS=-j$(nproc); rc=$?; find . -name rpmtests.log|xargs cat; exit $rc
+CMD make -j$(nproc) check; rc=$?; find . -name rpmtests.log|xargs cat; exit $rc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,81 @@
+set(PYTHON ${Python3_EXECUTABLE})
+set(pyexecdir ${Python3_SITEARCH})
+set(usrbindir ${CMAKE_INSTALL_FULL_BINDIR})
+set(usrlibdir ${CMAKE_INSTALL_FULL_LIBDIR})
+if (${WITH_INTERNAL_OPENPGP})
+	if (${WITH_OPENSSL})
+		set(CRYPTO openssl)
+	else()
+		set(CRYPTO libgcrypt)
+	endif()
+else()
+	set(CRYPTO sequoia)
+endif()
+
+configure_file(atlocal.in atlocal @ONLY)
+configure_file(package.m4.in package.m4 @ONLY)
+
+set(TESTSUITE_AT
+	rpmtests.at
+	rpmgeneral.at
+	rpmquery.at
+	rpmverify.at
+	rpmdb.at
+	rpmbuild.at
+	rpmbuildid.at
+	rpmi.at
+	rpme.at
+	rpmvercmp.at
+	rpmdeps.at
+	rpmconflict.at
+	rpmconfig.at
+	rpmconfig2.at
+	rpmconfig3.at
+	rpmreplace.at
+	rpmmacro.at
+	rpmpython.at
+	rpmdepmatch.at
+	rpmscript.at
+	rpmsigdig.at
+	rpmspec.at
+	rpmio.at
+	rpmorder.at
+	rpmvfylevel.at
+	rpmpgp.at
+)
+
+set(AUTOTEST ${AUTOM4TE} --language=autotest)
+add_custom_target(rpmtests COMMAND
+	${AUTOTEST} -I ${CMAKE_CURRENT_SOURCE_DIR} -o rpmtests rpmtests.at
+	SOURCES ${TESTSUITE_AT}
+)
+add_custom_target(populate_testing COMMAND
+	${CMAKE_CURRENT_SOURCE_DIR}/populate
+		${CMAKE_BINARY_DIR}
+		${CMAKE_CURRENT_BINARY_DIR}
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_INSTALL_FULL_BINDIR}
+		${CMAKE_MAKE_PROGRAM}
+	SOURCES populate
+)
+
+include(ProcessorCount)
+ProcessorCount(nproc)
+if (nproc GREATER 1)
+	set(jobs -j${nproc})
+endif()
+
+add_custom_target(check ${CMAKE_COMMAND} -E env
+	"abs_builddir=${CMAKE_CURRENT_BINARY_DIR}"
+	"abs_srcdir=${CMAKE_CURRENT_SOURCE_DIR}"
+	"abs_top_builddir=${CMAKE_BINARY_DIR}"
+	./rpmtests ${jobs}
+	DEPENDS populate_testing
+	DEPENDS rpmtests
+)
+
+set (testprogs rpmpgpcheck rpmpgppubkeyfingerprint)
+foreach(prg ${testprogs})
+	add_executable(${prg} ${prg}.c)
+	target_link_libraries(${prg} PRIVATE librpmio)
+endforeach()

--- a/tests/package.m4.in
+++ b/tests/package.m4.in
@@ -1,0 +1,6 @@
+# Signature of the current package.
+m4_define([AT_PACKAGE_NAME],      [@PROJECT_NAME@])
+m4_define([AT_PACKAGE_TARNAME],   [@PROJECT_NAME@])
+m4_define([AT_PACKAGE_VERSION],   [@PROJECT_VERSION@])
+m4_define([AT_PACKAGE_STRING],    [@PROJECT_NAME@ @PROJECT_VERSION@])
+m4_define([AT_PACKAGE_BUGREPORT], [@PROJECT_HOMEPAGE_URL@])


### PR DESCRIPTION
Apparently the "testsuite voodoo" comment in tests/Makefile.am has scared everybody (myself included) from even looking at how this all works. Turns out, it's not so magic afterall, and better yet is not at all tightly integrated with the rest of the surrounding autotools works. There are paths to be communicated and translated and for some items different mechanisms are more sensible, but that's to be expected.

While having a dependency to autom4te (from autoconf package) in a cmake build is not ideal, this is hardly an end of the world either as long as it doesn't require the entire build to be autoconf based. Means we don't need to port it to something else just now. Phew!