### PR TITLE
Nix packaging

### DIFF
--- a/tests/populate
+++ b/tests/populate
@@ -35,6 +35,7 @@ for cf in hosts resolv.conf passwd group mtab ; do
 	[ -f /etc/${cf} ] && cp /etc/${cf} testing/etc/${cf}
 done
 touch testing/etc/{shadow,gshadow}
+mkdir -p testing"${TMPDIR:-/tmp}"
 for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod locale systemd-sysusers; do
 	p=`which ${prog}`
 	if [ "${p}" != "" ]; then

--- a/tests/populate
+++ b/tests/populate
@@ -38,7 +38,8 @@ touch testing/etc/{shadow,gshadow}
 for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod locale systemd-sysusers; do
 	p=`which ${prog}`
 	if [ "${p}" != "" ]; then
-		ln -s ${p} testing/${bindir}/
+		mkdir -p testing"${p%/*}"
+		ln -s "${p}" testing"${p}"
 	fi
 done
 for d in /proc /sys /selinux /etc/selinux; do

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -296,6 +296,7 @@ RPMTEST_SETUP
 runroot rpmspec --parse \
 	--define "__rpmuncompress /usr/lib/rpm/rpmuncompress" \
 	--define "__make /usr/bin/make" \
+	--define "__mkdir /usr/bin/mkdir" \
 	--define "__patch /usr/bin/patch" \
 	--define "__chmod /usr/bin/chmod" \
 	--define "debug_package %{nil}" \


### PR DESCRIPTION
Hello,

We have rpm 4.18 in [nixpkgs](https://github.com/NixOS/nixpkgs) and I try to package newer version. I do it early since the build-system changed. While packaging I encounter some issue that might happen to other distro. I keep some patch in nixpkgs until I find a more generic way that works across distros. The commits presents in this PR are ok to be merged, I think I have added enough context in commit as per CONTRIBUTING.md ask each commit is few line so I bundled them together because they are done to serve one goal.

Current status of this PR:
Subject: [rpm 4.18.90] rpmtests: 276 380 381 382 411 failed

Other failure are binary not found so replacing cat with %{__cat}, same for cpio, wc, ... but I guess loose the ability to simply call `cat` is not something that is wanted so I work on another fix.
https://github.com/rpm-software-management/rpm/blob/07d57462614b1669de1d63661f58fd9fa322411b/tests/data/SPECS/parallel.spec#L19-L36
https://github.com/rpm-software-management/rpm/blob/07d57462614b1669de1d63661f58fd9fa322411b/tests/data/SPECS/filetriggers.spec#L15-L43