### PR TITLE
Adapt Dockerfile.fedora to F39

### DIFF
--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:38 AS base
 MAINTAINER rpm-maint@lists.rpm.org
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
-RUN rpm -e fedora-repos-modular
+RUN rpm --quiet -q fedora-repos-modular && rpm -e fedora-repos-modular ||:
 RUN sed -i -e "s:^enabled=.$:enabled=0:g" /etc/yum.repos.d/*openh264.repo
 # dummy for controlling per-repo gpgcheck via Semaphore setup
 RUN sed -i -e "s:^gpgcheck=.$:gpgcheck=1:g" /etc/yum.repos.d/*.repo


### PR DESCRIPTION
The fedora-repos-modular package is gone from F39.  This commit makes the Dockerfile work on a F39 host with the mktree.oci backend since we override the release with "podman build --from fedora:39 ..." there.