### PR TITLE
Add support for macro aliases

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -81,6 +81,7 @@ various common operations.
 | %define ...	   | define a macro
 | %undefine ...	   | undefine a macro
 | %global ...	   | define a macro whose body is available in global context
+| %alias ...       | define an alias on another macro or get alias definition | 4.20.0
 | %{load:...}	   | load a macro file | 4.12.0
 | %{expand:...}	   | like eval, expand ... to <body> and (re-)expand <body>
 | %{expr:...}	   | evaluate an [expression](#expression-expansion) | 4.15.0

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -16,7 +16,7 @@ expansion of the macro which contains nested macros.
 
 ## Defining a Macro
 
-To define a macro use:
+The usual macro definition syntax is as follows:
 
 ```
 	%define <name>[(opts)] <body>
@@ -24,14 +24,23 @@ To define a macro use:
 
 All whitespace surrounding `<body>` is removed.  Name may be composed
 of alphanumeric characters and the character `_`, and must be at least
-3 characters in length. A macro without an `(opts)` field is "simple"
-in that only recursive macro expansion is performed. A parameterized
-macro contains an `(opts)` field. Since rpm >= 4.17 `-` as opts disables all option
-processing, otherwise the opts (i.e. string between parentheses) are passed
-exactly as is to getopt(3) for argc/argv processing at the beginning of
-a macro invocation (only short options are supported). `--` can be used
-to separate options from arguments. While a parameterized macro is being
-expanded, the following shell-like macros are available:
+3 characters in length. The body is (re-)expanded on each macro invocation.
+
+### Parametric macros
+A macro which contains an `(opts)` field is called parametric.
+The opts (i.e. string between parentheses) are passed exactly as is
+to to getopt(3) for argc/argv processing at the beginning of
+a macro invocation. Only short options are supported.
+`--` can be used to separate options from arguments.
+Since rpm >= 4.17 `-` as opts disables all option processing.
+
+Macros `%define`d inside a parametric macro have a scope local to the
+macro, otherwise all macros are global.
+
+### Automatic macros
+
+While a parameterized macro is being expanded, the following shell-like
+automatic macros are available:
 
 | Macro  | Description
 | ------ | -----------
@@ -54,6 +63,36 @@ With rpm >= 4.17 and disabled option processing the mentioned macros are defined
 
 At the end of invocation of a parameterized macro, the above macros are
 automatically discarded.
+
+### Global macros
+
+A macro can be declared into the global scope as follows:
+
+```
+	%global <name>[(opts)] <body>
+```
+
+An important and useful feature of `%global` is that the body is expanded
+at the time of definition, as opposed to time of use with regular macros.
+This is important inside parametric macros because otherwise the body could
+be referring to macros that are out of scope at the time of use, but also
+useful to avoid re-expansion of expensive macros.
+
+### Aliases (rpm >= 4.20)
+
+A macro alias can be declared as follows:
+
+```
+    %alias <name> <target>
+```
+
+A macro alias is just that: an another name for a macro. Aliases can point
+to any other macro type and using it behaves exactly as if accessing the
+original macro, parameters and all, with one exception: `%undefine <name>`
+undefines the alias, rather than the target macro. An alias always exists
+in the same scope as the target macro, so an alias defined on automatic
+or locally scoped macros inside parametric macros become automatically
+undefined when leaving the parametric macro.
 
 ## Writing a Macro
 

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -637,6 +637,14 @@ validName(rpmMacroBuf mb, const char *name, size_t namelen, const char *action)
 	goto exit;
     }
 
+    /* The rest of the name can be alphanumerics or _ */
+    for (c = name+1; c-name < namelen; c++) {
+	if (!(risalnum(*c) || (*c == '_'))) {
+	    rpmMacroBufErr(mb, 1, _("Macro %%%s has illegal name (%s)\n"), name, action);
+	    goto exit;
+	}
+    }
+
     mep = findEntry(mb->mc, name, namelen, NULL);
     if (mep && (*mep)->flags & (ME_FUNC|ME_AUTO)) {
 	rpmMacroBufErr(mb, 1, _("Macro %%%s is a built-in (%s)\n"), name, action);

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -629,10 +629,10 @@ validName(rpmMacroBuf mb, const char *name, size_t namelen, const char *action)
 {
     rpmMacroEntry *mep;
     int rc = 0;
-    int c;
+    const char *c = name;
 
     /* Names must start with alphabetic, or _ and be at least 2 chars */
-    if (!((c = *name) && (risalpha(c) || (c == '_' && namelen > 1)))) {
+    if (!(risalpha(*c) || (*c == '_' && namelen > 1))) {
 	rpmMacroBufErr(mb, 1, _("Macro %%%s has illegal name (%s)\n"), name, action);
 	goto exit;
     }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -57,6 +57,107 @@ runroot rpm --eval '1. %{this}' --define "this that" --eval '2. %{this}' --undef
 ])
 RPMTEST_CLEANUP
 
+AT_SETUP([macro alias])
+AT_KEYWORDS([macros])
+RPMTEST_CHECK([
+runroot rpm \
+	--define "this that" \
+	--eval "%alias clone this" \
+	--eval "%this" \
+	--eval "%clone" \
+	--define "this what" \
+	--eval "%this" \
+	--eval "%clone" \
+	--undefine clone \
+	--eval "%this" \
+	--eval "%clone"
+],
+[0],
+[
+that
+that
+what
+what
+what
+%clone
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm \
+	--define "this(a) that %{?-a:arg} %1" \
+	--eval "%alias clone this" \
+	--eval "%clone -a 123" \
+	--eval "%clone -b"
+],
+[1],
+[
+that arg 123
+],
+[this: invalid option -- 'b'
+error: Unknown option b in this(a)
+])
+
+RPMTEST_CHECK([
+runroot rpm \
+	--define "this that" \
+	--eval "%alias me this" \
+	--eval "%alias myself me" \
+	--eval "%myself"
+],
+[0],
+[
+
+that
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm \
+	--define "param() %{alias one 1}%{one}" \
+	--eval "%param 123" \
+	--eval "%one"
+],
+[0],
+[123
+%one
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm \
+	--define "this that" \
+	--eval "%alias what this" \
+	--eval "%alias what" \
+	--eval "%alias this"
+],
+[0],
+[
+this
+
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpm \
+	--define "this that" \
+	--eval "%alias what() this"
+],
+[1],
+[],
+[error: Macro %what() has illegal name (%alias)
+])
+
+RPMTEST_CHECK([
+runroot rpm \
+	--eval "%alias iam notthere"
+],
+[1],
+[],
+[error: Invalid alias on %notthere
+])
+RPMTEST_CLEANUP
+
 AT_SETUP([simple true conditional rpm --eval])
 AT_KEYWORDS([macros])
 RPMTEST_CHECK([


### PR DESCRIPTION
Implement support for multi-level macro aliases, useful for the kind of thing aliases are: shortcuts, added level of indirection here and there for eg choosing between alternatives without copying and so on.

The new %alias macro primitive can be used to define an alias and get the alias definition. The dual functionality is necessary because all other references to the alias get routed to the aliased macro. With the exception of undefine which undefines the alias itself.
