### PR TITLE
Create content handler plugin hook

### DIFF
--- a/include/rpm/rpmte.h
+++ b/include/rpm/rpmte.h
@@ -26,6 +26,30 @@ typedef enum rpmElementType_e {
 typedef rpmFlags rpmElementTypes;
 
 /** \ingroup rpmte
+ * Transaction element file install function type.
+ *
+ * This function is called to install the files of transaction element
+ *
+ */
+typedef int (*rmpteFileInstallFunction)(rpmte te, rpmfi fi, filedata fp, rpmfiles files, rpmpsm psm, int nodigest, filedata *firstlink, int *firstlinkfile, diriter di, int *fdp, int rc, rpmPlugin plugin);
+
+/** \ingroup rpmte
+ * Transaction element archive reader function type.
+ *
+ * This function is called to get an archive reader iterator
+ *
+ */
+typedef rpmfi (*rpmteArchiveReaderFunction)(FD_t fd, rpmfiles files, int itype, rpmPlugin plugin);
+
+/** \ingroup rpmte
+ * Transaction element verification function type.
+ *
+ * This function is called to verify a package
+ *
+ */
+typedef int (*rpmteVerifyFunction)(FD_t fd, rpmts ts, rpmte p, rpmvs vs, vfydata pvd, int *pverified);
+
+/** \ingroup rpmte
  * Retrieve header from transaction element.
  * @param te		transaction element
  * @return		header (new reference)
@@ -209,6 +233,8 @@ const char * rpmteNEVR(rpmte te);
  */
 const char * rpmteNEVRA(rpmte te);
 
+FD_t rpmteFd(rpmte te);
+
 /** \ingroup rpmte
  * Retrieve key from transaction element.
  * @param te		transaction element
@@ -263,6 +289,42 @@ rpmfiles rpmteFiles(rpmte te);
  * @return 		verification status
  */
 int rpmteVerified(rpmte te);
+
+/** \ingroup rpmte
+ * Get file install function
+ * @param   te		transaction element
+ * @return		pointer to install function
+ */
+rmpteFileInstallFunction rpmteFileInstall(rpmte te);
+
+/** \ingroup rpmte
+ * Get archive reader function
+ * @param   te		transaction element
+ * @return		pointer to archive reader function
+ */
+rpmteArchiveReaderFunction rpmteArchiveReader(rpmte te);
+
+/** \ingroup rpmte
+ * Get verify package function
+ * @param   te		transaction element
+ * @return		pointer to verify function
+ */
+rpmteVerifyFunction rpmteVerify(rpmte te);
+
+/** \ingroup rpmte
+ * Get content handler plugin
+ * @param   te		transaction element
+ * @return		content handler plugin
+ */
+rpmPlugin rpmteContentHandlerPlugin(rpmte te);
+
+/** \ingroup rpmte
+ * Set content handler functions
+ * @param   te		transaction element
+ * @param   handler	structure containing handling functions
+ * @param   plugin	plugin providing content handling functions
+ */
+void rpmteSetContentHandler(rpmte te, rpmPluginContentHandler handler, rpmPlugin plugin);
 
 #ifdef __cplusplus
 }

--- a/include/rpm/rpmts.h
+++ b/include/rpm/rpmts.h
@@ -731,6 +731,18 @@ rpmtsi rpmtsiInit(rpmts ts);
  */
 rpmte rpmtsiNext(rpmtsi tsi, rpmElementTypes types);
 
+/** \ingroup rpmts
+ * Verify package file.
+ * @param fd		file descriptor
+ * @param ts		transaction set
+ * @param p 		transaction element
+ * @param vs		pointer to rpmvs_s structure
+ * @param pvd		pointer to vfydata_s structure
+ * @param pverified	pointer to verified result
+ * @return		return code
+ */
+int verifyPackageFile(FD_t fd, rpmts ts, rpmte p, rpmvs vs, vfydata pvd, int *pverified);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rpm/rpmtypes.h
+++ b/include/rpm/rpmtypes.h
@@ -85,6 +85,7 @@ typedef struct rpmstrPool_s * rpmstrPool;
 
 typedef struct rpmPlugin_s * rpmPlugin;
 typedef struct rpmPlugins_s * rpmPlugins;
+typedef struct rpmPluginContentHandler_s * rpmPluginContentHandler;
 
 typedef struct rpmgi_s * rpmgi;
 
