### PR TITLE
Enable debug information and optimizations in the CI build

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -74,6 +74,7 @@ COPY . .
 RUN chmod -R a-w .
 
 WORKDIR /srv/build
+ENV CFLAGS="-Og -g"
 RUN cmake \
 	-DENABLE_WERROR=ON \
 	-DENABLE_BDB_RO=ON \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -82,6 +82,6 @@ RUN cmake \
 	-DWITH_IMAEVM=ON \
 	-DMKTREE_BACKEND=rootfs \
 	../rpm
-RUN make tree
+RUN make -j$(nproc) tree
 
 RUN rm -rf /srv/{rpm,build}


### PR DESCRIPTION
The main reason is to get real-world relevant warnings from the CI build, gcc with no optimizations seems to miss all sorts of things. Debug info is just handy to have around when developing.