### PR TITLE
Remove obscure check for package build time from --rebuilddb (#2527)

### DIFF
--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -2470,8 +2470,7 @@ int rpmdbRebuild(const char * prefix, rpmts ts,
 	    /* let's sanity check this record a bit, otherwise just skip it */
 	    if (!(headerIsEntry(h, RPMTAG_NAME) &&
 		headerIsEntry(h, RPMTAG_VERSION) &&
-		headerIsEntry(h, RPMTAG_RELEASE) &&
-		headerIsEntry(h, RPMTAG_BUILDTIME)))
+		headerIsEntry(h, RPMTAG_RELEASE)))
 	    {
 		rpmlog(RPMLOG_ERR,
 			_("header #%u in the database is bad -- skipping.\n"),


### PR DESCRIPTION
Back in 1997, commit be0b90359bcd8156385178eb9b570c0538c0333f added a sanity check for --rebuilddb operation, skipping headers which lack some basic tags. Name, version and release are real requirements for packages, but checking for buildtime is odd, and plain wrong. Yes, we expect that to be present in packages built by rpm, but that's not used for any processing and certainly is not required for a package to be installable. And if it can be installed then it can't be right to throw it away when rebuilding, leaving untrackable orphan files in the process.

It is also documented as informational and optional by LSB. While severely outdated, it is right on this account.

Fixes: #2527