@@ -92,6 +93,15 @@ typedef struct rpmSpec_s * rpmSpec;
 
 typedef struct rpmRelocation_s rpmRelocation;
 
+typedef struct rpmpsm_s * rpmpsm;
+
+typedef struct filedata_s * filedata;
+
+typedef struct diriter_s * diriter;
+
+typedef struct vfydata_s * vfydata;
+
+typedef struct rpmvs_s * rpmvs;
 
 /** \ingroup rpmtypes 
  * RPM IO file descriptor type

--- a/lib/fsm.h
+++ b/lib/fsm.h
@@ -12,7 +12,15 @@
 extern "C" {
 #endif
 
-typedef struct rpmpsm_s * rpmpsm;
+struct filedata_s {
+    int stage;
+    int setmeta;
+    int skip;
+    rpmFileAction action;
+    const char *suffix;
+    char *fpath;
+    struct stat sb;
+};
 
 /**
  * Execute a file actions for package
@@ -29,6 +37,10 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 
 int rpmPackageFilesRemove(rpmts ts, rpmte te, rpmfiles files,
               rpmpsm psm, char ** failedFile);
+
+int fsmFileInstall(rpmte te, rpmfi fi, filedata fp, rpmfiles files, rpmpsm psm, int nodigest, filedata *firstlink, int *firstlinkfile, diriter di, int *fdp, int rc, rpmPlugin plugin);
+
+rpmfi fsmArchiveReader(FD_t fd, rpmfiles files, int itype, rpmPlugin plugin);
 
 RPM_GNUC_INTERNAL
 int rpmfiArchiveReadToFilePsm(rpmfi fi, FD_t fd, int nodigest, rpmpsm psm);

--- a/lib/rpmplugin.h
+++ b/lib/rpmplugin.h
@@ -3,6 +3,7 @@
 
 #include <rpm/rpmtypes.h>
 #include <rpm/rpmfi.h>
+#include <rpm/rpmte.h>
 
 /** \ingroup rpmplugin
  * Rpm plugin API 
@@ -36,6 +37,12 @@ typedef rpmFlags rpmFsmOp;
 #define XFO_ACTION(_a)	((_a) & XFA_MASK)	/*!< File op action part */
 #define XFO_FLAGS(_a)	((_a) & XFAF_MASK)	/*!< File op flags part */
 
+struct rpmPluginContentHandler_s {
+    rmpteFileInstallFunction fileInstall; /* File install function */
+    rpmteArchiveReaderFunction archiveReader; /* Archive reader */
+    rpmteVerifyFunction verify; /* Verify function */
+};
+
 /* plugin hook typedefs */
 typedef rpmRC (*plugin_init_func)(rpmPlugin plugin, rpmts ts);
 typedef void (*plugin_cleanup_func)(rpmPlugin plugin);
@@ -61,6 +68,9 @@ typedef rpmRC (*plugin_fsm_file_prepare_func)(rpmPlugin plugin, rpmfi fi,
 					      const char *dest,
 					      mode_t file_mode, rpmFsmOp op);
 
+typedef rpmRC (*plugin_content_handler_func)(rpmPlugin plugin, rpmte te,
+                                           rpmPluginContentHandler handler);
+
 typedef struct rpmPluginHooks_s * rpmPluginHooks;
 struct rpmPluginHooks_s {
     /* plugin constructor and destructor hooks */
@@ -80,6 +90,8 @@ struct rpmPluginHooks_s {
     plugin_fsm_file_pre_func		fsm_file_pre;
     plugin_fsm_file_post_func		fsm_file_post;
     plugin_fsm_file_prepare_func	fsm_file_prepare;
+    /* post rpmteNew plugin hooks */
+    plugin_content_handler_func		content_handler;
 };
 
 #ifdef __cplusplus

--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -420,3 +420,41 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
 
     return rc;
 }
