### PR TITLE
Allow to specify a default for bcond features in a macro file

### DIFF
--- a/docs/manual/conditionalbuilds.md
+++ b/docs/manual/conditionalbuilds.md
@@ -91,5 +91,19 @@ macros which is nicer in other situations, e.g.:
 
 Always test for the `with`-condition, not the `without`-counterpart!
 
+## Overrinding Defaults
+
+For distributions it can be useful to overwrite the build conditionals on a global scale. To not interfere with the users ability to overwrite the conditionals on the command line there is an option to overwrite the default value indenpendent on the one chosen in the spec file.
+
+To do this one can define a `%bcond_override_default_NAME` macro as one or zero or use the `%{bcond_override_default NAME VALUE}` macro. Distributions can put the former into a global macro file that is installed during local builds to propagate these changed defaults outside their build system. Using different versions of the macro file allows building the same set of packages in different ways - e.g. against different libraries - without altering all the spec files.
+
+E.g. add this in the macros file to disable support for zstd assuming this is a common conditional in the distribution:
+```
+%bcond_override_default_zstd 0
+```
+
+All packages with a `zstd` bcond will now build as if the bcond was defined as `%bcond zstd 0`.
+I.e. unless `--with zstd` is used, the bcond will be disabled.
+
 ## References
 * [macros](https://github.com/rpm-software-management/rpm/blob/master/macros.in)

--- a/macros.in
+++ b/macros.in
@@ -88,7 +88,9 @@
 # Based on those and a default (used when neither is given), bcond macros
 # define the macro `with_foo`, which should later be checked:
 
-%bcond()	%[ (%2)\
+%bcond_override_default()   %{expand:%%global bcond_override_default_%{1} %{2}}
+%__bcond_override_default()	%{expand:%%["%%{?bcond_override_default_%{1}}"||"%%{2}"]}
+%bcond()	%[ %{__bcond_override_default %{1} %{2}}\
     ? "%{expand:%%{!?_without_%{1}:%%global with_%{1} 1}}"\
     : "%{expand:%%{?_with_%{1}:%%global with_%{1} 1}}"\
 ]

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2438,7 +2438,7 @@ runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
 [],
 [])
 
-# bcond behavior, CLI overriding a complex defailt
+# bcond behavior, CLI overriding a complex default
 RPMTEST_CHECK([
 runroot rpmbuild -bb --quiet --with both_features /data/SPECS/bcondtest.spec
 runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
@@ -2447,6 +2447,101 @@ runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
 [0],
 [has_bcond(both_features)
 has_bcond(normally_on)
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([bcond_override_default macros])
+AT_KEYWORDS([bcond build])
+RPMDB_INIT
+
+# check bcond_override_default by defining
+RPMTEST_CHECK([
+runroot rpm \
+	--eval "%bcond_override_default normally_on 0" \
+	--eval "%bcond_override_default normally_off 1" \
+	--eval "%bcond normally_on 1" \
+	--eval "%bcond normally_off 0" \
+	--eval "%{with normally_on}" \
+	--eval "%{with normally_off}" \
+],
+[0],
+[
+
+
+
+0
+1
+],
+[])
+
+# check bcond_override_default via helper macro
+RPMTEST_CHECK([
+runroot rpm \
+	-D "%bcond_override_default_normally_on 0" \
+	-D "%bcond_override_default_normally_off 1" \
+	--eval "%bcond normally_on 1" \
+	--eval "%bcond normally_off 0" \
+	--eval "%{with normally_on}" \
+	--eval "%{with normally_off}" \
+],
+[0],
+[
+
+0
+1
+],
+[])
+
+# check bcond_override_default via macro file
+
+# bcond behavior, without CLI options
+RPMTEST_CHECK([
+echo '%bcond_override_default_normally_on 0' > ${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros.d/macros.bcondtests
+echo '%bcond_override_default_normally_off 1' >> ${RPMTEST}/${RPM_CONFIGDIR_PATH}/macros.d/macros.bcondtests
+runroot rpmbuild -bb --quiet /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[has_bcond(normally_off)
+],
+[])
+
+# bcond behavior, --with
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet --with normally_on --with normally_off \
+    /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[has_bcond(both_features)
+has_bcond(normally_off)
+has_bcond(normally_on)
+],
+[])
+
+# bcond behavior, --without
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet --without normally_on --without normally_off \
+    /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[],
+[])
+
+# bcond behavior, CLI overriding a complex default
+RPMTEST_CHECK([
+runroot rpmbuild -bb --quiet --with both_features /data/SPECS/bcondtest.spec
+runroot rpm -q --provides -p /build/RPMS/noarch/bcondtest-1.0-1.noarch.rpm |
+    grep has_bcond | sort
+],
+[0],
+[has_bcond(both_features)
+has_bcond(normally_off)
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
The bcond mechanism of rpm allows to specify a default for a feature in a spec file, which can be overridden with the command line. SUSE wants to build packages with the same source in different projects. Thus we need a way to specify a default via an rpm macro.

Our first try was to misuse the command line feature by putting `%_with_foo 1` in the macros. But that has two disadvantages: it breaks the command line and it makes it impossible to change the default in a derived project, as rpm cannot undefine macros in a macrofile and the bcond implementation only checks for definedness.

So here's a small addition that makes it possible to set feature defaults: Feature `foo` can be enabled by adding
the macro
```
%bcond_default_foo 1
```
The mechanism uses expression evaluation, so it is possible to remove a default by using %nil as default.

Maybe we can use a better name as `bcond_default`. Any suggestions?

(The pull request is missing documentation and test cases, so do not merge)
