### PR TITLE
Reset sqlite log handler when db is closed

### DIFF
--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -208,6 +208,7 @@ static int sqlite_fini(rpmdb rdb)
 	    }
 	    rdb->db_dbenv = NULL;
 	    int xx = sqlite3_close(sdb);
+	    sqlite3_config(SQLITE_CONFIG_LOG, NULL, NULL);
 	    rc = (xx != SQLITE_OK);
 	}
     }


### PR DESCRIPTION
When db is opened rpm registers `rpmlog()` based callback within sqlite and passes `rpmdb` as user data. When db is closed and `rpmdb` gets eventually freed it might lead to UAF if another sqlite3 db is opened different than rpm db.

It happens ie if normal user invokes `dnf download`. First rpm database is opened and log handler is left after closing. Than `generate_completion_cache` plugin tries to open `/var/cache/dnf/packages.db` but failes due to permission issues leading to log message attempt triggering UAF and oftentimes segfault.