### PR TITLE
Header internals type cleanup

### DIFF
--- a/lib/header.c
+++ b/lib/header.c
@@ -84,8 +84,8 @@ typedef struct indexEntry_s * indexEntry;
 struct indexEntry_s {
     struct entryInfo_s info;	/*!< Description of tag data. */
     rpm_data_t data; 		/*!< Location of tag data. */
-    int length;			/*!< No. bytes of data. */
-    int rdlen;			/*!< No. bytes of data in region. */
+    uint32_t length;		/*!< No. bytes of data. */
+    uint32_t rdlen;		/*!< No. bytes of data in region. */
 };
 
 /** \ingroup header
@@ -175,7 +175,7 @@ static inline void ei2h(const struct entryInfo_s *pe, struct entryInfo_s *info)
 }
 
 static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
-			 int onDisk, rpm_constdata_t pend, int *length);
+			 int onDisk, rpm_constdata_t pend, uint32_t *length);
 
 /* Check tag type matches our definition */
 static int hdrchkTagType(rpm_tag_t tag, rpm_tagtype_t type)
@@ -283,8 +283,8 @@ Header headerNew(void)
 static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
 {
     struct entryInfo_s info;
-    int i, len = 0;
-    int32_t end = 0;
+    uint32_t i, len = 0;
+    uint32_t end = 0;
     const char *ds = (const char *) blob->dataStart;
     uint32_t il = (blob->regionTag) ? blob->il-1 : blob->il;
     entryInfo pe = (blob->regionTag) ? blob->pe+1 : blob->pe;
@@ -428,7 +428,7 @@ unsigned headerSizeof(Header h, int magicp)
  * Length is returned via *lenp, return zero on success, -1 on error.
  */
 static inline int strtaglen(const char *str, rpm_count_t c, const char *end,
-			    int *lenp)
+			    uint32_t *lenp)
 {
     const char *start = str;
     const char *s = NULL;
@@ -468,11 +468,11 @@ static inline int strtaglen(const char *str, rpm_count_t c, const char *end,
  * @return		0 on success, -1 on failure
  */
 static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
-			 int onDisk, rpm_constdata_t pend, int *len)
+			 int onDisk, rpm_constdata_t pend, uint32_t *len)
 {
     const char * s = p;
     const char * se = pend;
-    int length = 0;
+    uint32_t length = 0;
 
     switch (type) {
     case RPM_STRING_TYPE:
@@ -1444,10 +1444,10 @@ static void copyData(rpm_tagtype_t type, rpm_data_t dstPtr,
  * @return 		(malloc'ed) copy of entry data, NULL on error
  */
 static void *
-grabData(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t c, int * lengthPtr)
+grabData(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t c, uint32_t * lengthPtr)
 {
     rpm_data_t data = NULL;
-    int length;
+    uint32_t length;
 
     if (dataLength(type, p, c, 0, NULL, &length))
 	return NULL;
@@ -1466,7 +1466,7 @@ static int intAddEntry(Header h, rpmtd td)
 {
     indexEntry entry;
     rpm_data_t data;
-    int length = 0;
+    uint32_t length = 0;
 
     /* Count must always be >= 1 for headerAddEntry. */
     if (td->count <= 0)
@@ -1508,7 +1508,7 @@ static int intAddEntry(Header h, rpmtd td)
 static int intAppendEntry(Header h, rpmtd td)
 {
     indexEntry entry;
-    int length;
+    uint32_t length;
 
     if (td->type == RPM_STRING_TYPE || td->type == RPM_I18NSTRING_TYPE) {
 	/* we can't do this */
@@ -1561,7 +1561,7 @@ int headerAddI18NString(Header h, rpmTagVal tag, const char * string,
 {
     indexEntry table, entry;
     const char ** strArray;
-    int length;
+    uint32_t length;
     int ghosts;
     rpm_count_t i, langNum;
     char * buf;
@@ -1699,7 +1699,7 @@ int headerMod(Header h, rpmtd td)
     indexEntry entry;
     rpm_data_t oldData;
     rpm_data_t data;
-    int length = 0;
+    uint32_t length = 0;
 
     /* First find the tag */
     entry = findEntry(h, td->tag, td->type);

--- a/lib/header.c
+++ b/lib/header.c
@@ -396,7 +396,7 @@ unsigned headerSizeof(Header h, int magicp)
     if (magicp == HEADER_MAGIC_YES)
 	size += sizeof(rpm_header_magic);
 
-    size += 2 * sizeof(int32_t);	/* count of index entries */
+    size += 2 * sizeof(uint32_t);	/* count of index entries */
 
     for (i = 0, entry = h->index; i < h->indexUsed; i++, entry++) {
 	/* Regions go in as is ... */
@@ -503,7 +503,7 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
 }
 
 /** \ingroup header
- * Swap int32_t and int16_t arrays within header region.
+ * Swap uint32_t and uint16_t arrays within header region.
  *
  * If a header region tag is in the set to be swabbed, as the data for a
  * a header region is located after all other tag data.

--- a/lib/header.c
+++ b/lib/header.c
@@ -529,7 +529,7 @@ static int regionSwab(indexEntry entry, uint32_t il, uint32_t dl,
 		entryInfo pe,
 		unsigned char * dataStart,
 		const unsigned char * dataEnd,
-		int regionid, int fast, int *nbytes)
+		int regionid, int fast, uint32_t *nbytes)
 {
     if ((entry != NULL && regionid >= 0) || (entry == NULL && regionid != 0))
 	return -1;
@@ -693,8 +693,8 @@ static void * doExport(const struct indexEntry_s *hindex, int indexUsed,
     for (i = 0, entry = index; i < indexUsed; i++, entry++) {
 	const char * src;
 	unsigned char *t;
-	int count;
-	int rdlen;
+	uint32_t count;
+	uint32_t rdlen;
 	unsigned int diff;
 
 	if (entry->data == NULL || entry->length <= 0)
@@ -923,7 +923,7 @@ rpmRC hdrblobImport(hdrblob blob, int fast, Header *hdrp, char **emsg)
 {
     Header h = NULL;
     indexEntry entry; 
-    int rdlen;
+    uint32_t rdlen;
 
     h = headerCreate(blob->ei, blob->il);
 

--- a/lib/header.c
+++ b/lib/header.c
@@ -286,7 +286,7 @@ static rpmRC hdrblobVerifyInfo(hdrblob blob, char **emsg)
     int i, len = 0;
     int32_t end = 0;
     const char *ds = (const char *) blob->dataStart;
-    int32_t il = (blob->regionTag) ? blob->il-1 : blob->il;
+    uint32_t il = (blob->regionTag) ? blob->il-1 : blob->il;
     entryInfo pe = (blob->regionTag) ? blob->pe+1 : blob->pe;
     /* Can't typecheck signature header tags, sigh */
     int typechk = (blob->regionTag == RPMTAG_HEADERIMMUTABLE ||
@@ -518,7 +518,7 @@ static int dataLength(rpm_tagtype_t type, rpm_constdata_t p, rpm_count_t count,
  * @param fast		use offsets for data sizes if possible
  * @return		no. bytes of data in region, -1 on error
  */
-static int regionSwab(indexEntry entry, int il, int dl,
+static int regionSwab(indexEntry entry, uint32_t il, uint32_t dl,
 		entryInfo pe,
 		unsigned char * dataStart,
 		const unsigned char * dataEnd,
@@ -608,8 +608,8 @@ static void * doExport(const struct indexEntry_s *hindex, int indexUsed,
     char * dataStart;
     char * te;
     unsigned len, diff;
-    int32_t il = 0;
-    int32_t dl = 0;
+    uint32_t il = 0;
+    uint32_t dl = 0;
     indexEntry entry; 
     int i;
     int drlen, ndribbles;
@@ -1936,8 +1936,8 @@ rpmRC hdrblobRead(FD_t fd, int magic, int exact_size, rpmTagVal regionTag, hdrbl
     uint32_t block[4];
     uint32_t *bs = (magic != 0) ? &block[0] : &block[2];
     int blen = (magic != 0) ? sizeof(block) : sizeof(block) / 2;
-    int32_t il;
-    int32_t dl;
+    uint32_t il;
+    uint32_t dl;
     uint32_t * ei = NULL;
     size_t uc;
     size_t nb;

--- a/lib/header.c
+++ b/lib/header.c
@@ -239,7 +239,7 @@ Header headerFree(Header h)
 	for (i = 0; i < h->indexUsed; i++, entry++) {
 	    if ((h->flags & HEADERFLAG_ALLOCATED) && ENTRY_IS_REGION(entry)) {
 		if (entry->length > 0) {
-		    int32_t * ei = entry->data;
+		    uint32_t * ei = entry->data;
 		    if ((ei - 2) == h->blob) h->blob = _free(h->blob);
 		    entry->data = NULL;
 		}
@@ -603,7 +603,7 @@ static int regionSwab(indexEntry entry, int il, int dl,
 static void * doExport(const struct indexEntry_s *hindex, int indexUsed,
 			headerFlags flags, unsigned int *bsize)
 {
-    int32_t * ei = NULL;
+    uint32_t * ei = NULL;
     entryInfo pe;
     char * dataStart;
     char * te;
@@ -1114,7 +1114,7 @@ static int copyTdEntry(const indexEntry entry, rpmtd td, headerGetFlags flags)
 	 * XXX a legacy header freshly read, but not yet unloaded to the rpmdb).
 	 */
 	if (ENTRY_IS_REGION(entry)) {
-	    int32_t * ei = ((int32_t *)entry->data) - 2;
+	    uint32_t * ei = ((uint32_t *)entry->data) - 2;
 	    entryInfo pe = (entryInfo) (ei + 2);
 	    unsigned char * dataStart = (unsigned char *) (pe + ntohl(ei[0]));
 	    int32_t rdl = -entry->info.offset;	/* negative offset */
@@ -1131,7 +1131,7 @@ static int copyTdEntry(const indexEntry entry, rpmtd td, headerGetFlags flags)
 	    }
 
 	    td->data = xmalloc(count);
-	    ei = (int32_t *) td->data;
+	    ei = (uint32_t *) td->data;
 	    ei[0] = htonl(ril);
 	    ei[1] = htonl(rdl);
 
@@ -1933,12 +1933,12 @@ static rpmRC hdrblobVerifyLengths(rpmTagVal regionTag, uint32_t il, uint32_t dl,
 
 rpmRC hdrblobRead(FD_t fd, int magic, int exact_size, rpmTagVal regionTag, hdrblob blob, char **emsg)
 {
-    int32_t block[4];
-    int32_t *bs = (magic != 0) ? &block[0] : &block[2];
+    uint32_t block[4];
+    uint32_t *bs = (magic != 0) ? &block[0] : &block[2];
     int blen = (magic != 0) ? sizeof(block) : sizeof(block) / 2;
     int32_t il;
     int32_t dl;
-    int32_t * ei = NULL;
+    uint32_t * ei = NULL;
     size_t uc;
     size_t nb;
     rpmRC rc = RPMRC_FAIL;		/* assume failure */
@@ -2007,9 +2007,9 @@ rpmRC hdrblobInit(const void *uh, size_t uc,
 	goto exit;
     }
 
-    blob->ei = (int32_t *) uh; /* discards const */
-    blob->il = ntohl((uint32_t)(blob->ei[0]));
-    blob->dl = ntohl((uint32_t)(blob->ei[1]));
+    blob->ei = (uint32_t *) uh; /* discards const */
+    blob->il = ntohl(blob->ei[0]);
+    blob->dl = ntohl(blob->ei[1]);
     if (hdrblobVerifyLengths(regionTag, blob->il, blob->dl, emsg) != RPMRC_OK)
 	goto exit;
 

--- a/lib/header_internal.h
+++ b/lib/header_internal.h
@@ -21,10 +21,10 @@ struct entryInfo_s {
 typedef struct hdrblob_s * hdrblob;
 struct hdrblob_s {
     uint32_t *ei;
-    int32_t il;
-    int32_t dl;
+    uint32_t il;
+    uint32_t dl;
     entryInfo pe;
-    int32_t pvlen;
+    uint32_t pvlen;
     uint8_t *dataStart;
     uint8_t *dataEnd;
 

--- a/lib/header_internal.h
+++ b/lib/header_internal.h
@@ -20,7 +20,7 @@ struct entryInfo_s {
 
 typedef struct hdrblob_s * hdrblob;
 struct hdrblob_s {
-    int32_t *ei;
+    uint32_t *ei;
     int32_t il;
     int32_t dl;
     entryInfo pe;

--- a/lib/header_internal.h
+++ b/lib/header_internal.h
@@ -29,8 +29,8 @@ struct hdrblob_s {
     uint8_t *dataEnd;
 
     rpmTagVal regionTag;
-    int32_t ril;
-    int32_t rdl;
+    uint32_t ril;
+    uint32_t rdl;
 };
 
 #ifdef __cplusplus

--- a/lib/package.c
+++ b/lib/package.c
@@ -183,7 +183,7 @@ static void appendhdrmsg(struct rpmsinfo_s *sinfo, struct pkgdata_s *pkgdata,
 
 static void updateHdrDigests(rpmDigestBundle bundle, struct hdrblob_s *blob)
 {
-    int32_t ildl[2] = { htonl(blob->ril), htonl(blob->rdl) };
+    uint32_t ildl[2] = { htonl(blob->ril), htonl(blob->rdl) };
 
     rpmDigestBundleUpdate(bundle, rpm_header_magic, sizeof(rpm_header_magic));
     rpmDigestBundleUpdate(bundle, ildl, sizeof(ildl));

--- a/lib/query.c
+++ b/lib/query.c
@@ -37,7 +37,7 @@ static void printFileInfo(const char * name,
     char sizefield[21];
     char ownerfield[8+1], groupfield[8+1];
     char timefield[100];
-    time_t when = mtime;  /* important if sizeof(int32_t) ! sizeof(time_t) */
+    time_t when = mtime;  /* important if sizeof(uint32_t) ! sizeof(time_t) */
     struct tm * tm, _tm;
     char * perms = rpmPermsString(mode);
     char *link = NULL;


### PR DESCRIPTION
*Fun* (for some idea of fun) refactoring of header internals to replace signed integers with unsigned ones in various places. This isn't supposed to change behavior (except maybe catch some errors we previously didn't) but with this type mess, you never know. So lotsa churn in small bisectable commits...

This is a significant chunk of #2385, but not complete.