### PR TITLE
Fix rpmkeys type confusion test.

### DIFF
--- a/tests/rpmsigdig.at
+++ b/tests/rpmsigdig.at
@@ -627,7 +627,11 @@ gpg(a72b7d4f62837bea) = 4:a72b7d4f62837bea-62553e62
 [])
 AT_CLEANUP
 
+# The internal OpenPGP parser rejects the key.  The Sequoia parser
+# just ignores the invalid components and imports the rest.  This test
+# checks the behavior of the internal parser.
 AT_SETUP([rpmkeys type confusion])
+AT_SKIP_IF([test x$PGP != xinternal])
 AT_CHECK([
 RPMDB_INIT
 


### PR DESCRIPTION
The `rpmkeys type confusion` test was added in ec13083f46a1e to check that the internal OpenPGP parser rejects a certificate with an invalid component.  The Sequoia backend happily accepts the certificate and ignores the invalid component, which causes the test to fail.  Mark the test as specific to the internal OpenPGP backend.

Fixes #2272.