### PR TITLE
python: Use Py_hash_t instead of long in hdr_hash

### DIFF
--- a/python/header-py.c
+++ b/python/header-py.c
@@ -248,9 +248,9 @@ static PyObject * hdrWrite(hdrObject *s, PyObject *args, PyObject *kwds)
     Py_RETURN_NONE;
 }
 
-static long hdr_hash(PyObject * h)
+static Py_hash_t hdr_hash(PyObject * h)
 {
-    return (long) h;
+    return (Py_hash_t) h;
 }
 
 static PyObject * hdr_reduce(hdrObject *s)


### PR DESCRIPTION
Fixes
python/header-py.c:744:2: error: incompatible function pointer types initializing 'hashfunc' (aka 'int (*)(struct _object *)') with an expression of type 'long (PyObject *)' (aka 'long (struct _object *)') [-Wincompatible-function-pointer-types]
|         hdr_hash,                       /* tp_hash */
|         ^~~~~~~~