### PR TITLE
Export our libraries as a cmake find_package() config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,3 +520,29 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/.git)
 	add_tarball(snapshot
 		    ${PROJECT_NAME}-${PROJECT_VERSION}-git${gitcount} HEAD)
 endif()
+
+# Voodoo rites to make our libraries cmake find_package() importable
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/cmake/rpm-config.cmake.in
+	${CMAKE_CURRENT_BINARY_DIR}/rpm-config.cmake
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rpm
+)
+write_basic_package_version_file(
+	${CMAKE_CURRENT_BINARY_DIR}/rpm-config-version.cmake
+	COMPATIBILITY SameMinorVersion
+)
+install(FILES
+	${CMAKE_CURRENT_BINARY_DIR}/rpm-config.cmake
+	${CMAKE_CURRENT_BINARY_DIR}/rpm-config-version.cmake
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/rpm
+)
+
+export(TARGETS librpm librpmio librpmbuild librpmsign
+	FILE rpm-targets.cmake
+	NAMESPACE rpm::
+)
+install(EXPORT rpm-targets
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+	NAMESPACE rpm::
+)

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -32,4 +32,4 @@ if(OpenMP_C_FOUND)
 endif()
 
 
-install(TARGETS librpmbuild)
+install(TARGETS librpmbuild EXPORT rpm-targets)

--- a/cmake/rpm-config.cmake.in
+++ b/cmake/rpm-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/rpm-targets.cmake")
+check_required_components(rpm)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -68,4 +68,4 @@ add_custom_command(OUTPUT tagtbl.C
 target_link_libraries(librpm PUBLIC librpmio)
 target_link_libraries(librpm PRIVATE PkgConfig::POPT LUA::LUA)
 
-install(TARGETS librpm)
+install(TARGETS librpm EXPORT rpm-targets)

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -48,5 +48,4 @@ if (OpenMP_C_FOUND)
         target_link_libraries(librpmio PRIVATE OpenMP::OpenMP_C)
 endif()
 
-install(TARGETS librpmio
-)
+install(TARGETS librpmio EXPORT rpm-targets)

--- a/sign/CMakeLists.txt
+++ b/sign/CMakeLists.txt
@@ -15,4 +15,4 @@ if (WITH_FSVERITY)
 	target_link_libraries(librpmsign PRIVATE PkgConfig::FSVERITY)
 endif()
 
-install(TARGETS librpmsign)
+install(TARGETS librpmsign EXPORT rpm-targets)


### PR DESCRIPTION
This is a fair amount of annoying voodoo boilerplate compared to what I would've expected, but the ability to just `find_package(rpm)` is very nice on the (API) user side.

Fixes: #2471