### PR TITLE
Convert %prep into a regular build scriptlet

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -345,10 +345,12 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
     opt_F = rpmExpandNumeric("%{_default_patch_fuzz}");		/* get default fuzz factor for %patch */
     opt_b = opt_d = opt_o = NULL;
 
-    /* Convert %patchN to %patch -PN to simplify further processing */
+    /* Emit a legible error on the obsolete %patchN form for now */
     if (! strchr(" \t\n", line[6])) {
-	rasprintf(&buf, "%%patch -P %s", line + 6);
-	spec->numConverted++;
+	rpmlog(RPMLOG_ERR,
+	       _("%%patchN is obsolete, "
+	         "use %%patch N (or %%patch -P N): %s\n"), line);
+	goto exit;
     }
     poptParseArgvString(buf ? buf : line, &argc, &argv);
 
@@ -447,11 +449,6 @@ int parsePrep(rpmSpec spec)
 	    goto exit;
 	}
     }
-
-    if (spec->numConverted)
-	rpmlog(RPMLOG_WARNING,
-	       _("%%patchN is deprecated (%i usages found), "
-	         "use %%patch N (or %%patch -P N)\n"), spec->numConverted);
 
 exit:
     argvFree(saveLines);

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -570,8 +570,7 @@ after_classification:
     /* Collect parsed line */
     if (spec->parsed == NULL)
 	spec->parsed = newStringBuf();
