### PR TITLE
Fix regression: -bp should check BuildRequires

### DIFF
--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -674,6 +674,9 @@ int main(int argc, char *argv[])
 	/* fallthrough */
     case 'p':
 	ba->buildAmount |= RPMBUILD_PREP;
+	if (!noDeps) {
+	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
+	}
 	break;
     case 'l':
 	ba->buildAmount |= RPMBUILD_FILECHECK;

--- a/tests/data/SPECS/specstep.spec
+++ b/tests/data/SPECS/specstep.spec
@@ -3,6 +3,7 @@ Version: 1.0
 Release: 1
 Summary: Testing spec steps
 License: GPL
+%{?preamble}
 
 %description
 %{summary}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -56,6 +56,14 @@ runroot rpmbuild -bp /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 [])
 
 AT_CHECK([
+runroot rpmbuild -bp -D "preamble BuildRequires:foo" /data/SPECS/specstep.spec 2>&1|grep ^error:
+],
+[0],
+[error: Failed build dependencies:
+],
+[])
+
+AT_CHECK([
 runroot rpmbuild -br /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],


### PR DESCRIPTION
Some source packages assume that BuildRequires are installed before %prep is executed.  For example, `openssh` BuildRequires `automake` and runs `autoreconf` in %prep.

Prior to 11c56d5 `rpmbuild -bp` checked BuildRequires and printed a helpful error message if there were any missing dependencies.  Since that commit, `rpmbuild -bp` skips the BuildRequires check, which can lead to misleading errors in %prep.

This commit restores the BuildRequires check in `rpmbuild -bp`.