### PR TITLE
Print full path if file removal fails

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -1174,9 +1174,9 @@ int rpmPackageFilesRemove(rpmts ts, rpmte te, rpmfiles files,
 
 	    if (rc) {
 		int lvl = strict_erasures ? RPMLOG_ERR : RPMLOG_WARNING;
-		rpmlog(lvl, _("%s %s: remove failed: %s\n"),
+		rpmlog(lvl, _("%s %s%s: remove failed: %s\n"),
 			S_ISDIR(fp->sb.st_mode) ? _("directory") : _("file"),
-			fp->fpath, strerror(errno));
+			rpmfiDN(fi), fp->fpath, strerror(errno));
             }
         }
 


### PR DESCRIPTION
For normal debug output the basename of the files are sufficient as when debugging is enabled the directories are also printed. But here the warning is given without a debug flag so we need the full context right there.