### PR TITLE
allow to support perl normal version scheme for rpm compatible versions

### DIFF
--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -45,6 +45,19 @@
 
 # by Ken Estes Mail.com kestes@staff.mail.com
 
+my $normalversion = 0;
+my $perln = 0;
+
+while ("@ARGV") {
+  if ($ARGV[0] =~ /^--/) {
+    $normalversion = 1 if $ARGV[0] eq "--normalversion"; # use normal form in perl(xxx)
+    $perln = 1 if $ARGV[0] eq "--perln";                 # use perln(xxx) and perl(xxx)
+    shift @ARGV;
+  } else {
+    last;
+  }
+}
+
 if ("@ARGV") {
   foreach (@ARGV) {
     next if !/\.pm$/;
@@ -65,13 +78,22 @@ if ("@ARGV") {
 foreach $module (sort keys %require) {
   if (length($require{$module}) == 0) {
     print "perl($module)\n";
+    print "perln($module)\n" if !$perln;
   } else {
 
     # I am not using rpm3.0 so I do not want spaces around my
     # operators. Also I will need to change the processing of the
     # $RPM_* variable when I upgrade.
 
-    print "perl($module) = $require{$module}\n";
+    if($normalversion)
+    {
+      print "perl($module) = ".version->parse($require{$module})->normal."\n";
+    }
+    else
+    {
+      print "perl($module) = $require{$module}\n";
+    }
+    print "perln($module) = ".version->parse($require{$module})->normal."\n" if $perln;
   }
 }
 

--- a/scripts/perl.req
+++ b/scripts/perl.req
@@ -43,8 +43,22 @@ $HAVE_VERSION = 0;
 eval { require version; $HAVE_VERSION = 1; };
 
 
+my $normalversion = 0;
+my $perln = 0;
+
+while ("@ARGV") {
+  if ($ARGV[0] =~ /^--/) {
+    $normalversion = 1 if $ARGV[0] eq "--normalversion"; # use normal form in perl(xxx)
+    $perln = 1 if $ARGV[0] eq "--perln";                 # use perln(xxx) and perl(xxx)
+    shift @ARGV;
+  } else {
+    last;
+  }
+}
+
 if ("@ARGV") {
   foreach (@ARGV) {
+    next if !/\.pm$/;
     process_file($_);
   }
 } else {
@@ -64,13 +78,22 @@ foreach $perlver (sort keys %perlreq) {
 foreach $module (sort keys %require) {
   if (length($require{$module}) == 0) {
     print "perl($module)\n";
+    print "perln($module)\n" if !$perln;
   } else {
 
     # I am not using rpm3.0 so I do not want spaces around my
     # operators. Also I will need to change the processing of the
     # $RPM_* variable when I upgrade.
 
-    print "perl($module) >= $require{$module}\n";
+    if($normalversion)
+    {
+      print "perl($module) = ".version->parse($require{$module})->normal."\n";
+    }
+    else
+    {
+      print "perl($module) = $require{$module}\n";
+    }
+    print "perln($module) = ".version->parse($require{$module})->normal."\n" if $perln;
   }
 }
 


### PR DESCRIPTION
We started to use perl nomal version scheme for perl packages in openSUSE which hopefully finally fixes the version conflicts between RPM and perl versions which trouble us for years. This submission adds a patch which supports this method in the RPM scripts directly. That way we can use this instead of reimplementing the provides handling.

The patch is done in a way that it does not affect current behaviour of the tools. For openSUSE we will for now reset the __perllib_provides variable in the spec file for each package until the transition phase is through (in which old and new version are mixed). Afterwards the attrs files will be change to call the scripts with the option directly always. For openSUSE it was decided to to not use the perln(...) scheme, but instead make the transition in the perl(...) namespace and handle the resulting version conflicts.

The patch contains both options in case other projects make another decision and want to use perln(...):
A way for transition would be to enable additional provides with version with perln(...), switch all requires with a version to perln(...), then switch perl(...) to the new scheme and then drop perln(...) again. That is conflict free, but has more package changing steps.