### PR TITLE
fix the Resource leak: f

### DIFF
--- a/tests/rpmpgppubkeyfingerprint.c
+++ b/tests/rpmpgppubkeyfingerprint.c
@@ -43,6 +43,7 @@ static int test(struct test *test)
     uint8_t *data = malloc(len);
     if (!data) {
 	fprintf(stderr, "out of memory\n");
+	fclose(f);
 	return 1;
     }
 
@@ -52,6 +53,7 @@ static int test(struct test *test)
 	fprintf(stderr, "%s: Read error: %s\n",
 		filename, strerror(err));
 	free(data);
+	fclose(f);
 	return 1;
     }
 


### PR DESCRIPTION
Failure to close the file before returning after opening it can result in resource leakage