### PR TITLE
Fix bzip2 detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ id0name(UID_0_USER /etc/passwd)
 id0name(GID_0_GROUP /etc/group)
 
 # map module/package findings to config.h
-if (${Bzip2_FOUND})
+if (${BZIP2_FOUND})
 	set(HAVE_BZLIB_H 1)
 endif()
 if (${LIBLZMA_FOUND})


### PR DESCRIPTION
HAVE_BZLIB_H was not set due to a typo leading to the bz2 support not being compiled in although the library was detected correctly.