### PR TITLE
Default to Sequoia crypto as per roadmap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(ENABLE_BDB_RO "Enable read-only Berkeley DB rpmdb support (EXPERIMENTAL)"
 option(ENABLE_TESTSUITE "Enable test-suite" ON)
 option(ENABLE_CI "Enable local CI (containerized test-suite)" OFF)
 
-option(WITH_INTERNAL_OPENPGP "Use internal OpenPGP parse (DEPRECATED)" ON)
+option(WITH_INTERNAL_OPENPGP "Use internal OpenPGP parse (DEPRECATED)" OFF)
 option(WITH_OPENSSL "Use openssl (instead of libgcrypt) for internal crypto" OFF)
 
 option(WITH_CAP "Build with capability support" ON)

--- a/INSTALL
+++ b/INSTALL
@@ -27,14 +27,13 @@ The source for the file utility + library is available from
     ftp://ftp.astron.com/pub/file/
 
 You will need a cryptographic library to support digests and
-signatures. This depends on the OpenPGP parser used: if using the deprecated
-internal parser (-DWITH_INTERNAL_OPENPGP=ON), the default is libgcrypt,
-but alternatively OpenSSL can be used by specifying -DWITH_OPENSSL=ON.
-If -DWITH_INTERNAL_OPENPGP=OFF is specified, Sequoia will be used for
-all cryptography.
+signatures. This depends on the OpenPGP parser used: the default is
+rpm-sequoia library, which is available from
+    https://github.com/rpm-software-management/rpm-sequoia
 
-Sequoia is used via the rpm-sequoia library, which is available from
-https://github.com/rpm-software-management/rpm-sequoia
+If using the deprecated internal parser (-DWITH_INTERNAL_OPENPGP=ON),
+the default is libgcrypt, but alternatively OpenSSL can be used by
+additionally specifying -DWITH_OPENSSL=ON.
 
 libgcrypt library is available from https://www.gnupg.org/software/libgcrypt/
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf -y install \
   elfutils-devel \
   openssl-devel \
   libgcrypt-devel \
+  rpm-sequoia-devel \
   file-devel \
   popt-devel \
   libarchive-devel \


### PR DESCRIPTION
Defaulting to a deprecated build option tends to looks a bit strange. Make Sequoia the default crypto option, update docs and add the dependency to CI environment.

Fixes: #2065