### PR TITLE
Catch runaway forked children from Lua scriptlets centrally

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -160,16 +160,10 @@ static rpmRC runLuaScript(rpmPlugins plugins, ARGV_const_t prefixes,
     if (cwd != -1) {
 	mode_t oldmask = umask(0);
 	umask(oldmask);
-	pid_t pid = getpid();
 
 	if (chdir("/") == 0 &&
 		rpmluaRunScript(lua, script, sname, NULL, *argvp) == 0) {
 	    rc = RPMRC_OK;
-	}
-	if (pid != getpid()) {
-	    /* Terminate child process forked in lua scriptlet */
-	    rpmlog(RPMLOG_ERR, _("No exec() called after fork() in lua scriptlet\n"));
-	    _exit(EXIT_FAILURE);
 	}
 	/* This failing would be fatal, return something different for it... */
 	if (fchdir(cwd)) {


### PR DESCRIPTION
Commit 2d418ad3c11bcf0261d0022ac177d13284a8d5fb added a safety catch for runaway children from package scriptlets, but we have many other ways to run Lua scriptlets too, and runaway children are equally harmful in them all. Catch them all centrally by wrapping lua_pcall() instead.

Besides handling more cases, there are a couple of more subtle improvements here: rpmlog() in a child process is undefined behavior due to the locking it does, but also nonsensical - rpmlog() is more than fprintf() and any warnings/errors it collects end up in the wrong process. Check and log from the parent instead.

Finally, make it a warning instead of an error because we're not failing the scriptlet because of this, and make the message more generic as besides exec(), this can be avoided by waiting for the child in the script too.