### PR TITLE
Allow piping from rpm2archive

### DIFF
--- a/docs/man/rpm2archive.8.md
+++ b/docs/man/rpm2archive.8.md
@@ -17,12 +17,13 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-**rpm2archive** converts the .rpm files specified as arguments to tar
-files. By default they are gzip compressed and saved with postfix
-\".tgz\".
+**rpm2archive** converts the .rpm files specified as arguments to tar archives
+on standard out.
 
-If \'-\' is given as argument, an rpm stream is read from standard in
-and written to standard out.
+If a \'-\' argument is given, an rpm stream is read from standard in.
+
+If standard out is connected to a terminal, the output is written to tar files
+with a \".tgz\" suffix, gzip compressed by default.
 
 In opposite to **rpm2cpio** **rpm2archive** also works with RPM packages
 containing files greater than 4GB which are not supported by cpio.
@@ -41,8 +42,8 @@ EXAMPLES
 ========
 
 \
-***rpm2archive glint-1.0-1.i386.rpm ; tar -xvz
-glint-1.0-1.i386.rpm.tgz***\
+***rpm2archive glint-1.0-1.i386.rpm \| tar -xvz***\
+***rpm2archive glint-1.0-1.i386.rpm ; tar -xvz glint-1.0-1.i386.rpm.tgz***\
 ***cat glint-1.0-1.i386.rpm \| rpm2archive - \| tar -tvz***
 
 SEE ALSO

--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -141,13 +141,13 @@ static int process_package(rpmts ts, const char * filename)
 	fprintf(stderr, "Error: Format pax restricted is not supported\n");
 	exit(EXIT_FAILURE);
     }
-    if (!strcmp(filename, "-")) {
-	if (isatty(STDOUT_FILENO)) {
+    if (!isatty(STDOUT_FILENO)) {
+	archive_write_open_fd(a, STDOUT_FILENO);
+    } else {
+        if (!strcmp(filename, "-")) {
 	    fprintf(stderr, "Error: refusing to output archive data to a terminal.\n");
 	    exit(EXIT_FAILURE);
 	}
-	archive_write_open_fd(a, STDOUT_FILENO);
-    } else {
 	char * outname;
 	if (urlIsURL(filename)) {
 	    const char * fname = strrchr(filename, '/');


### PR DESCRIPTION
If stdout is not a terminal, output the archive(s) to it, instead of creating file(s) on disk.  This makes rpm2archive consistent with rpm2cpio. This makes rpm2archive consistent with rpm2cpio.

Based on a patch from yangchenguang <yangchenguang@uniontech.com>.