### PR TITLE
Make test-suite os detection stricter

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ get_property(TOOLPROGS DIRECTORY ../tools PROPERTY BUILDSYSTEM_TARGETS)
 
 function(os_release var key)
 	execute_process(
-		COMMAND sh -c "grep ^${key} /etc/os-release | cut -d= -f2"
+		COMMAND sh -c ". /etc/os-release; echo ${var}"
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 		OUTPUT_VARIABLE value
 	)


### PR DESCRIPTION
On Rocky Linux /etc/os-release contains not only ID="rocky", but also ID_LIKE="rhel centos fedora" and the grepping got that wrong. Let the shell do the work for us.

Reported-by: Dmitry Mikushin <dmitry@kernelgen.org>