### PR TITLE
Try telling cmake that the project needs to be built before testing

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,11 @@ add_custom_command(OUTPUT rpmtests COMMAND
 	${AUTOTEST} -I ${CMAKE_CURRENT_SOURCE_DIR} -o rpmtests rpmtests.at
 	DEPENDS ${TESTSUITE_AT}
 )
+
+# Use our top-level targets as an ordering clue to cmake: the project
+# needs to be built before we can populate anything...
+get_property(top_targets DIRECTORY .. PROPERTY BUILDSYSTEM_TARGETS)
+
 add_custom_target(populate_testing COMMAND
 	${CMAKE_CURRENT_SOURCE_DIR}/populate
 		${CMAKE_BINARY_DIR}
@@ -58,6 +63,7 @@ add_custom_target(populate_testing COMMAND
 		${CMAKE_INSTALL_FULL_BINDIR}
 		${CMAKE_MAKE_PROGRAM}
 	SOURCES populate
+	DEPENDS ${top_targets}
 )
 
 set (testprogs rpmpgpcheck rpmpgppubkeyfingerprint)


### PR DESCRIPTION
Recently there have been a fair amount of random failures in the CI, due to apparent ordering errors / lack of dependencies that have been hard to reproduce locally. The key is probably CI running "make check" right away, which then proceeds on all the relevant targets in parallel. And nowhere at all we're telling it that the tests need the entire project to be already built. So apparently the "make install" in tests/populate often ends up building a significant part of the project and ... that two competing makes in the tree ever actually manage to complete at all is a small miracle.

There doesn't seem to be a way to add a dependency on the ALL target in cmake, so have
populate_testing target depend on top-level cli utils to enforce at least "mostly sane" situation when running "make check" without a preceeding build. This should address the issue of random CI failures in ticket #2357.