### PR TITLE
tests: fix the print with --eval .'%undefine xxx'.

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -929,7 +929,7 @@ runroot rpm \
 2
 .    .
 2
-..
+.
 %xxx
 ])
 AT_CLEANUP


### PR DESCRIPTION
https://github.com/rpm-software-management/rpm/commit/aec8bdb53a3013eabf16368e17a65ab69c2136ee introduced function changes, which cause the output of the following command is changed.
`rpm --define '%foo() %{expand:%define xxx 1} %{echo:%xxx} %{expand: %global xxx 2} %{echo:%xxx}' --eval .'%foo'. --eval '%xxx' --eval .'%undefine xxx'. --eval '%xxx'`
Before https://github.com/rpm-software-management/rpm/commit/aec8bdb53a3013eabf16368e17a65ab69c2136ee, the result of the command is :
```
1
2
.    .
2
..
2
```
now is:
```
1
2
.    .
2
.
2
```