### PR TITLE
Add a "plugin development" testcase

### DIFF
--- a/tests/data/SPECS/simple.spec
+++ b/tests/data/SPECS/simple.spec
@@ -1,0 +1,26 @@
+Name:           simple
+Version:        1.0
+Release:        1
+Summary:        Simple test package
+Group:		Testing
+License:        GPL
+BuildArch:	noarch
+
+%description
+%{summary}
+
+%install
+mkdir -p $RPM_BUILD_ROOT/opt/bin
+cat << EOF > $RPM_BUILD_ROOT/opt/bin/simple
+#!/bin/sh
+echo yay
+EOF
+
+chmod a+x $RPM_BUILD_ROOT/opt/bin/simple
+
+%post
+touch /var/lib/simple
+
+%files
+%defattr(-,root,root,-)
+/opt/bin/simple

--- a/tests/data/debugplugin/CMakeLists.txt
+++ b/tests/data/debugplugin/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.18)
+project(trpm VERSION 1.0 DESCRIPTION "test rpm plugin API" LANGUAGES C)
+find_package(rpm REQUIRED)
+
+set(CMAKE_SHARED_MODULE_PREFIX "")
+
+add_library(debug MODULE debug.c)
+target_link_libraries(debug PRIVATE rpm::librpm)
+install(TARGETS debug DESTINATION ${RPM_PLUGINDIR})
+install(FILES macros.transaction_debug DESTINATION ${RPM_MACROSDIR})

--- a/tests/data/debugplugin/debug.c
+++ b/tests/data/debugplugin/debug.c
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <rpm/rpmplugin.h>
+#include <rpm/rpmte.h>
+
+static rpmRC debug_init(rpmPlugin plugin, rpmts ts)
+{
+        fprintf(stderr, "%s\n", __func__);
+        return RPMRC_OK;
+}
+
+static void debug_cleanup(rpmPlugin plugin)
+{
+        fprintf(stderr, "%s\n", __func__);
+}
+
+static rpmRC debug_tsm_pre(rpmPlugin plugin, rpmts ts)
+{
+        fprintf(stderr, "%s\n", __func__);
+        return RPMRC_OK;
+}
+
+static rpmRC debug_tsm_post(rpmPlugin plugin, rpmts ts, int res)
+{
+        fprintf(stderr, "%s: %d\n", __func__, res);
+        return RPMRC_OK;
+}
+
+static rpmRC debug_psm_pre(rpmPlugin plugin, rpmte te)
+{
+        fprintf(stderr, "%s: %s\n", __func__, rpmteNEVRA(te));
+        return RPMRC_OK;
+}
+
+static rpmRC debug_psm_post(rpmPlugin plugin, rpmte te, int res)
+{
+        fprintf(stderr, "%s: %s:%d\n", __func__, rpmteNEVRA(te), res);
+        return RPMRC_OK;
+}
+
+static rpmRC debug_scriptlet_pre(rpmPlugin plugin,
+				const char *s_name, int type)
+{
+        fprintf(stderr, "%s: %s %d\n", __func__, s_name, type);
+        return RPMRC_OK;
+}
+
+static rpmRC debug_scriptlet_fork_post(rpmPlugin plugin,
+				    const char *path, int type)
+{
+        fprintf(stderr, "%s: %s %d\n", __func__, path, type);
+        return RPMRC_OK;
+}
+
+static rpmRC debug_scriptlet_post(rpmPlugin plugin,
+				    const char *s_name, int type, int res)
+{
+        fprintf(stderr, "%s: %s %d: %d\n", __func__, s_name, type, res);
+        return RPMRC_OK;
+}
+
+/* we can't predict the transaction id so hide it from the output */
+static char *cleanpath(const char *path)
+{
+    char *p = rstrdup(path);
+    char *t = strrchr(p, ';');
+    if (t)
+	*(t+1) = '\0';
+    return p;
+}
+
+static rpmRC debug_fsm_file_pre(rpmPlugin plugin, rpmfi fi,
+		const char* path, mode_t file_mode, rpmFsmOp op)
+{
+    char *p = cleanpath(path);
+    fprintf(stderr, "%s: %s %s %o %x\n", __func__,
+		rpmfiFN(fi), p, file_mode, op);
+    free(p);
+    return RPMRC_OK;
+}
+static rpmRC debug_fsm_file_post(rpmPlugin plugin, rpmfi fi,
+		const char* path, mode_t file_mode, rpmFsmOp op, int res)
+{
+    char *p = cleanpath(path);
+    fprintf(stderr, "%s: %s %s %o %x: %d\n", __func__,
+		rpmfiFN(fi), p, file_mode, op, res);
+    free(p);
+    return RPMRC_OK;
+}
+static rpmRC debug_fsm_file_prepare(rpmPlugin plugin, rpmfi fi,
+		int fd, const char* path, const char *dest,
+		mode_t file_mode, rpmFsmOp op)
+{
+    char *p = cleanpath(path);
+    fprintf(stderr, "%s: %s %d %s %s %o %x\n", __func__,
+		rpmfiFN(fi), (fd != -1), p, dest, file_mode, op);
+    free(p);
+    return RPMRC_OK;
+}
+
+struct rpmPluginHooks_s debug_hooks = {
+        .init = debug_init,
+        .cleanup = debug_cleanup,
+        .tsm_pre = debug_tsm_pre,
+        .tsm_post = debug_tsm_post,
+        .psm_pre = debug_psm_pre,
+        .psm_post = debug_psm_post,
+        .scriptlet_pre = debug_scriptlet_pre,
+        .scriptlet_fork_post = debug_scriptlet_fork_post,
+        .scriptlet_post = debug_scriptlet_post,
+        .fsm_file_pre = debug_fsm_file_pre,
+        .fsm_file_post = debug_fsm_file_post,
+        .fsm_file_prepare = debug_fsm_file_prepare,
+};

