### PR TITLE
Revert recent %_root_prefix macro addition (RhBug:2233454)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,11 @@ function(makemacros)
 	set(infodir "\${prefix}/${CMAKE_INSTALL_INFODIR}")
 	set(mandir "\${prefix}/${CMAKE_INSTALL_MANDIR}")
 	set(rundir /run)
-	set(root_prefix /usr)
+
+	pkg_get_variable(sysusersdir systemd sysusersdir)
+	if (NOT sysusersdir)
+		set(sysusersdir /usr/lib/sysusers.d)
+	endif()
 
 	findutil(__7ZIP "7za;7z")
 	findutil(__BZIP2 bzip2)

--- a/macros.in
+++ b/macros.in
@@ -957,7 +957,6 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	Macro(s) slavishly copied from autoconf's config.status.
 #
 %_prefix		@prefix@
-%_root_prefix		@root_prefix@
 %_exec_prefix		%{_prefix}
 %_bindir		%{_exec_prefix}/bin
 %_sbindir		%{_exec_prefix}/sbin
@@ -971,7 +970,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %_includedir		%{_prefix}/include
 %_infodir		%{_datadir}/info
 %_mandir		%{_datadir}/man
-%_sysusersdir		%{_root_prefix}/lib/sysusers.d
+%_sysusersdir		@sysusersdir@
 
 #==============================================================================
 # ---- config.guess platform macros.

--- a/macros.in
+++ b/macros.in
@@ -136,6 +136,9 @@
 %_passwd_path		/etc/passwd
 %_group_path		/etc/group
 
+# location of sysusers.d(5) directory
+%_sysusersdir		@sysusersdir@
+
 # sysusers helper binary (or a replacement script), uncomment to disable
 #%__systemd_sysusers	@__SYSTEMD_SYSUSERS@
 %__systemd_sysusers	%{_rpmconfigdir}/sysusers.sh
@@ -970,7 +973,6 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %_includedir		%{_prefix}/include
 %_infodir		%{_datadir}/info
 %_mandir		%{_datadir}/man
-%_sysusersdir		@sysusersdir@
 
 #==============================================================================
 # ---- config.guess platform macros.


### PR DESCRIPTION
Commit cececfb6851234aca3e8d102de1c192c6bdf3e67 introduced %_root_prefix macro but this unnecessarily breaks widespread use in scl-utils: https://bugzilla.redhat.com/show_bug.cgi?id=2233454

Just query the value from pkg-config if available and otherwise use hardcoded value pointing to /usr instead. We don't need an intermediate global macro for this.