### PR TITLE
Move checks and package initialization after build

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -483,7 +483,7 @@ exit:
  * @param NVR		package name-version-release
  * @return		RPMRC_OK if OK
  */
-static int checkForRequired(Header h, const char * NVR)
+static int checkForRequired(Header h)
 {
     int res = RPMRC_OK;
     const rpmTagVal * p;
@@ -492,7 +492,7 @@ static int checkForRequired(Header h, const char * NVR)
 	if (!headerIsEntry(h, *p)) {
 	    rpmlog(RPMLOG_ERR,
 			_("%s field must be present in package: %s\n"),
-			rpmTagGetName(*p), NVR);
+			rpmTagGetName(*p), headerGetString(h, RPMTAG_NAME));
 	    res = RPMRC_FAIL;
 	}
     }
@@ -506,7 +506,7 @@ static int checkForRequired(Header h, const char * NVR)
  * @param NVR		package name-version-release
  * @return		RPMRC_OK if OK
  */
-static int checkForDuplicates(Header h, const char * NVR)
+static int checkForDuplicates(Header h)
 {
     int res = RPMRC_OK;
     rpmTagVal tag, lastTag = RPMTAG_NOT_FOUND;
@@ -515,7 +515,7 @@ static int checkForDuplicates(Header h, const char * NVR)
     while ((tag = headerNextTag(hi)) != RPMTAG_NOT_FOUND) {
 	if (tag == lastTag) {
 	    rpmlog(RPMLOG_ERR, _("Duplicate %s entries in package: %s\n"),
-		     rpmTagGetName(tag), NVR);
+		     rpmTagGetName(tag), headerGetString(h, RPMTAG_NAME));
 	    res = RPMRC_FAIL;
 	}
 	lastTag = tag;
@@ -1240,7 +1240,7 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	}
     }
 
-    if (checkForDuplicates(pkg->header, NVR)) {
+    if (checkForDuplicates(pkg->header)) {
 	goto exit;
     }
 
@@ -1248,7 +1248,7 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	copyInheritedTags(pkg->header, spec->packages->header);
     }
 
