### PR TITLE
Bring RPM_MASK_RETURN_TYPE in to the signed int range

### DIFF
--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -485,8 +485,8 @@ enum rpmTagReturnType_e {
     RPM_ANY_RETURN_TYPE         = 0,
     RPM_SCALAR_RETURN_TYPE      = 0x00010000,
     RPM_ARRAY_RETURN_TYPE       = 0x00020000,
-    RPM_MAPPING_RETURN_TYPE     = 0x00040000,
-    RPM_MASK_RETURN_TYPE        = 0xffff000
+    RPM_MAPPING_RETURN_TYPE     = 0x00040000
+#define RPM_MASK_RETURN_TYPE    0xffff0000
 };
 
 typedef rpmFlags rpmTagReturnType;

--- a/include/rpm/rpmtag.h
+++ b/include/rpm/rpmtag.h
@@ -486,7 +486,7 @@ enum rpmTagReturnType_e {
     RPM_SCALAR_RETURN_TYPE      = 0x00010000,
     RPM_ARRAY_RETURN_TYPE       = 0x00020000,
     RPM_MAPPING_RETURN_TYPE     = 0x00040000,
-    RPM_MASK_RETURN_TYPE        = 0xffff0000
+    RPM_MASK_RETURN_TYPE        = 0xffff000
 };
 
 typedef rpmFlags rpmTagReturnType;


### PR DESCRIPTION
Set to 0xffff0000 (or 4294901760), I was getting:

     error: ISO C restricts enumerator values to range of 'int' (4294901760 is too large) [-Werror,-Wpedantic]

This happened not when building rpm itself, but when building rpminspect which links with librpm and uses rpm's headers.  The system in question was FreeBSD 13.1 which has clang 13.0.0.

It is a corner case, but I like testing things on non-Linux platforms as often as I can to find errors like this.

With this change, the rpm test suite passes for me.