### PR TITLE
Allow setting platform macro settings externally

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -143,6 +143,38 @@ and then install with:
 
     make install
 
+By default, rpm installs a series of default platforms based on the CPU
+architecture names in subdirectories called
+
+    /usr/lib/platform/<arch>-linux
+
+This is enough for regular Linux distributions. However, some distributions
+may use more specific platform names that refer to particular computer
+systems, like SBCs or specific CPU tuning when compiling. Examples of such
+platform names are: "genericx86_64", "intel_skylake_64", "raspberrypi_armv7",
+"raspberrypi_armv8", etc.
+
+If the platform name is put into /etc/rpm/platform, then rpmbuild uses it
+and the only macros file rpmbuild looks for is
+
+    /usr/lib/platform/`cat /etc/rpm/platform`-linux/macros
+
+If this file does not exist, many rpm macros will not have their expected
+values set and e.g. %configure will fail when trying to run rpmbuild.
+
+To allow creating the macros file for such a custom platform, the shell
+variables listed below must be set. If RPM_CUSTOM_ARCH is not set, the rest
+is ignored.
+
+    export RPM_CUSTOM_ARCH=genericx86_64
+    export RPM_CUSTOM_ISANAME=x86
+    export RPM_CUSTOM_ISABITS=64
+    export RPM_CUSTOM_CANONARCH=x86_64
+    export RPM_CUSTOM_CANONCOLOR=0 # to use /usr/lib for %_libdir
+    export RPM_CUSTOM_CANONCOLOR=3 # to use /usr/lib64 for %_libdir
+
+    make install # this also installs /usr/lib/platform/genericx86_64-linux/macros
+
 Rpm comes with an automated self-test suite. The test-suite requires
 autom4te from autoconf (https://www.gnu.org/software/autoconf/) and
 bwrap (https://github.com/containers/bubblewrap/). It is enabled by

--- a/INSTALL
+++ b/INSTALL
@@ -143,12 +143,13 @@ and then install with:
 
     make install
 
+
 By default, rpm installs a series of default platforms based on the CPU
 architecture names in subdirectories called
 
-    /usr/lib/platform/<arch>-linux
+    /usr/lib/platform/<arch>-<os>
 
-This is enough for regular Linux distributions. However, some distributions
+This is enough for many distributions. However, some distributions
 may use more specific platform names that refer to particular computer
 systems, like SBCs or specific CPU tuning when compiling. Examples of such
 platform names are: "genericx86_64", "intel_skylake_64", "raspberrypi_armv7",
@@ -157,7 +158,7 @@ platform names are: "genericx86_64", "intel_skylake_64", "raspberrypi_armv7",
 If the platform name is put into /etc/rpm/platform, then rpmbuild uses it
 and the only macros file rpmbuild looks for is
 
-    /usr/lib/platform/`cat /etc/rpm/platform`-linux/macros
+    /usr/lib/platform/`cat /etc/rpm/platform`-<os>/macros
 
 If this file does not exist, many rpm macros will not have their expected
 values set and e.g. %configure will fail when trying to run rpmbuild.
@@ -173,7 +174,11 @@ is ignored.
     export RPM_CUSTOM_CANONCOLOR=0 # to use /usr/lib for %_libdir
     export RPM_CUSTOM_CANONCOLOR=3 # to use /usr/lib64 for %_libdir
 
-    make install # this also installs /usr/lib/platform/genericx86_64-linux/macros
+    make install 
+
+This also creates and installs the new platform file e.g.
+/usr/lib/platform/genericx86_64-linux/macros
+
 
 Rpm comes with an automated self-test suite. The test-suite requires
 autom4te from autoconf (https://www.gnu.org/software/autoconf/) and

--- a/installplatform
+++ b/installplatform
@@ -11,7 +11,7 @@ VENDOR="${4}"
 OS="${5}"
 RPMRC_GNU="${6}"
 
-for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2`; do
+for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2` ${RPM_CUSTOM_ARCH:+custom}; do
   RPMRC_OPTFLAGS="`sed -n 's/^optflags: '$ARCH' //p' $RPMRC`"
   RPMRC_OPTFLAGS="`echo $RPMRC_OPTFLAGS | sed -e 's, ,\ ,g'`"
   case $RPMRC_OPTFLAGS in
@@ -30,6 +30,13 @@ for ARCH in noarch `grep ^arch_canon $RPMRC | cut -d: -f2`; do
   CANONCOLOR=
   FILTER=cat
   case "${ARCH}" in
+    custom)
+	ARCH=$RPM_CUSTOM_ARCH
+	ISANAME=$RPM_CUSTOM_ISANAME
+	ISABITS=$RPM_CUSTOM_ISABITS
+	CANONARCH=$RPM_CUSTOM_CANONARCH
+	CANONCOLOR=$RPM_CUSTOM_CANONCOLOR
+    ;;
     sparc64*) 
 	ISANAME=sparc
 	ISABITS=64


### PR DESCRIPTION
By default, rpm installs a series of default platforms based on the CPU architecture names in subdirectories called `/usr/lib/platform/<arch>-linux`.

This is enough for regular Linux distributions. However, some distributions may use more specific platform names that refer to particular computer systems, like SBCs or specific CPU tuning when compiling.

If the platform subdirectory does not exist in `/usr/lib/platform` then rpmbuild does not work.

Allow creating such custom platform subdirectory with feeding the necessary data using external variables: `RPM_CUSTOM_ARCH`, `RPM_CUSTOM_ISANAME`, `RPM_CUSTOM_ISABITS`, `RPM_CUSTOM_CANONARCH` and `RPM_CUSTOM_CANONCOLOR`

Fixes #2578 