### PR TITLE
Make %optflags empty on noarch target

### DIFF
--- a/rpmrc.in
+++ b/rpmrc.in
@@ -9,6 +9,8 @@
 #############################################################
 # Values for RPM_OPT_FLAGS for various platforms
 
+optflags: noarch %{nil}
+
 # "fat" binary with both archs, for Darwin
 optflags: fat -O2 -g -arch i386 -arch ppc
 

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -58,6 +58,23 @@ RPMTEST_CHECK([runroot rpm --showrc],[0],
 [ignore])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpm --target])
+AT_KEYWORDS([basic])
+RPMTEST_CHECK([
+runroot rpm --target x86_64 --eval "x%{optflags}x"
+],
+[0],
+[x-O2 -gx]
+)
+
+RPMTEST_CHECK([
+runroot rpm --target noarch --eval "x%{optflags}x"
+],
+[0],
+[xx]
+)
+RPMTEST_CLEANUP
+
 
 # ------------------------------
 # Check rpm --querytags


### PR DESCRIPTION
As there hasn't been any optflags set for noarch, whatever flags from the current host end up there and even in the produced binary and source rpms. Which seems decidedly wrong for a noarch package, and hurts reproducibility of said packages for no good reason.

Inspired by this bug report which reveals that cmake use in otherwise noarch packages ends up on relying on %optflags being set up for the architecture we're running on:
https://bugzilla.redhat.com/show_bug.cgi?id=2231727