### PR TITLE
Add new plugin slots for pre/post chroot events

### DIFF
--- a/docs/manual/plugins.md
+++ b/docs/manual/plugins.md
@@ -27,6 +27,9 @@ struct rpmPluginHooks_s {
     plugin_fsm_file_pre_func            fsm_file_pre;
     plugin_fsm_file_post_func           fsm_file_post;
     plugin_fsm_file_prepare_func        fsm_file_prepare;
+    /* per chroot hooks */
+    plugin_chroot_pre_func              chroot_pre;
+    plugin_chroot_post_func             chroot_post;
 };
 ```
 
@@ -66,6 +69,15 @@ Post hook is is guaranteed to execute whenever pre hook was executed.
 
 Warning: The exact relations and semantics of these hooks is subject to change as there are plans to improve rpms ability to undo file operations in case of failure.
 
+## Per chroot hooks
+
+Hooks `chroot_pre` and `chroot_post` execute once per each chroot() call
+rpm does during a transaction. The pre-hook runs just before the actual
+chroot() call and the post-hook right after it, regardless of whether
+the call succeeded or not. The direction (in/out) of the operation is
+passed in the second argument.
+
+Post hook is guaranteed to execute whenever pre hook was executed.
 ## Examples
 
 For a few simple examples, see the plugins shipped with rpm itself: [https://github.com/rpm-software-management/rpm/tree/master/plugins](https://github.com/rpm-software-management/rpm/tree/master/plugins)

--- a/include/rpm/rpmplugin.h
+++ b/include/rpm/rpmplugin.h
@@ -15,6 +15,10 @@ typedef enum rpmScriptletExecutionFlow_e {
     RPMSCRIPTLET_EXEC    = 1 << 1
 } rpmScriptletExecutionFlow;
 
+enum rpmChrootDirection_e {
+    RPMCHROOT_IN = 0,
+    RPMCHROOT_OUT = 1,
+};
 
 /** \ingroup rpmfi
  * File disposition flags during package install/erase transaction.
@@ -61,6 +65,10 @@ typedef rpmRC (*plugin_fsm_file_prepare_func)(rpmPlugin plugin, rpmfi fi,
 					      const char *dest,
 					      mode_t file_mode, rpmFsmOp op);
 
+typedef rpmRC (*plugin_chroot_pre_func)(rpmPlugin plugin, int direction);
+typedef rpmRC (*plugin_chroot_post_func)(rpmPlugin plugin, int direction,
+					int res);
+
 typedef struct rpmPluginHooks_s * rpmPluginHooks;
 struct rpmPluginHooks_s {
     /* plugin constructor and destructor hooks */
@@ -80,6 +88,9 @@ struct rpmPluginHooks_s {
     plugin_fsm_file_pre_func		fsm_file_pre;
     plugin_fsm_file_post_func		fsm_file_post;
     plugin_fsm_file_prepare_func	fsm_file_prepare;
+    /* per chroot hooks */
+    plugin_chroot_pre_func		chroot_pre;
+    plugin_chroot_post_func		chroot_post;
 };
 
 #ifdef __cplusplus

--- a/lib/rpmchroot.h
+++ b/lib/rpmchroot.h
@@ -2,6 +2,7 @@
 #define _RPMCHROOT_H
 
 #include <rpm/rpmutil.h>
+#include <rpm/rpmtypes.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,7 +15,7 @@ extern "C" {
  * return		-1 on error, 0 on success
  */
 RPM_GNUC_INTERNAL
-int rpmChrootSet(const char *rootDir);
+int rpmChrootSet(const char *rootDir, rpmPlugins plugins);
 
 /** \ingroup rpmchroot
  * Enter chroot if necessary.

--- a/lib/rpmplugins.c
+++ b/lib/rpmplugins.c
@@ -420,3 +420,37 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
 
     return rc;
 }
+
+rpmRC rpmpluginsCallChrootPre(rpmPlugins plugins, int direction)
+{
+    plugin_chroot_pre_func hookFunc = NULL;
+    int i;
+    rpmRC rc = RPMRC_OK;
+
+    for (i = 0; i < plugins->count; i++) {
+	rpmPlugin plugin = plugins->plugins[i];
+	RPMPLUGINS_SET_HOOK_FUNC(chroot_pre);
+	if (hookFunc && hookFunc(plugin, direction) == RPMRC_FAIL) {
+	    rpmlog(RPMLOG_ERR, "Plugin %s: hook chroot_pre failed\n", plugin->name);
+	    rc = RPMRC_FAIL;
+	}
+    }
+    return rc;
+}
+
+rpmRC rpmpluginsCallChrootPost(rpmPlugins plugins, int direction, int res)
+{
+    plugin_chroot_post_func hookFunc = NULL;
+    int i;
+    rpmRC rc = RPMRC_OK;
+
+    for (i = 0; i < plugins->count; i++) {
+	rpmPlugin plugin = plugins->plugins[i];
+	RPMPLUGINS_SET_HOOK_FUNC(chroot_post);
+	if (hookFunc && hookFunc(plugin, direction, res) == RPMRC_FAIL) {
+	    rpmlog(RPMLOG_ERR, "Plugin %s: hook chroot_post failed\n", plugin->name);
+	    rc = RPMRC_FAIL;
+	}
+    }
+    return rc;
+}

--- a/lib/rpmplugins.h
+++ b/lib/rpmplugins.h
@@ -168,6 +168,26 @@ rpmRC rpmpluginsCallFsmFilePrepare(rpmPlugins plugins, rpmfi fi,
                                    int fd, const char *path, const char *dest,
                                    mode_t mode, rpmFsmOp op);
 
+/*
+ * Call the chroot pre plugin hook. Called just before chroot in or out.
+ * @param plugins	plugins structure
+ * @param direction	RPMCHROOT_IN/RPMCHROOT_OUT
+ * return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ */
+RPM_GNUC_INTERNAL
+rpmRC rpmpluginsCallChrootPre(rpmPlugins plugins, int direction);
+
+/*
+ * Call the chroot post plugin hook. Called after chroot in or out,
+ * whether it succeeded or not.
+ * @param plugins	plugins structure
+ * @param direction	RPMCHROOT_IN/RPMCHROOT_OUT
+ * @param res		chroot code (0 on success)
+ * return		RPMRC_OK on success, RPMRC_FAIL otherwise
+ */
+RPM_GNUC_INTERNAL
+rpmRC rpmpluginsCallChrootPost(rpmPlugins plugins, int direction, int res);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/transaction.c
+++ b/lib/transaction.c
@@ -1466,7 +1466,7 @@ static int rpmtsSetup(rpmts ts, rpmprobFilterFlags ignoreSet)
      * this ensures we can successfully perform open(".") which is
      * required to reliably restore cwd after Lua scripts.
      */ 
-    if (rpmtsOpenDB(ts, dbmode) || rpmChrootSet(rpmtsRootDir(ts)))
+    if (rpmtsOpenDB(ts, dbmode) || rpmChrootSet(rpmtsRootDir(ts), rpmtsPlugins(ts)))
 	return -1;
 
     ts->ignoreSet = ignoreSet;
@@ -1513,7 +1513,7 @@ static int rpmtsFinish(rpmts ts)
     if (rpmtsGetDSIRotational(ts) == 0)
 	setSSD(0);
     rpmtsFreeDSI(ts);
-    return rpmChrootSet(NULL);
+    return rpmChrootSet(NULL, NULL);
 }
 
 static int rpmtsPrepare(rpmts ts)

--- a/lib/verify.c
+++ b/lib/verify.c
@@ -478,7 +478,7 @@ int rpmcliVerify(rpmts ts, QVA_t qva, char * const * argv)
      */
     rpmtsOpenDB(ts, O_RDONLY);
     rpmdbOpenAll(rpmtsGetRdb(ts));
-    if (rpmChrootSet(rpmtsRootDir(ts)) || rpmChrootIn()) {
+    if (rpmChrootSet(rpmtsRootDir(ts), rpmtsPlugins(ts)) || rpmChrootIn()) {
 	ec = 1;
 	goto exit;
     }
@@ -501,7 +501,7 @@ int rpmcliVerify(rpmts ts, QVA_t qva, char * const * argv)
 
     rpmtsEmpty(ts);
 
-    if (rpmChrootOut() || rpmChrootSet(NULL))
+    if (rpmChrootOut() || rpmChrootSet(NULL, NULL))
 	ec = 1;
 
 exit:

--- a/tests/data/debugplugin/debug.c
+++ b/tests/data/debugplugin/debug.c
@@ -99,6 +99,20 @@ static rpmRC debug_fsm_file_prepare(rpmPlugin plugin, rpmfi fi,
     return RPMRC_OK;
 }
 
+static rpmRC debug_chroot_pre(rpmPlugin plugin, int direction)
+{
+    fprintf(stderr, "%s: %s\n", __func__,
+		(direction == RPMCHROOT_IN) ? "in" : "out");
+    return RPMRC_OK;
+}
+
+static rpmRC debug_chroot_post(rpmPlugin plugin, int direction, int res)
+{
+    fprintf(stderr, "%s: %s: %d\n", __func__,
+		(direction == RPMCHROOT_IN) ? "in" : "out", res);
+    return RPMRC_OK;
+}
+
 struct rpmPluginHooks_s debug_hooks = {
         .init = debug_init,
         .cleanup = debug_cleanup,
@@ -112,4 +126,6 @@ struct rpmPluginHooks_s debug_hooks = {
         .fsm_file_pre = debug_fsm_file_pre,
         .fsm_file_post = debug_fsm_file_post,
         .fsm_file_prepare = debug_fsm_file_prepare,
+	.chroot_pre = debug_chroot_pre,
+	.chroot_post = debug_chroot_post,
 };

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -70,5 +70,44 @@ debug_psm_post: simple-1.0-1.noarch:0
 debug_tsm_post: 0
 debug_cleanup
 ])
+
+# there's no /bin/sh in the empty root so we need --nodeps and --noscripts
+RPMTEST_CHECK([
+runroot rpm -U --root /test --nodeps --noscripts -U /build/RPMS/noarch/simple-1.0-1.noarch.rpm
+],
+[0],
+[],
+[debug_init
+debug_tsm_pre
+debug_chroot_pre: in
+debug_chroot_post: in: 0
+debug_chroot_pre: out
+debug_chroot_post: out: 0
+debug_chroot_pre: in
+debug_chroot_post: in: 0
+debug_psm_pre: simple-1.0-1.noarch
+debug_chroot_pre: out
+debug_chroot_post: out: 0
+debug_chroot_pre: in
+debug_chroot_post: in: 0
+debug_fsm_file_pre:  /opt 40755 80000001
+debug_fsm_file_prepare:  1 /opt /opt 40755 80000001
+debug_fsm_file_post:  /opt 40755 80000001: 0
+debug_fsm_file_pre:  /opt/bin 40755 80000001
+debug_fsm_file_prepare:  1 /opt/bin /opt/bin 40755 80000001
+debug_fsm_file_post:  /opt/bin 40755 80000001: 0
+debug_fsm_file_pre: /opt/bin/simple /opt/bin/simple; 100755 1
+debug_fsm_file_prepare: /opt/bin/simple 1 /opt/bin/simple; /opt/bin/simple 100755 1
+debug_fsm_file_post: /opt/bin/simple /opt/bin/simple 100755 1: 0
+debug_chroot_pre: out
+debug_chroot_post: out: 0
+debug_chroot_pre: in
+debug_chroot_post: in: 0
+debug_psm_post: simple-1.0-1.noarch:0
+debug_chroot_pre: out
+debug_chroot_post: out: 0
+debug_tsm_post: 0
+debug_cleanup
+])
 RPMTEST_CLEANUP
 


### PR DESCRIPTION
These pre/post hooks get called before and after every chroot() call rpm makes. The initial inspiration came from the now removed experimental non-privileged chroot support with unshare() but this is probably an interesting boundary for various other purposes too.