### PR TITLE
add more libmagic exceptions for HTML, SVG and PNG

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1181,6 +1181,9 @@ static const struct skipped_extension_s skipped_extensions[] = {
 	{ ".h",  "C Header",                 "text/x-c"   },
 	{ ".la", "libtool library file",     "text/plain" },
 	{ ".pc", "pkgconfig file",           "text/plain" },
+	{ ".html", "HTML document",                           "text/html" },
+	{ ".png",  "PNG image data",                          "image/png" },
+	{ ".svg",  "SVG Scalable Vector Graphics image",      "image/svg+xml" },
 	{ NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
I noticed there are ~150K .html files in all libreoffice rpm files and the detection is significantly delaying package build. Thus, I introduce more exceptions for commonly used file formats.