### PR TITLE
Add option to not store expanded spec

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -805,7 +805,9 @@ rpmRC packageSources(rpmSpec spec, char **cookie)
     headerPutUint32(sourcePkg->header, RPMTAG_SOURCEPACKAGE, &one, 1);
 
     /* Include spec in parsed and expanded form */
-    headerPutString(sourcePkg->header, RPMTAG_SPEC, getStringBuf(spec->parsed));
+    if (!rpmExpandNumeric("%{?no_store_expanded_spec}")) {
+	headerPutString(sourcePkg->header, RPMTAG_SPEC, getStringBuf(spec->parsed));
+    }
 
     if (spec->buildrequires) {
 	(void) rpmlibNeedsFeature(sourcePkg, "DynamicBuildRequires", "4.15.0-1");


### PR DESCRIPTION
Add option to not store expanded spec in .src.rpm
because some usages of macros are hard to make reproducible.

Fixes #2343

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).

btw: if you have better proposals for the name of the value, I'll take it.

