### PR TITLE
Use uniform formatting for SEE ALSO sections

### DIFF
--- a/docs/man/rpm-plugin-audit.8.md
+++ b/docs/man/rpm-plugin-audit.8.md
@@ -67,4 +67,4 @@ There are currently no options for this plugin in particular. See
 SEE ALSO
 ========
 
-*ausearch*(8) *rpm-plugins*(8)
+**ausearch**(8), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-dbus-announce.8.md
+++ b/docs/man/rpm-plugin-dbus-announce.8.md
@@ -35,4 +35,4 @@ There are currently no options for this plugin in particular. See
 SEE ALSO
 ========
 
-*dbus-monitor*(1) *rpm-plugins*(8)
+**dbus-monitor**(1), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-fapolicyd.8.md
+++ b/docs/man/rpm-plugin-fapolicyd.8.md
@@ -26,4 +26,4 @@ There are currently no options for this plugin in particular. See
 SEE ALSO
 ========
 
-*fapolicyd*(8) *rpm-plugins*(8)
+**fapolicyd**(8), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-ima.8.md
+++ b/docs/man/rpm-plugin-ima.8.md
@@ -30,4 +30,4 @@ See **rpm-plugins**(8) on how to control plugins in general.
 SEE ALSO
 ========
 
-*evmctl*(1) *rpmsign*(8) *rpm*(8)
+**evmctl**(1), **rpmsign**(8), **rpm**(8)

--- a/docs/man/rpm-plugin-prioreset.8.md
+++ b/docs/man/rpm-plugin-prioreset.8.md
@@ -30,4 +30,4 @@ There are currently no options for this plugin in particular. See
 SEE ALSO
 ========
 
-*rpm*(8) *rpm-plugins*(8)
+**rpm**(8), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-selinux.8.md
+++ b/docs/man/rpm-plugin-selinux.8.md
@@ -28,4 +28,4 @@ See **rpm-plugins**(8) on how to control plugins in general.
 SEE ALSO
 ========
 
-*rpm*(8) *rpm-plugins*(8)
+**rpm**(8), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-syslog.8.md
+++ b/docs/man/rpm-plugin-syslog.8.md
@@ -24,4 +24,4 @@ There are currently no options for this plugin in particular. See
 SEE ALSO
 ========
 
-*rpm*(8) *rpm-plugins*(8)
+**rpm**(8), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-systemd-inhibit.8.md
+++ b/docs/man/rpm-plugin-systemd-inhibit.8.md
@@ -43,4 +43,4 @@ There are currently no options for this plugin in particular. See
 SEE ALSO
 ========
 
-*systemd-inhibit*(1) *rpm*(8) *rpm-plugins*(8)
+**systemd-inhibit**(1), **rpm**(8), **rpm-plugins**(8)

--- a/docs/man/rpm-plugin-unshare.8.md
+++ b/docs/man/rpm-plugin-unshare.8.md
@@ -37,4 +37,4 @@ See **rpm-plugins**(8) on how to control plugins in general.
 SEE ALSO
 ========
 
-*dbus-monitor*(1) *rpm-plugins*(8)
+**dbus-monitor**(1), **rpm-plugins**(8)

--- a/docs/man/rpm-plugins.8.md
+++ b/docs/man/rpm-plugins.8.md
@@ -50,6 +50,6 @@ line.
 SEE ALSO
 ========
 
-*rpm*(8) *rpm-plugin-audit*(8) *rpm-plugin-ima*(8)
-*rpm-plugin-prioreset*(8) *rpm-plugin-selinux*(8) *rpm-plugin-syslog*(8)
-*rpm-plugin-systemd-inhibit*(8)
+**rpm**(8), **rpm-plugin-audit**(8), **rpm-plugin-ima**(8),
+**rpm-plugin-prioreset**(8), **rpm-plugin-selinux**(8),
+**rpm-plugin-syslog**(8), **rpm-plugin-systemd-inhibit**(8)

--- a/docs/man/rpm.8.md
+++ b/docs/man/rpm.8.md
@@ -1070,14 +1070,8 @@ Temporary
 SEE ALSO
 ========
 
-    rpm-misc(8),
-    popt(3),
-    rpm2cpio(8),
-    rpmbuild(8),
-    rpmdb(8),
-    rpmkeys(8),
-    rpmsign(8),
-    rpmspec(8),
+**rpm-misc**(8), **popt**(3), **rpm2cpio**(8), **rpmbuild**(8), **rpmdb**(8),
+**rpmkeys**(8), **rpmsign**(8), **rpmspec**(8)
 
 **rpm \--help** - as rpm supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the

--- a/docs/man/rpm2archive.8.md
+++ b/docs/man/rpm2archive.8.md
@@ -49,7 +49,7 @@ EXAMPLES
 SEE ALSO
 ========
 
-*rpm2cpio*(8) *rpm*(8)
+**rpm2cpio**(8), **rpm**(8)
 
 AUTHOR
 ======

