### PR TITLE
Dependency generation sanity

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -316,6 +316,7 @@ static int getOutputFrom(ARGV_t argv,
 	rpmlog(RPMLOG_DEBUG, "\texecv(%s) pid %d\n",
                         argv[0], (unsigned)getpid());
 
+	unsetenv("DEBUGINFOD_URLS");
 	if (buildRoot)
 	    setenv("RPM_BUILD_ROOT", buildRoot, 1);
 

--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,3 +1,4 @@
 %__elf_provides		%{_rpmconfigdir}/elfdeps --provides
 %__elf_requires		%{_rpmconfigdir}/elfdeps --requires
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
+%__elf_exclude_path	^/lib/modules/.*\.ko?(\.[[:alnum:]]*)$

--- a/macros.in
+++ b/macros.in
@@ -753,6 +753,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
   LANG=C\
   export LANG\
   unset CDPATH DISPLAY ||:\
+  unset DEBUGINFOD_URLS ||:\
   %{?buildroot:RPM_BUILD_ROOT=\"%{buildroot}\"\
   export RPM_BUILD_ROOT}\
   %{?_javaclasspath:CLASSPATH=\"%{_javaclasspath}\"\


### PR DESCRIPTION
Disable ELF dependency generation on kernel modules, there will not be any so it's waste of time. Prevent tools like `readelf` in scripts from doing network lookups during build.