### PR TITLE
Bump actions/checkout from v2 to latest (v3)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build the Fedora testing environment
         run: sudo ./mktree.docker build
         working-directory: ./tests


### PR DESCRIPTION
This should've been part of the previous commit, just got forgotten.