### PR TITLE
Make CPU and thread-related macros available on all platforms

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -700,6 +700,22 @@ package or when debugging this package.\
 # Macro to fix broken permissions in sources
 %_fixperms      %{__chmod} -Rf a+rX,u+w,g-w,o-w
 
+# Maximum number of CPU's to use when building, 0 for unlimited.
+#%_smp_ncpus_max 0
+
+%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
+	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
+        ncpus_max=%{?_smp_ncpus_max}; \\\
+        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
+        echo "$RPM_BUILD_NCPUS";)
+
+%_smp_mflags -j%{_smp_build_ncpus}
+
+# Maximum number of threads to use when building, 0 for unlimited
+#%_smp_nthreads_max 0
+
+%_smp_build_nthreads %{_smp_build_ncpus}
+
 #==============================================================================
 # ---- Scriptlet template templates.
 #	Global defaults used for building scriptlet templates.

--- a/platform.in
+++ b/platform.in
@@ -48,22 +48,6 @@
 
 %_defaultdocdir		%{_datadir}/doc
 
-# Maximum number of CPU's to use when building, 0 for unlimited.
-#%_smp_ncpus_max 0
-
-%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
-	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
-        ncpus_max=%{?_smp_ncpus_max}; \\\
-        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
-        echo "$RPM_BUILD_NCPUS";)
-
-%_smp_mflags -j%{_smp_build_ncpus}
-
-# Maximum number of threads to use when building, 0 for unlimited
-#%_smp_nthreads_max 0
-
-%_smp_build_nthreads %{_smp_build_ncpus}
-
 #==============================================================================
 # ---- Build policy macros.
 #


### PR DESCRIPTION
%_smp_mflags and the related macros that it grew around itself used to be platform specific as they relied on external tooling (eg getconf for getting processor count), but since rpm 4.15 this has been backed by the built-in %{getncpus} macro which is available on all platforms, so there's zero reason to duplicate this stuff on all platform files.

Fixes: #2265