-    if (checkForRequired(pkg->header, NVR)) {
+    if (checkForRequired(pkg->header)) {
 	goto exit;
     }
 

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -415,7 +415,7 @@ static inline char * findLastChar(char * s)
 
 /**
  */
-static int isMemberInEntry(Header h, const char *name, rpmTagVal tag)
+int isMemberInEntry(Header h, const char *name, rpmTagVal tag)
 {
     struct rpmtd_s td;
     int found = 0;
@@ -437,7 +437,7 @@ static int isMemberInEntry(Header h, const char *name, rpmTagVal tag)
 
 /**
  */
-static rpmRC checkForValidArchitectures(rpmSpec spec)
+rpmRC checkForValidArchitectures(rpmSpec spec)
 {
     char *arch = rpmExpand("%{_target_cpu}", NULL);
     char *os = rpmExpand("%{_target_os}", NULL);
@@ -483,7 +483,7 @@ exit:
  * @param NVR		package name-version-release
  * @return		RPMRC_OK if OK
  */
-static int checkForRequired(Header h)
+int checkForRequired(Header h)
 {
     int res = RPMRC_OK;
     const rpmTagVal * p;
@@ -506,7 +506,7 @@ static int checkForRequired(Header h)
  * @param NVR		package name-version-release
  * @return		RPMRC_OK if OK
  */
-static int checkForDuplicates(Header h)
+int checkForDuplicates(Header h)
 {
     int res = RPMRC_OK;
     rpmTagVal tag, lastTag = RPMTAG_NOT_FOUND;
@@ -545,7 +545,7 @@ static struct optionalTag {
 
 /**
  */
-static void fillOutMainPackage(Header h)
+void fillOutMainPackage(Header h)
 {
     const struct optionalTag *ot;
 

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1185,11 +1185,13 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	    NVR = xstrdup(name);
 	pkg = newPackage(NVR, spec->pool, &spec->packages);
 	headerPutString(pkg->header, RPMTAG_NAME, NVR);
+    } else if (spec->sourcePackage) {
+	NVR = xstrdup("(main package)");
+	pkg = spec->packages;
     } else {
 	NVR = xstrdup("(main package)");
 	pkg = newPackage(NULL, spec->pool, &spec->packages);
 	spec->sourcePackage = newPackage(NULL, spec->pool, NULL);
-	
     }
 
     if ((rc = readLine(spec, STRIP_TRAILINGSPACE | STRIP_COMMENTS)) > 0) {

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -891,12 +891,6 @@ static rpmRC parseSpecSection(rpmSpec *specptr, int secondary)
     int storedParsePart;
     int initialPackage = 1;
 
-    if (secondary) {
-	initialPackage = 0;
-	parsePart = PART_EMPTY;
-	prevParsePart = PART_NONE;
-    }
-
     /* All the parse*() functions expect to have a line pre-read */
     /* in the spec's line buffer.  Except for parsePreamble(),   */
     /* which handles the initial entry into a spec file.         */

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -621,6 +621,25 @@ void * specLuaFini(rpmSpec spec);
 
 RPM_GNUC_INTERNAL
 void addLuaSource(const struct Source *p);
+
+RPM_GNUC_INTERNAL
+int isMemberInEntry(Header h, const char *name, rpmTagVal tag);
+
+RPM_GNUC_INTERNAL
+rpmRC checkForValidArchitectures(rpmSpec spec);
+
+RPM_GNUC_INTERNAL
+int checkForRequired(Header h);
+
+RPM_GNUC_INTERNAL
+int checkForDuplicates(Header h);
+
+RPM_GNUC_INTERNAL
+void fillOutMainPackage(Header h);
+
+RPM_GNUC_INTERNAL
+void copyInheritedTags(Header h, Header fromh);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rpm/rpmspec.h
+++ b/include/rpm/rpmspec.h
@@ -37,6 +37,7 @@ enum rpmSpecFlags_e {
     RPMSPEC_FORCE	= (1 << 1),
     RPMSPEC_NOLANG	= (1 << 2),
     RPMSPEC_NOUTF8	= (1 << 3),
+    RPMSPEC_NOFINALIZE  = (1 << 4),
 };
 
 typedef rpmFlags rpmSpecFlags;

--- a/tests/data/SPECS/dynamic.spec
+++ b/tests/data/SPECS/dynamic.spec
@@ -1,12 +1,14 @@
-Summary: dynamic hello -- hello, world rpm
 Name: dynamic
 Version: 1.0
 Release: 1
+BuildArch: noarch
+%{?!FULLDYNAMIC:
 Group: Utilities
 License: GPL
 Distribution: RPM test suite.
 URL: http://rpm.org
-BuildArch:	noarch
+Summary: dynamic hello -- hello, world rpm
+}
 
 %description
 Simple rpm demonstration.
@@ -21,6 +23,13 @@ echo "Q: Why?\nA: Because we can!" > FAQ
 mkdir -p $RPM_BUILD_ROOT/usr/local/bin
 echo " " > $RPM_BUILD_ROOT/usr/local/bin/hello
 
+%{?FULLDYNAMIC:
+echo "Group: Utilities" >> %{specpartsdir}/mainpkg.specpart
+echo "License: GPL" >> %{specpartsdir}/mainpkg.specpart
+echo "Distribution: RPM test suite." >> %{specpartsdir}/mainpkg.specpart
+echo "URL: http://rpm.org" >> %{specpartsdir}/mainpkg.specpart
+echo "Summary: dynamic hello -- hello, world rpm" >> %{specpartsdir}/mainpkg.specpart
+}
 
 echo "%package docs" >> %{specpartsdir}/docs.specpart
 %{?!FAIL:echo "Summary: Documentation for dynamic spec" >> %{specpartsdir}/docs.specpart}

--- a/tests/data/SPECS/dynamic.spec
+++ b/tests/data/SPECS/dynamic.spec
@@ -29,6 +29,13 @@ echo "License: GPL" >> %{specpartsdir}/mainpkg.specpart
 echo "Distribution: RPM test suite." >> %{specpartsdir}/mainpkg.specpart
 echo "URL: http://rpm.org" >> %{specpartsdir}/mainpkg.specpart
 echo "Summary: dynamic hello -- hello, world rpm" >> %{specpartsdir}/mainpkg.specpart
+%{?DOUBLESUMMARY:
+echo "Summary: dynamic hello -- hello, world again" >> %{specpartsdir}/mainpkg.specpart
+}
+%{?WRONGTAG:
+echo "LicenseToKill: True" >> %{specpartsdir}/mainpkg.specpart
+}
+
 }
 
 echo "%package docs" >> %{specpartsdir}/docs.specpart

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2407,6 +2407,32 @@ runroot rpm -ql /build/RPMS/noarch/dynamic-docs-1.0-1.noarch.rpm
 RPMTEST_CLEANUP
 
 # ------------------------------
+# Check if dynamic spec generation works for main package, too
+AT_SETUP([rpmbuild with dynamic spec generation for main package])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --define "_prefix /usr/local" -D "FULLDYNAMIC 1" -ba /data/SPECS/dynamic.spec
+],
+[0],
+[ignore],
+[ignore])
+
+RPMTEST_CHECK([
+
+runroot rpm -qp --qf "%{Summary}\n" /build/RPMS/noarch/dynamic-docs-1.0-1.noarch.rpm
+runroot rpm -ql /build/RPMS/noarch/dynamic-docs-1.0-1.noarch.rpm
+],
+[0],
+[Documentation for dynamic spec
+/usr/local/share/doc/dynamic-docs-1.0
+/usr/local/share/doc/dynamic-docs-1.0/FAQ
+],
+[])
+RPMTEST_CLEANUP
+
+# ------------------------------
 # Check failing dynamic spec generation
 AT_SETUP([rpmbuild with dynamic spec generation fail])
 AT_KEYWORDS([build])

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2450,6 +2450,40 @@ error: parsing failed
 RPMTEST_CLEANUP
 
 # ------------------------------
+# Check failing dynamic spec generation
+AT_SETUP([rpmbuild with dynamic spec generation fail])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "DOUBLESUMMARY 1" -ba /data/SPECS/dynamic.spec
+],
+[0],
+[],
+[warning: line 6: second Summary
+])
+
+RPMTEST_CLEANUP
+
+# ------------------------------
+# Check failing dynamic spec generation
+AT_SETUP([rpmbuild with dynamic spec generation fail])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "WRONGTAG 1" -ba /data/SPECS/dynamic.spec
+],
+[1],
+[],
+[error: line 6: Unknown tag: LicenseToKill: True
+error: parsing failed
+])
+
+RPMTEST_CLEANUP
+
+
+# ------------------------------
 # Check source name with space
 AT_SETUP([rpmbuild source name with space])
 AT_KEYWORDS([build])

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -63,7 +63,7 @@ static struct rpmBuildArguments_s rpmBTArgs;
 
 extern int _fsm_debug;
 
-static rpmSpecFlags spec_flags = 0;	/*!< Bit(s) to control spec parsing. */
+static rpmSpecFlags spec_flags = RPMSPEC_NOFINALIZE; /*!< Bit(s) to control spec parsing. */
 static int noDeps = 0;			/*!< from --nodeps */
 static int shortCircuit = 0;		/*!< from --short-circuit */
 static char buildMode = 0;		/*!< Build mode (one of "btBC") */


### PR DESCRIPTION
as far as possible. This allows setting these tags during the build using the dynamic spec feature.

Move

copyTagsDuringParse
requiredTags
optionalTags
isMemberInEntry()
checkForValidArchitectures()
checkForRequired()
checkForDuplicates()
fillOutMainPackage()
copyInheritedTags()

from build/parsePreamble.c to build/parseSpec.c

Use an already existing main package in parsePreamble()

New function finalizeSourceHeader() to move some initialization after build.

Add RPMSPEC_DONTFINALIZE flag to delay package finialization after the build in rpmbuild. rpmspec and API parsing without the flag still finializes the packages right away.