+
+static int handler_is_valid(rpmPluginContentHandler handler) {
+    return handler->archiveReader && handler->fileInstall && handler->verify;
+}
+
+rpmRC rpmpluginsCallContentHandler(rpmPlugins plugins, rpmte te)
+{
+    plugin_content_handler_func hookFunc;
+    int i;
+    rpmRC rc = RPMRC_OK;
+    struct rpmPluginContentHandler_s handler = {};
+
+    for (i = 0; i < plugins->count; i++) {
+	rpmPlugin plugin = plugins->plugins[i];
+	RPMPLUGINS_SET_HOOK_FUNC(content_handler);
+	if (!hookFunc)
+	    continue;
+	int hrc = hookFunc(plugin, te, &handler);
+	if (hrc == RPMRC_FAIL) {
+	    rpmlog(RPMLOG_WARNING, "Plugin %s: hook content_handler failed\n", plugin->name);
+	    continue;
+	}
+	if (!handler_is_valid(&handler))
+	    continue;
+	if (rpmteContentHandlerPlugin(te)) {
+	    /* Another plugin already claimed the content */
+	    const char * filename = (const char *)rpmteKey(te);
+	    rpmlog(RPMLOG_ERR,
+		   "Plugins %s and %s both claimed the content of %s: hook content_handler failed\n",
+		   rpmteContentHandlerPlugin(te)->name, plugin->name, filename);
+	    rc = RPMRC_FAIL;
+	    break;
+	}
+	rpmteSetContentHandler(te, &handler, plugin);
+    }
+
+    return rc;
+}

--- a/lib/rpmplugins.h
+++ b/lib/rpmplugins.h
@@ -168,6 +168,15 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
                                    int fd, const char *path, const char *dest,
                                    mode_t mode, rpmFsmOp op);
 
+/** \ingroup rpmplugins
+ * Call the content handler plugin hook
+ * @param plugins	plugins structure
+ * @param te		processed transaction element
+ * @return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ */
+RPM_GNUC_INTERNAL
+rpmRC rpmpluginsCallContentHandler(rpmPlugins plugins, rpmte te);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/rpmte.c
+++ b/lib/rpmte.c
@@ -81,6 +81,11 @@ struct rpmte_s {
     int failed;			/*!< (parent) install/erase failed */
 
     rpmfs fs;
+
+    rmpteFileInstallFunction fileInstall; /* File install function */
+    rpmteArchiveReaderFunction archiveReader; /* Archive reader */
+    rpmteVerifyFunction verify; /* Verify function */
+    rpmPlugin contentHandlerPlugin; /* Content handler plugin */
 };
 
 /* forward declarations */
@@ -221,6 +226,11 @@ static int addTE(rpmte p, Header h, fnpyKey key, rpmRelocation * relocs)
 
     if (p->type == TR_ADDED)
 	p->pkgFileSize = headerGetNumber(h, RPMTAG_LONGSIGSIZE) + 96 + 256;
+
+    p->fileInstall = NULL;
+    p->archiveReader = NULL;
+    p->verify = NULL;
+    p->contentHandlerPlugin = NULL;
 
     rc = 0;
 
@@ -435,6 +445,11 @@ FD_t rpmteSetFd(rpmte te, FD_t fd)
 	    te->fd = fdLink(fd);
     }
     return NULL;
+}
+
+FD_t rpmteFd(rpmte te)
+{
+    return (te != NULL ? te->fd : NULL);
 }
 
 fnpyKey rpmteKey(rpmte te)
@@ -809,6 +824,29 @@ int rpmteVerified(rpmte te)
 int rpmteAddOp(rpmte te)
 {
     return te->addop;
+}
+
+rmpteFileInstallFunction rpmteFileInstall(rpmte te) {
+    return (te != NULL ? te->fileInstall : NULL);
+}
+
+rpmteArchiveReaderFunction rpmteArchiveReader(rpmte te) {
+    return (te != NULL ? te->archiveReader : NULL);
+}
+
+rpmteVerifyFunction rpmteVerify(rpmte te) {
+    return (te != NULL ? te->verify : NULL);
+}
+
+rpmPlugin rpmteContentHandlerPlugin(rpmte te) {
+    return (te != NULL ? te->contentHandlerPlugin : NULL);
+}
+
+void rpmteSetContentHandler(rpmte te, rpmPluginContentHandler handler, rpmPlugin plugin) {
+    te->archiveReader = handler->archiveReader;
+    te->fileInstall = handler->fileInstall;
+    te->verify = handler->verify;
+    te->contentHandlerPlugin = plugin;    
 }
 
 int rpmteProcess(rpmte te, pkgGoal goal, int num)


### PR DESCRIPTION
### Description
This change creates a new `content_handler` plugin hook. This hook can be used by plugins to claim responsability for the package payload. The plugin will then be responsible for:
- reading the payload
- verifying it
- installing the files

The main motivation for this change is to enable features like [RPMCoW](https://fedoraproject.org/wiki/Changes/RPMCoW) where the package payload is not in a `cpio` format.