### PR TITLE
Python tests: Close open files

### DIFF
--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -225,6 +225,7 @@ try:
     myprint(h['arch'])
 except rpm.error as e:
     myprint(e)
+sink.close()
 ],
 [public key not available
 ],
@@ -232,7 +233,8 @@ except rpm.error as e:
 
 RPMPY_TEST([reading a signed package file 2],[
 
-keydata = open('${RPMDATA}/keys/rpm.org-rsa-2048-test.pub', 'rb').read()
+with open('${RPMDATA}/keys/rpm.org-rsa-2048-test.pub', 'rb') as keydata_file:
+    keydata = keydata_file.read()
 pubkey = rpm.pubkey(keydata)
 keyring = rpm.keyring()
 keyring.addKey(pubkey)
@@ -488,7 +490,8 @@ ts.closeDB()
 ts.openDB()
 c2 = ts.dbCookie()
 myprint(c1 == c2 != None)
-open("dbcookie", "w+").write(c1)
+with open("dbcookie", "w+") as dbcookie_file:
+    dbcookie_file.write(c1)
 ],
 [True
 ],
@@ -507,9 +510,11 @@ runroot rpm -i \
 RPMPY_CHECK([
 ts.openDB()
 c1 = ts.dbCookie()
-c2 = open("dbcookie", "r").read()
+with open("dbcookie", "r") as dbcookie_file:
+    c2 = dbcookie_file.read()
 myprint(c1 != c2)
-open("dbcookie", "w+").write(c1)
+with open("dbcookie", "w+") as dbcookie_file:
+    dbcookie_file.write(c1)
 ],
 [True
 ],
@@ -529,7 +534,8 @@ runroot rpm -i \
 RPMPY_CHECK([
 ts.openDB()
 c1 = ts.dbCookie()
-c2 = open("dbcookie", "r").read()
+with open("dbcookie", "r") as dbcookie_file:
+    c2 = dbcookie_file.read()
 myprint(c1 != c2)
 ],
 [True


### PR DESCRIPTION
I dialed up my Python debug settings, and got complaints about unclosed files on stderr, whis caused tests to fail for me.

This properly closes all the files the Python tests `open`.