### PR TITLE
Unbreak %dev directives in %files

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2229,14 +2229,11 @@ static rpmRC processBinaryFile(Package pkg, FileList fl, const char * fileName,
     if (fl->cur.isDir)
 	diskPath = rstrcat(&diskPath, "/");
 
+    if (fl->cur.devtype)
+	doGlob = 0;
+
     if (!doGlob) {
 	rc = addFile(fl, diskPath, NULL);
-	goto exit;
-    }
-
-    if (fl->cur.devtype) {
-	rpmlog(RPMLOG_ERR, _("%%dev glob not permitted: %s\n"), diskPath);
-	rc = RPMRC_FAIL;
 	goto exit;
     }
 

--- a/tests/data/SPECS/globtest.spec
+++ b/tests/data/SPECS/globtest.spec
@@ -38,3 +38,5 @@ ln -s %{testdir}/zub $RPM_BUILD_ROOT/%{testdir}/linkbad
 %{testdir}/b*g/
 %dir %{testdir}/foo
 %{testdir}/foo/*
+# Regression test for #2347
+%dev(b 1 2) /test-block

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -469,6 +469,7 @@ lrwxrwxrwx /opt/globtest/linkgood
 -rw-r--r-- /opt/globtest/zab
 -rw-r--r-- /opt/globtest/zeb
 -rw-r--r-- /opt/globtest/zib
+b--------- /test-block
 ],
 [warning: absolute symlink: /opt/globtest/linkbad -> /opt/globtest/zub
 warning: absolute symlink: /opt/globtest/linkgood -> /opt/globtest/zab


### PR DESCRIPTION
Somehow this fell through the cracks when refactoring processBinaryFile() in commit f062d5744c3ee338daaeb8e11b1fc20f9e44dee3, it basically disabled the use of the %dev directive altogether, oops.

Without rpmIsGlob() (which was also yanked in the recent cleanups), we can't easily determine whether a string is a glob pattern, so don't overcomplicate this and just remove the error message, and always consider any metachars in a %dev line literal.

Since %dev is meant for device *creation* [1] at install time and we never lstat() those filenames in addFile(), any use of globs within such a filename can only possibly be meant literally, period.

That doesn't mean we shouldn't actually document %dev itself in our own docs but let's do that separately.

Thanks Panu for discovering this regression and suggesting a fix!

[1] https://jfearn.fedorapeople.org/en-US/RPM/4/html-single/RPM_Guide/index.html

Fixes: #2347