### PR TITLE
Add FA_REFLINK file action

### DIFF
--- a/include/rpm/rpmfi.h
+++ b/include/rpm/rpmfi.h
@@ -164,6 +164,14 @@ int rpmfiDigestAlgo(rpmfi fi);
  */
 const unsigned char * rpmfiFDigest(rpmfi fi, int *algo, size_t *diglen);
 
+typedef struct {
+    int64_t src_fd;
+    uint64_t src_offset;
+    uint64_t src_length;
+} reflink_params_s;
+typedef reflink_params_s (*reflink_params_s_func)(rpmfi  fi);
+int rpmfilesSetReflinkFunc(rpmfiles fi, reflink_params_s_func func);
+
 /** \ingroup rpmfi
  * Return current file (hex) digest of file info set iterator.
  * The file info set iterator stores file digests in binary format to conserve

--- a/include/rpm/rpmfiles.h
+++ b/include/rpm/rpmfiles.h
@@ -114,6 +114,7 @@ typedef enum rpmFileAction_e {
     FA_SKIPNETSHARED	= 10,	/*!< ... untouched, state "netshared". */
     FA_SKIPCOLOR	= 11,	/*!< ... untouched, state "wrong color". */
     FA_TOUCH		= 12,	/*!< ... change metadata only. */
+    FA_REFLINK		= 13,	/*!< ... reflink from payload. */
     /* bits 16-31 reserved */
 } rpmFileAction;
 
@@ -121,7 +122,7 @@ typedef enum rpmFileAction_e {
     ((_a) == FA_SKIP || (_a) == FA_SKIPNSTATE || (_a) == FA_SKIPNETSHARED || (_a) == FA_SKIPCOLOR)
 
 #define XFA_CREATING(_a)	\
-    ((_a) == FA_CREATE || (_a) == FA_BACKUP || (_a) == FA_SAVE || (_a) == FA_ALTNAME)
+    ((_a) == FA_CREATE || (_a) == FA_BACKUP || (_a) == FA_SAVE || (_a) == FA_ALTNAME || (_a) == FA_REFLINK)
 
 /**
  * We pass these around as an array with a sentinel.

--- a/lib/fsm.h
+++ b/lib/fsm.h
@@ -31,7 +31,7 @@ int rpmPackageFilesRemove(rpmts ts, rpmte te, rpmfiles files,
               rpmpsm psm, char ** failedFile);
 
 RPM_GNUC_INTERNAL
-int rpmfiArchiveReadToFilePsm(rpmfi fi, FD_t fd, int nodigest, rpmpsm psm);
+int rpmfiArchiveReadToFilePsm(rpmfi fi, FD_t fd, int nodigest, rpmpsm psm, rpmFileAction action);
 
 RPM_GNUC_INTERNAL
 void rpmpsmNotify(rpmpsm psm, int what, rpm_loff_t amount);

--- a/lib/rpmfs.h
+++ b/lib/rpmfs.h
@@ -54,7 +54,6 @@ rpm_fstate_t * rpmfsGetStates(rpmfs fs);
 RPM_GNUC_INTERNAL
 rpmFileAction rpmfsGetAction(rpmfs fs, unsigned int ix);
 
-RPM_GNUC_INTERNAL
 void rpmfsSetAction(rpmfs fs, unsigned int ix, rpmFileAction action);
 
 RPM_GNUC_INTERNAL

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -241,6 +241,7 @@ static void rpmtsUpdateDSI(const rpmts ts, dev_t dev, const char *dirName,
 	break;
 
     case FA_CREATE:
+    case FA_REFLINK:
 	dsi->bneeded += bneeded;
 	dsi->ineeded++;
 	if (prevSize) {
@@ -460,7 +461,8 @@ static void handleInstInstalledFile(const rpmts ts, rpmte p, rpmfiles fi, int fx
 	    rConflicts = handleColorConflict(ts, fs, fi, fx,
 					     NULL, otherFi, ofx);
 	    /* If resolved, we need to adjust in-rpmdb state too */
-	    if (rConflicts == 0 && rpmfsGetAction(fs, fx) == FA_CREATE)
+	    rpmFileAction action = rpmfsGetAction(fs, fx);
+	    if (rConflicts == 0 && (action == FA_CREATE || action == FA_REFLINK))
 		rState = RPMFILE_STATE_WRONGCOLOR;
 	}
 


### PR DESCRIPTION
This PR adds a new  `FA_REFLINK` file action. This action reflinks a file instead of doing a copy. 

This can be used as follows:
- plugins call `rpmfilesSetReflinkFunc` that will setup a function that can be called to get reflink parameters for a file.
- they call `rpmfsSetAction` to set the `FA_REFLINK` action. 
- RPM will try to reflink the file and fall back to copying if reflinking fails

