### PR TITLE
Fix a typo

### DIFF
--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -342,7 +342,7 @@ packages.
 #### Supplements
 #### Enhances
 
-#### OrderWithRequires (sicne rpm >= 4.9)
+#### OrderWithRequires (since rpm >= 4.9)
 
 #### Prereq
 


### PR DESCRIPTION
(sicne rpm >= 4.9) -> (since rpm >= 4.9)