### PR TITLE
Fix undefined symbols from plugins in some circumstances

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -40,6 +40,7 @@ set(plugindir ${CMAKE_INSTALL_FULL_LIBDIR}/rpm-plugins)
 
 get_property(plugins DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(plugin ${plugins})
+	target_link_libraries(${plugin} PRIVATE librpmio librpm)
 	install(TARGETS ${plugin} DESTINATION ${plugindir})
 endforeach()
 


### PR DESCRIPTION
Another bit lost in the cmake transition: plugin linkage to librpm and librpmio. In rpm itself this doesn't really matter because the running process supplies the necessary symbols but it's a different story when eg a Python process uses dlopen()'ed bindings.