### PR TITLE
Consider available memory and address space for parallel execution

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -317,15 +317,6 @@ static rpmRC buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
         nthreads = omp_get_max_threads();
     if (nthreads_max > 0 && nthreads > nthreads_max)
 	nthreads = nthreads_max;
-#if __WORDSIZE == 32
-    /* On 32bit platforms, address space shortage is an issue. Play safe. */
-    int platlimit = 4;
-    if (nthreads > platlimit) {
-	nthreads = platlimit;
-	rpmlog(RPMLOG_DEBUG,
-	    "limiting number of threads to %d due to platform\n", platlimit);
-    }
-#endif
     if (nthreads > 0)
 	omp_set_num_threads(nthreads);
 #endif

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -68,7 +68,10 @@ to perform useful operations. The current list is
 	%trace		toggle print of debugging information before/after
 			expansion
 	%dump		print the active (i.e. non-covered) macro table
-	%getncpus	return the number of CPUs
+	%getncpus	expand to the number of available CPUs
+	%{getncpus:<total|proc|thread>} expand to the number of available CPUs,
+                "proc" and "thread" additionally accounting for available
+                memory (eg address space limitations for threads)
 	%getconfdir	expand to rpm "home" directory (typically /usr/lib/rpm)
 	%dnl		discard to next line (without expanding)
 	%verbose	expand to 1 if rpm is in verbose mode, 0 if not

--- a/macros.in
+++ b/macros.in
@@ -727,6 +727,11 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 
 %_smp_build_nthreads %{_smp_build_ncpus}
 
+# Assumed task size of processes and threads in megabytes.
+# Used to limit the amount of parallelism based on available memory.
+%_smp_tasksize_proc 512
+%_smp_tasksize_thread %{_smp_tasksize_proc}
+
 #==============================================================================
 # ---- Scriptlet template templates.
 #	Global defaults used for building scriptlet templates.

--- a/macros.in
+++ b/macros.in
@@ -714,8 +714,8 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # Maximum number of CPU's to use when building, 0 for unlimited.
 #%_smp_ncpus_max 0
 
-%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
-	&& RPM_BUILD_NCPUS="%{getncpus}"; \\\
+%_smp_build_ncpus() %([ -z "$RPM_BUILD_NCPUS" ] \\\
+	&& RPM_BUILD_NCPUS="%{getncpus %{?1}}"; \\\
         ncpus_max=%{?_smp_ncpus_max}; \\\
         if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
         echo "$RPM_BUILD_NCPUS";)
@@ -725,7 +725,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # Maximum number of threads to use when building, 0 for unlimited
 #%_smp_nthreads_max 0
 
-%_smp_build_nthreads %{_smp_build_ncpus}
+%_smp_build_nthreads %{_smp_build_ncpus:thread}
 
 # Assumed task size of processes and threads in megabytes.
 # Used to limit the amount of parallelism based on available memory.

--- a/rpmio/rpmio.c
+++ b/rpmio/rpmio.c
@@ -530,16 +530,8 @@ static int parsethreadn(const char *s, char **end)
     if (threads == 0) {
 	/* Disable autodetection inside OpenMP parallel regions */
 	if (!omp_in_parallel())
-	    threads = rpmExpandNumeric("%{getncpus}");
+	    threads = rpmExpandNumeric("%{getncpus:thread}");
     }
-
-#if __WORDSIZE == 32
-    /* Limit threads up to 4 for 32-bit systems.  */
-    if (threads > 4) {
-	threads = 4;
-	rpmlog(RPMLOG_DEBUG, "threading compression limited to 4 threads on 32-bit systems\n");
-    }
-#endif
 
     return threads;
 }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -263,8 +263,26 @@ runroot_other ${RPM_CONFIGDIR}/rpmuncompress "/tmp/some%%ath"
 [0],
 [xxxxxxxxxxxxxxxxxxxxxxxxx
 ])
-
 AT_CLEANUP
+
+AT_SETUP([getncpus macro])
+AT_KEYWORDS([macros])
+# skip if nproc not available
+AT_SKIP_IF([test -z "$(nproc 2>/dev/null)"])
+AT_CHECK([
+mem=$(expr $(getconf PAGESIZE) \* $(getconf _PHYS_PAGES) / 1024 / 1024)
+expr $(runroot rpm --eval "%{getncpus}") = $(nproc)
+expr $(runroot rpm --define "_smp_tasksize_thread ${mem}" --eval "%{getncpus:thread}") = 1
+expr $(runroot rpm --define "_smp_tasksize_proc ${mem}" --eval "%{getncpus:proc}") = 1
+],
+[ignore],
+[1
+1
+1
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([basename macro])
 AT_KEYWORDS([macros])
 AT_CHECK([
@@ -338,8 +356,8 @@ runroot rpm --eval "%dirname dir"
 runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
-runroot rpm --eval "%{getncpus:}"
-runroot rpm --eval "%{getncpus:5}"
+runroot rpm --eval "%{getconfdir:}"
+runroot rpm --eval "%{getconfdir:5}"
 runroot rpm --eval "%{define:}"
 runroot rpm --eval "%{define:foo}"
 runroot rpm --eval "%{define:foo bar}%{foo}"
@@ -368,8 +386,8 @@ bar baz\baz
 [error: %dirname: argument expected
 error: %dirname: argument expected
 error: %uncompress: argument expected
-error: %getncpus: unexpected argument
-error: %getncpus: unexpected argument
+error: %getconfdir: unexpected argument
+error: %getconfdir: unexpected argument
 error: Macro % has illegal name (%define)
 error: Macro %foo has empty body
 error: Macro %foo has empty body


### PR DESCRIPTION
See commits for details, but short summary: add optional proc/thread argument to %{getncpus} macro which consider the available memory and address space, based on newly added tunables for tasksize. 

The goal here is to avoid build failures due to gross overallocation on constrained systems, and to allow packagers to easily adjust for gigantic builds.

Fixes: #804 