### PR TITLE
to check pandoc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ pkg_check_modules(READLINE readline)
 pkg_check_modules(ZSTD libzstd)
 pkg_check_modules(LIBELF libelf)
 pkg_check_modules(LIBDW libdw)
+pkg_check_modules(PANDOC pandoc REQUIRED)
 
 if (ENABLE_OPENMP)
 	find_package(OpenMP REQUIRED)


### PR DESCRIPTION
Hi,
    ``PANDOC`` is required to build manual and It shall be checked.
    This PR is to check ``PANDOC`` in ```CMakeList.txt```.
    Could U help to review it?  Thanks