### PR TITLE
Fix GCC compiler error

### DIFF
--- a/plugins/dbus_announce.c
+++ b/plugins/dbus_announce.c
@@ -66,11 +66,13 @@ static rpmRC open_dbus(rpmPlugin plugin, rpmts ts)
     }
     return RPMRC_OK;
  err:
-    int ignore = dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) ||
-		 dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND);
-    rpmlog(ignore ? RPMLOG_DEBUG : RPMLOG_WARNING,
-	   "dbus_announce plugin: Error connecting to dbus (%s)\n",
-	   err.message);
+    {
+ 	int ignore = dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) ||
+		     dbus_error_has_name(&err, DBUS_ERROR_FILE_NOT_FOUND);
+	rpmlog(ignore ? RPMLOG_DEBUG : RPMLOG_WARNING,
+	       "dbus_announce plugin: Error connecting to dbus (%s)\n",
+	       err.message);
+    }
     dbus_error_free(&err);
     return RPMRC_OK;
 }


### PR DESCRIPTION
Fixing the following compiler error on gcc (GCC) 8.5.0 20210514 (RedHat 8.5.0-18):

```
/root/rpm/plugins/dbus_announce.c:69:5: error: a label can only be part of a statement and a declaration is not a statement
     int ignore = dbus_error_has_name(&err, DBUS_ERROR_NO_SERVER) ||
     ^~~
```