### PR TITLE
Private /tmp directory for scriptlets

### DIFF
--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -10,7 +10,6 @@
 #include <sys/statvfs.h>
 #include <fcntl.h>
 
-#define _GNU_SOURCE
 #include <sched.h>
 #include <sys/mount.h>
 #include <stdbool.h>


### PR DESCRIPTION
Ensure a private /tmp directory is used for each scriptlet that is run during installation. Sometimes packagers place vulnerable code in these snippets that operates naively on /tmp and allows for escalation of privileges for local users.

This is intended as POC/RFC. We monitor the %post etc. scriptlets added by our maintainers and regularly identify issues with those. Not all will be fixed with this (everything that operates out of /tmp can still cause issues), but the hope is to at least prevent issues in /tmp once and for all.

We applied this patch to openSUSE Tumbleweed, build the distribution with it and ran several openQA test suites on this (e.g. https://openqa.opensuse.org/tests/3507153) without seeing any issues. But I assume that getting this upstream might require changes due to reasons outlines in the contributing guidelines, but I hope we can enable this by default

I assume that there will need to be a way to opt out of this via a cmd argument, but didn't implement this yet.