### PR TITLE
Replace rpmTagType_e with a list of defines and an rpmTagType typedef

### DIFF
--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -450,22 +450,24 @@ typedef enum rpmSigTag_e {
 /** \ingroup header
  * The basic types of data in tags from headers.
  */
-typedef enum rpmTagType_e {
-#define	RPM_MIN_TYPE		1
-    RPM_NULL_TYPE		=  0,
-    RPM_CHAR_TYPE		=  1,
-    RPM_INT8_TYPE		=  2,
-    RPM_INT16_TYPE		=  3,
-    RPM_INT32_TYPE		=  4,
-    RPM_INT64_TYPE		=  5,
-    RPM_STRING_TYPE		=  6,
-    RPM_BIN_TYPE		=  7,
-    RPM_STRING_ARRAY_TYPE	=  8,
-    RPM_I18NSTRING_TYPE		=  9,
-#define	RPM_MAX_TYPE		9
-#define RPM_FORCEFREE_TYPE	0xff
-#define RPM_MASK_TYPE		0x0000ffff
-} rpmTagType;
+#define RPM_MIN_TYPE          1
+#define RPM_MAX_TYPE          9
+
+#define RPM_NULL_TYPE         0
+#define RPM_CHAR_TYPE         1
+#define RPM_INT8_TYPE         2
+#define RPM_INT16_TYPE        3
+#define RPM_INT32_TYPE        4
+#define RPM_INT64_TYPE        5
+#define RPM_STRING_TYPE       6
+#define RPM_BIN_TYPE          7
+#define RPM_STRING_ARRAY_TYPE 8
+#define RPM_I18NSTRING_TYPE   9
+
+#define RPM_FORCEFREE_TYPE    0xff
+#define RPM_MASK_TYPE         0x0000ffff
+
+typedef uint32_t rpmTagType;
 
 /** \ingroup rpmtag
  * The classes of data in tags from headers.


### PR DESCRIPTION
I ran in to a problem with some versions of clang building rpm where the value of RPM_MASK_TYPE (0x0000ffff) triggered an overflow error. Per the C standard, the underlying type of the enum is implementation defined.  It should be an int unless the values of the enum cannot fit in an int or unsigned int.  I think that gcc is more forward thinking here than clang because with clang this particular enum becomes an int and when RPM_MASK_TYPE is used, you get an overflow error. RPM_MASK_TYPE is not part of the enum.

I generally find enums in header files to lead to confusion and problems anyway.  And especially in cases like this where developers may be expecting to use the preprocessor to determine if values are defined or not.  Changing this enum to be a list of defined macros resolves the issue for me.  I retained the rpmTagType variable type as well, but made it be a uint32_t.  I originally wanted to make it a uint16_t because RPM_MASK_TYPE is 0x0000ffff, but that causes overflow warnings as well because rpmTagType sometimes gets RPMTAG_NOT_FOUND, which is a uint32_t.  So just use uint32_t consistently.

If this looks reasonable to people, I do not mind fixing up the other enums in header files.  I just wanted to start with this one.