### PR TITLE
Install /etc/dbus-1/system.d/org.rpm.conf

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -12,6 +12,10 @@ if(WITH_DBUS)
 	target_link_libraries(systemd_inhibit PRIVATE PkgConfig::DBUS)
 	add_library(dbus_announce MODULE dbus_announce.c)
 	target_link_libraries(dbus_announce PRIVATE PkgConfig::DBUS)
+	install(FILES
+	  org.rpm.conf
+	  DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d/
+	)
 endif()
 
 if(WITH_IMAEVM)


### PR DESCRIPTION
which was accidentially dropped when converting to cmake

Use CMAKE_INSTALL_FULL_SYSCONFDIR as it expands to /etc instead of /usr/etc

Resolves: #2474