--- a/docs/man/rpm2cpio.8.md
+++ b/docs/man/rpm2cpio.8.md
@@ -28,7 +28,7 @@ stream is read from standard in.
 SEE ALSO
 ========
 
-*rpm*(8)
+**rpm**(8)
 
 AUTHOR
 ======

--- a/docs/man/rpmbuild.8.md
+++ b/docs/man/rpmbuild.8.md
@@ -351,13 +351,8 @@ Temporary
 SEE ALSO
 ========
 
-    gendiff(1),
-    popt(3),
-    rpm(8),
-    rpm2cpio(8),
-    rpmkeys(8)
-    rpmspec(8),
-    rpmsign(8),
+**gendiff**(1), **popt**(3), **rpm**(8), **rpm2cpio**(8), **rpmkeys**(8),
+**rpmspec**(8), **rpmsign**(8)
 
 **rpmbuild \--help** - as rpm supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the

--- a/docs/man/rpmdb.8.md
+++ b/docs/man/rpmdb.8.md
@@ -29,13 +29,8 @@ the database indices from the installed package headers.
 SEE ALSO
 ========
 
-    popt(3),
-    rpm(8),
-    rpmkeys(8),
-    rpmsign(8),
-    rpm2cpio(8),
-    rpmbuild(8),
-    rpmspec(8),
+**popt**(3), **rpm**(8), **rpmkeys**(8), **rpmsign**(8), **rpm2cpio**(8),
+**rpmbuild**(8), **rpmspec**(8)
 
 **rpm \--help** - as rpm supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the

--- a/docs/man/rpmdeps.8.md
+++ b/docs/man/rpmdeps.8.md
@@ -65,9 +65,7 @@ OPTIONS
 SEE ALSO
 ========
 
-**rpm**(8),
-
-**rpmbuild**(8),
+**rpm**(8), **rpmbuild**(8)
 
 AUTHORS
 =======

--- a/docs/man/rpmgraph.8.md
+++ b/docs/man/rpmgraph.8.md
@@ -38,11 +38,9 @@ implemented.
 SEE ALSO
 ========
 
-**dot**(1),
+**dot**(1), **dotty**(1)
 
-**dotty**(1),
-
-** http://www.graphviz.org/ \<URL:http://www.graphviz.org/\>**
+**http://www.graphviz.org/ \<URL:http://www.graphviz.org/\>**
 
 AUTHORS
 =======

--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -50,13 +50,8 @@ Here\'s how to remove the Red Hat GPG/DSA key
 SEE ALSO
 ========
 
-    popt(3),
-    rpm(8),
-    rpmdb(8),
-    rpmsign(8),
-    rpm2cpio(8),
-    rpmbuild(8),
-    rpmspec(8),
+**popt**(3), **rpm**(8), **rpmdb**(8), **rpmsign**(8), **rpm2cpio**(8),
+**rpmbuild**(8), **rpmspec**(8)
 
 **rpmkeys \--help** - as rpm supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the

--- a/docs/man/rpmlua.8.md
+++ b/docs/man/rpmlua.8.md
@@ -57,11 +57,7 @@ Run an interactive session:
 SEE ALSO
 ========
 
-    lua(1)
-    popt(3),
-    getopt(3),
-    rpm(8),
-
+**lua**(1), **popt**(3), **getopt**(3), **rpm**(8)
 
 **http://www.rpm.org/ \<URL:http://www.rpm.org/\>**
 

--- a/docs/man/rpmsign.8.md
+++ b/docs/man/rpmsign.8.md
@@ -126,13 +126,8 @@ it\'s sufficient to set just %\_gpg\_name.
 SEE ALSO
 ========
 
-    popt(3),
-    rpm(8),
-    rpmdb(8),
-    rpmkeys(8),
-    rpm2cpio(8),
-    rpmbuild(8),
-    rpmspec(8),
+**popt**(3), **rpm**(8), **rpmdb**(8), **rpmkeys**(8), **rpm2cpio**(8),
+**rpmbuild**(8), **rpmspec**(8)
 
 **rpmsign \--help** - as rpm supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the

--- a/docs/man/rpmspec.8.md
+++ b/docs/man/rpmspec.8.md
@@ -136,13 +136,8 @@ Run interactive macros shell in spec context:
 SEE ALSO
 ========
 
-    popt(3),
-    rpm(8),
-    rpmdb(8),
-    rpmkeys(8),
-    rpmsign(8),
-    rpm2cpio(8),
-    rpmbuild(8),
+**popt**(3), **rpm**(8), **rpmdb**(8), **rpmkeys**(8), **rpmsign**(8),
+**rpm2cpio**(8), **rpmbuild**(8)
 
 **rpmspec \--help** - as rpm supports customizing the options via popt
 aliases it\'s impossible to guarantee that what\'s described in the


### PR DESCRIPTION
While there is no generally agreed standard for this we should at least use only one. Comma separated lists are commonly used. Let's just pick *italic* for man pages.

Thanks to Frank Dana <https://github.com/ferdnyc> for pointing this out.

Resolves: #2731