### PR TITLE
Fix misleading error message on some invalid filetrigger conditions (…

### DIFF
--- a/build/parseReqs.c
+++ b/build/parseReqs.c
@@ -273,6 +273,17 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 	    }
 	}
 
+	/* needs to be checked before checkDep() */
+	if (nametag == RPMTAG_FILETRIGGERNAME ||
+	    nametag == RPMTAG_TRANSFILETRIGGERNAME)
+	{
+	    if (N[0] != '/') {
+		rasprintf(&emsg,
+		    _("file trigger conditions must begin with '/'"));
+		goto exit;
+	    }
+	}
+
 	/* check that dependency is well-formed */
 	if (checkDep(spec, N, EVR, &emsg))
 	    goto exit;
@@ -292,15 +303,6 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 				   "'>' in Obsoletes"));
 	    }
 	}
-
-	if (nametag == RPMTAG_FILETRIGGERNAME ||
-	    nametag == RPMTAG_TRANSFILETRIGGERNAME) {
-	    if (N[0] != '/') {
-		rasprintf(&emsg, _("Only absolute paths are allowed in "
-				    "file triggers"));
-	    }
-	}
-
 
 	/* Deny more "normal" triggers fired by the same pakage. File triggers are ok */
 	if (nametag == RPMTAG_TRIGGERNAME) {
@@ -333,8 +335,8 @@ rpmRC parseRCPOT(rpmSpec spec, Package pkg, const char *field, rpmTagVal tagN,
 exit:
     if (emsg) {
 	int lvl = (rc == RPMRC_OK) ? RPMLOG_WARNING : RPMLOG_ERR;
-	/* Automatic dependencies don't relate to spec lines */
-	if (tagflags & (RPMSENSE_FIND_REQUIRES|RPMSENSE_FIND_PROVIDES)) {
+	/* Automatic dependencies and triggers don't relate to spec lines */
+	if (tagflags & (RPMSENSE_FIND_REQUIRES|RPMSENSE_FIND_PROVIDES|RPMSENSE_TRIGGER)) {
 	    rpmlog(lvl, "%s: %s\n", emsg, r);
 	} else {
 	    rpmlog(lvl, _("line %d: %s: %s\n"),

--- a/build/parseScript.c
+++ b/build/parseScript.c
@@ -399,12 +399,6 @@ int parseScript(rpmSpec spec, int parsePart)
     /* get the index right.                                   */
     if (tag == RPMTAG_TRIGGERSCRIPTS || tag == RPMTAG_FILETRIGGERSCRIPTS ||
 	tag == RPMTAG_TRANSFILETRIGGERSCRIPTS) {
-	if (tag != RPMTAG_TRIGGERSCRIPTS && *reqargs != '/') {
-	    rpmlog(RPMLOG_ERR,
-	       _("line %d: file trigger condition must begin with '/': %s"),
-		spec->lineNum, reqargs);
-	    goto exit;
-	}
 	if (progArgc > 1) {
 	    rpmlog(RPMLOG_ERR,
 	      _("line %d: interpreter arguments not allowed in triggers: %s\n"),

--- a/tests/data/SPECS/badftrigger.spec
+++ b/tests/data/SPECS/badftrigger.spec
@@ -1,0 +1,14 @@
+Name: badftrigger
+Version: 1.0
+Release: 1
+Summary: Testing error reporting
+License: GPL
+BuildArch: noarch
+
+%description
+%{summary}
+
+%transfiletriggerin -- /something %{nosuchmacro}
+echo bad
+
+%files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2436,3 +2436,31 @@ runroot rpmbuild -bp --quiet /data/SPECS/source_space.spec
 [],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild bad filetrigger condition])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+rpmspec --parse /data/SPECS/badftrigger.spec
+],
+[1],
+[],
+[error: file trigger conditions must begin with '/': %{nosuchmacro}
+])
+
+RPMTEST_CHECK([
+rpmspec --define "nosuchmacro aaa" --parse /data/SPECS/badftrigger.spec
+],
+[1],
+[],
+[error: file trigger conditions must begin with '/': aaa
+])
+
+RPMTEST_CHECK([
+rpmspec --define "nosuchmacro /bbb" --parse /data/SPECS/badftrigger.spec
+],
+[0],
+[ignore],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
…#2584)

We used to test the first argument in parseScript() and then again in parseRCPOT(), with different error messages in each case as if they were separate issues. Only, the one in parseRCPOT() didn't get a chance to execute because it was caught by checkDep() before it (probably added after the file trigger check was initially added) and so for invalid file trigger conditions (such as an unexpanded macro), you'd get a very misleading error about dependency tokens where an absolute path is expected, and worse, it was reporting an incorrect line and a line number while at it.

Measure twice, cut once doesn't apply here. Check once and be consistent about reporting it. Due to the way triggers are handled, we can't report the line number correctly so don't even try, the wrong line number is far worse than not having it at all. Add some tests to go.

Fixes: #2584