### PR TITLE
Document %setup and %patch, officially deprecating %patchN

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -346,6 +346,9 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
 
     /* Convert %patchN to %patch -PN to simplify further processing */
     if (! strchr(" \t\n", line[6])) {
+	rpmlog(RPMLOG_WARNING,
+	    _("%%patchN is deprecated, use %%patch N (or %%patch -P N):\n%s"),
+	    line);
 	rasprintf(&buf, "%%patch -P %s", line + 6);
     }
     poptParseArgvString(buf ? buf : line, &argc, &argv);

--- a/docs/manual/autosetup.md
+++ b/docs/manual/autosetup.md
@@ -13,11 +13,11 @@ manually specify each patch to be applied, eg
 ```
 %prep
 %setup -q
-%patch0
-%patch1
-%patch2
+%patch 0
+%patch 1
+%patch 2
 ...
-%patch149
+%patch 149
 ```
 
 This can get rather tedious when the number of patches is large. The new

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -471,6 +471,60 @@ In simple packages `%prep` is often just:
 %prep
 %autosetup
 ```
+
+#### %setup
+
+`%setup [options]`
+
+The primary function of `%setup` is to set up the build directory for the
+package, typically unpacking the package's sources but optionally it
+can just create the directory. It accepts a number of options:
+
+```
+-a N        unpack source N after changing to the build directory
+-b N        unpack source N before changing to the build directory
+-c          create the build directory (and change to it) before unpacking
+-D          do not delete the build directory prior to unpacking (used
+            when more than one source is to be unpacked with `-a` or `-b`)
+-n DIR      set the name of build directory (default is `%{name}-%{version}`)
+-T          skip the default unpacking of the first source (used with
+            `-a` or `-b`)
+-q          operate quietly
+```
+
+#### %patch
+
+`%patch [options] [arguments]`
+
+`%patch` is used to apply patches on top of the just unpacked pristine sources.
+Historically it supported multiple strange syntaxes and buggy behaviors,
+which are no longer maintained.  To apply patch number 1, the following
+are recognized:
+
+1. `%patch 1` (since rpm >= 4.18)
+2. `%patch -P1` (all rpm versions)
+3. `%patch1` (deprecated, do not use)
+
+For new packages, the positional argument form 1) is preferred. For maximal
+compatibility use 2). Both forms can be used to apply several patches at once,
+in the order they appear on the line. The third form where the number is
+a part of the directive is deprecated and should not be used anymore.
+
+It accepts a number of options. With the exception of `-P`, they are merely
+passed down to the `patch` command.
+```
+-b SUF      backup patched files with suffix SUF
+-d DIR      change to directory DIR before doing anything else
+-E          remove files emptied by patching
+-F N        maximum fuzz factor (on context patches)
+-p N        strip N leading slashes from paths
+-R          assume reversed patch
+-o FILE     send output to FILE instead of patching in place 
+-z SUF      same as -b
+-Z          set mtime and atime from context diff headers using UTC
+
+-P N        apply patch number N, same as passing N as a positional argument
+```
  
 ### %generate_buildrequires (since rpm >= 4.15)
 

--- a/tests/data/SPECS/hello-g3.spec
+++ b/tests/data/SPECS/hello-g3.spec
@@ -12,7 +12,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q -n hello-1.0
-%patch0 -p1 -b .modernize
+%patch -p1 -b .modernize 0
 
 %build
 

--- a/tests/data/SPECS/hello-r2.spec
+++ b/tests/data/SPECS/hello-r2.spec
@@ -15,7 +15,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q
-%patch0 -p1 -b .modernize
+%patch -p1 -b .modernize 0
 
 %build
 make

--- a/tests/data/SPECS/hello.spec
+++ b/tests/data/SPECS/hello.spec
@@ -22,7 +22,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q
-%patch0 -p1 -b .modernize
+%patch -p1 -b .modernize 0
 
 %build
 make

--- a/tests/data/SPECS/hello2.spec
+++ b/tests/data/SPECS/hello2.spec
@@ -15,7 +15,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q -n hello-1.0
-%patch0 -p1 -b .modernize
+%patch -p1 -b .modernize -P0
 
 %build
 make CFLAGS="-g -O1"

--- a/tests/data/SPECS/hello2cp.spec
+++ b/tests/data/SPECS/hello2cp.spec
@@ -15,7 +15,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q -n hello-1.0
-%patch0 -p1 -b .modernize
+%patch -p1 -b .modernize 0
 
 %build
 make CFLAGS="-g -O1"

--- a/tests/data/SPECS/hello2ln.spec
+++ b/tests/data/SPECS/hello2ln.spec
@@ -15,7 +15,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q -n hello-1.0
-%patch0 -p1 -b .modernize
+%patch -p1 -b .modernize 0
 
 %build
 make CFLAGS="-g -O1"

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -298,6 +298,19 @@ run rpmbuild \
 [ignore])
 AT_CLEANUP
 
+AT_SETUP([rpmbuild with deprecated patch])
+AT_KEYWORDS([build])
+RPMDB_INIT
+AT_CHECK([
+runroot rpmbuild -bp --quiet /data/SPECS/hello2-suid.spec
+],
+[0],
+[ignore],
+[warning: %patchN is deprecated, use %patch N (or %patch -P N):
+%patch0 -p1 -b .modernize
+])
+AT_CLEANUP
+
 AT_SETUP([rpmbuild scriptlet -f])
 AT_KEYWORDS([build])
 RPMDB_INIT


### PR DESCRIPTION
Document %setup and %patch in the reference manual, even if briefly.
Convert our own %patch uses in the testsuite to modern syntaxes and officially deprecate the stupid %patchN syntax so we may some day actually get rid of it.