### PR TITLE
Eliminate signedness mismatch from RPMTAG_NOT_FOUND

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2858,7 +2858,7 @@ exit:
     return rc;
 }
 
-static rpmTag copyTagsFromMainDebug[] = {
+static rpmTagVal copyTagsFromMainDebug[] = {
     RPMTAG_ARCH,
     RPMTAG_SUMMARY,
     RPMTAG_DESCRIPTION,

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -528,7 +528,7 @@ rpmTagClass rpmTagGetClass(rpmTagVal tag);
 /** \ingroup rpmtag
  * Return tag value from name.
  * @param tagstr	name of tag
- * @return		tag value, -1 on not found
+ * @return		tag value, RPMTAG_NOT_FOUND on not found
  */
 rpmTagVal rpmTagGetValue(const char * tagstr);
 

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -396,7 +396,7 @@ typedef enum rpmTag_e {
  * Rpm database index tags.
  */
 typedef enum rpmDbiTag_e {
-    RPMDBI_PACKAGES		= 0,	/* Installed package headers. */
+    RPMDBI_PACKAGES		= 1,	/* Installed package headers. */
     RPMDBI_LABEL		= 2,	/* NEVRA label pseudo index */
     RPMDBI_NAME			= RPMTAG_NAME,
     RPMDBI_BASENAMES		= RPMTAG_BASENAMES,

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -32,8 +32,6 @@ extern "C" {
  */
 /** @todo: Somehow supply type **/
 typedef enum rpmTag_e {
-    RPMTAG_NOT_FOUND		= -1,			/*!< Unknown tag */
-
     RPMTAG_HEADERIMAGE		= HEADER_IMAGE,		/*!< Current image. */
     RPMTAG_HEADERSIGNATURES	= HEADER_SIGNATURES,	/*!< Signatures. */
     RPMTAG_HEADERIMMUTABLE	= HEADER_IMMUTABLE,	/*!< Original image. */
@@ -391,6 +389,7 @@ typedef enum rpmTag_e {
     RPMTAG_FIRSTFREE_TAG	/*!< internal */
 } rpmTag;
 
+#define RPMTAG_NOT_FOUND		-1
 #define	RPMTAG_EXTERNAL_TAG		1000000
 
 /** \ingroup rpmtag

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -389,7 +389,7 @@ typedef enum rpmTag_e {
     RPMTAG_FIRSTFREE_TAG	/*!< internal */
 } rpmTag;
 
-#define RPMTAG_NOT_FOUND		-1
+#define RPMTAG_NOT_FOUND		0
 #define	RPMTAG_EXTERNAL_TAG		1000000
 
 /** \ingroup rpmtag


### PR DESCRIPTION
 RPMTAG_NOT_FOUND being -1 while all the valid data is unsigned causes all manner of headaches throughout the code in the form of type mismatches and potential associated bugs. Zero makes for a much nicer not-found value, shuffle things around a little to make this possible. Related to #2385.

The caveat of course is that RPMTAG_NOT_FOUND has been -1 forever and so there may be (external) code testing for < 0 rather than the explicit value. 

Thoughts?