### PR TITLE
Make user/group info reliable operation across chroot

### DIFF
--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -913,14 +913,6 @@ unique to verify mode are:
 
 :   
 
-**\--nouser**
-
-:   
-
-**\--nogroup**
-
-:   
-
 **\--nomtime**
 
 :   
@@ -932,6 +924,15 @@ unique to verify mode are:
 **\--nordev**
 
 :   Don\'t verify the corresponding file attribute.
+
+**\--nouser**
+
+:   
+
+**\--nogroup**
+
+:  Don\'t verify file user/group ownership. Note that only local
+   passwd(5) and group(5) databases are consulted.
 
 **\--nocaps**
 

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -646,6 +646,9 @@ are taken directly from the on-disk files. Refer to
 [users and groups](users_and_groups.md) for dealing with other users
 and groups.
 
+Note that rpm only uses information from the local passwd(5) and group(5)
+files.
+
 There are two directives to override the default:
 
 #### `%attr(<mode>, <user>, <group>) <file|directory>`

--- a/lib/rpmchroot.c
+++ b/lib/rpmchroot.c
@@ -102,11 +102,10 @@ int rpmChrootSet(const char *rootDir)
 	    rpmlog(RPMLOG_ERR, _("Unable to open current directory: %m\n"));
 	    rc = -1;
 	}
-
-	/* Force preloading of dlopen()'ed libraries before chroot */
-	if (rpmugInit())
-	    rc = -1;
     }
+
+    /* Reset user and group caches */
+    rpmugFree();
 
     return rc;
 }

