### PR TITLE
Check inside --root when querying for files

### DIFF
--- a/lib/query.c
+++ b/lib/query.c
@@ -470,11 +470,13 @@ static rpmdbMatchIterator initQueryIterator(QVA_t qva, rpmts ts, const char * ar
 
 	if (mi == NULL) {
 	    struct stat sb;
-	    if (lstat(fn, &sb) != 0)
+	    char * full_fn = rpmGetPath(rpmtsRootDir(ts), fn, NULL);
+	    if (lstat(full_fn, &sb) != 0)
 		rpmlog(RPMLOG_ERR, _("file %s: %s\n"), fn, strerror(errno));
 	    else
 		rpmlog(RPMLOG_NOTICE,
 			_("file %s is not owned by any package\n"), fn);
+	    free(full_fn);
 	}
 
 	free(fn);


### PR DESCRIPTION
rpm -qf checks if the argument actually exists if it can't be found in the rpmdb and gives different messages based on that.

This was done without taking the root dir into account leading to wrong messages if the file only exists in the root dir but not outside.

Resolves: #2576