### PR TITLE
Allow setting plaform macro settings externally

### DIFF
--- a/installplatform
+++ b/installplatform
@@ -11,7 +11,7 @@ VENDOR="${4}"
 OS="${5}"
 RPMRC_GNU="${6}"
 
-for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2`; do
+for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2` ${RPM_CUSTOM_ARCH:+custom}; do
   RPMRC_OPTFLAGS="`sed -n 's/^optflags: '$ARCH' //p' $RPMRC`"
   RPMRC_OPTFLAGS="`echo $RPMRC_OPTFLAGS | sed -e 's, ,\ ,g'`"
   case $RPMRC_OPTFLAGS in
@@ -30,6 +30,13 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2`; do
   CANONCOLOR=
   FILTER=cat
   case "${ARCH}" in
+    custom)
+	ARCH=$RPM_CUSTOM_ARCH
+	ISANAME=$RPM_CUSTOM_ISANAME
+	ISABITS=$RPM_CUSTOM_ISABITS
+	CANONARCH=$RPM_CUSTOM_CANONARCH
+	CANONCOLOR=$RPM_CUSTOM_CANONCOLOR
+    ;;
     sparc64*) 
 	ISANAME=sparc
 	ISABITS=64


### PR DESCRIPTION
Yocto has their own way to set the platform names via BSPs (Board Support Packages). These names are more specific than basic CPU architectures, and such a platform name ends up in /etc/rpm/platform but the corresponding subdirectory under /usr/lib/rpm/platform does not exist.

Allow creating such custom platform subdirectory with feeding the necessary data using external variables: RPM_CUSTOM_ARCH, RPM_CUSTOM_ISANAME, RPM_CUSTOM_ISABITS, RPM_CUSTOM_CANONARCH and RPM_CUSTOM_CANONCOLOR

Fixes #2578 