### PR TITLE
Fix rpm is blocked when install a package which contains fifo files

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1015,8 +1015,13 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 
 	    if (!rc && fd == -1 && !S_ISLNK(fp->sb.st_mode)) {
 		/* Only follow safe symlinks, and never on temporary files */
-		fd = fsmOpenat(di.dirfd, fp->fpath,
-				fp->suffix ? AT_SYMLINK_NOFOLLOW : 0, 0);
+		int flags = fp->suffix ? AT_SYMLINK_NOFOLLOW : 0;
+
+		/* Open the FIFO file in O_RDWR mode to prevent process blocking */
+		if (S_ISFIFO(fp->sb.st_mode))
+		    flags |= O_RDWR;
+
+		fd = fsmOpenat(di.dirfd, fp->fpath, flags, 0);
 		if (fd < 0)
 		    rc = RPMERR_OPEN_FAILED;
 	    }


### PR DESCRIPTION
When installing an RPM package that contains fifo files, the installation is blocked. For details, see #2195.