### PR TITLE
Fix systemd-sysusers helper path discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,11 @@ function(makemacros)
 	set(extutils
 		7zip bzip2 cat chmod chown cp curl file gpg grep gzip id cc ln
 		install lrzip lzip xz make mkdir mv patch rm sed tar unzip
-		zstd gem git hg bzr quilt ld objdump strip
+		zstd gem git hg bzr quilt ld objdump strip systemd-sysusers
 	)
 	foreach (util ${extutils})
 		string(TOUPPER ${util} UTIL)
+		string(REPLACE "-" "_" UTIL ${UTIL})
 		find_program(__${UTIL} ${util})
 		if (NOT EXISTS ${__${UTIL}})
 			message(DEBUG "${util} not found, assuming /usr/bin")

--- a/macros.in
+++ b/macros.in
@@ -136,8 +136,8 @@
 %_passwd_path		/etc/passwd
 %_group_path		/etc/group
 
-# sysusers helper binary or script, uncomment to disable
-%__systemd_sysusers	%{_bindir}/systemd-sysusers
+# sysusers helper binary (or a replacement script), uncomment to disable
+%__systemd_sysusers	@__SYSTEMD_SYSUSERS@
 
 #
 #	Path to script that creates debug symbols in a /usr/lib/debug


### PR DESCRIPTION
systemd-sysusers location does not depend on rpm's idea of %_bindir, use cmake to discover it along with the other tools we use. To handle this, we the need to translate the dash into an underscore in the variable name.