### PR TITLE
Fix a segfault on a non-stringable argument to macro call from Lua

### DIFF
--- a/rpmio/rpmlua.c
+++ b/rpmio/rpmlua.c
@@ -1178,8 +1178,13 @@ static int mc_call(lua_State *L)
 
 	for (int i = 1; i <= nitem; i++) {
 	    lua_rawgeti(L, 1, i);
-	    argvAdd(&argv, lua_tostring(L, -1));
-	    lua_pop(L, 1);
+	    const char *s= lua_tostring(L, -1);
+	    if (s) {
+		argvAdd(&argv, s);
+		lua_pop(L, 1);
+	    } else {
+		luaL_argerror(L, i, "cannot convert to string");
+	    }
 	}
 
 	if (rpmExpandThisMacro(*mc, name, argv, &buf, 0) >= 0) {

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -713,6 +713,15 @@ nil
  1:%{?aaa} 2:%{yyy}
 that
 ])
+
+AT_CHECK([[
+runroot rpm \
+	--eval "%{lua:macros.defined({1,2,{}})}"
+]],
+[1],
+[],
+[[error: lua script failed: [string "<lua>"]:1: bad argument #3 to 'defined' (cannot convert to string)
+]])
 AT_CLEANUP
 
 AT_SETUP([lua macros recursion])


### PR DESCRIPTION
When natively calling a parametric macro from Lua, with the arguments inside a table, we can't assume lua_tostring() always succeeds as it can fail eg on a table. Report the error instead of crashing in argvAdd(), and add a test as well.