### PR TITLE
Fix error handling of rpm.execute() and rpm.redirect2null()

### DIFF
--- a/tests/populate
+++ b/tests/populate
@@ -35,7 +35,7 @@ for cf in hosts resolv.conf passwd group mtab ; do
 	[ -f /etc/${cf} ] && cp /etc/${cf} testing/etc/${cf}
 done
 touch testing/etc/{shadow,gshadow}
-for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod locale systemd-sysusers; do
+for prog in gzip cat cp patch tar sh bash ln chmod rm mkdir uname grep sed find file ionice mktemp nice cut sort diff touch install wc coreutils xargs mknod locale systemd-sysusers true false; do
 	p=`which ${prog}`
 	if [ "${p}" != "" ]; then
 		ln -s ${p} testing/${bindir}/

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -1268,4 +1268,24 @@ runroot_other rpmlua -e "print(macros.basename('/some/thing'))"
 [thing
 ],
 [])
+
+AT_CHECK([
+runroot_other rpmlua -e "for i, v in ipairs({'true', 'false', 'grue'}) do print(rpm.execute('/bin/'..v)) end"
+],
+[0],
+[0.0
+nil	exit code	256.0
+nil	No such file or directory	2.0
+],
+[])
+
+# This uses io.stderr:write() because the grue from the previous test 
+# appears to have eaten stdout of the forked child, or something.
+AT_CHECK([
+runroot_other rpmlua -e 'pid = posix.fork(); if pid == 0 then a,b,c=rpm.redirect2null(-1); io.stderr:write(string.format("%s\t%s\t%s\n", a,b,c)) else posix.wait(pid) end'
+],
+[0],
+[],
+[nil	Bad file descriptor	9.0
+])
 AT_CLEANUP


### PR DESCRIPTION
The error handling of these Lua functions is wrong in so many ways I wont list them all here, but eg. rpm.execute() tries to find an strerror() string for an exit code of a process, returns a waitpid() error with code 0 and string "success" and rpm.redirect2null() always returns a failure despite success and never any meaningful error code. The latter probably did the right thing when it was in lposix.c but the pushresult() and pusherror() versions in rpmlua.c are rather different.

To sort the mess, handle the actual error code checking at call site and the pushfoo() functions do just that: push the result on the stack and nothing else. Add some test-cases to go.

Fixes: #2528