### PR TITLE
Mount the common tree snapshot as read-only

### DIFF
--- a/tests/mktree.native
+++ b/tests/mktree.native
@@ -74,8 +74,8 @@ case $CMD in
         exit 0
     ;;
     check)
-        mount_tree $SANDBOX_DIR
-        snapshot shell --chdir /srv ./rpmtests "$@"
+        mount_tree
+        snapshot shell --tmpfs /tmp --chdir /srv ./rpmtests "$@"
         exit
     ;;
     reset)

--- a/tests/mktree.podman
+++ b/tests/mktree.podman
@@ -35,8 +35,9 @@ case $CMD in
         exit 0
     ;;
     check)
-        $PODMAN run --privileged -it --rm -v /srv --workdir /srv \
-                    -e ROOTLESS=$ROOTLESS $IMAGE mktree check "$@"
+        $PODMAN run --privileged -it --rm --read-only --tmpfs /tmp \
+                    -v /srv --workdir /srv -e ROOTLESS=$ROOTLESS \
+                    $IMAGE mktree check "$@"
     ;;
     reset)
         $PODMAN stop $NAME >/dev/null &&

--- a/tests/mktree.rootfs
+++ b/tests/mktree.rootfs
@@ -1,8 +1,11 @@
 #!/bin/bash
 #
-# Rootfs mktree backend for use on throwaway build systems (e.g. containers).
-# Installs RPM and the test-suite into / and runs it natively.
+# Rootfs mktree backend for use in throwaway build containers.
+# Installs RPM into / and runs the test-suite against the same.
+#
 # PWD must be host-mounted for OverlayFS mounts to work.
+# The / filesystem should be read-only to prevent parallel tests from altering
+# it (online changes to an underlying filesystem are disallowed in OverlayFS).
 
 DATA_DIR=/usr/share/mktree
 


### PR DESCRIPTION
This ensures no single test can (accidentally or intentionally) alter the shared tree and influence the subsequent tests.

This also makes us comply with the following OverlayFS requirement which could otherwise be violated when running parallel tests:

    Changes to the underlying filesystems while part of a mounted
    overlay filesystem are not allowed. If the underlying filesystem is
    changed, the behavior of the overlay is undefined, though it will
    not result in a crash or deadlock.

Contrary to what I thought in commit
    cf8716f204f1eed196ca7ae905288261e0c88c3b,
to make this work, all we need is to mount a new tmpfs at /tmp in the snapshot, as that's where some of the processes (patch(1) in particular) need to write.

Update the comment in mktree.rootfs accordingly, too.