### PR TITLE
Fix build-order regression from 1c98b67911e19a5f92c7fa4492aaa1000a06edad

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
-# Use our top-level targets as an ordering clue to cmake: the project
-# needs to be built before we can populate anything...
-get_property(TOP_TARGETS DIRECTORY .. PROPERTY BUILDSYSTEM_TARGETS)
+# Use our cli tools as an ordering clue to cmake: the project
+# needs to be built before we can populate anything. The tools depend
+# on all the libraries so we get a good coverage.
+get_property(TOOLPROGS DIRECTORY ../tools PROPERTY BUILDSYSTEM_TARGETS)
 
 function(os_release var key)
 	execute_process(
@@ -139,5 +140,5 @@ add_custom_target(tree
 	BYPRODUCTS mktree.output
 	DEPENDS rpmtests
 	DEPENDS ${TESTPROGS}
-	DEPENDS ${TOP_TARGETS}
+	DEPENDS ${TOOLPROGS}
 )


### PR DESCRIPTION
Running the test-suite obviously requires on having the project completely built first. The test-suite was relying on the cli tools in the top level directory for this, but now that we moved the tools elsewhere there are zero targets at the top-level. Oops.

Update the property get_property() path accordingly, this should've been in commit 1c98b67911e19a5f92c7fa4492aaa1000a06edad. Rename the variable and add commentary on why we're doing this the way we are, it's not entirely obvious.

Suggested-by: Michal Domonkos <mdomonko@redhat.com>