### PR TITLE
Making the os_release function more strict

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ get_property(TOP_TARGETS DIRECTORY .. PROPERTY BUILDSYSTEM_TARGETS)
 
 function(os_release var key)
 	execute_process(
-		COMMAND sh -c "grep ^${key} /etc/os-release | cut -d= -f2"
+		COMMAND sh -c "grep ^${key}= /etc/os-release | cut -d= -f2 | xargs"
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 		OUTPUT_VARIABLE value
 	)


### PR DESCRIPTION
Making the `os_release` CMake function more strict:

1. Adding '=' to match pattern, because on Rocky Linux `/etc/os-release` contains not only `ID="rocky"`, but also `ID_LIKE="rhel centos fedora"`
2. Adding `'| xargs'`, because on Rocky Linux `ID="rocky"` line contains extra quotes