### PR TITLE
Fix broken markdown quoting …

### DIFF
--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -96,13 +96,13 @@ definition:
 
 Version of the packaged content, typically software.
 
-The version string consists of alphanumeric characters, and can optionally
-be segmented with separators `.`, ```_``` and `+`.
+The version string consists of alphanumeric characters, which can optionally
+be segmented with the separators `.`, `_` and `+`, plus `~` and `^` (see below).
 
-Tilde (`~`) can be used to force sorting lower than base (1.1~201601 < 1.1)
-Caret (`^`) can be used to force sorting higher than base (1.1^201601 > 1.1)
+Tilde (`~`) can be used to force sorting lower than base (1.1\~201601 < 1.1)
+Caret (`^`) can be used to force sorting higher than base (1.1^201601 > 1.1).
 These are useful for handling pre- and post-release versions, such as
-1.0~rc1 and 2.0^a.
+1.0\~rc1 and 2.0^a.
 
 #### Release
 

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -99,7 +99,7 @@ Version of the packaged content, typically software.
 The version string consists of alphanumeric characters, which can optionally
 be segmented with the separators `.`, `_` and `+`, plus `~` and `^` (see below).
 
-Tilde (`~`) can be used to force sorting lower than base (1.1\~201601 < 1.1)
+Tilde (`~`) can be used to force sorting lower than base (1.1\~201601 < 1.1).
 Caret (`^`) can be used to force sorting higher than base (1.1^201601 > 1.1).
 These are useful for handling pre- and post-release versions, such as
 1.0\~rc1 and 2.0^a.


### PR DESCRIPTION
… introduced in [commit 8b635e2](https://github.com/rpm-software-management/rpm/commit/8b635e2016931ec5bb7dddd6608c09b0b16f7b8e):
- [Lines 98 - 101](https://github.com/rpm-software-management/rpm/commit/8b635e2016931ec5bb7dddd6608c09b0b16f7b8e#diff-f0f022b189e54462e3284599236a3b192b721928da4bea1a85d738b25ba5eaa7R98-R101): The two tildes lacked quoting, hence the text between them was struck out.
- [Line 96](https://github.com/rpm-software-management/rpm/commit/8b635e2016931ec5bb7dddd6608c09b0b16f7b8e#diff-f0f022b189e54462e3284599236a3b192b721928da4bea1a85d738b25ba5eaa7R96): Eliminate IMO superfluous triple quoting:  **\`\`\`** → **\`**
- Rephrase [lines 95 - 96](https://github.com/rpm-software-management/rpm/commit/8b635e2016931ec5bb7dddd6608c09b0b16f7b8e#diff-f0f022b189e54462e3284599236a3b192b721928da4bea1a85d738b25ba5eaa7R95-R96), to be more concise.