### PR TITLE
Axe the experimental non-privileged chroot support from b4c832ca

### DIFF
--- a/lib/poptALL.c
+++ b/lib/poptALL.c
@@ -24,8 +24,6 @@
 
 static int _debug = 0;
 
-extern int _rpm_nouserns;
-
 extern int _fsm_debug;
 
 extern int _print_pkts;
@@ -272,8 +270,6 @@ struct poptOption rpmcliAllPoptTable[] = {
 	NULL, NULL},
  { "rpmiodebug", '\0', POPT_ARG_VAL|POPT_ARGFLAG_DOC_HIDDEN, &_rpmio_debug, -1,
 	N_("debug rpmio I/O"), NULL},
- { "nouserns", '\0', POPT_ARG_VAL|POPT_ARGFLAG_DOC_HIDDEN, &_rpm_nouserns, -1,
-	N_("disable user namespace support"), NULL},
  { "stats", '\0', POPT_ARG_VAL|POPT_ARGFLAG_DOC_HIDDEN, &_rpmts_stats, -1,
 	NULL, NULL},
 

--- a/lib/rpmchroot.c
+++ b/lib/rpmchroot.c
@@ -8,8 +8,6 @@
 #include "rpmug.h"
 #include "debug.h"
 
-int _rpm_nouserns = 0;
-
 struct rootState_s {
     char *rootDir;
     int chrootDone;
@@ -22,60 +20,6 @@ static struct rootState_s rootState = {
    .chrootDone = 0,
    .cwd = -1,
 }; 
-
-#if defined(HAVE_UNSHARE) && defined(CLONE_NEWUSER)
-/*
- * If setgroups file exists (Linux >= 3.19), we need to write "deny" to it,
- * otherwise gid_map will fail.
- */
-static int deny_setgroups(void)
-{
-    int fd = open("/proc/self/setgroups", O_WRONLY, 0);
-    int xx = -1;
-    if (fd >= 0) {
-	xx = write(fd, "deny\n", strlen("deny\n"));
-	close (fd);
-    }
-    return (xx == -1);
-}
-
-static int setup_map(const char *path, unsigned int id, unsigned int oid)
-{
-    int xx = -1;
-    int fd = open(path, O_WRONLY);
-    if (fd >= 0) {
-	char buf[256];
-	int ret = snprintf(buf, sizeof(buf), "%u %u 1\n", id, oid);
-	xx = write(fd, buf, ret);
-	close (fd);
-    }
-    return (xx == -1);
-}
-
-/*
- * Try to become root by creating a user namespace. We don't really care
- * if this fails here because in that case chroot() will just fail as it
- * normally would.
- */
-static void try_become_root(void)
-{
-    static int unshared = 0;
-    uid_t uid = getuid();
-    gid_t gid = getgid();
-    if (!unshared && unshare(CLONE_NEWUSER | CLONE_NEWNS) == 0) {
-	deny_setgroups();
-	setup_map("/proc/self/uid_map", 0, uid);
-	setup_map("/proc/self/gid_map", 0, gid);
-	unshared = 1;
-    }
-    rpmlog(RPMLOG_DEBUG, "user ns: %d original user %d:%d current %d:%d\n",
-	    unshared, uid, gid, getuid(), getgid());
-}
-#else
-static void try_become_root(void)
-{
-}
-#endif
 
 int rpmChrootSet(const char *rootDir)
 {
@@ -126,9 +70,6 @@ int rpmChrootIn(void)
     if (rootState.chrootDone > 0) {
 	rootState.chrootDone++;
     } else if (rootState.chrootDone == 0) {
-	if (!_rpm_nouserns && getuid())
-	    try_become_root();
-
 	rpmlog(RPMLOG_DEBUG, "entering chroot %s\n", rootState.rootDir);
 	if (chdir("/") == 0 && chroot(rootState.rootDir) == 0) {
 	    rootState.chrootDone = 1;

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -150,8 +150,7 @@ function runroot()
     setup_env
     snapshot exec "$@" \
              --define "_buildhost testhost" \
-             --define "_topdir /build" \
-             --nouserns
+             --define "_topdir /build"
 }
 
 function runroot_other()


### PR DESCRIPTION
While the chroot call itself works nicely for a regular user with this, user/group mapping does not and cannot be made to work, because that requires a fork and we cannot very well fork the process from deep down here.

Better to put the irrepairable thing out of its misery, users are far better of wrapping rpm with the unshare command instead.