### PR TITLE
Generate Python egg-info from automake builds (4.18.x)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -964,5 +964,6 @@ AC_CONFIG_FILES([Makefile
  	tests/Makefile
  	plugins/Makefile
 	python/setup.py
+	python/rpm.egg-info
   ])
 AC_OUTPUT

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -3,14 +3,21 @@
 include $(top_srcdir)/rpm.am
 AM_CFLAGS = @RPMCFLAGS@
 
-EXTRA_DIST = rpm/__init__.py rpm/transaction.py
+CLEANFILES =
+EXTRA_DIST = rpm/__init__.py rpm/transaction.py rpm.egg-info.in
 
 AM_CPPFLAGS = -I$(top_srcdir)/include/
 AM_CPPFLAGS += -I$(top_srcdir)/python
 AM_CPPFLAGS += @PYTHON_CFLAGS@
 
+egginfo = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-py$(PYTHON_VERSION).egg-info
+$(egginfo):
+	cat rpm.egg-info > $(egginfo)
+CLEANFILES += $(egginfo)
+
 pkgpyexec_LTLIBRARIES = _rpm.la
 pkgpyexec_DATA = rpm/__init__.py rpm/transaction.py
+pyexec_DATA = $(egginfo)
 
 _rpm_la_LDFLAGS = -module -avoid-version -shared
 _rpm_la_LIBADD = \

--- a/python/rpm.egg-info.in
+++ b/python/rpm.egg-info.in
@@ -1,0 +1,10 @@
+Metadata-Version: 1.0
+Name: @PACKAGE_NAME@
+Version: @PACKAGE_VERSION@
+Summary: Python bindings for rpm
+Home-page: @PACKAGE_URL@
+Author: Rpm community
+Author-email: rpm-maint@lists.rpm.org
+License: GNU General Public License v2
+Description: Python bindings for rpm
+Platform: UNKNOWN


### PR DESCRIPTION
To compensate for the loss of egg-info from the python distutils build, create one ourselves.

This is effectively a backport of e31fb5b75898bfa09180dba02475c6d01764d94f which dismissed the need for an automake version, but unfortunately Python 3.12 and automake-based rpm versions do co-exist in the same time-space continuum and we'll have to deal with this in rpm 4.18 as well.

As to why not just use distutils from python-setuptools: that variant turns the egg-info into a directory, which in rpm is a one-way street. And we don't need that multi megabyte Python library to fill in these couple of values, really.