### PR TITLE
Never use current user info or file ownership during build

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -19,7 +19,6 @@
 #include <rpm/rpmfileutil.h>
 #include "rpmbuild_internal.h"
 #include "rpmbuild_misc.h"
-#include "rpmug.h"
 
 #include "debug.h"
 
@@ -496,7 +495,6 @@ exit:
 	}
     }
 
-    rpmugFree();
     if (missing_buildreqs && !rc) {
 	rc = RPMRC_MISSINGBUILDREQUIRES;
     }

--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -14,7 +14,6 @@
 #include "rpmbuild_internal.h"
 #include "rpmbuild_misc.h"
 #include "rpmmacro_internal.h"
-#include "rpmug.h"
 #include "debug.h"
 
 static void appendMb(rpmMacroBuf mb, const char *s, int nl)

--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -21,7 +21,6 @@
 #include <rpm/rpmfi.h>
 #include <rpm/rpmstrpool.h>
 
-#include "rpmug.h"
 #include "rpmfi_internal.h"		/* rpmfiles stuff for now */
 #include "rpmbuild_internal.h"
 
@@ -1682,16 +1681,14 @@ rpmRC rpmfcGenerateDepends(const rpmSpec spec, Package pkg)
 	    if (rpmExpandNumeric("%{?_use_weak_usergroup_deps}"))
 		deptag = RPMTAG_RECOMMENDNAME;
 
-	    /* filter out root and current user/group */
-	    if (user && !rstreq(user, UID_0_USER) &&
-			!rstreq(user, rpmugUname(getuid()))) {
+	    /* filter out root user/group */
+	    if (user && !rstreq(user, UID_0_USER)) {
 		rpmds ds = rpmdsSingleNS(fc->pool, deptag, "user",
 					user, NULL, ugfl);
 		rpmdsMerge(packageDependencies(pkg, deptag), ds);
 		rpmdsFree(ds);
 	    }
-	    if (group && !rstreq(group, GID_0_GROUP) &&
-			 !rstreq(group, rpmugGname(getgid()))) {
+	    if (group && !rstreq(group, GID_0_GROUP)) {
 		rpmds ds = rpmdsSingleNS(fc->pool, deptag, "group",
 					group, NULL, ugfl);
 		rpmdsMerge(packageDependencies(pkg, deptag), ds);

--- a/lib/rpmug.h
+++ b/lib/rpmug.h
@@ -1,16 +1,22 @@
 #ifndef _RPMUG_H
 #define _RPMUG_H
 
+#include <rpm/rpmutil.h>
 #include <sys/types.h>
 
+RPM_GNUC_INTERNAL
 int rpmugUid(const char * name, uid_t * uid);
 
+RPM_GNUC_INTERNAL
 int rpmugGid(const char * name, gid_t * gid);
 
+RPM_GNUC_INTERNAL
 const char * rpmugUname(uid_t uid);
 
+RPM_GNUC_INTERNAL
 const char * rpmugGname(gid_t gid);
 
+RPM_GNUC_INTERNAL
 void rpmugFree(void);
 
 #endif /* _RPMUG_H */


### PR DESCRIPTION
There's no situation where rpmbuild should use uid/gid from either the filesystem or current user. The former made sense in the pre-historic times before Buildroot was a thing, but in the last 20+ years that's always the wrong thing to do. Always. The only user/group info rpm can legitimately use is the one that is explicitly specified in the packaging, and otherwise fallback to root/equivalent.

Besides fixing a long-standing annoyance with src.rpm file ownership, this also fixes a regression in 4.19.0 where a non-local or otherwise unresolvable user info could cause a segfault during rpmbuild (RhBug:2248763).

Fixes: #2604