### PR TITLE
Only add arch, os and platform, self-provides once

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -742,6 +742,9 @@ static void addTargets(Package Pkgs)
     char *optflags = rpmExpand("%{optflags}", NULL);
 
     for (Package pkg = Pkgs; pkg != NULL; pkg = pkg->next) {
+	if (headerIsEntry(pkg->header, RPMTAG_OS)) {
+	    continue;
+	}
 	headerPutString(pkg->header, RPMTAG_OS, os);
 	/* noarch subpackages already have arch set here, leave it alone */
 	if (!headerIsEntry(pkg->header, RPMTAG_ARCH)) {


### PR DESCRIPTION
per package even if we do multiple parse passes. This is a quick fix for the dynamic spec feature that executes the parsing code multiple times.

This needs to be sorted out properly to only do the necessary things (for the build scripts) here and postpone everything else after the secondary parses. But that requires larger changes.