### PR TITLE
Add %{rpmversion} builtin macro for getting the running rpm version

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -112,6 +112,7 @@ various common operations.
 | %{getncpus:...}  | accepts arguments `total`, `proc` and `thread`, additionally accounting for available memory (eg address space limitations for threads| 4.19.0
 | %getconfdir	   | expand to rpm "home" directory (typically /usr/lib/rpm) | 4.7.0
 | %{getenv:...}	   | getenv(3) macro analogue | 4.7.0
+| %rpmversion      | expand to running rpm version
 
 ### Output
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1339,6 +1339,11 @@ static void doTrace(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
     }
 }
 
+static void doRpmver(MacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
+{
+    mbAppendStr(mb, VERSION);
+}
+
 static struct builtins_s {
     const char * name;
     macroFunc func;
@@ -1370,6 +1375,7 @@ static struct builtins_s {
     { "quote",		doFoo,		1,	0 },
     { "rep",		doString,	1,	0 },
     { "reverse",	doString,	1,	0 },
+    { "rpmversion",	doRpmver,	0,	0 },
     { "shrink",		doFoo,		1,	0 },
     { "sub",		doString,	1,	0 },
     { "suffix",		doFoo,		1,	0 },

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -344,6 +344,17 @@ runroot rpm \
 ])
 AT_CLEANUP
 
+AT_SETUP([rpmversion macro])
+AT_KEYWORDS([macros])
+AT_CHECK([
+runroot rpm --eval "%{rpmversion}"
+],
+[0],
+[AT_PACKAGE_VERSION
+],
+[])
+AT_CLEANUP
+
 AT_SETUP([builtin macro arguments])
 AT_KEYWORDS([macros])
 AT_CHECK([


### PR DESCRIPTION
Seems like a useful thing to have, and a bit crazy that we haven't had any reasonable mechanism for this before now.

Fixes: #2523