### PR TITLE
Exit from mktree on failure

### DIFF
--- a/tests/mktree.oci
+++ b/tests/mktree.oci
@@ -2,6 +2,8 @@
 #
 # OCI-based mktree backend
 
+set -e
+
 PROGRAM=$(basename $0)
 if [ "$PROGRAM" == "mktree" ]; then
     # Running from build directory
@@ -54,7 +56,7 @@ rpmtests()
 
 unshared()
 {
-    [ $(id -u) != 0 ] && [ $NATIVE == yes ] || return
+    [ $(id -u) != 0 ] && [ $NATIVE == yes ] || return 0
     $PODMAN unshare $0 $CMD "$@"
     exit
 }
@@ -69,10 +71,9 @@ case $CMD in
         if [ $NATIVE == yes ]; then
             # Native build
             id=$($PODMAN create $IMAGE/base)
-            trap : INT
+            trap "$PODMAN rm $id >/dev/null" EXIT
             make_install $($PODMAN mount $id)
             $PODMAN commit -q $id $IMAGE
-            $PODMAN rm $id >/dev/null
         else
             # Standalone build
             $PODMAN build --target full -t $IMAGE $ARGS

--- a/tests/mktree.rootfs
+++ b/tests/mktree.rootfs
@@ -7,6 +7,8 @@
 # The / filesystem should be read-only to prevent parallel tests from altering
 # it (online changes to an underlying filesystem are disallowed in OverlayFS).
 
+set -e
+
 CMD=$1; shift
 case $CMD in
     build)


### PR DESCRIPTION
Right now, if the podman image fails to build or rpm fails to build/install, we happily continue and run the test-suite, only to eventually fail with some cryptic error, such as:

    error: cannot find rpm

Not too helpful, indeed.  Instead, just fail the whole tree preparation process if we encounter an error.

Fix the return code of unshared() so that we don't fail on that, though. Also, when building the RPM layer, use a proper cleanup trap instead of ignoring SIGINT since a failing make_install() can now terminate the script.

Fixes: #2667