### PR TITLE
Remember to set include directories from pkgconfig for Lua

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -14,6 +14,7 @@ set_target_properties(librpmbuild PROPERTIES
 	SOVERSION ${RPM_SOVERSION}
 )
 target_sources(librpmbuild PRIVATE ${librpmbuild_SOURCES})
+target_include_directories(librpmbuild PRIVATE ${LUA_INCLUDE_DIRS})
 target_link_libraries(librpmbuild PUBLIC librpmio librpm)
 target_link_libraries(librpmbuild PRIVATE
 	libmisc

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,6 +60,7 @@ add_custom_command(OUTPUT tagtbl.C
 )
 
 target_sources(librpm PRIVATE ${librpm_SOURCES} tagtbl.C)
+target_include_directories(librpm PRIVATE ${LUA_INCLUDE_DIRS})
 target_link_libraries(librpm PUBLIC librpmio)
 target_link_libraries(librpm PRIVATE ${POPT_LIBRARIES} ${LUA_LIBRARIES})
 

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -32,6 +32,7 @@ set_target_properties(librpmio PROPERTIES
 	SOVERSION ${RPM_SOVERSION}
 )
 target_sources(librpmio PRIVATE ${librpmio_SOURCES})
+target_include_directories(librpmio PRIVATE ${LUA_INCLUDE_DIRS})
 target_link_libraries(librpmio PRIVATE ${POPT_LIBRARIES} ${LUA_LIBRARIES})
 
 set(iolibs ZLIB BZIP2 LIBLZMA ZSTD)


### PR DESCRIPTION
We should really do this for all our dependencies, but notably Debian and derivates have multiple versions of Lua available, each in different includedir, and build fails without this.

Fixes: #2258