### PR TITLE
support for POSIX getopt() behaviour

### DIFF
--- a/rpmio/rgetopt.c
+++ b/rpmio/rgetopt.c
@@ -28,6 +28,7 @@ int rgetopt(int argc, char * const argv[], const char *opts,
     optind = 0;
 #else
     optind = 1;
+    optarg = NULL;
 #endif
 
     while ((c = getopt(argc, argv, opts)) != -1) {
@@ -39,6 +40,7 @@ int rgetopt(int argc, char * const argv[], const char *opts,
 	    rc = -1;
 	    break;
 	}
+	optarg = NULL;
     }
     return (rc < 0) ? -optopt : optind;
 }


### PR DESCRIPTION
[POSIX defines optarg only for options with arguments](https://pubs.opengroup.org/onlinepubs/000095399/functions/getopt.html) and callback() is expecting optarg to be NULL for options without arguments, however, at least on musl optarg will carry a pointer to the argument of the previous option with argument.  This commit makes the behaviour deterministic and expected.