--- a/tests/data/debugplugin/macros.transaction_debug
+++ b/tests/data/debugplugin/macros.transaction_debug
@@ -1,0 +1,1 @@
+%__transaction_debug    %{__plugindir}/debug.so

--- a/tests/rpmdevel.at
+++ b/tests/rpmdevel.at
@@ -35,3 +35,40 @@ RPMTEST_CHECK([[
 )
 RPMTEST_CLEANUP
 
+AT_SETUP([rpm plugin development])
+AT_KEYWORDS([devel])
+RPMDB_INIT
+
+runroot rpmbuild --quiet -bb \
+	/data/SPECS/simple.spec \
+	/data/SPECS/fakeshell.spec
+
+runroot rpm -U /build/RPMS/noarch/fakeshell-1.0-1.noarch.rpm
+
+cmake /data/debugplugin && make && make install DESTDIR=${RPMTEST}
+
+RPMTEST_CHECK([
+runroot rpm -U /build/RPMS/noarch/simple-1.0-1.noarch.rpm
+],
+[0],
+[],
+[debug_init
+debug_tsm_pre
+debug_psm_pre: simple-1.0-1.noarch
+debug_fsm_file_pre:  /opt/bin 40755 80000001
+debug_fsm_file_prepare:  1 /opt/bin /opt/bin 40755 80000001
+debug_fsm_file_post:  /opt/bin 40755 80000001: 0
+debug_fsm_file_pre: /opt/bin/simple /opt/bin/simple; 100755 1
+debug_fsm_file_prepare: /opt/bin/simple 1 /opt/bin/simple; /opt/bin/simple 100755 1
+debug_fsm_file_post: /opt/bin/simple /opt/bin/simple 100755 1: 0
+debug_scriptlet_pre: %post(simple-1.0-1.noarch) 3
+debug_scriptlet_fork_post: /bin/sh 3
+debug_scriptlet_post: %post(simple-1.0-1.noarch) 3: 0
+debug_psm_post: simple-1.0-1.noarch:0
+debug_psm_pre: simple-1.0-1.noarch
+debug_psm_post: simple-1.0-1.noarch:0
+debug_tsm_post: 0
+debug_cleanup
+])
+RPMTEST_CLEANUP
+


### PR DESCRIPTION
Add an externally built debug plugin which outputs something from each hook. This serves as a generic plugin functionality test, both from the POV of developing one externally and the actual functionality.