### PR TITLE
Eliminate remaining %{u2p:...} uses

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -709,8 +709,8 @@ package or when debugging this package.\
 %___build_args		-e
 %___build_cmd		%{?_sudo:%{_sudo} }%{?_remsh:%{_remsh} %{_remhost} }%{?_remsudo:%{_remsudo} }%{?_remchroot:%{_remchroot} %{_remroot} }%{___build_shell} %{___build_args}
 %___build_pre	\
-  RPM_SOURCE_DIR=\"%{u2p:%{_sourcedir}}\"\
-  RPM_BUILD_DIR=\"%{u2p:%{_builddir}}\"\
+  RPM_SOURCE_DIR=\"%{_sourcedir}\"\
+  RPM_BUILD_DIR=\"%{_builddir}\"\
   RPM_OPT_FLAGS=\"%{optflags}\"\
   RPM_ARCH=\"%{_arch}\"\
   RPM_OS=\"%{_os}\"\
@@ -725,7 +725,7 @@ package or when debugging this package.\
   LANG=C\
   export LANG\
   unset CDPATH DISPLAY ||:\
-  %{?buildroot:RPM_BUILD_ROOT=\"%{u2p:%{buildroot}}\"\
+  %{?buildroot:RPM_BUILD_ROOT=\"%{buildroot}\"\
   export RPM_BUILD_ROOT}\
   %{?_javaclasspath:CLASSPATH=\"%{_javaclasspath}\"\
   export CLASSPATH}\
@@ -734,7 +734,7 @@ package or when debugging this package.\
   \
   %[%{verbose}?"set -x":""]\
   umask 022\
-  cd \"%{u2p:%{_builddir}}\"\
+  cd \"%{_builddir}\"\
 
 
 #%___build_body		%{nil}


### PR DESCRIPTION
The build and source directories are plain old directories, never any sort of URLs. Drop the misleading and obfuscating u2p macro uses from the build environment setting.

As of this commit, u2p is unused within rpm.