### PR TITLE
WIP: Use Python Stable ABI for the bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ endif()
 list(APPEND db_backends dummy)
 
 if (ENABLE_PYTHON)
-	find_package(Python3 3.2 COMPONENTS Interpreter Development REQUIRED)
+	find_package(Python3 3.7 COMPONENTS Interpreter Development REQUIRED)
 endif()
 
 if (WITH_CAP)

--- a/INSTALL
+++ b/INSTALL
@@ -80,7 +80,7 @@ These are available from
     http://tukaani.org/xz/
 
 Python bindings to RPM library are built by default, but it can be disabled
-with -DENABLE_PYTHON=OFF. You'll need to have Python >= 3.2
+with -DENABLE_PYTHON=OFF. You'll need to have Python >= 3.7
 runtime and C API development environment installed.
 Python is available from:
     http://www.python.org/

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,7 +17,10 @@ Python3_add_library(_rpm
 	rpmver-py.c rpmver-py.h
 	spec-py.c spec-py.h
 )
-	
+
+# Select Python stable ABI
+target_compile_definitions(_rpm PRIVATE Py_LIMITED_API=0x03070000)
+
 target_link_libraries(_rpm PRIVATE librpmio librpm librpmbuild librpmsign)
 
 install(TARGETS _rpm

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -693,7 +693,8 @@ PyTypeObject hdr_Type = {
 
 PyObject * hdr_Wrap(PyTypeObject *subtype, Header h)
 {
-    hdrObject * hdr = (hdrObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    hdrObject *hdr = (hdrObject *)subtype_alloc(subtype, 0);
     if (hdr == NULL) return NULL;
     hdr->h = h;
     return (PyObject *) hdr;

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -647,6 +647,7 @@ static PyType_Slot hdr_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* hdr_Type;
 PyType_Spec hdr_Type_Spec = {
     .name = "rpm.hdr",
     .basicsize = sizeof(hdrObject),
@@ -679,8 +680,8 @@ PyObject * versionCompare (PyObject * self, PyObject * args, PyObject * kwds)
     hdrObject * h1, * h2;
     char * kwlist[] = {"version0", "version1", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, &hdr_Type,
-	    &h1, &hdr_Type, &h2))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, hdr_Type,
+	    &h1, hdr_Type, &h2))
 	return NULL;
 
     return Py_BuildValue("i", rpmVersionCompare(h1->h, h2->h));

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -577,24 +577,7 @@ static int hdr_setattro(PyObject * o, PyObject * n, PyObject * v)
     return PyObject_GenericSetAttr(o, n, v);
 }
 
-static PyMappingMethods hdr_as_mapping = {
-	(lenfunc) 0,			/* mp_length */
-	(binaryfunc) hdr_subscript,	/* mp_subscript */
-	(objobjargproc)hdr_ass_subscript,/* mp_ass_subscript */
-};
 
-static PySequenceMethods hdr_as_sequence = {
-    0,				/* sq_length */
-    0,				/* sq_concat */
-    0,				/* sq_repeat */
-    0,				/* sq_item */
-    0,				/* sq_slice */
-    0,				/* sq_ass_item */
-    0,				/* sq_ass_slice */
-    (objobjproc)hdrContains,	/* sq_contains */
-    0,				/* sq_inplace_concat */
-    0,				/* sq_inplace_repeat */
-};
 
 static char hdr_doc[] =
   "A header object represents an RPM package header.\n"
@@ -648,47 +631,27 @@ static char hdr_doc[] =
   "the strings in header lookups don't get translated, or the lookups\n"
   "will fail.\n";
 
-PyTypeObject hdr_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.hdr",			/* tp_name */
-	sizeof(hdrObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) hdr_dealloc, 	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc) 0, 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	&hdr_as_sequence,		/* tp_as_sequence */
-	&hdr_as_mapping,		/* tp_as_mapping */
-	hdr_hash,			/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	(getattrofunc) hdr_getattro,	/* tp_getattro */
-	(setattrofunc) hdr_setattro,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	hdr_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	PyObject_SelfIter,		/* tp_iter */
-	(iternextfunc)hdr_iternext,	/* tp_iternext */
-	hdr_methods,			/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	hdr_new,			/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot hdr_Type_Slots[] = {
+    {Py_tp_dealloc, hdr_dealloc},
+    {Py_sq_contains, hdrContains},
+    {Py_mp_subscript, hdr_subscript},
+    {Py_mp_ass_subscript, hdr_ass_subscript},
+    {Py_tp_hash, hdr_hash},
+    {Py_tp_getattro, hdr_getattro},
+    {Py_tp_setattro, hdr_setattro},
+    {Py_tp_doc, hdr_doc},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, hdr_iternext},
+    {Py_tp_methods, hdr_methods},
+    {Py_tp_new, hdr_new},
+    {0, NULL},
+};
+
+PyType_Spec hdr_Type_Spec = {
+    .name = "rpm.hdr",
+    .basicsize = sizeof(hdrObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = hdr_Type_Slots,
 };
 
 PyObject * hdr_Wrap(PyTypeObject *subtype, Header h)

--- a/python/header-py.c
+++ b/python/header-py.c
@@ -327,7 +327,8 @@ static PyObject *hdr_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
 static void hdr_dealloc(hdrObject * s)
 {
     if (s->h) headerFree(s->h);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject * hdr_iternext(hdrObject *s)

--- a/python/header-py.h
+++ b/python/header-py.h
@@ -5,9 +5,10 @@
 
 typedef struct hdrObject_s hdrObject;
 
-extern PyTypeObject hdr_Type;
+extern PyTypeObject* hdr_Type;
+extern PyType_Spec hdr_Type_Spec;
 
-#define hdrObject_Check(v)	((v)->ob_type == &hdr_Type)
+#define hdrObject_Check(v)	((v)->ob_type == hdr_Type)
 
 #define DEPRECATED_METHOD(_msg) \
     PyErr_WarnEx(PyExc_PendingDeprecationWarning, (_msg), 2);

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -229,6 +229,7 @@ static PyType_Slot rpmarchive_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmarchive_Type;
 PyType_Spec rpmarchive_Type_Spec = {
     .name = "rpm.archive",
     .basicsize = sizeof(rpmarchiveObject),

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -21,7 +21,8 @@ static void rpmarchive_dealloc(rpmarchiveObject * s)
     rpmfilesFree(s->files);
     rpmfiArchiveClose(s->archive);
     rpmfiFree(s->archive);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject *rpmarchive_error(int rc)

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -218,7 +218,16 @@ static PyObject *rpmarchive_iternext(rpmarchiveObject *s)
     return next;
 }
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.archive' instances");
+    return NULL;
+}
+
 static PyType_Slot rpmarchive_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmarchive_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
@@ -233,7 +242,7 @@ PyTypeObject* rpmarchive_Type;
 PyType_Spec rpmarchive_Type_Spec = {
     .name = "rpm.archive",
     .basicsize = sizeof(rpmarchiveObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmarchive_Type_Slots,
 };
 

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -218,47 +218,22 @@ static PyObject *rpmarchive_iternext(rpmarchiveObject *s)
     return next;
 }
 
-PyTypeObject rpmarchive_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.archive",			/* tp_name */
-	sizeof(rpmarchiveObject),		/* tp_basicsize */
-	0,				/* tp_itemsize */
-	(destructor) rpmarchive_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	0,				/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,		/* tp_as_sequence */
-	0,		/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmarchive_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	PyObject_SelfIter,		/* tp_iter */
-	(iternextfunc) rpmarchive_iternext,		/* tp_iternext */
-	rpmarchive_methods,		/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	0,				/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmarchive_Type_Slots[] = {
+    {Py_tp_dealloc, rpmarchive_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmarchive_doc},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, rpmarchive_iternext},
+    {Py_tp_methods, rpmarchive_methods},
+    {0, NULL},
+};
+
+PyType_Spec rpmarchive_Type_Spec = {
+    .name = "rpm.archive",
+    .basicsize = sizeof(rpmarchiveObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = rpmarchive_Type_Slots,
 };
 
 PyObject * rpmarchive_Wrap(PyTypeObject *subtype,

--- a/python/rpmarchive-py.c
+++ b/python/rpmarchive-py.c
@@ -264,7 +264,8 @@ PyTypeObject rpmarchive_Type = {
 PyObject * rpmarchive_Wrap(PyTypeObject *subtype,
 			   rpmfiles files, rpmfi archive)
 {
-    rpmarchiveObject *s = (rpmarchiveObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmarchiveObject *s = (rpmarchiveObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->files = rpmfilesLink(files);

--- a/python/rpmarchive-py.h
+++ b/python/rpmarchive-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmarchiveObject_s rpmarchiveObject;
 
-extern PyTypeObject rpmarchive_Type;
+extern PyTypeObject* rpmarchive_Type;
+extern PyType_Spec rpmarchive_Type_Spec;
 
-#define rpmarchiveObject_Check(v)	((v)->ob_type == &rpmarchive_Type)
+#define rpmarchiveObject_Check(v)	((v)->ob_type == rpmarchive_Type)
 
 PyObject * rpmarchive_Wrap(PyTypeObject *subtype,
 			   rpmfiles files, rpmfi archive);

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -115,7 +115,7 @@ rpmds_Find(rpmdsObject * s, PyObject * arg)
 {
     rpmdsObject * o;
 
-    if (!PyArg_Parse(arg, "O!:Find", &rpmds_Type, &o))
+    if (!PyArg_Parse(arg, "O!:Find", rpmds_Type, &o))
 	return NULL;
 
     /* XXX make sure ods index is valid, real fix in lib/rpmds.c. */
@@ -129,7 +129,7 @@ rpmds_Merge(rpmdsObject * s, PyObject * arg)
 {
     rpmdsObject * o;
 
-    if (!PyArg_Parse(arg, "O!:Merge", &rpmds_Type, &o))
+    if (!PyArg_Parse(arg, "O!:Merge", rpmds_Type, &o))
 	return NULL;
 
     return Py_BuildValue("i", rpmdsMerge(&s->ds, o->ds));
@@ -139,7 +139,7 @@ rpmds_Search(rpmdsObject * s, PyObject * arg)
 {
     rpmdsObject * o;
 
-    if (!PyArg_Parse(arg, "O!:Merge", &rpmds_Type, &o))
+    if (!PyArg_Parse(arg, "O!:Merge", rpmds_Type, &o))
         return NULL;
 
     return Py_BuildValue("i", rpmdsSearch(s->ds, o->ds));
@@ -149,7 +149,7 @@ static PyObject *rpmds_Compare(rpmdsObject * s, PyObject * o)
 {
     rpmdsObject * ods;
 
-    if (!PyArg_Parse(o, "O!:Compare", &rpmds_Type, &ods))
+    if (!PyArg_Parse(o, "O!:Compare", rpmds_Type, &ods))
 	return NULL;
 
     return PyBool_FromLong(rpmdsCompare(s->ds, ods->ds));
@@ -173,7 +173,7 @@ static PyObject * rpmds_Rpmlib(rpmdsObject * s, PyObject *args, PyObject *kwds)
     /* XXX check return code, permit arg (NULL uses system default). */
     rpmdsRpmlibPool(pool, &ds, NULL);
 
-    return rpmds_Wrap(&rpmds_Type, ds);
+    return rpmds_Wrap(rpmds_Type, ds);
 }
 
 static struct PyMethodDef rpmds_methods[] = {
@@ -363,6 +363,7 @@ static PyType_Slot rpmds_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmds_Type;
 PyType_Spec rpmds_Type_Spec = {
     .name = "rpm.ds",
     .basicsize = sizeof(rpmdsObject),

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -406,7 +406,8 @@ rpmds dsFromDs(rpmdsObject * s)
 
 PyObject * rpmds_Wrap(PyTypeObject *subtype, rpmds ds)
 {
-    rpmdsObject * s = (rpmdsObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmdsObject *s = (rpmdsObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->ds = ds;

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -225,7 +225,8 @@ static void
 rpmds_dealloc(rpmdsObject * s)
 {
     s->ds = rpmdsFree(s->ds);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static Py_ssize_t rpmds_length(rpmdsObject * s)

--- a/python/rpmds-py.c
+++ b/python/rpmds-py.c
@@ -249,11 +249,6 @@ rpmds_subscript(rpmdsObject * s, PyObject * key)
     return utf8FromString(rpmdsDNEVR(s->ds));
 }
 
-static PyMappingMethods rpmds_as_mapping = {
-        (lenfunc) rpmds_length,		/* mp_length */
-        (binaryfunc) rpmds_subscript,	/* mp_subscript */
-        (objobjargproc)0,		/* mp_ass_subscript */
-};
 
 static int rpmds_init(rpmdsObject * s, PyObject *args, PyObject *kwds)
 {
@@ -353,48 +348,26 @@ static char rpmds_doc[] =
     "a provide of the header NEVR."
     ;
 
-PyTypeObject rpmds_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.ds",			/* tp_name */
-	sizeof(rpmdsObject),		/* tp_basicsize */
-	0,				/* tp_itemsize */
-	/* methods */
-	(destructor) rpmds_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0,			/* tp_getattr */
-	(setattrfunc)0,			/* tp_setattr */
-	0,				/* tp_compare */
-	(reprfunc)0,			/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	&rpmds_as_mapping,		/* tp_as_mapping */
-	(hashfunc)0,			/* tp_hash */
-	(ternaryfunc)0,			/* tp_call */
-	(reprfunc)0,			/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-	rpmds_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	PyObject_SelfIter,		/* tp_iter */
-	(iternextfunc) rpmds_iternext,	/* tp_iternext */
-	rpmds_methods,			/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	(initproc) rpmds_init,		/* tp_init */
-	0,				/* tp_alloc */
-	(newfunc) rpmds_new,		/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmds_Type_Slots[] = {
+    {Py_tp_dealloc, rpmds_dealloc},
+    {Py_mp_length, rpmds_length},
+    {Py_mp_subscript, rpmds_subscript},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmds_doc},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, rpmds_iternext},
+    {Py_tp_methods, rpmds_methods},
+    {Py_tp_init, rpmds_init},
+    {Py_tp_new, rpmds_new},
+    {0, NULL},
+};
+
+PyType_Spec rpmds_Type_Spec = {
+    .name = "rpm.ds",
+    .basicsize = sizeof(rpmdsObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmds_Type_Slots,
 };
 
 /* ---------- */

--- a/python/rpmds-py.h
+++ b/python/rpmds-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmdsObject_s rpmdsObject;
 
-extern PyTypeObject rpmds_Type;
+extern PyTypeObject* rpmds_Type;
+extern PyType_Spec rpmds_Type_Spec;
 
-#define rpmdsObject_Check(v)	((v)->ob_type == &rpmds_Type)
+#define rpmdsObject_Check(v)	((v)->ob_type == rpmds_Type)
 
 rpmds dsFromDs(rpmdsObject * ds);
 

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -344,46 +344,21 @@ static PyGetSetDef rpmfd_getseters[] = {
     { NULL },
 };
 
-PyTypeObject rpmfd_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.fd",			/* tp_name */
-	sizeof(rpmfdObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	/* methods */
-	(destructor) rpmfd_dealloc, 	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	(setattrfunc)0,			/* tp_setattr */
-	0,				/* tp_compare */
-	(reprfunc)0,			/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	(hashfunc)0,			/* tp_hash */
-	(ternaryfunc)0,			/* tp_call */
-	(reprfunc)0,			/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmfd_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	rpmfd_methods,			/* tp_methods */
-	0,				/* tp_members */
-	rpmfd_getseters,		/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	(initproc)rpmfd_init,		/* tp_init */
-	(allocfunc)0,			/* tp_alloc */
-	PyType_GenericNew,		/* tp_new */
-	(freefunc)0,			/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmfd_Type_Slots[] = {
+    {Py_tp_dealloc, rpmfd_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmfd_doc},
+    {Py_tp_methods, rpmfd_methods},
+    {Py_tp_getset, rpmfd_getseters},
+    {Py_tp_init, rpmfd_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
+};
+
+PyType_Spec rpmfd_Type_Spec = {
+    .name = "rpm.fd",
+    .basicsize = sizeof(rpmfdObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmfd_Type_Slots,
 };

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -140,7 +140,8 @@ static void rpmfd_dealloc(rpmfdObject *s)
     Py_XDECREF(res);
     free(s->mode);
     free(s->flags);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject *rpmfd_fileno(rpmfdObject *s)

--- a/python/rpmfd-py.c
+++ b/python/rpmfd-py.c
@@ -25,7 +25,7 @@ int rpmfdFromPyObject(PyObject *obj, rpmfdObject **fdop)
 	Py_INCREF(obj);
 	fdo = (rpmfdObject *) obj;
     } else {
-	fdo = (rpmfdObject *) PyObject_CallFunctionObjArgs((PyObject *)&rpmfd_Type,
+	fdo = (rpmfdObject *) PyObject_CallFunctionObjArgs((PyObject *)rpmfd_Type,
                                                            obj, NULL);
     }
     if (fdo == NULL) return 0;
@@ -356,6 +356,7 @@ static PyType_Slot rpmfd_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmfd_Type;
 PyType_Spec rpmfd_Type_Spec = {
     .name = "rpm.fd",
     .basicsize = sizeof(rpmfdObject),

--- a/python/rpmfd-py.h
+++ b/python/rpmfd-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmfdObject_s rpmfdObject;
 
-extern PyTypeObject rpmfd_Type;
+extern PyTypeObject* rpmfd_Type;
+extern PyType_Spec rpmfd_Type_Spec;
 
-#define rpmfdObject_Check(v)	((v)->ob_type == &rpmfd_Type)
+#define rpmfdObject_Check(v)	((v)->ob_type == rpmfd_Type)
 
 FD_t rpmfdGetFd(rpmfdObject *fdo);
 

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -611,7 +611,8 @@ PyTypeObject rpmfiles_Type = {
 
 PyObject * rpmfiles_Wrap(PyTypeObject *subtype, rpmfiles files)
 {
-    rpmfilesObject *s = (rpmfilesObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmfilesObject *s = (rpmfilesObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->files = files;

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -20,7 +20,8 @@ struct rpmfileObject_s {
 static void rpmfile_dealloc(rpmfileObject * s)
 {
     s->files = rpmfilesFree(s->files);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static char rpmfile_doc[] =
@@ -379,7 +380,8 @@ struct rpmfilesObject_s {
 static void rpmfiles_dealloc(rpmfilesObject * s)
 {
     s->files = rpmfilesFree(s->files);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject * rpmfiles_new(PyTypeObject * subtype, PyObject *args, PyObject *kwds)

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -215,7 +215,7 @@ static PyObject *rpmfile_links(rpmfileObject *s)
 		o = rpmfile_Wrap(s->files, lix);
 	    }
 
-	    PyTuple_SET_ITEM(result, i, o);
+	    PyTuple_SetItem(result, i, o);
 	}
     }
     return result;
@@ -476,7 +476,7 @@ static PyObject *rpmfiles_subscript(rpmfilesObject *s, PyObject *item)
 	result = PyTuple_New(slicelength);
 	if (result) {
 	    for (cur = start, i = 0; i < slicelength; cur += step, i++) {
-		PyTuple_SET_ITEM(result, i, rpmfiles_getitem(s, cur));
+		PyTuple_SetItem(result, i, rpmfiles_getitem(s, cur));
 	    }
 	}
 	return result;

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -327,6 +327,7 @@ static PyType_Slot rpmfile_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmfile_Type;
 PyType_Spec rpmfile_Type_Spec = {
     .name = "rpm.file",
     .basicsize = sizeof(rpmfileObject),
@@ -336,7 +337,7 @@ PyType_Spec rpmfile_Type_Spec = {
 
 PyObject * rpmfile_Wrap(rpmfiles files, int ix)
 {
-    rpmfileObject *s = PyObject_New(rpmfileObject, &rpmfile_Type);
+    rpmfileObject *s = PyObject_New(rpmfileObject, rpmfile_Type);
     if (s == NULL) return NULL;
 
     s->files = rpmfilesLink(files);
@@ -450,7 +451,7 @@ static PyObject *rpmfiles_archive(rpmfilesObject *s,
 	archive = rpmfiNewArchiveReader(fd, s->files, RPMFI_ITER_READ_ARCHIVE);
     }
 
-    return rpmarchive_Wrap(&rpmarchive_Type, s->files, archive);
+    return rpmarchive_Wrap(rpmarchive_Type, s->files, archive);
 }
 
 static PyObject *rpmfiles_subscript(rpmfilesObject *s, PyObject *item)
@@ -537,6 +538,7 @@ static PyType_Slot rpmfiles_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmfiles_Type;
 PyType_Spec rpmfiles_Type_Spec = {
     .name = "rpm.files",
     .basicsize = sizeof(rpmfilesObject),

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -316,48 +316,22 @@ static struct PyMethodDef rpmfile_methods[] = {
     { NULL, NULL, 0, NULL }
 };
 
-PyTypeObject rpmfile_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.file",			/* tp_name */
-	sizeof(rpmfileObject),		/* tp_basicsize */
-	0,				/* tp_itemsize */
-	/* methods */
-	(destructor) rpmfile_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	0,				/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	(reprfunc)rpmfile_name,		/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmfile_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	rpmfile_methods,		/* tp_methods */
-	0,				/* tp_members */
-	rpmfile_getseters,		/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	0,				/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmfile_Type_Slots[] = {
+    {Py_tp_dealloc, rpmfile_dealloc},
+    {Py_tp_str, rpmfile_name},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmfile_doc},
+    {Py_tp_methods, rpmfile_methods},
+    {Py_tp_getset, rpmfile_getseters},
+    {0, NULL},
+};
+
+PyType_Spec rpmfile_Type_Spec = {
+    .name = "rpm.file",
+    .basicsize = sizeof(rpmfileObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = rpmfile_Type_Slots,
 };
 
 PyObject * rpmfile_Wrap(rpmfiles files, int ix)
@@ -433,18 +407,6 @@ static int rpmfiles_contains(rpmfilesObject *s, PyObject *value)
     return (rpmfilesFindFN(s->files, fn) >= 0) ? 1 : 0;
 }
 
-static PySequenceMethods rpmfiles_as_sequence = {
-    (lenfunc)rpmfiles_length,		/* sq_length */
-    0,					/* sq_concat */
-    0,					/* sq_repeat */
-    (ssizeargfunc) rpmfiles_getitem,	/* sq_item */
-    0,					/* sq_slice */
-    0,					/* sq_ass_item */
-    0,					/* sq_ass_slice */
-    (objobjproc)rpmfiles_contains,	/* sq_contains */
-    0,					/* sq_inplace_concat */
-    0,					/* sq_inplace_repeat */
-};
 
 static PyObject * rpmfiles_find(rpmfileObject *s,
 				PyObject *args, PyObject *kwds)
@@ -536,11 +498,6 @@ static PyObject *rpmfiles_subscript(rpmfilesObject *s, PyObject *item)
     return NULL;
 }
 
-static PyMappingMethods rpmfiles_as_mapping = {
-    (lenfunc) rpmfiles_length,		/* mp_length */
-    (binaryfunc) rpmfiles_subscript,	/* mp_subscript */
-    0,					/* mp_ass_subscript */
-};
 
 static struct PyMethodDef rpmfiles_methods[] = {
     { "archive", (PyCFunction) rpmfiles_archive, METH_VARARGS|METH_KEYWORDS,
@@ -565,48 +522,26 @@ static char rpmfiles_doc[] =
     "\ttag : Obsolete. Leave alone!\n\n"
     "rpm.files is basically a sequence of rpm.file objects.\nNote that this is a read only data structure. To write file data you\nhave to write it directly into aheader object.";
 
-PyTypeObject rpmfiles_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.files",			/* tp_name */
-	sizeof(rpmfilesObject),		/* tp_basicsize */
-	0,				/* tp_itemsize */
-	/* methods */
-	(destructor) rpmfiles_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	0,				/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	&rpmfiles_as_sequence,		/* tp_as_sequence */
-	&rpmfiles_as_mapping,		/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmfiles_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	rpmfiles_methods,		/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	(newfunc) rpmfiles_new,		/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmfiles_Type_Slots[] = {
+    {Py_tp_dealloc, rpmfiles_dealloc},
+    {Py_sq_length, rpmfiles_length},
+    {Py_sq_item, rpmfiles_getitem},
+    {Py_sq_contains, rpmfiles_contains},
+    {Py_mp_length, rpmfiles_length},
+    {Py_mp_subscript, rpmfiles_subscript},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmfiles_doc},
+    {Py_tp_methods, rpmfiles_methods},
+    {Py_tp_new, rpmfiles_new},
+    {0, NULL},
+};
+
+PyType_Spec rpmfiles_Type_Spec = {
+    .name = "rpm.files",
+    .basicsize = sizeof(rpmfilesObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmfiles_Type_Slots,
 };
 
 PyObject * rpmfiles_Wrap(PyTypeObject *subtype, rpmfiles files)

--- a/python/rpmfiles-py.c
+++ b/python/rpmfiles-py.c
@@ -321,7 +321,16 @@ static struct PyMethodDef rpmfile_methods[] = {
     { NULL, NULL, 0, NULL }
 };
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.file' instances");
+    return NULL;
+}
+
 static PyType_Slot rpmfile_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmfile_dealloc},
     {Py_tp_str, rpmfile_name},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -336,7 +345,7 @@ PyTypeObject* rpmfile_Type;
 PyType_Spec rpmfile_Type_Spec = {
     .name = "rpm.file",
     .basicsize = sizeof(rpmfileObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmfile_Type_Slots,
 };
 

--- a/python/rpmfiles-py.h
+++ b/python/rpmfiles-py.h
@@ -6,11 +6,13 @@
 typedef struct rpmfileObject_s rpmfileObject;
 typedef struct rpmfilesObject_s rpmfilesObject;
 
-extern PyTypeObject rpmfile_Type;
-extern PyTypeObject rpmfiles_Type;
+extern PyTypeObject* rpmfile_Type;
+extern PyType_Spec rpmfile_Type_Spec;
+extern PyTypeObject* rpmfiles_Type;
+extern PyType_Spec rpmfiles_Type_Spec;
 
-#define rpmfileObject_Check(v)	((v)->ob_type == &rpmfile_Type)
-#define rpmfilesObject_Check(v)	((v)->ob_type == &rpmfiles_Type)
+#define rpmfileObject_Check(v)	((v)->ob_type == rpmfile_Type)
+#define rpmfilesObject_Check(v)	((v)->ob_type == rpmfiles_Type)
 
 PyObject * rpmfile_Wrap(rpmfiles files, int ix);
 PyObject * rpmfiles_Wrap(PyTypeObject *subtype, rpmfiles files);

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -121,7 +121,16 @@ static int rpmii_bool(rpmiiObject *s)
 static char rpmii_doc[] =
 "";
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.ii' instances");
+    return NULL;
+}
+
 static PyType_Slot rpmii_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmii_dealloc},
     {Py_nb_bool, rpmii_bool},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -137,7 +146,7 @@ PyTypeObject* rpmii_Type;
 PyType_Spec rpmii_Type_Spec = {
     .name = "rpm.ii",
     .basicsize = sizeof(rpmiiObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmii_Type_Slots,
 };
 

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -86,7 +86,8 @@ static void rpmii_dealloc(rpmiiObject * s)
     s->ii = rpmdbIndexIteratorFree(s->ii);
     rpmtdFree(s->keytd);
     Py_DECREF(s->ref);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static int rpmii_bool(rpmiiObject *s)

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -67,11 +67,11 @@ rpmii_instances(rpmiiObject * s)
     PyObject * tuple;
     for (int i = 0; i < entries; i++) {
         tuple = PyTuple_New(2);
-        PyTuple_SET_ITEM(tuple, 0,
-                         PyLong_FromLong(rpmdbIndexIteratorPkgOffset(s->ii, i)));
-        PyTuple_SET_ITEM(tuple, 1,
-                         PyLong_FromLong(rpmdbIndexIteratorTagNum(s->ii, i)));
-	PyList_SET_ITEM(list, i, tuple);
+        PyTuple_SetItem(tuple, 0,
+                        PyLong_FromLong(rpmdbIndexIteratorPkgOffset(s->ii, i)));
+        PyTuple_SetItem(tuple, 1,
+                        PyLong_FromLong(rpmdbIndexIteratorTagNum(s->ii, i)));
+	PyList_SetItem(list, i, tuple);
     }
     return list;
 }

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -95,63 +95,27 @@ static int rpmii_bool(rpmiiObject *s)
     return (s->ii != NULL);
 }
 
-static PyNumberMethods rpmii_as_number = {
-	0, /* nb_add */
-	0, /* nb_subtract */
-	0, /* nb_multiply */
-	0, /* nb_remainder */
-	0, /* nb_divmod */
-	0, /* nb_power */
-	0, /* nb_negative */
-	0, /* nb_positive */
-	0, /* nb_absolute */
-	(inquiry)rpmii_bool, /* nb_bool/nonzero */
-};
 
 static char rpmii_doc[] =
 "";
 
-PyTypeObject rpmii_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.ii",			/* tp_name */
-	sizeof(rpmiiObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) rpmii_dealloc, 	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	&rpmii_as_number,		/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmii_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	PyObject_SelfIter,		/* tp_iter */
-	(iternextfunc) rpmii_iternext,	/* tp_iternext */
-	rpmii_methods,			/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	0,				/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmii_Type_Slots[] = {
+    {Py_tp_dealloc, rpmii_dealloc},
+    {Py_nb_bool, rpmii_bool},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmii_doc},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, rpmii_iternext},
+    {Py_tp_methods, rpmii_methods},
+    {0, NULL},
+};
+
+PyType_Spec rpmii_Type_Spec = {
+    .name = "rpm.ii",
+    .basicsize = sizeof(rpmiiObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = rpmii_Type_Slots,
 };
 
 PyObject * rpmii_Wrap(PyTypeObject *subtype, rpmdbIndexIterator ii, PyObject *s)

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -65,12 +65,34 @@ rpmii_instances(rpmiiObject * s)
     int entries = rpmdbIndexIteratorNumPkgs(s->ii);
     PyObject * list = PyList_New(entries);
     PyObject * tuple;
+    PyObject * item;
+    int res;
     for (int i = 0; i < entries; i++) {
         tuple = PyTuple_New(2);
-        PyTuple_SetItem(tuple, 0,
-                        PyLong_FromLong(rpmdbIndexIteratorPkgOffset(s->ii, i)));
-        PyTuple_SetItem(tuple, 1,
-                        PyLong_FromLong(rpmdbIndexIteratorTagNum(s->ii, i)));
+        item = PyLong_FromLong(rpmdbIndexIteratorPkgOffset(s->ii, i));
+        if (!item) {
+            Py_DECREF(list);
+            Py_DECREF(tuple);
+            return NULL;
+        }
+        res = PyTuple_SetItem(tuple, 0, item);
+        if (res < 0) {
+            Py_DECREF(list);
+            Py_DECREF(tuple);
+            return NULL;
+        }
+        item = PyLong_FromLong(rpmdbIndexIteratorTagNum(s->ii, i));
+        if (!item) {
+            Py_DECREF(list);
+            Py_DECREF(tuple);
+            return NULL;
+        }
+        PyTuple_SetItem(tuple, 1, item);
+        if (res < 0) {
+            Py_DECREF(list);
+            Py_DECREF(tuple);
+            return NULL;
+        }
 	PyList_SetItem(list, i, tuple);
     }
     return list;

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -111,6 +111,7 @@ static PyType_Slot rpmii_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmii_Type;
 PyType_Spec rpmii_Type_Spec = {
     .name = "rpm.ii",
     .basicsize = sizeof(rpmiiObject),

--- a/python/rpmii-py.c
+++ b/python/rpmii-py.c
@@ -156,7 +156,8 @@ PyTypeObject rpmii_Type = {
 
 PyObject * rpmii_Wrap(PyTypeObject *subtype, rpmdbIndexIterator ii, PyObject *s)
 {
-    rpmiiObject * iio = (rpmiiObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmiiObject *iio = (rpmiiObject *)subtype_alloc(subtype, 0);
     if (iio == NULL) return NULL;
 
     iio->ii = ii;

--- a/python/rpmii-py.h
+++ b/python/rpmii-py.h
@@ -3,9 +3,10 @@
 
 typedef struct rpmiiObject_s rpmiiObject;
 
-extern PyTypeObject rpmii_Type;
+extern PyTypeObject* rpmii_Type;
+extern PyType_Spec rpmii_Type_Spec;
 
-#define rpmiiObject_Check(v)	((v)->ob_type == &rpmii_Type)
+#define rpmiiObject_Check(v)	((v)->ob_type == rpmii_Type)
 
 PyObject * rpmii_Wrap(PyTypeObject *subtype, rpmdbIndexIterator ii, PyObject *s);
 

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -184,7 +184,8 @@ PyTypeObject rpmKeyring_Type = {
 
 PyObject * rpmPubkey_Wrap(PyTypeObject *subtype, rpmPubkey pubkey)
 {
-    rpmPubkeyObject *s = (rpmPubkeyObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmPubkeyObject *s = (rpmPubkeyObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->pubkey = pubkey;
@@ -193,7 +194,8 @@ PyObject * rpmPubkey_Wrap(PyTypeObject *subtype, rpmPubkey pubkey)
 
 PyObject * rpmKeyring_Wrap(PyTypeObject *subtype, rpmKeyring keyring)
 {
-    rpmKeyringObject *s = (rpmKeyringObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmKeyringObject *s = (rpmKeyringObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->keyring = keyring;

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -57,47 +57,21 @@ static struct PyMethodDef rpmPubkey_methods[] = {
 
 static char rpmPubkey_doc[] = "";
 
-PyTypeObject rpmPubkey_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.pubkey",			/* tp_name */
-	sizeof(rpmPubkeyObject),	/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) rpmPubkey_dealloc,/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmPubkey_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	rpmPubkey_methods,		/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	rpmPubkey_new,			/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmPubkey_Type_Slots[] = {
+    {Py_tp_dealloc, rpmPubkey_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmPubkey_doc},
+    {Py_tp_methods, rpmPubkey_methods},
+    {Py_tp_new, rpmPubkey_new},
+    {0, NULL},
+};
+
+PyType_Spec rpmPubkey_Type_Spec = {
+    .name = "rpm.pubkey",
+    .basicsize = sizeof(rpmPubkeyObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmPubkey_Type_Slots,
 };
 
 struct rpmKeyringObject_s {
@@ -139,47 +113,21 @@ static struct PyMethodDef rpmKeyring_methods[] = {
 static char rpmKeyring_doc[] =
 "";
 
-PyTypeObject rpmKeyring_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.keyring",			/* tp_name */
-	sizeof(rpmKeyringObject),	/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) rpmKeyring_dealloc,/* tp_dealloc */
-	0,				/* tp_print */
-	0,		 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmKeyring_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	rpmKeyring_methods,		/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	rpmKeyring_new,			/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmKeyring_Type_Slots[] = {
+    {Py_tp_dealloc, rpmKeyring_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmKeyring_doc},
+    {Py_tp_methods, rpmKeyring_methods},
+    {Py_tp_new, rpmKeyring_new},
+    {0, NULL},
+};
+
+PyType_Spec rpmKeyring_Type_Spec = {
+    .name = "rpm.keyring",
+    .basicsize = sizeof(rpmKeyringObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmKeyring_Type_Slots,
 };
 
 PyObject * rpmPubkey_Wrap(PyTypeObject *subtype, rpmPubkey pubkey)

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -11,7 +11,8 @@ struct rpmPubkeyObject_s {
 static void rpmPubkey_dealloc(rpmPubkeyObject * s)
 {
     s->pubkey = rpmPubkeyFree(s->pubkey);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject *rpmPubkey_new(PyTypeObject *subtype, 
@@ -108,7 +109,8 @@ struct rpmKeyringObject_s {
 static void rpmKeyring_dealloc(rpmKeyringObject * s)
 {
     rpmKeyringFree(s->keyring);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject *rpmKeyring_new(PyTypeObject *subtype, 

--- a/python/rpmkeyring-py.c
+++ b/python/rpmkeyring-py.c
@@ -67,6 +67,7 @@ static PyType_Slot rpmPubkey_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmPubkey_Type;
 PyType_Spec rpmPubkey_Type_Spec = {
     .name = "rpm.pubkey",
     .basicsize = sizeof(rpmPubkeyObject),
@@ -98,7 +99,7 @@ static PyObject *rpmKeyring_addKey(rpmKeyringObject *s, PyObject *arg)
 {
     rpmPubkeyObject *pubkey = NULL;
 
-    if (!PyArg_Parse(arg, "O!", &rpmPubkey_Type, &pubkey))
+    if (!PyArg_Parse(arg, "O!", rpmPubkey_Type, &pubkey))
 	return NULL;
 
     return Py_BuildValue("i", rpmKeyringAddKey(s->keyring, pubkey->pubkey));
@@ -123,6 +124,7 @@ static PyType_Slot rpmKeyring_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmKeyring_Type;
 PyType_Spec rpmKeyring_Type_Spec = {
     .name = "rpm.keyring",
     .basicsize = sizeof(rpmKeyringObject),
@@ -153,7 +155,7 @@ PyObject * rpmKeyring_Wrap(PyTypeObject *subtype, rpmKeyring keyring)
 int rpmKeyringFromPyObject(PyObject *item, rpmKeyring *keyring)
 {
     rpmKeyringObject *kro;
-    if (!PyArg_Parse(item, "O!", &rpmKeyring_Type, &kro))
+    if (!PyArg_Parse(item, "O!", rpmKeyring_Type, &kro))
 	return 0;
     *keyring = kro->keyring;
     return 1;

--- a/python/rpmkeyring-py.h
+++ b/python/rpmkeyring-py.h
@@ -6,8 +6,10 @@
 typedef struct rpmPubkeyObject_s rpmPubkeyObject;
 typedef struct rpmKeyringObject_s rpmKeyringObject;
 
-extern PyTypeObject rpmKeyring_Type;
-extern PyTypeObject rpmPubkey_Type;
+extern PyTypeObject* rpmKeyring_Type;
+extern PyType_Spec rpmKeyring_Type_Spec;
+extern PyTypeObject* rpmPubkey_Type;
+extern PyType_Spec rpmPubkey_Type_Spec;
 
 PyObject * rpmPubkey_Wrap(PyTypeObject *subtype, rpmPubkey pubkey);
 PyObject * rpmKeyring_Wrap(PyTypeObject *subtype, rpmKeyring keyring);

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -242,7 +242,8 @@ PyTypeObject rpmmi_Type = {
 
 PyObject * rpmmi_Wrap(PyTypeObject *subtype, rpmdbMatchIterator mi, PyObject *s)
 {
-    rpmmiObject * mio = (rpmmiObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmmiObject *mio = (rpmmiObject *)subtype_alloc(subtype, 0);
     if (mio == NULL) return NULL;
 
     mio->mi = mi;

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -76,7 +76,7 @@ rpmmi_iternext(rpmmiObject * s)
 	return NULL;
     }
     headerLink(h);
-    return hdr_Wrap(&hdr_Type, h);
+    return hdr_Wrap(hdr_Type, h);
 }
 
 static PyObject *
@@ -194,6 +194,7 @@ static PyType_Slot rpmmi_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmmi_Type;
 PyType_Spec rpmmi_Type_Spec = {
     .name = "rpm.mi",
     .basicsize = sizeof(rpmmiObject),

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -143,23 +143,7 @@ static int rpmmi_bool(rpmmiObject *s)
     return (s->mi != NULL);
 }
 
-PyMappingMethods rpmmi_as_mapping = {
-    (lenfunc) rpmmi_length,		/* mp_length */
-    0,
-};
 
-static PyNumberMethods rpmmi_as_number = {
-	0, /* nb_add */
-	0, /* nb_subtract */
-	0, /* nb_multiply */
-	0, /* nb_remainder */
-	0, /* nb_divmod */
-	0, /* nb_power */
-	0, /* nb_negative */
-	0, /* nb_positive */
-	0, /* nb_absolute */
-	(inquiry)rpmmi_bool, /* nb_bool/nonzero */
-};
 
 static char rpmmi_doc[] =
   "rpm.mi match iterator object represents the result of a\n"
@@ -197,47 +181,24 @@ static char rpmmi_doc[] =
   "	    print('%s-%s-%s' % (h['name'], h['version'], h['release']))\n"
 ;
 
-PyTypeObject rpmmi_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.mi",			/* tp_name */
-	sizeof(rpmmiObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) rpmmi_dealloc, 	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	&rpmmi_as_number,		/* tp_as_number */
-	0,				/* tp_as_sequence */
-	&rpmmi_as_mapping,		/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmmi_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	PyObject_SelfIter,		/* tp_iter */
-	(iternextfunc) rpmmi_iternext,	/* tp_iternext */
-	rpmmi_methods,			/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	0,				/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmmi_Type_Slots[] = {
+    {Py_tp_dealloc, rpmmi_dealloc},
+    {Py_nb_bool, rpmmi_bool},
+    {Py_mp_length, rpmmi_length},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmmi_doc},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, rpmmi_iternext},
+    {Py_tp_methods, rpmmi_methods},
+    {0, NULL},
+};
+
+PyType_Spec rpmmi_Type_Spec = {
+    .name = "rpm.mi",
+    .basicsize = sizeof(rpmmiObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = rpmmi_Type_Slots,
 };
 
 PyObject * rpmmi_Wrap(PyTypeObject *subtype, rpmdbMatchIterator mi, PyObject *s)

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -129,7 +129,8 @@ static void rpmmi_dealloc(rpmmiObject * s)
 {
     s->mi = rpmdbFreeIterator(s->mi);
     Py_DECREF(s->ref);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static Py_ssize_t rpmmi_length(rpmmiObject * s)

--- a/python/rpmmi-py.c
+++ b/python/rpmmi-py.c
@@ -181,7 +181,16 @@ static char rpmmi_doc[] =
   "	    print('%s-%s-%s' % (h['name'], h['version'], h['release']))\n"
 ;
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.mi' instances");
+    return NULL;
+}
+
 static PyType_Slot rpmmi_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmmi_dealloc},
     {Py_nb_bool, rpmmi_bool},
     {Py_mp_length, rpmmi_length},
@@ -198,7 +207,7 @@ PyTypeObject* rpmmi_Type;
 PyType_Spec rpmmi_Type_Spec = {
     .name = "rpm.mi",
     .basicsize = sizeof(rpmmiObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmmi_Type_Slots,
 };
 

--- a/python/rpmmi-py.h
+++ b/python/rpmmi-py.h
@@ -3,9 +3,10 @@
 
 typedef struct rpmmiObject_s rpmmiObject;
 
-extern PyTypeObject rpmmi_Type;
+extern PyTypeObject* rpmmi_Type;
+extern PyType_Spec rpmmi_Type_Spec;
 
-#define rpmmiObject_Check(v)	((v)->ob_type == &rpmmi_Type)
+#define rpmmiObject_Check(v)	((v)->ob_type == rpmmi_Type)
 
 PyObject * rpmmi_Wrap(PyTypeObject *subtype, rpmdbMatchIterator mi, PyObject *s);
 

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -226,31 +226,6 @@ static void addRpmTags(PyObject *module)
     rpmtdFree(names);
 }
 
-/*
-  Do any common preliminary work before python 2 vs python 3 module creation:
-*/
-static int prepareInitModule(void)
-{
-    if (PyType_Ready(&hdr_Type) < 0) return 0;
-    if (PyType_Ready(&rpmarchive_Type) < 0) return 0;
-    if (PyType_Ready(&rpmds_Type) < 0) return 0;
-    if (PyType_Ready(&rpmfd_Type) < 0) return 0;
-    if (PyType_Ready(&rpmfile_Type) < 0) return 0;
-    if (PyType_Ready(&rpmfiles_Type) < 0) return 0;
-    if (PyType_Ready(&rpmKeyring_Type) < 0) return 0;
-    if (PyType_Ready(&rpmmi_Type) < 0) return 0;
-    if (PyType_Ready(&rpmii_Type) < 0) return 0;
-    if (PyType_Ready(&rpmProblem_Type) < 0) return 0;
-    if (PyType_Ready(&rpmPubkey_Type) < 0) return 0;
-    if (PyType_Ready(&rpmstrPool_Type) < 0) return 0;
-    if (PyType_Ready(&rpmte_Type) < 0) return 0;
-    if (PyType_Ready(&rpmts_Type) < 0) return 0;
-    if (PyType_Ready(&rpmver_Type) < 0) return 0;
-    if (PyType_Ready(&spec_Type) < 0) return 0;
-    if (PyType_Ready(&specPkg_Type) < 0) return 0;
-
-    return 1;
-}
 static int initModule(PyObject *m);
 
 static int rpmModuleTraverse(PyObject *m, visitproc visit, void *arg) {
@@ -282,7 +257,6 @@ PyObject *
 PyInit__rpm(void)
 {
     PyObject * m;
-    if (!prepareInitModule()) return NULL;
     m = PyModule_Create(&moduledef);
     initModule(m);
     return m;

--- a/python/rpmmodule.c
+++ b/python/rpmmodule.c
@@ -301,55 +301,72 @@ static int initModule(PyObject *m)
     if (pyrpmError != NULL)
 	PyDict_SetItemString(d, "error", pyrpmError);
 
-    Py_INCREF(&hdr_Type);
-    PyModule_AddObject(m, "hdr", (PyObject *) &hdr_Type);
+    if (!initAndAddType(m, &hdr_Type, &hdr_Type_Spec, "hdr")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmarchive_Type);
-    PyModule_AddObject(m, "archive", (PyObject *) &rpmarchive_Type);
+    if (!initAndAddType(m, &rpmarchive_Type, &rpmarchive_Type_Spec, "archive")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmds_Type);
-    PyModule_AddObject(m, "ds", (PyObject *) &rpmds_Type);
+    if (!initAndAddType(m, &rpmds_Type, &rpmds_Type_Spec, "ds")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmfd_Type);
-    PyModule_AddObject(m, "fd", (PyObject *) &rpmfd_Type);
+    if (!initAndAddType(m, &rpmfd_Type, &rpmfd_Type_Spec, "fd")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmfile_Type);
-    PyModule_AddObject(m, "file", (PyObject *) &rpmfile_Type);
+    if (!initAndAddType(m, &rpmfile_Type, &rpmfile_Type_Spec, "file")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmfiles_Type);
-    PyModule_AddObject(m, "files", (PyObject *) &rpmfiles_Type);
+    if (!initAndAddType(m, &rpmfiles_Type, &rpmfiles_Type_Spec, "files")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmKeyring_Type);
-    PyModule_AddObject(m, "keyring", (PyObject *) &rpmKeyring_Type);
+    if (!initAndAddType(m, &rpmKeyring_Type, &rpmKeyring_Type_Spec, "keyring")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmmi_Type);
-    PyModule_AddObject(m, "mi", (PyObject *) &rpmmi_Type);
+    if (!initAndAddType(m, &rpmmi_Type, &rpmmi_Type_Spec, "mi")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmii_Type);
-    PyModule_AddObject(m, "ii", (PyObject *) &rpmii_Type);
+    if (!initAndAddType(m, &rpmii_Type, &rpmii_Type_Spec, "ii")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmProblem_Type);
-    PyModule_AddObject(m, "prob", (PyObject *) &rpmProblem_Type);
+    if (!initAndAddType(m, &rpmProblem_Type, &rpmProblem_Type_Spec, "prob")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmPubkey_Type);
-    PyModule_AddObject(m, "pubkey", (PyObject *) &rpmPubkey_Type);
+    if (!initAndAddType(m, &rpmPubkey_Type, &rpmPubkey_Type_Spec, "pubkey")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmstrPool_Type);
-    PyModule_AddObject(m, "strpool", (PyObject *) &rpmstrPool_Type);
+    if (!initAndAddType(m, &rpmstrPool_Type, &rpmstrPool_Type_Spec, "strpool")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmte_Type);
-    PyModule_AddObject(m, "te", (PyObject *) &rpmte_Type);
+    if (!initAndAddType(m, &rpmte_Type, &rpmte_Type_Spec, "te")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmts_Type);
-    PyModule_AddObject(m, "ts", (PyObject *) &rpmts_Type);
+    if (!initAndAddType(m, &rpmts_Type, &rpmts_Type_Spec, "ts")) {
+	return 0;
+    }
 
-    Py_INCREF(&rpmver_Type);
-    PyModule_AddObject(m, "ver", (PyObject *) &rpmver_Type);
+    if (!initAndAddType(m, &rpmver_Type, &rpmver_Type_Spec, "ver")) {
+	return 0;
+    }
 
-    Py_INCREF(&spec_Type);
-    PyModule_AddObject(m, "spec", (PyObject *) &spec_Type);
-    Py_INCREF(&specPkg_Type);
-    PyModule_AddObject(m, "specPkg", (PyObject *) &specPkg_Type);
+    if (!initAndAddType(m, &spec_Type, &spec_Type_Spec, "spec")) {
+	return 0;
+    }
+    if (!initAndAddType(m, &specPkg_Type, &specPkg_Type_Spec, "specPkg")) {
+	return 0;
+    }
 
     addRpmTags(m);
 

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -81,6 +81,7 @@ static PyType_Slot rpmProblem_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmProblem_Type;
 PyType_Spec rpmProblem_Type_Spec = {
     .name = "rpm.prob",
     .basicsize = sizeof(rpmProblemObject),
@@ -112,7 +113,7 @@ PyObject *rpmps_AsList(rpmps ps)
     psi = rpmpsInitIterator(ps);
 
     while ((prob = rpmpsiNext(psi))) {
-        PyObject *pyprob = rpmprob_Wrap(&rpmProblem_Type, prob);
+        PyObject *pyprob = rpmprob_Wrap(rpmProblem_Type, prob);
         if (!pyprob) {
             Py_DECREF(problems);
             rpmpsFreeIterator(psi);

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -67,7 +67,8 @@ static PyObject *rpmprob_str(rpmProblemObject *s)
 static void rpmprob_dealloc(rpmProblemObject *s)
 {
     s->prob = rpmProblemFree(s->prob);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 PyTypeObject rpmProblem_Type = {

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -117,7 +117,8 @@ PyTypeObject rpmProblem_Type = {
 
 PyObject *rpmprob_Wrap(PyTypeObject *subtype, rpmProblem prob)
 {
-    rpmProblemObject * s = (rpmProblemObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmProblemObject *s = (rpmProblemObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->prob = rpmProblemLink(prob);

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -71,7 +71,16 @@ static void rpmprob_dealloc(rpmProblemObject *s)
     free(s);
 }
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.prob' instances");
+    return NULL;
+}
+
 static PyType_Slot rpmProblem_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_dealloc, rpmprob_dealloc},
     {Py_tp_str, rpmprob_str},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -85,7 +94,7 @@ PyTypeObject* rpmProblem_Type;
 PyType_Spec rpmProblem_Type_Spec = {
     .name = "rpm.prob",
     .basicsize = sizeof(rpmProblemObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmProblem_Type_Slots,
 };
 

--- a/python/rpmps-py.c
+++ b/python/rpmps-py.c
@@ -71,48 +71,21 @@ static void rpmprob_dealloc(rpmProblemObject *s)
     free(s);
 }
 
-PyTypeObject rpmProblem_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.prob",			/* tp_name */
-	sizeof(rpmProblemObject),		/* tp_basicsize */
-	0,				/* tp_itemsize */
-	/* methods */
-	(destructor)rpmprob_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0,			/* tp_getattr */
-	(setattrfunc)0,			/* tp_setattr */
-	0,				/* tp_compare */
-	(reprfunc)0,			/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	(hashfunc)0,			/* tp_hash */
-	(ternaryfunc)0,			/* tp_call */
-	(reprfunc)rpmprob_str,		/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmprob_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	(richcmpfunc)0,			/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	0,				/* tp_methods */
-	0,				/* tp_members */
-	rpmprob_getseters,		/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	(newfunc)0,			/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmProblem_Type_Slots[] = {
+    {Py_tp_dealloc, rpmprob_dealloc},
+    {Py_tp_str, rpmprob_str},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmprob_doc},
+    {Py_tp_getset, rpmprob_getseters},
+    {0, NULL},
+};
+
+PyType_Spec rpmProblem_Type_Spec = {
+    .name = "rpm.prob",
+    .basicsize = sizeof(rpmProblemObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = rpmProblem_Type_Slots,
 };
 
 PyObject *rpmprob_Wrap(PyTypeObject *subtype, rpmProblem prob)

--- a/python/rpmps-py.h
+++ b/python/rpmps-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmProblemObject_s rpmProblemObject;
 
-extern PyTypeObject rpmProblem_Type;
+extern PyTypeObject* rpmProblem_Type;
+extern PyType_Spec rpmProblem_Type_Spec;
 
-#define rpmProblemObject_Check(v)	((v)->ob_type == &rpmProblem_Type)
+#define rpmProblemObject_Check(v)	((v)->ob_type == rpmProblem_Type)
 
 PyObject * rpmprob_Wrap(PyTypeObject *subtype, rpmProblem prob);
 

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -13,7 +13,8 @@ static char strpool_doc[] = "";
 static void strpool_dealloc(rpmstrPoolObject *s)
 {
     s->pool = rpmstrPoolFree(s->pool);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject *strpool_new(PyTypeObject *subtype,

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -139,7 +139,8 @@ PyTypeObject rpmstrPool_Type = {
 
 PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool)
 {
-    rpmstrPoolObject *s = (rpmstrPoolObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmstrPoolObject *s = (rpmstrPoolObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     /* permit referencing a pre-existing pool as well */

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -101,6 +101,7 @@ static PyType_Slot rpmstrPool_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmstrPool_Type;
 PyType_Spec rpmstrPool_Type_Spec = {
     .name = "rpm.strpool",
     .basicsize = sizeof(rpmstrPoolObject),
@@ -123,7 +124,7 @@ PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool)
 int poolFromPyObject(PyObject *item, rpmstrPool *pool)
 {
     rpmstrPoolObject *p = NULL;
-    if (PyArg_Parse(item, "O!", &rpmstrPool_Type, &p))
+    if (PyArg_Parse(item, "O!", rpmstrPool_Type, &p))
 	*pool = p->pool;
     return (p != NULL);
 }

--- a/python/rpmstrpool-py.c
+++ b/python/rpmstrpool-py.c
@@ -88,53 +88,24 @@ static struct PyMethodDef strpool_methods[] = {
     { NULL,	NULL }
 };
 
-static PyMappingMethods strpool_as_mapping = {
-    (lenfunc) strpool_length,		/* mp_length */
-    (binaryfunc) strpool_id2str,	/* mp_subscript */
-    (objobjargproc) 0,			/* mp_ass_subscript */
+
+static PyType_Slot rpmstrPool_Type_Slots[] = {
+    {Py_tp_dealloc, strpool_dealloc},
+    {Py_mp_length, strpool_length},
+    {Py_mp_subscript, strpool_id2str},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, strpool_doc},
+    {Py_tp_methods, strpool_methods},
+    {Py_tp_new, strpool_new},
+    {0, NULL},
 };
 
-PyTypeObject rpmstrPool_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.strpool",			/* tp_name */
-	sizeof(rpmstrPoolObject),	/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) strpool_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	&strpool_as_mapping,		/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	strpool_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	strpool_methods,		/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	strpool_new,			/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+PyType_Spec rpmstrPool_Type_Spec = {
+    .name = "rpm.strpool",
+    .basicsize = sizeof(rpmstrPoolObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmstrPool_Type_Slots,
 };
 
 PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool)

--- a/python/rpmstrpool-py.h
+++ b/python/rpmstrpool-py.h
@@ -5,7 +5,8 @@
 
 typedef struct rpmstrPoolObject_s rpmstrPoolObject;
 
-extern PyTypeObject rpmstrPool_Type;
+extern PyTypeObject* rpmstrPool_Type;
+extern PyType_Spec rpmstrPool_Type_Spec;
 
 PyObject * rpmstrPool_Wrap(PyTypeObject *subtype, rpmstrPool pool);
 

--- a/python/rpmsystem-py.h
+++ b/python/rpmsystem-py.h
@@ -11,4 +11,12 @@
 
 PyObject * utf8FromString(const char *s);
 
+#ifndef Py_TPFLAGS_IMMUTABLETYPE
+/*
+ * Flag was added in Python 3.10.
+ * If the current Python doesn't have it, rpm's type objects will be mutable.
+ */
+#define Py_TPFLAGS_IMMUTABLETYPE 0
+#endif
+
 #endif	/* H_SYSTEM_PYTHON */

--- a/python/rpmtd-py.c
+++ b/python/rpmtd-py.c
@@ -54,7 +54,7 @@ PyObject *rpmtd_AsPyobj(rpmtd td)
                 Py_DECREF(res);
                 return NULL;
             }
-	    PyList_SET_ITEM(res, ix, item);
+	    PyList_SetItem(res, ix, item);
 	}
     } else {
 	res = rpmtd_ItemAsPyobj(td, tclass);

--- a/python/rpmtd-py.c
+++ b/python/rpmtd-py.c
@@ -37,6 +37,7 @@ PyObject *rpmtd_AsPyobj(rpmtd td)
     PyObject *res = NULL;
     int array = (rpmTagGetReturnType(td->tag) == RPM_ARRAY_RETURN_TYPE);
     rpmTagClass tclass = rpmtdClass(td);
+    int r;
 
     if (!array && rpmtdCount(td) < 1) {
 	Py_RETURN_NONE;
@@ -54,7 +55,11 @@ PyObject *rpmtd_AsPyobj(rpmtd td)
                 Py_DECREF(res);
                 return NULL;
             }
-	    PyList_SetItem(res, ix, item);
+	    r = PyList_SetItem(res, ix, item);
+	    if (r < 0) {
+		Py_DECREF(res);
+		return NULL;
+	    }
 	}
     } else {
 	res = rpmtd_ItemAsPyobj(td, tclass);

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -116,7 +116,7 @@ rpmte_Parent(rpmteObject * s, PyObject * unused)
 {
     rpmte parent = rpmteParent(s->te);
     if (parent)
-	return rpmte_Wrap(&rpmte_Type, parent);
+	return rpmte_Wrap(rpmte_Type, parent);
 
     Py_RETURN_NONE;
 }
@@ -190,7 +190,7 @@ rpmte_DS(rpmteObject * s, PyObject * args, PyObject * kwds)
     if (ds == NULL) {
 	Py_RETURN_NONE;
     }
-    return rpmds_Wrap(&rpmds_Type, rpmdsLink(ds));
+    return rpmds_Wrap(rpmds_Type, rpmdsLink(ds));
 }
 
 static PyObject *
@@ -200,7 +200,7 @@ rpmte_Files(rpmteObject * s, PyObject * args, PyObject * kwds)
     if (files == NULL) {
 	Py_RETURN_NONE;
     }
-    return rpmfiles_Wrap(&rpmfiles_Type, files);
+    return rpmfiles_Wrap(rpmfiles_Type, files);
 }
 
 static PyObject *
@@ -273,6 +273,7 @@ static PyType_Slot rpmte_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmte_Type;
 PyType_Spec rpmte_Type_Spec = {
     .name = "rpm.te",
     .basicsize = sizeof(rpmteObject),

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -310,7 +310,8 @@ PyTypeObject rpmte_Type = {
 
 PyObject * rpmte_Wrap(PyTypeObject *subtype, rpmte te)
 {
-    rpmteObject *s = (rpmteObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmteObject *s = (rpmteObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->te = te;

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -265,47 +265,19 @@ static struct PyMethodDef rpmte_methods[] = {
 static char rpmte_doc[] =
 "";
 
-PyTypeObject rpmte_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.te",			/* tp_name */
-	sizeof(rpmteObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor)0,		 	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0,		 	/* tp_getattr */
-	(setattrfunc)0,			/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmte_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	rpmte_methods,			/* tp_methods */
-	0,				/* tp_members */
-	0,				/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	0,				/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmte_Type_Slots[] = {
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmte_doc},
+    {Py_tp_methods, rpmte_methods},
+    {0, NULL},
+};
+
+PyType_Spec rpmte_Type_Spec = {
+    .name = "rpm.te",
+    .basicsize = sizeof(rpmteObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = rpmte_Type_Slots,
 };
 
 PyObject * rpmte_Wrap(PyTypeObject *subtype, rpmte te)

--- a/python/rpmte-py.c
+++ b/python/rpmte-py.c
@@ -265,7 +265,16 @@ static struct PyMethodDef rpmte_methods[] = {
 static char rpmte_doc[] =
 "";
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.te' instances");
+    return NULL;
+}
+
 static PyType_Slot rpmte_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
     {Py_tp_doc, rpmte_doc},
@@ -277,7 +286,7 @@ PyTypeObject* rpmte_Type;
 PyType_Spec rpmte_Type_Spec = {
     .name = "rpm.te",
     .basicsize = sizeof(rpmteObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = rpmte_Type_Slots,
 };
 

--- a/python/rpmte-py.h
+++ b/python/rpmte-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmteObject_s rpmteObject;
 
-extern PyTypeObject rpmte_Type;
+extern PyTypeObject* rpmte_Type;
+extern PyType_Spec rpmte_Type_Spec;
 
-#define rpmteObject_Check(v)	((v)->ob_type == &rpmte_Type)
+#define rpmteObject_Check(v)	((v)->ob_type == rpmte_Type)
 
 PyObject * rpmte_Wrap(PyTypeObject *subtype, rpmte te);
 

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -844,7 +844,8 @@ static void rpmts_dealloc(rpmtsObject * s)
 
 static PyObject * rpmts_new(PyTypeObject * subtype, PyObject *args, PyObject *kwds)
 {
-    rpmtsObject * s = (rpmtsObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    rpmtsObject *s = (rpmtsObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->ts = rpmtsCreate();

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -1047,45 +1047,23 @@ static PyGetSetDef rpmts_getseters[] = {
 	{ NULL }
 };
 
-PyTypeObject rpmts_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.ts",			/* tp_name */
-	sizeof(rpmtsObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) rpmts_dealloc, 	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	(setattrfunc)0,			/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr, 	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	rpmts_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	PyObject_SelfIter,		/* tp_iter */
-	(iternextfunc) rpmts_iternext,	/* tp_iternext */
-	rpmts_methods,			/* tp_methods */
-	0,				/* tp_members */
-	rpmts_getseters,		/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	(initproc) rpmts_init,		/* tp_init */
-	0,				/* tp_alloc */
-	(newfunc) rpmts_new,		/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmts_Type_Slots[] = {
+    {Py_tp_dealloc, rpmts_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, rpmts_doc},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, rpmts_iternext},
+    {Py_tp_methods, rpmts_methods},
+    {Py_tp_getset, rpmts_getseters},
+    {Py_tp_init, rpmts_init},
+    {Py_tp_new, rpmts_new},
+    {0, NULL},
+};
+
+PyType_Spec rpmts_Type_Spec = {
+    .name = "rpm.ts",
+    .basicsize = sizeof(rpmtsObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmts_Type_Slots,
 };

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -420,7 +420,7 @@ rpmts_HdrFromFdno(rpmtsObject * s, PyObject *arg)
     Py_XDECREF(fdo);
 
     if (rpmrc == RPMRC_OK) {
-	ho = hdr_Wrap(&hdr_Type, h);
+	ho = hdr_Wrap(hdr_Type, h);
     } else {
 	Py_INCREF(Py_None);
 	ho = Py_None;
@@ -494,7 +494,7 @@ static PyObject *rpmts_getKeyring(rpmtsObject *s, PyObject *args, PyObject *kwds
 
     keyring = rpmtsGetKeyring(s->ts, autoload);
     if (keyring) {
-	return rpmKeyring_Wrap(&rpmKeyring_Type, keyring);
+	return rpmKeyring_Wrap(rpmKeyring_Type, keyring);
     } else {
 	Py_RETURN_NONE;
     }
@@ -534,7 +534,7 @@ rpmtsCallback(const void * arg, const rpmCallbackType what,
     } else {
 	PyObject *o;
 	if (arg) {
-	    o = rpmte_Wrap(&rpmte_Type, (rpmte) arg);
+	    o = rpmte_Wrap(rpmte_Type, (rpmte) arg);
 	} else {
 	    o = Py_None;
 	    Py_INCREF(o);
@@ -632,7 +632,7 @@ rpmts_iternext(rpmtsObject * s)
 
     te = rpmtsiNext(s->tsi, 0);
     if (te != NULL) {
-	result = rpmte_Wrap(&rpmte_Type, te);
+	result = rpmte_Wrap(rpmte_Type, te);
     } else {
 	s->tsi = rpmtsiFree(s->tsi);
     }
@@ -683,7 +683,7 @@ rpmts_Match(rpmtsObject * s, PyObject * args, PyObject * kwds)
 	}
     }
 
-    mio = rpmmi_Wrap(&rpmmi_Type, rpmtsInitIterator(s->ts, tag, key, len), (PyObject*)s);
+    mio = rpmmi_Wrap(rpmmi_Type, rpmtsInitIterator(s->ts, tag, key, len), (PyObject*)s);
 
 exit:
     Py_XDECREF(str);
@@ -714,7 +714,7 @@ rpmts_index(rpmtsObject * s, PyObject * args, PyObject * kwds)
         PyErr_SetString(PyExc_KeyError, "No index for this tag");
         return NULL;
     }
-    mio = rpmii_Wrap(&rpmii_Type, ii, (PyObject*)s);
+    mio = rpmii_Wrap(rpmii_Type, ii, (PyObject*)s);
 
 exit:
     return mio;
@@ -1061,6 +1061,7 @@ static PyType_Slot rpmts_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmts_Type;
 PyType_Spec rpmts_Type_Spec = {
     .name = "rpm.ts",
     .basicsize = sizeof(rpmtsObject),

--- a/python/rpmts-py.c
+++ b/python/rpmts-py.c
@@ -838,7 +838,8 @@ static void rpmts_dealloc(rpmtsObject * s)
     s->ts = rpmtsFree(s->ts);
     Py_XDECREF(s->scriptFd);
     Py_XDECREF(s->keyList);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject * rpmts_new(PyTypeObject * subtype, PyObject *args, PyObject *kwds)

--- a/python/rpmts-py.h
+++ b/python/rpmts-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmtsObject_s rpmtsObject;
 
-extern PyTypeObject rpmts_Type;
+extern PyTypeObject* rpmts_Type;
+extern PyType_Spec rpmts_Type_Spec;
 
-#define rpmtsObject_Check(v)	((v)->ob_type == &rpmts_Type)
+#define rpmtsObject_Check(v)	((v)->ob_type == rpmts_Type)
 
 int rpmtsFromPyObject(PyObject *item, rpmts *ts);
 

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -123,47 +123,23 @@ static PyGetSetDef ver_getseters[] = {
     { NULL },
 };
 
-PyTypeObject rpmver_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.ver",			/* tp_name */
-	sizeof(rpmverObject),	/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) ver_dealloc,	/* tp_dealloc */
-	0,				/* tp_print */
-	(getattrfunc)0, 		/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	(reprfunc)ver_get_evr,		/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	ver_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	(richcmpfunc)ver_richcmp,	/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	0,				/* tp_methods */
-	0,				/* tp_members */
-	ver_getseters,			/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	ver_new,			/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot rpmver_Type_Slots[] = {
+    {Py_tp_dealloc, ver_dealloc},
+    {Py_tp_repr, ver_get_evr},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, ver_doc},
+    {Py_tp_richcompare, ver_richcmp},
+    {Py_tp_getset, ver_getseters},
+    {Py_tp_new, ver_new},
+    {0, NULL},
+};
+
+PyType_Spec rpmver_Type_Spec = {
+    .name = "rpm.ver",
+    .basicsize = sizeof(rpmverObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = rpmver_Type_Slots,
 };
 
 PyObject * rpmver_Wrap(PyTypeObject *subtype, rpmver ver)

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -135,6 +135,7 @@ static PyType_Slot rpmver_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* rpmver_Type;
 PyType_Spec rpmver_Type_Spec = {
     .name = "rpm.ver",
     .basicsize = sizeof(rpmverObject),

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -14,7 +14,8 @@ static char ver_doc[] = "";
 static void ver_dealloc(rpmverObject *s)
 {
     s->ver = rpmverFree(s->ver);
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 int verFromPyObject(PyObject *o, rpmver *ver)

--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -171,7 +171,9 @@ PyObject * rpmver_Wrap(PyTypeObject *subtype, rpmver ver)
     rpmverObject *s = NULL;
 
     if (ver) {
-	s = (rpmverObject *)subtype->tp_alloc(subtype, 0);
+	allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype,
+                                                            Py_tp_alloc);
+	s = (rpmverObject *)subtype_alloc(subtype, 0);
 	if (s == NULL) return NULL;
 	s->ver = ver;
     }

--- a/python/rpmver-py.h
+++ b/python/rpmver-py.h
@@ -5,9 +5,10 @@
 
 typedef struct rpmverObject_s rpmverObject;
 
-extern PyTypeObject rpmver_Type;
+extern PyTypeObject* rpmver_Type;
+extern PyType_Spec rpmver_Type_Spec;
 
-#define verObject_Check(v)	(((PyObject*)v)->ob_type == &rpmver_Type)
+#define verObject_Check(v)	(((PyObject*)v)->ob_type == rpmver_Type)
 
 int verFromPyObject(PyObject *item, rpmver *ver);
 PyObject * rpmver_Wrap(PyTypeObject *subtype, rpmver ver);

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -31,7 +31,7 @@
 
 static PyObject *makeHeader(Header h)
 {
-    return hdr_Wrap(&hdr_Type, headerLink(h));
+    return hdr_Wrap(hdr_Type, headerLink(h));
 }
 
 struct specPkgObject_s {
@@ -98,6 +98,7 @@ static PyType_Slot specPkg_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* specPkg_Type;
 PyType_Spec specPkg_Type_Spec = {
     .name = "rpm.specpkg",
     .basicsize = sizeof(specPkgObject),
@@ -206,7 +207,7 @@ static PyObject * spec_get_packages(specObject *s, void *closure)
     iter = rpmSpecPkgIterInit(s->spec);
 
     while ((pkg = rpmSpecPkgIterNext(iter)) != NULL) {
-	PyObject *po = specPkg_Wrap(&specPkg_Type, pkg, s);
+	PyObject *po = specPkg_Wrap(specPkg_Type, pkg, s);
         if (!po) {
             rpmSpecPkgIterFree(iter);
             Py_DECREF(pkgList);
@@ -273,6 +274,7 @@ static PyType_Slot spec_Type_Slots[] = {
     {0, NULL},
 };
 
+PyTypeObject* spec_Type;
 PyType_Spec spec_Type_Spec = {
     .name = "rpm.spec",
     .basicsize = sizeof(specObject),

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -337,7 +337,8 @@ PyTypeObject spec_Type = {
 PyObject *
 spec_Wrap(PyTypeObject *subtype, rpmSpec spec) 
 {
-    specObject * s = (specObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    specObject *s = (specObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->spec = spec; 
@@ -346,7 +347,8 @@ spec_Wrap(PyTypeObject *subtype, rpmSpec spec)
 
 PyObject * specPkg_Wrap(PyTypeObject *subtype, rpmSpecPkg pkg, specObject *source)
 {
-    specPkgObject * s = (specPkgObject *)subtype->tp_alloc(subtype, 0);
+    allocfunc subtype_alloc = (allocfunc)PyType_GetSlot(subtype, Py_tp_alloc);
+    specPkgObject *s = (specPkgObject *)subtype_alloc(subtype, 0);
     if (s == NULL) return NULL;
 
     s->pkg = pkg;

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -144,7 +144,8 @@ spec_dealloc(specObject * s)
     if (s->spec) {
 	s->spec=rpmSpecFree(s->spec);
     }
-    Py_TYPE(s)->tp_free((PyObject *)s);
+    freefunc free = PyType_GetSlot(Py_TYPE(s), Py_tp_free);
+    free(s);
 }
 
 static PyObject * getSection(rpmSpec spec, int section)

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -89,47 +89,20 @@ static PyGetSetDef specpkg_getseters[] = {
     { NULL }   /* sentinel */
 };
 
-PyTypeObject specPkg_Type = {
-	PyVarObject_HEAD_INIT(&PyType_Type, 0)
-	"rpm.specpkg",			/* tp_name */
-	sizeof(specPkgObject),		/* tp_size */
-	0,				/* tp_itemsize */
-	(destructor) specPkg_dealloc, 	/* tp_dealloc */
-	0,				/* tp_print */
-	0, 				/* tp_getattr */
-	0,				/* tp_setattr */
-	0,				/* tp_compare */
-	0,				/* tp_repr */
-	0,				/* tp_as_number */
-	0,				/* tp_as_sequence */
-	0,				/* tp_as_mapping */
-	0,				/* tp_hash */
-	0,				/* tp_call */
-	0,				/* tp_str */
-	PyObject_GenericGetAttr,	/* tp_getattro */
-	PyObject_GenericSetAttr,	/* tp_setattro */
-	0,				/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	specPkg_doc,			/* tp_doc */
-	0,				/* tp_traverse */
-	0,				/* tp_clear */
-	0,				/* tp_richcompare */
-	0,				/* tp_weaklistoffset */
-	0,				/* tp_iter */
-	0,				/* tp_iternext */
-	0,				/* tp_methods */
-	0,				/* tp_members */
-	specpkg_getseters,		/* tp_getset */
-	0,				/* tp_base */
-	0,				/* tp_dict */
-	0,				/* tp_descr_get */
-	0,				/* tp_descr_set */
-	0,				/* tp_dictoffset */
-	0,				/* tp_init */
-	0,				/* tp_alloc */
-	0,				/* tp_new */
-	0,				/* tp_free */
-	0,				/* tp_is_gc */
+static PyType_Slot specPkg_Type_Slots[] = {
+    {Py_tp_dealloc, specPkg_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_doc, specPkg_doc},
+    {Py_tp_getset, specpkg_getseters},
+    {0, NULL},
+};
+
+PyType_Spec specPkg_Type_Spec = {
+    .name = "rpm.specpkg",
+    .basicsize = sizeof(specPkgObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .slots = specPkg_Type_Slots,
 };
 
 struct specObject_s {
@@ -291,47 +264,20 @@ static struct PyMethodDef spec_methods[] = {
     { NULL, NULL }
 };
 
-PyTypeObject spec_Type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "rpm.spec",               /*tp_name*/
-    sizeof(specObject),        /*tp_basicsize*/
-    0,                         /*tp_itemsize*/
-    (destructor) spec_dealloc, /*tp_dealloc*/
-    0,                         /*tp_print*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    spec_doc,                  /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    spec_methods,	       /* tp_methods */
-    0,                         /* tp_members */
-    spec_getseters,            /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    0,                         /* tp_init */
-    0,                         /* tp_alloc */
-    spec_new,                  /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
+static PyType_Slot spec_Type_Slots[] = {
+    {Py_tp_dealloc, spec_dealloc},
+    {Py_tp_doc, spec_doc},
+    {Py_tp_methods, spec_methods},
+    {Py_tp_getset, spec_getseters},
+    {Py_tp_new, spec_new},
+    {0, NULL},
+};
+
+PyType_Spec spec_Type_Spec = {
+    .name = "rpm.spec",
+    .basicsize = sizeof(specObject),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = spec_Type_Slots,
 };
 
 PyObject *

--- a/python/spec-py.c
+++ b/python/spec-py.c
@@ -89,7 +89,16 @@ static PyGetSetDef specpkg_getseters[] = {
     { NULL }   /* sentinel */
 };
 
+static PyObject *disabled_new(PyTypeObject *type,
+                              PyObject *args, PyObject *kwds)
+{
+    PyErr_SetString(PyExc_TypeError,
+                    "TypeError: cannot create 'rpm.specpkg' instances");
+    return NULL;
+}
+
 static PyType_Slot specPkg_Type_Slots[] = {
+    {Py_tp_new, disabled_new},
     {Py_tp_dealloc, specPkg_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_setattro, PyObject_GenericSetAttr},
@@ -102,7 +111,7 @@ PyTypeObject* specPkg_Type;
 PyType_Spec specPkg_Type_Spec = {
     .name = "rpm.specpkg",
     .basicsize = sizeof(specPkgObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = specPkg_Type_Slots,
 };
 

--- a/python/spec-py.h
+++ b/python/spec-py.h
@@ -6,11 +6,13 @@
 typedef struct specPkgObject_s specPkgObject;
 typedef struct specObject_s specObject;
 
-extern PyTypeObject spec_Type;
-extern PyTypeObject specPkg_Type;
+extern PyTypeObject* spec_Type;
+extern PyType_Spec spec_Type_Spec;
+extern PyTypeObject* specPkg_Type;
+extern PyType_Spec specPkg_Type_Spec;
 
-#define specObject_Check(v)	((v)->ob_type == &spec_Type)
-#define specPkgObject_Check(v)	((v)->ob_type == &specPkg_Type)
+#define specObject_Check(v)	((v)->ob_type == spec_Type)
+#define specPkgObject_Check(v)	((v)->ob_type == specPkg_Type)
 
 PyObject * spec_Wrap(PyTypeObject *subtype, rpmSpec spec);
 PyObject * specPkg_Wrap(PyTypeObject *subtype, rpmSpecPkg pkg, specObject *source);


### PR DESCRIPTION
These are the changes needed to use Python's stable ABI. This allows the extension to be used without recompilation with multiple versions of Python (from 3.7 until an ABI break).

Hack to make this easier:
- type objects are allocated when the module loads, stored in global pointers, and never released
- the module may only be loaded once per process, so each type is leaked at most once, and the global pointers aren't clobbered.

There is no support for installing for, nor testing with, multiple versions of Python at once. That's left up to distributors for now. (AFAIK it's a bit of uncharted territorry for projects that aren't Python-first.)

The individual commits carry explanations for each kind of change, but the in-between commits won't necessarily build. (i.e. you'd need a Git *merge commit* to  preserve both messages and bisectability.)

I am asking for help with the build system. As it is (in the last commit), it's a bit chaotic:
- With CMake 3.26+, stable ABI will be used by default.
  - This requires Python 3.7+
  - This can be turned off using `cmake -DENABLE_PYTHON_SABI=OFF` (e.g. to allow an older Python version)
- With older CMake, or `ENABLE_PYTHON_SABI=OFF`, stable ABI is not used

If that's fine, I can put it in the build documentation.
If it would be better to build stable ABI even with older CMake, it shouldn't be hard to set the flag manually instead of using CMake's integration.

I've built and ran the tests with Python 3.6-3.12. Sadly I don't have easy access to 3.5 and below.

Fixes: #2345
