### PR TITLE
Allow SOURCE_DATE_EPOCH=0 again

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1035,6 +1035,7 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
     uint32_t defaultalgo = RPM_HASH_MD5, digestalgo;
     rpm_loff_t totalFileSize = 0;
     Header h = pkg->header; /* just a shortcut */
+    int override_date = 0;
     time_t source_date_epoch = 0;
     char *srcdate = getenv("SOURCE_DATE_EPOCH");
 
@@ -1050,6 +1051,7 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	    rpmlog(RPMLOG_ERR, _("unable to parse %s=%s\n"), "SOURCE_DATE_EPOCH", srcdate);
 	    fl->processingFailed = 1;
 	}
+	override_date = 1;
     }
 
     /*
@@ -1195,7 +1197,7 @@ static void genCpioListAndHeader(FileList fl, Package pkg, int isSrc)
 	    }
 	}
 	
-	if (source_date_epoch && flp->fl_mtime > source_date_epoch) {
+	if (override_date && flp->fl_mtime > source_date_epoch) {
 	    flp->fl_mtime = source_date_epoch;
 	}
 	/*

--- a/tests/data/SPECS/source_date_epoch.spec
+++ b/tests/data/SPECS/source_date_epoch.spec
@@ -1,0 +1,21 @@
+Name:    test
+Version: 1
+Release: 1
+Summary: test SOURCE_DATE_EPOCH
+License: GPLv2
+BuildArch: noarch
+
+%global source_date_epoch_from_changelog 0
+%global clamp_mtime_to_source_date_epoch 1
+%global use_source_date_epoch_as_buildtime 1
+
+%description
+
+%build
+echo "this is a test" > 0.txt
+
+%install
+%{__install} -m 644 -D 0.txt %{buildroot}/0.txt
+
+%files
+/0.txt

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -519,6 +519,48 @@ drwxrwxrwx   1 root     root            0 Feb 20  2020 ./j/dir
 [])
 RPMTEST_CLEANUP
 
+AT_SETUP([rpmbuild SOURCE_DATE_EPOCH])
+AT_KEYWORDS([build])
+RPMTEST_CHECK([
+RPMDB_INIT
+
+runroot \
+  --setenv SOURCE_DATE_EPOCH 1699460418 \
+  rpmbuild \
+  -bb --quiet \
+  --define "use_source_date_epoch_as_buildtime 1" \
+  --define "clamp_mtime_to_source_date_epoch 1" \
+  /data/SPECS/source_date_epoch.spec
+
+runroot rpm -q --dump /build/RPMS/noarch/test-1-1.noarch.rpm
+],
+[0],
+[/0.txt 15 1699460418 91751cee0a1ab8414400238a761411daa29643ab4b8243e9a91649e25be53ada 0100644 root root 0 0 0 X
+],
+[])
+RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild SOURCE_DATE_EPOCH=0])
+AT_KEYWORDS([build])
+RPMTEST_CHECK([
+RPMDB_INIT
+
+runroot \
+  --setenv SOURCE_DATE_EPOCH 0 \
+  rpmbuild \
+  -bb --quiet \
+  --define "use_source_date_epoch_as_buildtime 1" \
+  --define "clamp_mtime_to_source_date_epoch 1" \
+  /data/SPECS/source_date_epoch.spec
+
+runroot rpm -q --dump /build/RPMS/noarch/test-1-1.noarch.rpm
+],
+[0],
+[/0.txt 15 0 91751cee0a1ab8414400238a761411daa29643ab4b8243e9a91649e25be53ada 0100644 root root 0 0 0 X
+],
+[])
+RPMTEST_CLEANUP
+
 AT_SETUP([rpmbuild unpackaged files])
 AT_KEYWORDS([build])
 RPMDB_INIT


### PR DESCRIPTION
Commit 11132fc21fb01ed63c621d852bc081a914d4f021 assumed that the value of 0 is never used in practice and thus used it to indicate "disabled", however that assumption has turned out to be wrong because ostree uses precisely that value as mtime in inodes, which in turn breaks existing workflows in this space (see the associated ticket).

Fix this by reverting the above commit (except leaving source_date_epoch initialized to 0, to prevent GCC warnings as mentioned in that commit).

As to why not just initialize source_date_epoch to -1: time_t happens to be a signed integer on most platforms but POSIX doesn't specify its signed-ness.

Add some accompanying tests too.

Fixes: #2679