### PR TITLE
Sanitize the helper tool search path in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,24 +72,25 @@ function(makemacros)
 	set(mandir "\${prefix}/${CMAKE_INSTALL_MANDIR}")
 	set(RUNDIR /run)
 
-	set(acutils
-		awk ar as cpp cxx
-	)
-	foreach (V ${acutils})
-		string(TOUPPER ${V} n)
-		set(${n} /usr/bin/${V})
-	endforeach()
 	set(extutils
 		7zip bzip2 cat chmod chown cp curl file gpg grep gzip id cc ln
 		install lrzip lzip xz make mkdir mv patch rm sed tar unzip
 		zstd gem git hg bzr quilt ld objdump strip systemd-sysusers
+		awk ar as cpp c++
 	)
 	foreach (util ${extutils})
 		string(TOUPPER ${util} UTIL)
 		string(REPLACE "-" "_" UTIL ${UTIL})
-		find_program(__${UTIL} ${util})
+		string(REPLACE "+" "X" UTIL ${UTIL})
+		find_program(__${UTIL} ${util}
+			PATHS ENV MYPATH
+			PATHS /usr/local/bin /usr/bin /bin
+			PATHS /usr/local/sbin /usr/sbin /sbin
+			NO_DEFAULT_PATH
+		)
+		message(INFO ${util} " got " ${UTIL} ": " ${__${UTIL}})
 		if (NOT EXISTS ${__${UTIL}})
-			message(DEBUG "${util} not found, assuming /usr/bin")
+			message(WARNING "${util} not found, assuming /usr/bin")
 			set(__${UTIL} /usr/bin/${util})
 		endif()
 	endforeach()

--- a/INSTALL
+++ b/INSTALL
@@ -132,6 +132,9 @@ You can view the various cmake compile options with:
 and fine tune the built components + features, eg:
     cmake -DENABLE_PYTHON=OFF ..
 
+If you have tools outside the regular FHS paths that you need rpm to find,
+you can augment the search path via MYPATH environment variable to cmake.
+
 Now build the system with:
 
     make

--- a/macros.in
+++ b/macros.in
@@ -23,7 +23,7 @@
 # ---- Generally useful path macros.
 #
 %__7zip			@__7ZIP@
-%__awk			@AWK@
+%__awk			@__AWK@
 %__bzip2		@__BZIP2@
 %__cat			@__CAT@
 %__chmod		@__CHMOD@
@@ -60,11 +60,11 @@
 #==============================================================================
 # ---- Build system path macros.
 #
-%__ar			@AR@
-%__as			@AS@
+%__ar			@__AR@
+%__as			@__AS@
 %__cc			@__CC@
-%__cpp			@CPP@
-%__cxx			@CXX@
+%__cpp			@__CPP@
+%__cxx			@__CXX@
 %__ld			@__LD@
 %__objdump		@__OBJDUMP@
 %__strip		@__STRIP@


### PR DESCRIPTION
By default cmake uses $PATH for find_program() lookups, which seems reasonable and even obvious until you start seeing things like /usr/lib64/ccache/cc in the macros file.

Have cmake use a sanitized path (the usual bins) by default and allow augmenting via MYPATH environment variable again (another thing temporarily lost in the cmake transition). This gives us more reasonable output even with ccache installed while still allowing flexibility for more custom setups.

In the autoconf days configure would AS,CC, CPP, CXX, LD and whatnot from the auto* environment directly, but cmake has no direct counterpart for many of those and for the rest, are equally infected by ccache hacks as find_program() is. Handle all the tool lookups with the same logic and same lookup. Also take care of c++ <-> CXX mapping, no compiler I know of installs a file called "cxx" anywhere in the path, its just "c++".