### PR TITLE
Fix regression of mktree not always rebuilding

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,7 +131,10 @@ add_custom_target(reset
 )
 
 add_custom_target(tree
-	DEPENDS mktree.output
+	COMMAND ./mktree build
+	DEPENDS rpmtests
+	DEPENDS ${TESTPROGS}
+	DEPENDS ${TOOLPROGS}
 )
 
 add_custom_command(OUTPUT rpmtests
@@ -139,12 +142,4 @@ add_custom_command(OUTPUT rpmtests
 		-o rpmtests rpmtests.at
 	DEPENDS ${TESTSUITE_AT}
 	DEPENDS local.at
-)
-
-add_custom_command(OUTPUT mktree.output
-	COMMAND ./mktree build
-	DEPENDS rpmtests
-	DEPENDS ${TESTPROGS}
-	DEPENDS ${TOOLPROGS}
-	DEPENDS mktree
 )

--- a/tests/mktree.fedora
+++ b/tests/mktree.fedora
@@ -168,9 +168,6 @@ case $CMD in
         # Add RPM installation layer
         rm -rf "$INST_DIR"
         make_install $INST_DIR
-
-        # Signal change to build system
-        touch mktree.output
     ;;
     atshell)
         set -a


### PR DESCRIPTION
Commit d4e808ebda3ec1d85fcdb176eae31901b74c6e91 added cmake caching for mktree so that we don't rebuild the tree on each "make check" invocation.  However, this means we can now easily miss some test dependencies being updated since we don't depend on everything, e.g. the data/ dir.

To fix this, instead of adding each and every file and directory as a dependency of the mktree.output command, just rebuild the tree every time.  The base image (made with DNF) is already cached anyway, and the added overhead is tiny and outweighs the (potential) engineering hours lost due to this.

The funny thing is, this was already fixed once in 2019: fc05045008d84429bf51154642e18fda70d3f256

Sometimes you've just gotta fix stuff twice before it sticks!

Fixes: #2725