### PR TITLE
Support generating dependencies for multiple files at once

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -1037,7 +1037,8 @@ static const struct applyDep_s applyDepTable[] = {
     { 0, 0, NULL },
 };
 
-static int applyAttr(rpmfc fc, int aix, const char *aname,
+static int applyAttr(rpmfc fc, int aix,
+			const struct rpmfcAttr_s *attr,
 			const struct exclreg_s *excl,
 			const struct applyDep_s *dep)
 {
@@ -1045,6 +1046,7 @@ static int applyAttr(rpmfc fc, int aix, const char *aname,
     int n, *ixs;
 
     if (fattrHashGetEntry(fc->fahash, aix, &ixs, &n, NULL)) {
+	const char *aname = attr->name;
 	char *mname = rstrscat(NULL, "__", aname, "_", dep->name, NULL);
 
 	if (rpmMacroIsDefined(NULL, mname)) {
@@ -1082,7 +1084,7 @@ static rpmRC rpmfcApplyInternal(rpmfc fc)
 	    continue;
 	exclInit(dep->name, &excl);
 	for (rpmfcAttr *attr = fc->atypes; attr && *attr; attr++, aix++) {
-	    if (applyAttr(fc, aix, (*attr)->name, &excl, dep))
+	    if (applyAttr(fc, aix, (*attr), &excl, dep))
 		rc = RPMRC_FAIL;
 	}
 	exclFini(&excl);

--- a/docs/manual/dependency_generators.md
+++ b/docs/manual/dependency_generators.md
@@ -30,6 +30,7 @@ A file attribute is represented by a macro file in `%{_fileattrsdir}` (typically
 %__NAME_exclude_path
 %__NAME_exclude_magic
 %__NAME_exclude_flags
+%__NAME_protocol
 ```
 
 NAME needs to be replaced by the name choosen for the file attribute and needs to be the same as the file name of the macro file itself (without the `.attr` suffix). While technically all of them are optional, typically two or more of them are present to form a meaningul attribute. All the values are further macro-expanded on use, and additionally, the path and magic related values are interpreted as extended regular expressions.
@@ -114,6 +115,21 @@ shelling out to execute a script that calls `basename`:
 
 ```
 %__foo_provides()	%{basename:%{1}}
+```
+
+### Multifile protocol (rpm >= 4.20)
+
+Generators may optionally support an enhanced mode where all matching
+files are passed to the generator at once, and the generator is expected
+to output the processed filename prepended with `;` before outputing
+dependencies of that file. Files with no dependencies may be omitted.
+This is several orders of magnitude faster than the traditional behavior
+where a generator is launched separately for each and every file.
+Enabling the multifile mode is done by setting
+`%__NAME_protocol` to `multifile` in the attribute file, eg
+
+```
+%__foo_protocol multifile
 ```
 
 ## Tweaking Dependency Generators

--- a/fileattrs/elf.attr
+++ b/fileattrs/elf.attr
@@ -1,4 +1,5 @@
-%__elf_provides		%{_rpmconfigdir}/elfdeps --provides
-%__elf_requires		%{_rpmconfigdir}/elfdeps --requires
+%__elf_provides		%{_rpmconfigdir}/elfdeps --provides --multifile
+%__elf_requires		%{_rpmconfigdir}/elfdeps --requires --multifile
 %__elf_magic		^(setuid,? )?(setgid,? )?(sticky )?ELF (32|64)-bit.*$
 %__elf_exclude_path	^/lib/modules/.*\.ko?(\.[[:alnum:]]*)$
+%__elf_protocol		multifile

--- a/tools/elfdeps.c
+++ b/tools/elfdeps.c
@@ -16,6 +16,7 @@ int soname_only = 0;
 int fake_soname = 1;
 int filter_soname = 1;
 int require_interp = 0;
+int multifile = 0;
 
 typedef struct elfInfo_s {
     Elf *elf;
@@ -332,8 +333,12 @@ static int processFile(const char *fn, int dtype)
 
     rc = 0;
     /* dump the requested dependencies for this file */
-    for (ARGV_t dep = dtype ? ei->requires : ei->provides; dep && *dep; dep++) {
-	fprintf(stdout, "%s\n", *dep);
+    ARGV_t dep = dtype ? ei->requires : ei->provides;
+    if (dep && *dep) {
+	if (multifile)
+	    fprintf(stdout, ";%s\n", fn);
+	for (; dep && *dep; dep++)
+	    fprintf(stdout, "%s\n", *dep);
     }
 
 exit:
@@ -363,6 +368,7 @@ int main(int argc, char *argv[])
 	{ "no-fake-soname", 0, POPT_ARG_VAL, &fake_soname, 0, NULL, NULL },
 	{ "no-filter-soname", 0, POPT_ARG_VAL, &filter_soname, 0, NULL, NULL },
 	{ "require-interp", 0, POPT_ARG_VAL, &require_interp, -1, NULL, NULL },
+	{ "multifile", 'm', POPT_ARG_VAL, &multifile, -1, NULL, NULL },
 	POPT_AUTOHELP 
 	POPT_TABLEEND
     };


### PR DESCRIPTION
The first commits are just refactoring preliminaries, the beef is in the second-last commit which adds a new opt-in generator mode where all the files are processed in one go per extracted dependency type instead of launching a new generator for every file separately. 
This is a several orders of magnitude faster for even cheap generators (such as the ELF generator which gets multifile support in the last commit), even more so for heavy interpreters like Python/Perl and friends.

The new mode is opt-in because it requires a small change to the generator itself: rpm keeps track of dependencies on per-file level, so in the multifile "protocol", the generator needs to output the filename it's processing prepended with `;` before outputing the generated dependencies.