### PR TITLE
Run test-suite with plugins enabled now that we can

### DIFF
--- a/plugins/dbus_announce.c
+++ b/plugins/dbus_announce.c
@@ -66,7 +66,9 @@ static rpmRC open_dbus(rpmPlugin plugin, rpmts ts)
     }
     return RPMRC_OK;
  err:
-    rpmlog(RPMLOG_WARNING,
+    int ignore = dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) ||
+		 dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND);
+    rpmlog(ignore ? RPMLOG_DEBUG : RPMLOG_WARNING,
 	   "dbus_announce plugin: Error connecting to dbus (%s)\n",
 	   err.message);
     dbus_error_free(&err);

--- a/plugins/systemd_inhibit.c
+++ b/plugins/systemd_inhibit.c
@@ -53,13 +53,11 @@ static int inhibit(void)
     }
     
     if (dbus_error_is_set(&err)) {
-	if (!dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) &&
-	    !dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND))
-	{
-	    rpmlog(RPMLOG_WARNING,
+	int ignore = dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) ||
+		     dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND);
+	rpmlog(ignore ? RPMLOG_DEBUG : RPMLOG_WARNING,
 	       "Unable to get systemd shutdown inhibition lock: %s\n",
 		err.message);
-	}
 	dbus_error_free(&err);
     }
 

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -153,7 +153,7 @@ function runroot()
     snapshot exec "$@" \
              --define "_buildhost testhost" \
              --define "_topdir /build" \
-             --noplugins --nouserns
+             --nouserns
 }
 
 function runroot_other()

--- a/tests/mktree.fedora
+++ b/tests/mktree.fedora
@@ -114,6 +114,7 @@ case $CMD in
             coreutils \
             cpio \
             curl \
+            dbus-libs \
             debugedit \
             diffutils \
             elfutils-libelf \


### PR DESCRIPTION
With the fancy new container-based test-suite, we can actually enable plugins in the test-suite :partying_face: 

The first commit is required for doing this, the second is merely for consistency.