### PR TITLE
Issue a warning when signing created an OpenPGP v3 signature

### DIFF
--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -142,13 +142,13 @@ static rpmtd makeSigTag(Header sigh, int ishdr, uint8_t *pkt, size_t pktlen)
     unsigned int pubkey_algo;
 
     if (pgpPrtParams(pkt, pktlen, PGPTAG_SIGNATURE, &sigp)) {
-	rpmlog(RPMLOG_ERR, _("Unsupported PGP signature\n"));
+	rpmlog(RPMLOG_ERR, _("Unsupported OpenPGP signature\n"));
 	goto exit;
     }
 
     hash_algo = pgpDigParamsAlgo(sigp, PGPVAL_HASHALGO);
     if (rpmDigestLength(hash_algo) == 0) {
-	rpmlog(RPMLOG_ERR, _("Unsupported PGP hash algorithm %u\n"), hash_algo);
+	rpmlog(RPMLOG_ERR, _("Unsupported OpenPGP hash algorithm %u\n"), hash_algo);
 	goto exit;
     }
 
@@ -162,7 +162,7 @@ static rpmtd makeSigTag(Header sigh, int ishdr, uint8_t *pkt, size_t pktlen)
 	sigtag = ishdr ? RPMSIGTAG_RSA : RPMSIGTAG_PGP;
 	break;
     default:
-	rpmlog(RPMLOG_ERR, _("Unsupported PGP pubkey algorithm %u\n"),
+	rpmlog(RPMLOG_ERR, _("Unsupported OpenPGP pubkey algorithm %u\n"),
 		pubkey_algo);
 	goto exit;
 	break;

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -140,6 +140,7 @@ static rpmtd makeSigTag(Header sigh, int ishdr, uint8_t *pkt, size_t pktlen)
     rpmtd sigtd = NULL;
     unsigned int hash_algo;
     unsigned int pubkey_algo;
+    int ver;
 
     if (pgpPrtParams(pkt, pktlen, PGPTAG_SIGNATURE, &sigp)) {
 	rpmlog(RPMLOG_ERR, _("Unsupported OpenPGP signature\n"));
@@ -166,6 +167,12 @@ static rpmtd makeSigTag(Header sigh, int ishdr, uint8_t *pkt, size_t pktlen)
 		pubkey_algo);
 	goto exit;
 	break;
+    }
+
+    ver = pgpDigParamsVersion(sigp);
+    if (ver < 4) {
+	rpmlog(RPMLOG_WARNING, _("Deprecated OpenPGP signature version %d\n"),
+		ver);
     }
 
     /* Looks sane, create the tag data */


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2141686 revealed that much of the rpm-ecosystem is still using the obsolete v3 OpenPGP signature format, I think largely due to workarounds for legacy rpm versions (from around the turn of the millennium) that have just been forgotten in place. Lets at least issue a wake-up warning when that happens.

Unfortunately this is can't really be tested as current GnuPG versions just ignore any --force-v3-sigs arguments.

Fixes: #2286