### PR TITLE
Fix macro scoping level on re-entry from %[] expresssion (#2354)

### DIFF
--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -526,6 +526,43 @@ runroot rpm \
 [])
 AT_CLEANUP
 
+AT_SETUP([expression macro level])
+AT_KEYWORDS([macros])
+AT_CHECK([[
+runroot rpm \
+	--define 'expopt(r) %[%{undefined yyy} ? "aa " : "bb "]%{-r:the -r option was set}%{!-r:the -r option was not set}' \
+	--eval '%expopt' \
+	--eval '%expopt -r' \
+	--define 'yyy 1' \
+	--eval '%expopt' \
+	--eval '%expopt -r'
+]],
+[0],
+[aa the -r option was not set
+aa the -r option was set
+bb the -r option was not set
+bb the -r option was set
+],
+[])
+
+AT_CHECK([[
+runroot rpm \
+	--define 'expopt(r) %{expr:%{undefined yyy} ? "aa " : "bb "}%{-r:the -r option was set}%{!-r:the -r option was not set}' \
+	--eval '%expopt' \
+	--eval '%expopt -r' \
+	--define 'yyy 1' \
+	--eval '%expopt' \
+	--eval '%expopt -r'
+]],
+[0],
+[aa the -r option was not set
+aa the -r option was set
+bb the -r option was not set
+bb the -r option was set
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([short circuiting])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
This is the same issue as commit 1767bc4fd82bfacee622e698f9f0ae42c02126fa was with Lua, and so the same fix works: restore the nesting level from the macro context when re-entering macro engine from %[] expression. Analysis and suggested fix by Michael Schroeder, reproducer from Miro Hrončok.

Add tests for both %[] and %{expr:...}, although the latter isn't affected because the expression is macro-expanded beforehand.

Fixes: #2354