### PR TITLE
Fix install of block and character special files (#2195, #2275)

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1022,7 +1022,8 @@ setmeta:
 		/* Only follow safe symlinks, and never on temporary files */
 		if (fp->suffix)
 		    flags |= AT_SYMLINK_NOFOLLOW;
-		fd = fsmOpenat(di.dirfd, fp->fpath, flags, 0);
+		fd = fsmOpenat(di.dirfd, fp->fpath, flags,
+				S_ISDIR(fp->sb.st_mode));
 		if (fd < 0)
 		    rc = RPMERR_OPEN_FAILED;
 	    }

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -558,7 +558,7 @@ static int fsmChown(int fd, int dirfd, const char *path, mode_t mode, uid_t uid,
 	    }
 	}
     } else {
-	int flags = S_ISLNK(mode) ? AT_SYMLINK_NOFOLLOW : 0;
+	int flags = AT_SYMLINK_NOFOLLOW;
 	rc = fchownat(dirfd, path, uid, gid, flags);
 	if (rc < 0) {
 	    struct stat st;

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1014,6 +1014,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
                     rc = RPMERR_UNKNOWN_FILETYPE;
             }
 
+setmeta:
 	    /* Special files require path-based ops */
 	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
 	    if (!rc && fd == -1 && mayopen) {
@@ -1024,7 +1025,6 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 		    rc = RPMERR_OPEN_FAILED;
 	    }
 
-setmeta:
 	    if (!rc && fp->setmeta) {
 		rc = fsmSetmeta(fd, di.dirfd, fp->fpath,
 				fi, plugins, fp->action,

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1014,7 +1014,9 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
                     rc = RPMERR_UNKNOWN_FILETYPE;
             }
 
-	    if (!rc && fd == -1 && !S_ISLNK(fp->sb.st_mode)) {
+	    /* Special files require path-based ops */
+	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
+	    if (!rc && fd == -1 && mayopen) {
 		/* Only follow safe symlinks, and never on temporary files */
 		fd = fsmOpenat(di.dirfd, fp->fpath,
 				fp->suffix ? AT_SYMLINK_NOFOLLOW : 0, 0);

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1018,9 +1018,11 @@ setmeta:
 	    /* Special files require path-based ops */
 	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
 	    if (!rc && fd == -1 && mayopen) {
+		int flags = O_RDONLY;
 		/* Only follow safe symlinks, and never on temporary files */
-		fd = fsmOpenat(di.dirfd, fp->fpath,
-				fp->suffix ? AT_SYMLINK_NOFOLLOW : 0, 0);
+		if (fp->suffix)
+		    flags |= AT_SYMLINK_NOFOLLOW;
+		fd = fsmOpenat(di.dirfd, fp->fpath, flags, 0);
 		if (fd < 0)
 		    rc = RPMERR_OPEN_FAILED;
 	    }

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -64,6 +64,12 @@ if grep -q '#define WITH_CAP 1' "${abs_top_builddir}/config.h"; then
 else
     CAP_DISABLED=true;
 fi
+if mknod foodev c 123 123; then
+   MKNOD_DISABLED=false
+   rm -f foodev
+else
+   MKNOD_DISABLED=true
+fi
 
 MALLOC_DEBUG=libc_malloc_debug.so.0
 if ! LD_PRELOAD=${MALLOC_DEBUG} /bin/true 2>&1 | grep -q ERROR; then

--- a/tests/data/SPECS/dev.spec
+++ b/tests/data/SPECS/dev.spec
@@ -1,0 +1,14 @@
+Name: dev
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Testing dev behavior
+BuildArch: noarch
+
+%description
+%{summary}
+
+%files
+%dev(c 11 22) /test-char
+%dev(b 33 44) /test-block

--- a/tests/data/SPECS/fifo.spec
+++ b/tests/data/SPECS/fifo.spec
@@ -1,0 +1,16 @@
+Name: fifo
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Testing fifo behavior
+BuildArch: noarch
+
+%description
+%{summary}
+
+%install
+mknod ${RPM_BUILD_ROOT}/test-fifo p
+
+%files
+/test-fifo

--- a/tests/populate
+++ b/tests/populate
@@ -34,7 +34,7 @@ done
 for cf in hosts resolv.conf passwd shadow group gshadow mtab ; do
 	[ -f /etc/${cf} ] && ln -s /etc/${cf} testing/etc/${cf}
 done
-for prog in gzip cat cp patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs; do
+for prog in gzip cat cp patch tar sh ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod; do
 	p=`which ${prog}`
 	if [ "${p}" != "" ]; then
 		ln -s ${p} testing/${bindir}/

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1389,6 +1389,21 @@ runroot rpm -q --whatprovides /
 [])
 AT_CLEANUP
 
+AT_SETUP([rpm -U fifo])
+AT_KEYWORDS([install])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/fifo.spec
+runroot rpm -U --ignoreos /build/RPMS/noarch/fifo-1.0-1.noarch.rpm
+runroot rpm -Vv --nouser --nogroup fifo
+],
+[0],
+[.........    /test-fifo
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([rpm -U with Obsoletes])
 AT_KEYWORDS([install])
 AT_CHECK([

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1404,6 +1404,23 @@ runroot rpm -Vv --nouser --nogroup fifo
 [])
 AT_CLEANUP
 
+AT_SETUP([rpm -U dev])
+AT_KEYWORDS([install])
+AT_SKIP_IF([$MKNOD_DISABLED])
+AT_CHECK([
+RPMDB_INIT
+
+runroot rpmbuild -bb --quiet /data/SPECS/dev.spec
+runroot rpm -U --ignoreos /build/RPMS/noarch/dev-1.0-1.noarch.rpm
+runroot rpm -Vv --nouser --nogroup dev
+],
+[0],
+[.........    /test-block
+.........    /test-char
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([rpm -U with Obsoletes])
 AT_KEYWORDS([install])
 AT_CHECK([


### PR DESCRIPTION
While it's possible to open special files, they are, well, special and have "side-effects" also known as, ahem, semantics. Opening a device file in Unix means accessing that *device*, and FIFOs have their own semantics.  In other words, for rpm's purposes, we should never EVER open these files as a part of the install / permission setting etc. Fix this major brainfart in 25a435e90844ea98fe5eb7bef22c1aecf3a9c033.

OTOH this forces us back to the less secure path based operations for these files, which is what we were trying to avoid in the first place. There always was a tiny race between create + open for these (because there's no atomic way to create + open anything but regular files) but this opens up the window quite a bit.
Nobody should be placing device nodes in user-owned directories but FIFO's may be a different story.

We haven't had tests for device nodes because it requires privileges the test-suite usually doesn't have, not testing FIFOs I have no excuse for. Add that test now.

Fixes: #2195, #2275