### PR TITLE
Move OpenSSL code to newer API

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -44,7 +44,7 @@ additionally specifying -DWITH_OPENSSL=ON.
 
 libgcrypt library is available from https://www.gnupg.org/software/libgcrypt/
 
-If using the OpenSSL library for encryption, it must be version 1.0.2 or
+If using the OpenSSL library for encryption, it must be version 3.0.0 or
 later. Note: when compiling against OpenSSL, there is a possible license
 incompatibility. For more details on this, see
 https://people.gnome.org/~markmc/openssl-and-the-gpl.html

--- a/rpmio/rpmpgp_legacy/CMakeLists.txt
+++ b/rpmio/rpmpgp_legacy/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(rpmpgp_legacy PRIVATE
 )
 target_include_directories(rpmpgp_legacy PRIVATE ..)
 if (WITH_OPENSSL)
-	find_package(OpenSSL 1.0.2 REQUIRED)
+	find_package(OpenSSL 3.0.0 REQUIRED)
 	target_sources(rpmpgp_legacy PRIVATE digest_openssl.c)
 	target_link_libraries(rpmpgp_legacy PRIVATE OpenSSL::Crypto)
 else()


### PR DESCRIPTION
Avoid the now deprecated RSA and DSA data types and use the generic EVP_PKEY

Resolves: #2294