### PR TITLE
Always run tests without --nouser and --nogroup, now that we can

### DIFF
--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -56,8 +56,6 @@ if mknod foodev c 123 123 2>/dev/null; then
    rm -f foodev
 else
    MKNOD_DISABLED=true
-   # not related to mknod but close enough for a "am I privileged" test
-   VERIFYOPTS="--nouser --nogroup"
 fi
 
 MALLOC_DEBUG=libc_malloc_debug.so.0


### PR DESCRIPTION
With the new container based test-suite we no longer need these hacks. Leaving the mknod conditional in place though as that may still be restricted.