### PR TITLE
Enable large file support on 32-bit systems again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(CMAKE_SHARED_MODULE_PREFIX "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(GNUInstallDirs)
 add_compile_definitions(_GNU_SOURCE)
+add_definitions(-D_FILE_OFFSET_BITS=64)
 
 function(makemacros)
 	set(prefix ${CMAKE_INSTALL_PREFIX})

--- a/rpm.pc.in
+++ b/rpm.pc.in
@@ -11,6 +11,6 @@ URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Requires: popt
 Requires.private: @ZSTD_REQUIRES@
 # Conflicts:
-Cflags: -I${includedir}
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64
 Libs: -L${libdir} -lrpm -lrpmio
 Libs.private: -lpopt -lrt -lpthread @WITH_LZMA_LIB@ @WITH_BZ2_LIB@ @WITH_ZLIB_LIB@ @LUA_LIBS@


### PR DESCRIPTION
Replace 32-bit sizes in types like off_t with 64-bits when building on 32-bit architectures, to enable large file support there.

This fixes a nasty regression introduced in the cmake transition.  As autotools would set this flag to 64 automatically for us, applications linking against librpm (such as libdnf, librepo, libsolv or drpm) are already adapted to that and are also building with the value of 64 (explicitly, we never exported this flag through pkg-config ourselves). However, us suddenly expecting 32-bits in those types on 32-bit systems can blow up badly e.g. in functions that take an off_t parameter, like Fseek().

There perhaps aren't that many low-level users of librpm but drpm is one such example where exactly this happens when built against our current master.  It calls headerRead(), leading to Fseek() which receives a 64-bit offset parameter where it expects a 32-bit one, thus silently overwriting the following parameter from 1 to 0 (SEEK_CUR to SEEK_SET) which messes up the whole reading sequence in drpm's rpm_read(), producing a failure in drpm's test suite that doesn't make any sense at first sight.

While at it, also export the flag through pkg-config so that anyone linking against librpm is now guaranteed to work correctly even if they don't set the flag themselves (kudos to Petr Pisar for suggesting this).