### PR TITLE
Rename SPECPARTS to .SPECPARTS to make it less disruptive

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -274,11 +274,11 @@ static int doSetupMacro(rpmSpec spec, const char *line)
     }
 
     /* mkdir for dynamic specparts */
-    buf = rpmExpand("%{__mkdir_p} SPECPARTS", NULL);
+    buf = rpmExpand("%{__mkdir_p} .SPECPARTS", NULL);
     appendBuf(spec, buf, 1);
     free(buf);
 
-    buf = rpmGenPath("%{_builddir}", "%{buildsubdir}", "SPECPARTS");
+    buf = rpmGenPath("%{_builddir}", "%{buildsubdir}", ".SPECPARTS");
     rpmPushMacro(spec->macros, "specpartsdir", NULL, buf, RMIL_SPEC);
     free(buf);
 

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -333,7 +333,7 @@ if [ $STATUS -ne 0 ]; then
   exit $STATUS
 fi
 cd 'hello-1.0'
-/usr/bin/mkdir -p SPECPARTS
+/usr/bin/mkdir -p .SPECPARTS
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 echo "Patch #0 (hello-1.0-modernize.patch):"
 /usr/bin/patch --no-backup-if-mismatch -f -p1 -b --suffix .modernize --fuzz=0 < /build/SOURCES/hello-1.0-modernize.patch


### PR DESCRIPTION
Fixes https://github.com/rpm-software-management/rpm/issues/2532