### PR TITLE
docs/macros.md: Fix expansion shorthand

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -182,7 +182,7 @@ A macro that is expanded to 1 if "with_python3" is defined and 0 otherwise:
 or shortly
 
 ```
-0%{!?with_python3:1}
+0%{?with_python3:1}
 ```
 
 `%{?macro_name}` is a shortcut for `%{?macro_name:%macro_name}`.


### PR DESCRIPTION
The Macros documentation claimed that
```spec
0%{!?with_python3:1}
```
was a shorthand for
```spec
%{?with_python3:1}%{!?with_python3:0}
```
which 'is expanded to 1 if "with_python3" is defined and 0 otherwise'.

That's true of the latter, but not the former, which would expand to `1` (actually `01`) if `with_python3` is _not_ defined. Correct to `0%{?with_python3:1}`.