### PR TITLE
Set %_sysusersdir independent from our prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ function(makemacros)
 	set(infodir "\${prefix}/${CMAKE_INSTALL_INFODIR}")
 	set(mandir "\${prefix}/${CMAKE_INSTALL_MANDIR}")
 	set(RUNDIR /run)
+	set(root_prefix /usr)
 
 	set(extutils
 		7zip bzip2 cat chmod chown cp curl file gpg grep gzip id cc ln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ function(makemacros)
 	set(oldincludedir "${CMAKE_INSTALL_FULL_OLDINCLUDEDIR}")
 	set(infodir "\${prefix}/${CMAKE_INSTALL_INFODIR}")
 	set(mandir "\${prefix}/${CMAKE_INSTALL_MANDIR}")
-	set(RUNDIR /run)
+	set(rundir /run)
 	set(root_prefix /usr)
 
 	set(extutils

--- a/config.h.in
+++ b/config.h.in
@@ -102,7 +102,7 @@
 #cmakedefine HAVE___SECURE_GETENV @HAVE___SECURE_GETENV@
 #cmakedefine MAJOR_IN_MKDEV @MAJOR_IN_MKDEV@
 #cmakedefine MAJOR_IN_SYSMACROS @MAJOR_IN_SYSMACROS@
-#cmakedefine RUNDIR @RUNDIR@
+#cmakedefine RUNDIR @rundir@
 #cmakedefine WITH_ACL @WITH_ACL@
 #cmakedefine WITH_AUDIT @WITH_AUDIT@
 #cmakedefine ENABLE_BDB_RO @ENABLE_BDB_RO@

--- a/macros.in
+++ b/macros.in
@@ -956,6 +956,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	Macro(s) slavishly copied from autoconf's config.status.
 #
 %_prefix		@prefix@
+%_root_prefix		@root_prefix@
 %_exec_prefix		%{_prefix}
 %_bindir		%{_exec_prefix}/bin
 %_sbindir		%{_exec_prefix}/sbin
@@ -969,7 +970,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %_includedir		%{_prefix}/include
 %_infodir		%{_datadir}/info
 %_mandir		%{_datadir}/man
-%_sysusersdir		%{_prefix}/lib/sysusers.d
+%_sysusersdir		%{_root_prefix}/lib/sysusers.d
 
 #==============================================================================
 # ---- config.guess platform macros.

--- a/platform.in
+++ b/platform.in
@@ -44,7 +44,7 @@
 %_initddir		%{_sysconfdir}/rc.d/init.d
 # Deprecated misspelling, present for backwards compatibility.
 %_initrddir		%{_initddir}
-%_rundir		@RUNDIR@
+%_rundir		@rundir@
 
 %_defaultdocdir		%{_datadir}/doc
 


### PR DESCRIPTION
This is always in /usr no matter what prefixes are used either in rpm or systemd as it is package installed system configuration.

Setting this hard coded to not require systemd as a build dependency. Otherwise the sysusers_dir or sysusersdir pkg-config variable could be used.

Borrowing the _root_prefix idea from systemd for /usr independent of _prefix