### PR TITLE
Issue %patchN deprecation warning just once

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -346,10 +346,8 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
 
     /* Convert %patchN to %patch -PN to simplify further processing */
     if (! strchr(" \t\n", line[6])) {
-	rpmlog(RPMLOG_WARNING,
-	    _("%%patchN is deprecated, use %%patch N (or %%patch -P N):\n%s"),
-	    line);
 	rasprintf(&buf, "%%patch -P %s", line + 6);
+	spec->numConverted++;
     }
     poptParseArgvString(buf ? buf : line, &argc, &argv);
 
@@ -448,6 +446,11 @@ int parsePrep(rpmSpec spec)
 	    goto exit;
 	}
     }
+
+    if (spec->numConverted)
+	rpmlog(RPMLOG_WARNING,
+	       _("%%patchN is deprecated (%i usages found), "
+	         "use %%patch N (or %%patch -P N)\n"), spec->numConverted);
 
 exit:
     argvFree(saveLines);

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -151,6 +151,8 @@ struct rpmSpec_s {
     StringBuf parsed;		/*!< parsed spec contents */
 
     Package packages;		/*!< Package list. */
+
+    int numConverted;		/*!< no. of automatic %patchN conversions */
 };
 
 #define PACKAGE_NUM_DEPS 12

--- a/build/spec.c
+++ b/build/spec.c
@@ -231,6 +231,7 @@ rpmSpec newSpec(void)
     spec->numSources = 0;
     spec->autonum_patch = -1;
     spec->autonum_source = -1;
+    spec->numConverted = 0;
 
     spec->sourceRpmName = NULL;
     spec->sourcePkgId = NULL;

--- a/tests/data/SPECS/hello-patch.spec
+++ b/tests/data/SPECS/hello-patch.spec
@@ -1,0 +1,20 @@
+Name: hello
+Version: 1.0
+Release: 1
+Group: Testing
+License: GPL
+Summary: Simple rpm demonstration.
+
+Source0: hello-1.0.tar.gz
+Patch0: hello-1.0-install.patch
+Patch1: hello-1.0-modernize.patch
+
+%description
+Simple rpm demonstration.
+
+%prep
+%setup -q
+%patch0 -p1 -b .install
+%patch1 -p1 -b .modernize
+
+%changelog

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -354,12 +354,11 @@ AT_SETUP([rpmbuild with deprecated patch])
 AT_KEYWORDS([build])
 RPMDB_INIT
 AT_CHECK([
-runroot rpmbuild -bp --quiet /data/SPECS/hello2-suid.spec
+runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ],
 [0],
 [ignore],
-[warning: %patchN is deprecated, use %patch N (or %patch -P N):
-%patch0 -p1 -b .modernize
+[warning: %patchN is deprecated (2 usages found), use %patch N (or %patch -P N)
 ])
 AT_CLEANUP
 


### PR DESCRIPTION
Avoid polluting the build log with this warning repeated as many times as there are %patchN lines.  Once per build should be enough for the packager to notice (there's also a warning summary now).

Basically, make the warning context-independent, meaning that it doesn't matter which line caused it (so don't even print it), we just want to warn about such usage being present in the SPEC.

Suppressing duplicate log messages could be a useful feature on its own so we may eventually want to implement this in rpmlog() with something like a RPMLOG_NODUP flag (and perhaps print the number of suppressed messages in the summary, too) but until then, just keep it simple and use a static int.

Rather than adding another %patch to hello2-suid.spec which is also used elsewhere in the test suite, just make a simplified clone dedicated to %patch testing.

Fixes: #2383