### PR TITLE
cmake: Fix rpm vendor setting and drop enforced "redhat" vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,9 @@ option(WITH_AUDIT "Build with audit support" ON)
 option(WITH_FSVERITY "Build with fsverity support" OFF)
 option(WITH_IMAEVM "Build with IMA support" OFF)
 
+set(RPM_VENDOR "vendor" CACHE STRING "rpm vendor string")
+
 set(RPMCONFIGDIR "${CMAKE_INSTALL_PREFIX}/lib/rpm" CACHE PATH "rpm home")
-set(RPMCANONVENDOR "vendor" CACHE STRING "rpm vendor string")
 
 # emulate libtool versioning
 set(RPM_SOVERSION 9)
@@ -90,7 +91,7 @@ function(makemacros)
 
 	set(host_cpu ${CMAKE_HOST_SYSTEM_PROCESSOR})
 	string(TOLOWER ${CMAKE_HOST_SYSTEM_NAME} host_os)
-	set(host_vendor redhat)
+	string(TOLOWER ${RPM_VENDOR} host_vendor)
 	set(host ${host_cpu}-${host_vendor}-${host_os})
 
 	set(RPMCANONVENDOR ${host_vendor})


### PR DESCRIPTION
Somehow across the Autotools->CMake migration, we accidentally dropped the configurability of the RPM vendor and always set it to "redhat". Restore the configuration knob with a CMake variable and eliminate the circular setting in the CMakeLists that blows away what the user sets.