### PR TITLE
Fix compiler error on clang

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -879,6 +879,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
     int nodigest = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOFILEDIGEST) ? 1 : 0;
     int nofcaps = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOCAPS) ? 1 : 0;
     int firstlinkfile = -1;
+    int mayopen;
     char *tid = NULL;
     struct filedata_s *fdata = xcalloc(fc, sizeof(*fdata));
     struct filedata_s *firstlink = NULL;
@@ -1016,7 +1017,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 
 setmeta:
 	    /* Special files require path-based ops */
-	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
+	    mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
 	    if (!rc && fd == -1 && mayopen) {
 		int flags = O_RDONLY;
 		/* Only follow safe symlinks, and never on temporary files */


### PR DESCRIPTION
Turns out declarations cannot be labeled according to the C standard. And while some compilers don't seem to care others do.

Moving the declaration of mayopen to the start of the function to avoid this problem.

Resolves: #2435