### PR TITLE
Make 'cmake -L' output meaningful

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ function(findutil UTIL TRY)
 		message(DEBUG "${util} not found, assuming /usr/bin/${util}")
 		set(${UTIL} /usr/bin/${util} PARENT_SCOPE)
 	endif()
+	mark_as_advanced(${UTIL})
 endfunction()
 
 function(makemacros)
@@ -207,6 +208,8 @@ set_target_properties(LUA::LUA PROPERTIES
 add_library(MAGIC::MAGIC UNKNOWN IMPORTED)
 find_library(MAGIC_LIBRARY NAMES magic REQUIRED)
 find_path(MAGIC_INCLUDE_DIR NAMES magic.h REQUIRED)
+mark_as_advanced(MAGIC_LIBRARY)
+mark_as_advanced(MAGIC_INCLUDE_DIR)
 set_target_properties(MAGIC::MAGIC PROPERTIES
 		      IMPORTED_LOCATION "${MAGIC_LIBRARY}")
 target_include_directories(MAGIC::MAGIC INTERFACE "${MAGIC_INCLUDE_DIR}")
@@ -266,12 +269,15 @@ if (WITH_IMAEVM)
 	add_library(IMA::IMA UNKNOWN IMPORTED)
 	find_path(IMA_INCLUDE_DIR NAMES imaevm.h REQUIRED)
 	find_library(IMA_LIBRARY NAMES imaevm REQUIRED)
+	mark_as_advanced(IMA_INCLUDE_DIR)
+	mark_as_advanced(IMA_LIBRARY)
 	set_target_properties(IMA::IMA PROPERTIES
 			      IMPORTED_LOCATION "${IMA_LIBRARY}")
 	target_include_directories(IMA::IMA INTERFACE "${IMA_INCLUDE_DIR}")
 endif()
 
 find_program(__FIND_DEBUGINFO find-debuginfo)
+mark_as_advanced(__FIND_DEBUGINFO)
 
 function(chkdef func req)
 	string(TOUPPER ${func} FUNC)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_program(PANDOC NAMES pandoc)
+mark_as_advanced(PANDOC)
 
 add_subdirectory(man)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(TESTSUITE_AT
 )
 
 find_program(AUTOM4TE autom4te REQUIRED)
+mark_as_advanced(AUTOM4TE)
 set(AUTOTEST ${AUTOM4TE} --language=autotest)
 
 set(TESTPROGS rpmpgpcheck rpmpgppubkeyfingerprint)
@@ -73,7 +74,9 @@ endif()
 
 # Detect suitable mktree backend
 find_program(BWRAP bwrap)
+mark_as_advanced(BWRAP)
 find_program(PODMAN NAMES podman docker)
+mark_as_advanced(PODMAN)
 if ("${MKTREE_BACKEND}" STREQUAL "")
 	if (BWRAP AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mktree.${OS_NAME})
 		set(MKTREE_BACKEND ${OS_NAME})


### PR DESCRIPTION
Mark all the program and library path details as advanced, they're not something you need to be acutely aware of when compiling rpm. This way -L[H] actually shows the "user configurable" parts.