### PR TITLE
Don't let macro '%-x' add extra space between flag and argument

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -41,6 +41,7 @@ expanded, the following shell-like macros are available:
 | %#     | the number of arguments
 | %{-f}	 | if present at invocation, the last occurence of flag f (flag and argument)
 | %{-f*} |	if present at invocation, the argument to the last occurence of flag f
+| %f{-f**} | if present at invocation, all occurrences of flag f (flag and argument, space separated)
 | %1, %2, ...|	the arguments themselves (after getopt(3) processing)
 
 With rpm >= 4.17 and disabled option processing the mentioned macros are defined as:

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -849,7 +849,7 @@ static int mbopt(int c, const char *oarg, int oint, void *data)
     /* Define option macros. */
     rasprintf(&name, "-%c", c);
     if (oarg) {
-	rasprintf(&body, "-%c %s", c, oarg);
+	rasprintf(&body, "-%c%s%s", c, fill, oarg);
     } else {
 	rasprintf(&body, "-%c", c);
     }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -236,6 +236,24 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([parametrized macro 9])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --define '%foo(b:) %{-b}' \
+    --eval '%foo -bb' \
+    --eval '%foo -bb=1' \
+    --eval '%foo -b b' \
+    --eval '%foo -b b=1' \
+],
+[0],
+[-bb
+-bb=1
+-b b
+-b b=1
+])
+AT_CLEANUP
+
 AT_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -224,6 +224,18 @@ runroot rpm \
 ])
 RPMTEST_CLEANUP
 
+AT_SETUP([parametrized macro 8])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm \
+    --define '%foo(b:c) %{-b**}' \
+    --eval '%foo 5 a -b2 -bd=1 -c -b e=2'
+],
+[0],
+[-b2 -bd=1 -b e=2
+])
+AT_CLEANUP
+
 AT_SETUP([uncompress macro 1])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
Fixes #2454, depends on #2449  (the commits from #2449 are included to avoid breaking CI)