### PR TITLE
char arrays need to be initialized before use

### DIFF
--- a/rpmbuild.c
+++ b/rpmbuild.c
@@ -319,7 +319,7 @@ static struct poptOption optionsTable[] = {
 
 static int isSpecFile(const char * specfile)
 {
-    char buf[256];
+    char buf[256]= {0};
     const char * s;
     FILE * f;
     int count;


### PR DESCRIPTION
static int isSpecFile(const char * specfile)
{
    char buf[256];
    
  -------------
  count = fread(buf, sizeof(buf[0]), sizeof(buf), f);