### PR TITLE
Fix an "expected expression" error

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1015,6 +1015,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
             }
 
 setmeta:
+			; /* Empty statement for label */
 	    /* Special files require path-based ops */
 	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
 	    if (!rc && fd == -1 && mayopen) {

--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1014,8 +1014,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
                     rc = RPMERR_UNKNOWN_FILETYPE;
             }
 
-setmeta:
-			; /* Empty statement for label */
+setmeta:;
 	    /* Special files require path-based ops */
 	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
 	    if (!rc && fd == -1 && mayopen) {


### PR DESCRIPTION
In C, a label should be followed by a statement, not a declaration. The `setmeta` label in `lib/fsm.c` violated this, and led to a build error with an error message like the one below:

```
  fsm.c:1019:6: error: expected expression
              int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
              ^
  fsm.c:1020:29: error: use of undeclared identifier 'mayopen'
              if (!rc && fd == -1 && mayopen) {
                                     ^
  2 errors generated.
```

This could be fixed by introducing an empty statement (a single semi-colon). That is a statement.

This failure was seen while packaging RPM for [Homebrew](https://github.com/Homebrew/brew) in https://github.com/Homebrew/homebrew-core/pull/125606. It occurred on both x86_64 and arm64 platforms, running macOS 13 (Ventura). Error log available [here](https://github.com/Homebrew/homebrew-core/actions/runs/4418689502/jobs/7746498587#step:7:510). The compiler used was Apple Clang 14.0.0 build 1400.
