### PR TITLE
Fix a test relying on glibc version of glob(3)

### DIFF
--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -858,7 +858,8 @@ for e in 1 2; do
     runroot_other cp /build/RPMS/noarch/versiontest-1.0-1.noarch.rpm /tmp/epoch${e}.rpm
 done
 # for testing sanity
-runroot_other echo '%_query_all_fmt %%{nevra}' > ${HOME}/.rpmmacros
+mkdir -p ${RPMTEST}/usr/lib/rpm/macros.d/
+runroot_other echo '%_query_all_fmt %%{nevra}' > ${RPMTEST}/usr/lib/rpm/macros.d/macros.epoch
 
 AT_CHECK([
 RPMDB_INIT


### PR DESCRIPTION
When fakechroot is called with FAKECHROOT_BASE and HOME both pointed at the same directory (as is the case with our test suite, see the file tests/atlocal.in), the pattern "~" gets expanded by glob() to the empty string.  However, this wasn't the case back when we bundled our own glob() implementation (before commit [1]) which would yield zero matches for such a pattern, probably due to a bug in that implementation.

We rely on this (glibc-only?) behavior in the recently added epoch tests (commits [2]) which create the "~/.rpmmacros" file and expect it to be loaded by RPM on startup.  This works since the commits were added after [1] and thus the pattern yields "/.rpmmacros" which is the correct path inside the fakechroot environment, but it prevents us from cherry picking [2] to stable branches where [1] is not (and won't be) present.

Fix that by simply choosing a different, non-tilde, default macro path in these tests.

Note: We could just consider this patch "backporting" work and only apply it on the respective stable branch(es), but this is a very non-obvious thing that took me a couple of days of head-scratching (as part of 4.18.1 preparation) so having it on master will make our life easier in case we need to include (and not forget) this on multiple stable branches.

Here's a simple C program showing the difference between the pre-[1] and post-[1] version of glob() (through the rpmGlob() wrapper):

    #include <rpm/rpmfileutil.h>
    int main()
    {
        ARGV_t path, paths = NULL;
        if (rpmGlob("~", NULL, &paths) != 0) {
            printf("No matches.\n");
            exit(1);
        }
        for (path = paths; *path; path++)
            printf("\"%s\"\n", *path);
    }
    
    $ gcc -lrpmio -o globtest globtest.c
    $ echo $HOME
    /home/test
    $ ./globtest
    "/home/test"
    
    $ mkdir myroot
    
    # before [1]
    $ FAKECHROOT_BASE=$PWD/myroot HOME=$PWD/myroot fakechroot ./globtest
    No matches.
    
    # after [1]
    $ FAKECHROOT_BASE=$PWD/myroot HOME=$PWD/myroot fakechroot ./globtest
    ""

[1] 66fa46c006bae0f28d93238b8f7f1c923645eee5
[2] 7788763e09b7beed75345e11c223735ad4829fdb
    89676fad73d0808588dca620344efa4d6b3889b4