### PR TITLE
Ensure proper working dir when processing rpmrc, platform and macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,8 @@ function(makemacros)
 		${CMAKE_COMMAND} -E env pkglibdir=${RPM_CONFIGDIR}
 			${CMAKE_SOURCE_DIR}/installplatform
 			rpmrc platform macros
-			${RPMCANONVENDOR} ${RPMCANONOS} ${RPMCANONGNU})"
+			${RPMCANONVENDOR} ${RPMCANONOS} ${RPMCANONGNU}
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR})"
 	)
 endfunction()
 


### PR DESCRIPTION
Fixes `cmake --install` failing on these files as the working directory is "unexpected" from the trad. makefile POV.

Reported-by: Tomasz Kłoczko <kloczek@github.com>