### PR TITLE
Simplify communicating crypto backend to the test-suite

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,14 +16,10 @@ os_release(OS_NAME ID)
 os_release(OS_VERSION VERSION_ID)
 
 set(PYTHON ${Python3_EXECUTABLE})
-if (${WITH_INTERNAL_OPENPGP})
-	if (${WITH_OPENSSL})
-		set(CRYPTO openssl)
-	else()
-		set(CRYPTO libgcrypt)
-	endif()
+if (WITH_INTERNAL_OPENPGP)
+	set(PGP internal)
 else()
-	set(CRYPTO sequoia)
+	set(PGP sequoia)
 endif()
 
 set(TESTSUITE_AT

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -4,22 +4,7 @@ RPMLIBDIR="@CMAKE_INSTALL_FULL_LIBDIR@"
 export RPMLIBDIR
 
 PYTHON=@PYTHON@
-
-CRYPTO=@CRYPTO@
-export CRYPTO
-if test x$CRYPTO = xlibgcrypt
-then
-    PGP=internal
-elif test x$CRYPTO = xopenssl
-then
-    PGP=internal
-elif test x$CRYPTO = xsequoia
-then
-    PGP=sequoia
-else
-    echo "Unhandled crypto backend: $CRYPTO"
-    exit
-fi
+PGP=@PGP@
 
 RPMTEST="$RPMTREE"
 RPMDATA="/data/"


### PR DESCRIPTION
It's fairly amusing how various aspects of integrating autotest seems easier with cmake than autoconf/automake.