### PR TITLE
python: Use Py_hash_t instead of long in hdr_hash

### DIFF
--- a/python/header-py.c
+++ b/python/header-py.c
@@ -316,9 +316,9 @@ static PyObject * hdr_dsOfHeader(PyObject * s)
                                  "(Oi)", s, RPMTAG_NEVR);
 }
 
-static long hdr_hash(PyObject * h)
+static Py_hash_t hdr_hash(PyObject * h)
 {
-    return (long) h;
+    return (Py_hash_t) h;
 }
 
 static PyObject * hdr_reduce(hdrObject *s)


### PR DESCRIPTION
Fixes
python/header-py.c:744:2: error: incompatible function pointer types initializing 'hashfunc' (aka 'int (*)(struct _object *)') with an expression of type 'long (PyObject *)' (aka 'long (struct _object *)') [-Wincompatible-function-pointer-types]
|         hdr_hash,                       /* tp_hash */
|         ^~~~~~~~