### PR TITLE
Fix tagtbl.C placement in build dir

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,7 @@ target_compile_definitions(librpm PRIVATE
 target_include_directories(librpm PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
+	${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_sources(librpm PRIVATE
@@ -66,7 +67,7 @@ if(WITH_CAP)
 endif()
 
 add_custom_command(OUTPUT tagtbl.C
-	COMMAND AWK=gawk ${CMAKE_CURRENT_SOURCE_DIR}/gentagtbl.sh ${CMAKE_SOURCE_DIR}/include/rpm/rpmtag.h > ${CMAKE_BINARY_DIR}/tagtbl.C
+	COMMAND AWK=gawk ${CMAKE_CURRENT_SOURCE_DIR}/gentagtbl.sh ${CMAKE_SOURCE_DIR}/include/rpm/rpmtag.h > tagtbl.C
 	DEPENDS ${CMAKE_SOURCE_DIR}/include/rpm/rpmtag.h gentagtbl.sh
 )
 


### PR DESCRIPTION
The COMMAND for tagtbl.C generation dumps the file in the top-level build directory whereas the OUTPUT is specified in the current (lib/) directory.  This leads to unnecessary relinking of all the libraries on each make invocation because OUTPUT is always missing.

Fix this by outputting the file in the current directory where OUTPUT can find it.

No functional change, just makes rebuilds quicker.