### PR TITLE
Fix silent wait when missing input RPM package

### DIFF
--- a/rpm2archive.c
+++ b/rpm2archive.c
@@ -83,6 +83,10 @@ static int process_package(rpmts ts, const char * filename)
     struct archive_entry *entry;
 
     if (!strcmp(filename, "-")) {
+        if(isatty(STDIN_FILENO)) {
+            fprintf(stderr, "Error: missing input RPM package\n");
+            exit(EXIT_FAILURE);
+        }
 	fdi = fdDup(STDIN_FILENO);
     } else {
 	fdi = Fopen(filename, "r.ufdio");


### PR DESCRIPTION
Fix silent wait when missing input RPM package
Signed-off-by: yangchenguang <yangchenguang@uniontech.com>