### PR TITLE
Add a Provides generator for rpm lua modules

### DIFF
--- a/fileattrs/CMakeLists.txt
+++ b/fileattrs/CMakeLists.txt
@@ -1,6 +1,6 @@
 install(FILES
 	debuginfo.attr desktop.attr elf.attr font.attr metainfo.attr
 	perl.attr perllib.attr pkgconfig.attr ocaml.attr
-	rpm_macro.attr script.attr sysusers.attr usergroup.attr
+	rpm_macro.attr rpm_lua.attr script.attr sysusers.attr usergroup.attr
 	DESTINATION ${RPM_CONFIGDIR}/fileattrs
 )

--- a/fileattrs/rpm_lua.attr
+++ b/fileattrs/rpm_lua.attr
@@ -1,0 +1,12 @@
+# Generate Provides for modules in /usr/lib/rpm/lua.
+# Analogous to the rpm_macro Provides generator
+# - /usr/lib/rpm/lua/fedora/common.lua -> rpm_lua(fedora.common)
+# - /usr/lib/rpm/lua/fedora/srpm/python.lua -> rpm_lua(fedora.srpm.python)
+
+%__rpm_lua_path ^%{_rpmluadir}/.+\.lua$
+%__rpm_lua_provides() %{lua:
+-- Strip BUILDROOT + /usr/lib/rpm/lua/
+local idx = macros.buildroot:len() + macros._rpmluadir:len() + 2
+local path = arg[1]:sub(idx, -5)
+print("rpm_lua(" .. path:gsub("/", ".") .. ")")
+}


### PR DESCRIPTION
Some packages in Fedora provide shared RPM lua code that's used by other packages.
It would be nice to have automatic Provides for this code like we have for rpm macros themselves.

Usecase:

Recently, forge.lua that's used by go-srpm-macros and fonts-srpm-macros moved out of redhat-rpm-config.
I would like to be able to add `Requires: rpm_lua(fedora.srpm.forge)` to those packages instead of having to rely on it being implicitly pulled in by redhat-rpm-config or adding conditional dependencies on forge-srpm-macros.