### PR TITLE
Fix missing includes on macOS

### DIFF
--- a/lib/rpmscript.c
+++ b/lib/rpmscript.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <lua.h>
+#include <signal.h>
 
 #include <rpm/rpmfileutil.h>
 #include <rpm/rpmmacro.h>

--- a/tools/rpmuncompress.c
+++ b/tools/rpmuncompress.c
@@ -98,7 +98,8 @@ static char *doUntar(const char *fn)
 	if (needtar) {
 	    rasprintf(&buf, "%s '%s' | %s %s -", zipper, fn, tar, taropts);
 	} else if (at->compressed == COMPRESSED_GEM) {
-	    const char *bn = basename(fn);
+	    char *tmp = xstrdup(fn);
+	    const char *bn = basename(tmp);
 	    size_t nvlen = strlen(bn) - 3;
 	    char *gem = rpmGetPath("%{__gem}", NULL);
 	    char *gemspec = NULL;
@@ -112,6 +113,7 @@ static char *doUntar(const char *fn)
 
 	    free(gemspec);
 	    free(gem);
+	    free(tmp);
 	} else {
 	    rasprintf(&buf, "%s '%s'", zipper, fn);
 	}

--- a/tools/rpmuncompress.c
+++ b/tools/rpmuncompress.c
@@ -1,6 +1,7 @@
 #include "system.h"
 
 #include <popt.h>
+#include <libgen.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
These two headers were missing, and would break with implicit function declarations disabled. I assume glibc and friends includes these through other headers.

This should fix the build on macOS.