### PR TITLE
Add --generate-subpackages to find_lang.sh

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -189,6 +189,17 @@ package or when debugging this package.\
 %endif\
 %{nil}
 
+%_langpack_template() \
+%package langpack-%{1}\
+Summary:       %{2} language data for %{name}\
+BuildArch:     noarch\
+Requires:      %{name} = %{version}-%{release}\
+Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
+%description langpack-%{1}\
+%{2} language data for %{name}.\
+%files langpack-%{1}\
+%{nil}
+
 %_defaultdocdir		%{_datadir}/doc
 %_defaultlicensedir	%{_datadir}/licenses
 

--- a/tests/data/SPECS/find-lang-test.spec
+++ b/tests/data/SPECS/find-lang-test.spec
@@ -27,7 +27,7 @@ done
 mkdir -p  $RPM_BUILD_ROOT/%{_datadir}/%{name}
 touch $RPM_BUILD_ROOT/%{_datadir}/%{name}/empty.txt
 
-%find_lang  %{name} --with-man --without-mo
+%find_lang  %{name} --with-man --without-mo %{?langpacks:--generate-subpackages}
 
 %files -f %{name}.lang
 %defattr(-,root,root,-)

--- a/tests/data/SPECS/find-lang-test.spec
+++ b/tests/data/SPECS/find-lang-test.spec
@@ -1,0 +1,35 @@
+# avoid depending on rpm configuration
+%define _datadir /usr/share
+
+Name:           find-lang-test 
+Version:        1.0
+Release:        1
+Summary:        Testing find-lang behavior
+Group:          Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%prep
+%setup -c -T
+
+%install
+for f in fi de_DE pl ""; do
+    mkdir -p $RPM_BUILD_ROOT/%{_datadir}/man/$f/man1
+    echo "This is $f language" | gzip > $RPM_BUILD_ROOT/%{_datadir}/man/$f/man1/%{name}.1.gz
+done
+
+
+#echo "This is en language" | gzip > $RPM_BUILD_ROOT/%{_datadir}/man/man1/%{name}.1.gz
+
+mkdir -p  $RPM_BUILD_ROOT/%{_datadir}/%{name}
+touch $RPM_BUILD_ROOT/%{_datadir}/%{name}/empty.txt
+
+%find_lang  %{name} --with-man --without-mo
+
+%files -f %{name}.lang
+%defattr(-,root,root,-)
+%{_datadir}/%{name}/empty.txt
+%{_datadir}/man/man1/%{name}*

--- a/tests/populate
+++ b/tests/populate
@@ -34,7 +34,7 @@ done
 for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do
 	[ -f /etc/${cf} ] && ln -s /etc/${cf} testing/etc/${cf}
 done
-for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod; do
+for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod locale; do
 	p=`which ${prog}`
 	if [ "${p}" != "" ]; then
 		ln -s ${p} testing/${bindir}/

--- a/tests/populate
+++ b/tests/populate
@@ -34,7 +34,7 @@ done
 for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do
 	[ -f /etc/${cf} ] && ln -s /etc/${cf} testing/etc/${cf}
 done
-for prog in gzip cat cp patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod; do
+for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod; do
 	p=`which ${prog}`
 	if [ "${p}" != "" ]; then
 		ln -s ${p} testing/${bindir}/

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -202,6 +202,34 @@ pl /usr/share/man/pl/man1/find-lang-test.1.gz
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild -ba find-lang --generate-subpackages])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+runroot rpmbuild -D "langpacks 1"\
+  -ba /data/SPECS/find-lang-test.spec
+],
+[0],
+[ignore],
+[ignore])
+
+AT_CHECK([[
+runroot rpm -qp --qf '%{NVRA}\n[%{FILELANGS} %{FILENAMES}\n]' /build/RPMS/noarch/find-lang-test*-1.0-1.noarch.rpm
+]],
+[0],
+[find-lang-test-1.0-1.noarch
+ /usr/share/find-lang-test/empty.txt
+ /usr/share/man/man1/find-lang-test.1.gz
+find-lang-test-langpack-de-1.0-1.noarch
+de /usr/share/man/de_DE/man1/find-lang-test.1.gz
+find-lang-test-langpack-fi-1.0-1.noarch
+fi /usr/share/man/fi/man1/find-lang-test.1.gz
+find-lang-test-langpack-pl-1.0-1.noarch
+pl /usr/share/man/pl/man1/find-lang-test.1.gz
+],
+[ignore])
+AT_CLEANUP
+
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -178,6 +178,30 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild -ba find-lang])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+runroot rpmbuild \
+  -ba /data/SPECS/find-lang-test.spec
+],
+[0],
+[ignore],
+[ignore])
+
+AT_CHECK([[
+runroot rpm -qp --qf '[%{FILELANGS} %{FILENAMES}\n]' /build/RPMS/noarch/find-lang-test-1.0-1.noarch.rpm
+]],
+[0],
+[ /usr/share/find-lang-test/empty.txt
+de /usr/share/man/de_DE/man1/find-lang-test.1.gz
+fi /usr/share/man/fi/man1/find-lang-test.1.gz
+ /usr/share/man/man1/find-lang-test.1.gz
+pl /usr/share/man/pl/man1/find-lang-test.1.gz
+],
+[ignore])
+AT_CLEANUP
+
 # ------------------------------
 # Check if rpmbuild --rebuild *.src.rpm works
 AT_SETUP([rpmbuild --rebuild])


### PR DESCRIPTION
Use the new dynamic spec feature to create language sub packages.

The is more of a RFC as there are a few things that need more polishing. The code for getting the language description is a bit ad-hoc and may need to switch to another entry in `locale` data. Suggestions welcome.

The package declaration should probably also move into a macro. Probably to the point where the spec parts are only one macro with the right parameters