### PR TITLE
fix install rpmrc, platform and macros files with off-source-tree build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,9 @@ function(makemacros)
 	install(CODE "execute_process(COMMAND
 		${CMAKE_COMMAND} -E env pkglibdir=${RPM_CONFIGDIR}
 			${CMAKE_SOURCE_DIR}/installplatform
-			rpmrc platform macros
+			${CMAKE_BINARY_DIR}/rpmrc
+			${CMAKE_BINARY_DIR}/platform
+			${CMAKE_BINARY_DIR}/macros
 			${RPMCANONVENDOR} ${RPMCANONOS} ${RPMCANONGNU})"
 	)
 endfunction()


### PR DESCRIPTION
Files like rpmrc, platform and macros are not in source tree and they are generated to ${CMAKE_BINARY_DIR} in cace of off-source tree build.

Close #2650