--- a/lib/rpmug.c
+++ b/lib/rpmug.c
@@ -130,33 +130,23 @@ static int lookup_str(const char *path, long val, int vcol, int rcol,
 int rpmugUid(const char * thisUname, uid_t * uid)
 {
     static char * lastUname = NULL;
-    static size_t lastUnameLen = 0;
-    static size_t lastUnameAlloced;
     static uid_t lastUid;
-    size_t thisUnameLen;
 
     if (!thisUname) {
-	lastUnameLen = 0;
+	lastUname = rfree(lastUname);
 	return -1;
     } else if (rstreq(thisUname, UID_0_USER)) {
 	*uid = 0;
 	return 0;
     }
 
-    thisUnameLen = strlen(thisUname);
-    if (lastUname == NULL || thisUnameLen != lastUnameLen ||
-	!rstreq(thisUname, lastUname))
-    {
-	if (lastUnameAlloced < thisUnameLen + 1) {
-	    lastUnameAlloced = thisUnameLen + 10;
-	    lastUname = xrealloc(lastUname, lastUnameAlloced);	/* XXX memory leak */
-	}
-	strcpy(lastUname, thisUname);
-
+    if (lastUname == NULL || !rstreq(thisUname, lastUname)) {
 	long id;
 	if (lookup_num(pwfile(), thisUname, 0, 2, &id))
 	    return -1;
 
+	free(lastUname);
+	lastUname = xstrdup(thisUname);
 	lastUid = id;
     }
 
@@ -168,32 +158,22 @@ int rpmugUid(const char * thisUname, uid_t * uid)
 int rpmugGid(const char * thisGname, gid_t * gid)
 {
     static char * lastGname = NULL;
-    static size_t lastGnameLen = 0;
-    static size_t lastGnameAlloced;
     static gid_t lastGid;
-    size_t thisGnameLen;
 
     if (thisGname == NULL) {
-	lastGnameLen = 0;
+	lastGname = rfree(lastGname);
 	return -1;
     } else if (rstreq(thisGname, GID_0_GROUP)) {
 	*gid = 0;
 	return 0;
     }
 
-    thisGnameLen = strlen(thisGname);
-    if (lastGname == NULL || thisGnameLen != lastGnameLen ||
-	!rstreq(thisGname, lastGname))
-    {
-	if (lastGnameAlloced < thisGnameLen + 1) {
-	    lastGnameAlloced = thisGnameLen + 10;
-	    lastGname = xrealloc(lastGname, lastGnameAlloced);	/* XXX memory leak */
-	}
-	strcpy(lastGname, thisGname);
-
+    if (lastGname == NULL || !rstreq(thisGname, lastGname)) {
 	long id;
 	if (lookup_num(grpfile(), thisGname, 0, 2, &id))
 	    return -1;
+	free(lastGname);
+	lastGname = xstrdup(thisGname);
 	lastGid = id;
     }
 
@@ -206,10 +186,10 @@ const char * rpmugUname(uid_t uid)
 {
     static uid_t lastUid = (uid_t) -1;
     static char * lastUname = NULL;
-    static size_t lastUnameLen = 0;
 
     if (uid == (uid_t) -1) {
 	lastUid = (uid_t) -1;
+	lastUname = rfree(lastUname);
 	return NULL;
     } else if (uid == (uid_t) 0) {
 	return UID_0_USER;
@@ -217,19 +197,13 @@ const char * rpmugUname(uid_t uid)
 	return lastUname;
     } else {
 	char *uname = NULL;
-	size_t len;
 
 	if (lookup_str(pwfile(), uid, 2, 0, &uname))
 	    return NULL;
 
 	lastUid = uid;
-	len = strlen(uname);
-	if (lastUnameLen < len + 1) {
-	    lastUnameLen = len + 20;
-	    lastUname = xrealloc(lastUname, lastUnameLen);
-	}
-	strcpy(lastUname, uname);
-	free(uname);
+	free(lastUname);
+	lastUname = uname;
 
 	return lastUname;
     }
@@ -239,10 +213,10 @@ const char * rpmugGname(gid_t gid)
 {
     static gid_t lastGid = (gid_t) -1;
     static char * lastGname = NULL;
-    static size_t lastGnameLen = 0;
 
     if (gid == (gid_t) -1) {
 	lastGid = (gid_t) -1;
+	lastGname = rfree(lastGname);
 	return NULL;
     } else if (gid == (gid_t) 0) {
 	return GID_0_GROUP;
@@ -250,19 +224,13 @@ const char * rpmugGname(gid_t gid)
 	return lastGname;
     } else {
 	char *gname = NULL;
-	size_t len;
 
 	if (lookup_str(grpfile(), gid, 2, 0, &gname))
 	    return NULL;
 
 	lastGid = gid;
-	len = strlen(gname);
-	if (lastGnameLen < len + 1) {
-	    lastGnameLen = len + 20;
-	    lastGname = xrealloc(lastGname, lastGnameLen);
-	}
-	strcpy(lastGname, gname);
-	free(gname);
+	free(lastGname);
+	lastGname = gname;
 
 	return lastGname;
     }

--- a/lib/rpmug.h
+++ b/lib/rpmug.h
@@ -11,8 +11,6 @@ const char * rpmugUname(uid_t uid);
 
 const char * rpmugGname(gid_t gid);
 
-int rpmugInit(void);
-
 void rpmugFree(void);
 
 #endif /* _RPMUG_H */

--- a/macros.in
+++ b/macros.in
@@ -132,6 +132,10 @@
 
 %_keyringpath		%{_dbpath}/pubkeys/
 
+# Location of passwd(5) and group(5)
+%_passwd_path		/etc/passwd
+%_group_path		/etc/group
+
 # sysusers helper binary or script, uncomment to disable
 %__systemd_sysusers	%{_bindir}/systemd-sysusers
 

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1454,9 +1454,9 @@ RPMDB_INIT
 
 runroot rpmbuild -bb --quiet --define "pkg user" --define "provs %{add_sysuser u myuser 876 - /home/myuser /bin/sh}"\
   /data/SPECS/deptest.spec
-runroot rpm -U /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm 2> /dev/null
-runroot_other tail -1 /etc/passwd
-runroot rpm -V ${VERIFYOPTS} deptest-user
+runroot rpm -U --root /alt /build/RPMS/noarch/deptest-user-1.0-1.noarch.rpm 2> /dev/null
+runroot_other tail -1 /alt/etc/passwd
+runroot rpm -V --root /alt ${VERIFYOPTS} deptest-user
 ],
 [0],
 [myuser:x:876:876::/home/myuser:/bin/sh


### PR DESCRIPTION
There's no telling what sort of caching getpwnam() and friends perform behind the scenes, and worse, there's no way to explicitly reset those caches. This can lead to chrooted operations using user/group data from the host, which is simply wrong.

Do our own parsing of /etc/passwd and /etc/group to fix. Besides the chroot matter, we then only ever lookup local system users and groups and not something from eg network name services. Technically we should track chroot status for each lookup and flush the cache if the state changed, but this is an internal API and rpm usages only ever call it from one side of the chroot for a given operation.

Fixes: #882