### PR TITLE
Set %_sharedstatedir to %{_var}/lib

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -966,7 +966,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %_libexecdir		%{_exec_prefix}/libexec
 %_datadir		%{_prefix}/share
 %_sysconfdir		/etc
-%_sharedstatedir	%{_prefix}/com
+%_sharedstatedir	%{_var}/lib
 %_localstatedir		%{_prefix}/var
 %_lib			lib
 %_libdir		%{_exec_prefix}/%{_lib}


### PR DESCRIPTION
Configure traditionally sets it to %{_prefix}/com which RPM has followed so far. But this directory is not used anywhere and everybody changes the location to /var/lib. As we are only changing the macro and not the configure default this should be relatively save to do.

Resolves: #2092