### PR TITLE
Turn `%patch` without arguments and options into an error

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -383,8 +383,8 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
     argvAppend(&patchnums, (ARGV_const_t) poptGetArgs(optCon));
 
     if (argvCount(patchnums) == 0) {
-	rpmlog(RPMLOG_WARNING, _("Patch number not specified: %s\n"), line);
-	argvAdd(&patchnums, "0");
+	rpmlog(RPMLOG_ERR, _("Patch number not specified: %s\n"), line);
+	goto exit;
     }
 
     /* Convert to number, generate patch command and append to %prep script */


### PR DESCRIPTION
Instead of treating `%patch` with no options and errors the same as `%patch 0`, just raise an error. There will be folks who have missed the warning-only phase, but we don't want to wait another ten years to finally rid ourselves of these legacy quirks.

Related: #2205