-    if (!(strip & STRIP_PARSED))
-	appendStringBufAux(spec->parsed, spec->line,(strip & STRIP_TRAILINGSPACE));
+    appendStringBufAux(spec->parsed, spec->line,(strip & STRIP_TRAILINGSPACE));
 
     /* FIX: spec->readStack->next should be dependent */
     return 0;

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -593,6 +593,18 @@ int parseLines(rpmSpec spec, int strip, ARGV_t *avp, StringBuf *sbp)
 	*sbp = newStringBuf();
 
     while (! (nextPart = isPart(spec->line))) {
+	/* HACK: Emit a legible error on the obsolete %patchN form for now */
+	if (sbp == &(spec->prep)) {
+	    size_t slen = strlen(spec->line);
+	    if (slen >= 7 && risdigit(spec->line[6]) &&
+		rstreqn(spec->line, "%patch", 6))
+	    {
+		rpmlog(RPMLOG_ERR, _("%%patchN is obsolete, "
+		    "use %%patch N (or %%patch -P N): %s\n"), spec->line);
+		nextPart = PART_ERROR;
+		break;
+	    }
+	}
 	if (avp)
 	    argvAdd(avp, spec->line);
 	if (sbp)

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -250,7 +250,6 @@ typedef enum rpmParseState_e {
 #define STRIP_NOTHING             0
 #define STRIP_TRAILINGSPACE (1 << 0)
 #define STRIP_COMMENTS      (1 << 1)
-#define STRIP_PARSED        (1 << 2) /* Avoid adding to spec->parsed (hack) */
 
 #define ALLOW_EMPTY         (1 << 16)
 

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -148,8 +148,6 @@ struct rpmSpec_s {
     StringBuf parsed;		/*!< parsed spec contents */
 
     Package packages;		/*!< Package list. */
-
-    int numConverted;		/*!< no. of automatic %patchN conversions */
 };
 
 #define PACKAGE_NUM_DEPS 12

--- a/build/spec.c
+++ b/build/spec.c
@@ -231,7 +231,6 @@ rpmSpec newSpec(void)
     spec->numSources = 0;
     spec->autonum_patch = -1;
     spec->autonum_source = -1;
-    spec->numConverted = 0;
 
     spec->sourceRpmName = NULL;
     spec->sourcePkgId = NULL;

--- a/include/rpm/rpmmacro.h
+++ b/include/rpm/rpmmacro.h
@@ -21,6 +21,10 @@ typedef struct rpmMacroEntry_s * rpmMacroEntry;
 
 typedef struct rpmMacroContext_s * rpmMacroContext;
 
+typedef struct rpmMacroBuf_s *rpmMacroBuf;
+
+typedef void (*macroFunc)(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed);
+
 extern rpmMacroContext rpmGlobalMacroContext;
 
 extern rpmMacroContext rpmCLIMacroContext;
@@ -120,6 +124,52 @@ int	rpmPushMacroFlags	(rpmMacroContext mc, const char * n,
 					const char * o,
 					const char * b, int level,
 					rpmMacroFlags flags);
+
+/** \ingroup rpmmacro
+ * Push an auxiliary macro to context.
+ * @param mc		macro context (NULL uses global context).
+ * @param n		macro name
+ * @param o		macro parameters (or NULL)
+ * @param f		macro function
+ * @param priv		private user data (or NULL)
+ * @param level		macro recursion level (0 is entry API)
+ * @param flags		macro flags
+ * @return		0 on success
+ */
+int rpmPushMacroAux(rpmMacroContext mc,
+		    const char * n, const char * o,
+		    macroFunc f, void *priv, int nargs,
+		    int level, rpmMacroFlags flags);
+
+/** \ingroup rpmmacro
+ * Return macro entry user data (in aux macro)
+ * @param me		macro entry
+ * @return		pointer to private data passed on define or NULL
+ */
+void *rpmMacroEntryPriv(rpmMacroEntry me);
+
+/** \ingroup rpmmacro
+ * Append a character to macro buffer (in aux macro)
+ * @param mb		macro buffer
+ * @param c		character to append
+ */
+void rpmMacroBufAppend(rpmMacroBuf mb, char c);
+
+/** \ingroup rpmmacro
+ * Append a string to macro buffer (in aux macro)
+ * @param mb		macro buffer
+ * @param str		string to append
+ */
+void rpmMacroBufAppendStr(rpmMacroBuf mb, const char *str);
+
+/** \ingroup rpmmacro
+ * Raise an error or warning in macro buffer (in aux macro)
+ * @param mb		macro buffer
+ * @param error		1 if error, 0 if warning
+ * @param fmt		j
+ */
+RPM_GNUC_PRINTF(3, 4)
+void rpmMacroBufErr(rpmMacroBuf mb, int error, const char *fmt, ...);
 
 /** \ingroup rpmmacro
  * Pop macro from context.

--- a/tests/data/SPECS/hello2-suid.spec
+++ b/tests/data/SPECS/hello2-suid.spec
@@ -15,7 +15,7 @@ Simple rpm demonstration.
 
 %prep
 %setup -q -n hello-1.0
-%patch0 -p1 -b .modernize
+%patch 0 -p1 -b .modernize
 
 %build
 make CFLAGS="-g -O1"

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -356,9 +356,10 @@ RPMDB_INIT
 RPMTEST_CHECK([
 runroot rpmbuild -bp --quiet /data/SPECS/hello-patch.spec
 ],
-[0],
+[1],
 [ignore],
-[warning: %patchN is deprecated (2 usages found), use %patch N (or %patch -P N)
+[error: %patchN is obsolete, use %patch N (or %patch -P N): %patch0 -p1 -b .install
+
 ])
 RPMTEST_CLEANUP
 

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -336,10 +336,13 @@ cd 'hello-1.0'
 rm -rf '/build/BUILD/hello-1.0-SPECPARTS'
 /usr/bin/mkdir -p '/build/BUILD/hello-1.0-SPECPARTS'
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+
 echo "Patch #0 (hello-1.0-modernize.patch):"
 /usr/bin/patch --no-backup-if-mismatch -f -p1 -b --suffix .modernize --fuzz=0 < /build/SOURCES/hello-1.0-modernize.patch
 
 
+
+%build
 make
 
 %install


### PR DESCRIPTION
This is a fun little series. Details in the commit messages, but briefly:
- Implement support for auxiliary macros, ie macros implemented in C outside the macro engine itself. Some renames + API exports required for this.
- Turn the deprecated %patchN into a hard error, this is the sacrificial lamb of this change :sheep: 
- Finally, convert %prep into a regular build scriptlet :partying_face:

Fixes: #2205