### PR TITLE
Fix Header leak when running rpm2cpio

### DIFF
--- a/rpm2cpio.c
+++ b/rpm2cpio.c
@@ -96,6 +96,8 @@ int main(int argc, char *argv[])
 
     rc = (ufdCopy(gzdi, fdo) == payload_size) ? EXIT_SUCCESS : EXIT_FAILURE;
 
+    headerFree(h);
+
     Fclose(fdo);
 
     Fclose(gzdi);	/* XXX gzdi == fdi */


### PR DESCRIPTION
Header "h" is alloced in rpmReadPackageFile but not freed when running rpm2cpio. Fix it.