### PR TITLE
Don't assume PWD of / in tests

### DIFF
--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -91,7 +91,7 @@ function snapshot()
         exec)
             @BWRAP@ --unshare-pid --dev-bind $RPMTEST / --clearenv \
                     --setenv PATH "@CMAKE_INSTALL_FULL_BINDIR@:/usr/bin" \
-                    --setenv HOME /root --chdir / --dev /dev --proc /proc \
+                    --setenv HOME /root --dev /dev --proc /proc \
                     --die-with-parent "$@"
         ;;
         shell)
@@ -105,7 +105,7 @@ function snapshot()
                 fi
             fi
             snapshot exec --unshare-uts --hostname $source \
-                          --bind $PWD /srv "$@"
+                          --bind $PWD /srv --chdir /srv "$@"
         ;;
     esac
 }

--- a/tests/mktree.fedora
+++ b/tests/mktree.fedora
@@ -185,8 +185,7 @@ case $CMD in
     ;;
     check)
         mount_tree
-        snapshot shell --tmpfs /tmp sh -c 'cd /srv && exec ./rpmtests "$@"' \
-                                    rpmtests "$@"
+        snapshot shell --tmpfs /tmp ./rpmtests "$@"
     ;;
     reset)
         rm -rf "$SANDBOX_DIR"

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2236,7 +2236,7 @@ error: /data/SPECS/eliftest.spec:40: bad %elif condition:  rubbish:4-3
 # multiline %if test
 RPMTEST_CHECK([
 runroot rpmbuild -ba --quiet      \
- data/SPECS/ifmultiline.spec
+ /data/SPECS/ifmultiline.spec
 ],
 [0],
 [],

--- a/tests/rpmgeneral.at
+++ b/tests/rpmgeneral.at
@@ -362,8 +362,8 @@ RPMTEST_CLEANUP
 AT_SETUP([rpm2cpio])
 AT_KEYWORDS([basic])
 RPMTEST_CHECK([
-runroot_other rpm2cpio data/RPMS/hello-2.0-1.x86_64.rpm | cpio -t --quiet
-runroot_other rpm2cpio data/SRPMS/hello-1.0-1.src.rpm | cpio -t --quiet
+runroot_other rpm2cpio /data/RPMS/hello-2.0-1.x86_64.rpm | cpio -t --quiet
+runroot_other rpm2cpio /data/SRPMS/hello-1.0-1.src.rpm | cpio -t --quiet
 ],
 [0],
 [./usr/bin/hello

--- a/tests/rpmi.at
+++ b/tests/rpmi.at
@@ -1493,7 +1493,7 @@ runroot rpm -U /build/RPMS/noarch/klang-client-1.0-1.noarch.rpm
 ])
 
 RPMTEST_CHECK([
-runroot_other mkdir -p etc/sysusers.d/
+runroot_other mkdir -p /etc/sysusers.d/
 runroot_other touch /etc/sysusers.d/klang.conf
 runroot rpm -U \
 	/build/RPMS/noarch/klang-common-1.0-1.noarch.rpm

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -106,7 +106,7 @@ foo 4\\
 foo 5
 EOF
 
-runroot rpm --eval '%{load:mtest}%{foo}'
+runroot rpm --eval '%{load:/mtest}%{foo}'
 ],
 [0],
 [

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -647,7 +647,7 @@ AT_SETUP([xml format])
 AT_KEYWORDS([query])
 RPMTEST_CHECK([
 RPMDB_INIT
-runroot rpm -qp --xml  data/RPMS/hello-2.0-1.x86_64.rpm
+runroot rpm -qp --xml  /data/RPMS/hello-2.0-1.x86_64.rpm
 ],
 [0],
 [<rpmHeader>


### PR DESCRIPTION
Instead, just use absolute paths everywhere.  This allows us to revert the ugly workaround for bwrap's double-chdir warning from commit 5e9c71296e8cd6c5f2f5a6188b303bbd7a2c74db as well as let "make shell" also start in /srv.

No functional change.