### PR TITLE
Don't include git refs in ChangeLog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ install(FILES CONTRIBUTING.md COPYING CREDITS INSTALL README TYPE DOC)
 
 add_custom_target(ChangeLog
 		   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		   COMMAND git log --no-merges
+		   COMMAND git log --no-merges --no-decorate
 				--output=${CMAKE_BINARY_DIR}/ChangeLog
 )
 


### PR DESCRIPTION
Right now, we "leak" any local branch or tag names into the ChangeLog which is unnecessary (e.g. "experiment-foo-123") and also just pollutes the diff when comparing ChangeLogs between releases.  Only show the plain log.

Fixes: #2647