### PR TITLE
Split ___build_pre macro to make mocking rpm build environment easier

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -735,7 +735,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %___build_shell		%{?_buildshell:%{_buildshell}}%{!?_buildshell:/bin/sh}
 %___build_args		-e
 %___build_cmd		%{?_sudo:%{_sudo} }%{?_remsh:%{_remsh} %{_remhost} }%{?_remsudo:%{_remsudo} }%{?_remchroot:%{_remchroot} %{_remroot} }%{___build_shell} %{___build_args}
-%___build_pre	\
+%___build_pre_env \
   RPM_SOURCE_DIR=\"%{_sourcedir}\"\
   RPM_BUILD_DIR=\"%{_builddir}\"\
   RPM_OPT_FLAGS=\"%{optflags}\"\
@@ -758,8 +758,10 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
   %{?_javaclasspath:CLASSPATH=\"%{_javaclasspath}\"\
   export CLASSPATH}\
   PKG_CONFIG_PATH=\"${PKG_CONFIG_PATH}:%{_libdir}/pkgconfig:%{_datadir}/pkgconfig\"\
-  export PKG_CONFIG_PATH\
-  \
+  export PKG_CONFIG_PATH
+
+%___build_pre	\
+  %{___build_pre_env} \
   %[%{verbose}?"set -x":""]\
   umask 022\
   cd \"%{_builddir}\"\


### PR DESCRIPTION
New macro ___build_package_notes_env contains environment variables that package-notes depends on. This allows easier mocking of rpm build environment and isolated execution of check phase of rpm packages possible.

Hi,
in many tests using upstream test suite is used approach that builds sources and
tests with optflags as used in Fedora builds. This proved to be problematic since
package-notes started to depend on environment variables defined through rpm
macros. There is a workaround that can solve this but since `___build_pre` macro
contains `cd` command at the end, evaluation of it in tests must be followed by
`cd` back to the original directory. This change allows us to get rid of this following
`cd` and has no effect on the current way of building.

Please see also this https://lists.fedorahosted.org/archives/list/devel@lists.fedoraproject.org/thread/UHJGLOXDDDRTHG4SC5P5FDF37OAMNRDH/ thread for more information.

Thanks for any help.
