### PR TITLE
Eliminate RPMTAG_NOT_FOUND signedness mismatch, take II

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -2858,7 +2858,7 @@ exit:
     return rc;
 }
 
-static rpmTag copyTagsFromMainDebug[] = {
+static rpmTagVal copyTagsFromMainDebug[] = {
     RPMTAG_ARCH,
     RPMTAG_SUMMARY,
     RPMTAG_DESCRIPTION,

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -528,7 +528,7 @@ rpmTagClass rpmTagGetClass(rpmTagVal tag);
 /** \ingroup rpmtag
  * Return tag value from name.
  * @param tagstr	name of tag
- * @return		tag value, -1 on not found
+ * @return		tag value, RPMTAG_NOT_FOUND on not found
  */
 rpmTagVal rpmTagGetValue(const char * tagstr);
 

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -389,7 +389,7 @@ typedef enum rpmTag_e {
     RPMTAG_FIRSTFREE_TAG	/*!< internal */
 } rpmTag;
 
-#define RPMTAG_NOT_FOUND		-1
+#define RPMTAG_NOT_FOUND		((uint32_t)-1)
 #define	RPMTAG_EXTERNAL_TAG		1000000
 
 /** \ingroup rpmtag

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -32,8 +32,6 @@ extern "C" {
  */
 /** @todo: Somehow supply type **/
 typedef enum rpmTag_e {
-    RPMTAG_NOT_FOUND		= -1,			/*!< Unknown tag */
-
     RPMTAG_HEADERIMAGE		= HEADER_IMAGE,		/*!< Current image. */
     RPMTAG_HEADERSIGNATURES	= HEADER_SIGNATURES,	/*!< Signatures. */
     RPMTAG_HEADERIMMUTABLE	= HEADER_IMMUTABLE,	/*!< Original image. */
@@ -391,6 +389,7 @@ typedef enum rpmTag_e {
     RPMTAG_FIRSTFREE_TAG	/*!< internal */
 } rpmTag;
 
+#define RPMTAG_NOT_FOUND		-1
 #define	RPMTAG_EXTERNAL_TAG		1000000
 
 /** \ingroup rpmtag


### PR DESCRIPTION
Unlike #2390, this doesn't change the bit-level value so it's backwards compatible, this is just for eliminating compiler level ambiguity.