### PR TITLE
Fix missing headers/footers in generated man pages

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -34,8 +34,8 @@ foreach(man ${manuals})
 	# XXX manuals should be pre-built in tarballs
 	if (EXISTS ${PANDOC})
 		add_custom_command(OUTPUT ${man} COMMAND ${PANDOC}
-				${CMAKE_CURRENT_SOURCE_DIR}/${man}.md -o ${man}
-				DEPENDS ${man}.md)
+				${CMAKE_CURRENT_SOURCE_DIR}/${man}.md
+				-s -t man -o ${man} DEPENDS ${man}.md)
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${man} TYPE MAN)
 	endif()
 endforeach()


### PR DESCRIPTION
Pass -s/--standalone to pandoc as it's needed in order for the man pages to render properly in man(1), we also used this option pre-cmake.

Fixes: #2283