### PR TITLE
Add back ima-evm-utils to mktree.fedora, oops

### DIFF
--- a/tests/mktree.fedora
+++ b/tests/mktree.fedora
@@ -97,6 +97,7 @@ case $CMD in
             gpg \
             grep \
             gzip \
+            ima-evm-utils \
             libacl \
             libarchive \
             libcap \


### PR DESCRIPTION
We actually do need this library in the test tree, in case the build is configured with -DWITH_IMAEVM=ON which links librpmsign to it, it's not a plugin.  We already include libfsverity for the same reason.

This is a fixup for commit 4c41faf7a592a5bb484cf7d645cc247d850d776a.