### PR TITLE
Actually return an error in parseScript if parsing fails

### DIFF
--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -95,7 +95,7 @@ int parseScript(rpmSpec spec, int parsePart)
     int index;
     char * reqargs = NULL;
 
-    int res = PART_ERROR; /* assume failure */
+    int nextPart, res = PART_ERROR; /* assume failure */
     int rc, argc;
     int arg;
     const char **argv = NULL;
@@ -367,7 +367,7 @@ int parseScript(rpmSpec spec, int parsePart)
 	goto exit;
     }
 
-    if ((res = parseLines(spec, STRIP_NOTHING, NULL, &sb)) == PART_ERROR)
+    if ((nextPart = parseLines(spec, STRIP_NOTHING, NULL, &sb)) == PART_ERROR)
 	goto exit;
 
     if (sb) {
@@ -478,6 +478,8 @@ int parseScript(rpmSpec spec, int parsePart)
 	    }
 	}
     }
+
+    res = nextPart;
 
 exit:
     free(reqargs);


### PR DESCRIPTION
The return value is stored in the "res" variable which is set to the return value of parseLines early in the function. Past that point, any "goto exit;" caused the function to return success. This was introduced by 52ce88851abb ("Port parseScript() to use parseLines(), no functional changes"). To fix it, reintroduce the nextPart variable.

CC @pmatilai as author of the commit introducing the regression.

Before this change, script sections with parse error caused an error message during built but then were just ignored and are missing in the binary package:

```
> cat test.spec
Name: pkg
Summary: Nothing to see here
Version: 0
Release: 0
License: WTFPL
%description
.

%pre -p <magic>
world.issues = 0;

%files
> rpmbuild -bb *.spec
error: line 12: unsupported internal script: <magic>
Processing files: pkg-0-0.x86_64
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/fabian/rpmbuild/BUILDROOT/pkg-0-0.x86_64
Wrote: /home/fabian/rpmbuild/RPMS/x86_64/pkg-0-0.x86_64.rpm
Executing(%clean): /usr/bin/bash -e /var/tmp/rpm-tmp.0LZpaW
+ umask 022
+ cd /home/fabian/rpmbuild/BUILD
+ /usr/bin/rm -rf /home/fabian/rpmbuild/BUILDROOT/pkg-0-0.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
Executing(rmbuild): /usr/bin/bash -e /var/tmp/rpm-tmp.L5DAPK
+ umask 022
+ cd /home/fabian/rpmbuild/BUILD
+ RPM_EC=0
++ jobs -p
+ exit 0
> echo $?
0
> rpm -qp --scripts /home/fabian/rpmbuild/RPMS/x86_64/pkg-0-0.x86_64.rpm
(nothing)
```

With this, the build fails:
```
> LD_LIBRARY_PATH=/tmp/rpmprefix/lib64/ /tmp/rpmprefix/bin/rpmspec -P *.spec
error: line 12: unsupported internal script: <magic>
> echo $?
1
```

This issue was hit in practice through a typo in a `%transfiletriggerin`:

```
%transfiletriggerin -P 1000600 -p <lua> -- /usr/lib/tmpfiles.d
-- This script will process files installed in /usr/lib/tmpfiles.d to create
-- tmpfiles automatically. The priority is set such that it will run
-- after the sysusers file trigger, but before any other triggers.
-- Note: /run is never mounted during transactional updates.
if posix.access("/run/systemd/system") then
    assert(rpm.execute("systemd-tmpfiles", "--create"))
endf
```

Now it fails the build with `error: invalid syntax in lua scriptlet: [string "%transfiletriggerin"]:7: syntax error near <eof>`