### PR TITLE
Determine %_smp_mflags at build time

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -699,6 +699,22 @@ package or when debugging this package.\
 # Macro to fix broken permissions in sources
 %_fixperms      %{__chmod} -Rf a+rX,u+w,g-w,o-w
 
+# Maximum number of CPU's to use when building, 0 for unlimited.
+#%_smp_ncpus_max 0
+
+%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
+	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
+        ncpus_max=%{?_smp_ncpus_max}; \\\
+        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
+        echo "$RPM_BUILD_NCPUS";)
+
+%_smp_mflags -j%{_smp_build_ncpus}
+
+# Maximum number of threads to use when building, 0 for unlimited
+#%_smp_nthreads_max 0
+
+%_smp_build_nthreads %{_smp_build_ncpus}
+
 #==============================================================================
 # ---- Scriptlet template templates.
 #	Global defaults used for building scriptlet templates.

--- a/macros.in
+++ b/macros.in
@@ -708,7 +708,7 @@ package or when debugging this package.\
         if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
         echo "$RPM_BUILD_NCPUS";)
 
-%_smp_mflags -j%{_smp_build_ncpus}
+%_smp_mflags -j${RPM_BUILD_NCPUS}
 
 # Maximum number of threads to use when building, 0 for unlimited
 #%_smp_nthreads_max 0

--- a/platform.in
+++ b/platform.in
@@ -48,22 +48,6 @@
 
 %_defaultdocdir		%{_datadir}/doc
 
-# Maximum number of CPU's to use when building, 0 for unlimited.
-#%_smp_ncpus_max 0
-
-%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
-	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
-        ncpus_max=%{?_smp_ncpus_max}; \\\
-        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
-        echo "$RPM_BUILD_NCPUS";)
-
-%_smp_mflags -j%{_smp_build_ncpus}
-
-# Maximum number of threads to use when building, 0 for unlimited
-#%_smp_nthreads_max 0
-
-%_smp_build_nthreads %{_smp_build_ncpus}
-
 #==============================================================================
 # ---- Build policy macros.
 #


### PR DESCRIPTION
This cherry-picks 3 commits from master
to not embed the build machine CPU core count into .src.rpms

Fixes #2343 