### PR TITLE
Fix unconditional uses of Linux-specific extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,7 @@ if (LIBDW_FOUND)
 	set(HAVE_LIBDW 1)
 endif()
 
+check_symbol_exists(GLOB_ONLYDIR "glob.h" HAVE_GLOB_ONLYDIR)
 check_symbol_exists(major "sys/sysmacros.h" MAJOR_IN_SYSMACROS)
 if (NOT MAJOR_IN_SYSMACROS)
 	check_symbol_exists(major "sys/mkdev.h" MAJOR_IN_MKDEV)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ include(CheckCCompilerFlag)
 set(OPTFUNCS
 	stpcpy stpncpy putenv mempcpy fdatasync lutimes mergesort
 	getauxval setprogname __progname syncfs sched_getaffinity unshare
-	secure_getenv __secure_getenv mremap
+	secure_getenv __secure_getenv mremap strchrnul
 )
 set(REQFUNCS
 	mkstemp getcwd basename dirname realpath setenv unsetenv regcomp

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(librpmbuild PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
 	${CMAKE_SOURCE_DIR}/lib
+	${Intl_INCLUDE_DIRS}
 )
 
 target_link_libraries(librpmbuild PUBLIC librpmio librpm)
@@ -25,6 +26,7 @@ target_link_libraries(librpmbuild PRIVATE
 	PkgConfig::POPT
 	LUA::LUA
 	MAGIC::MAGIC
+	${Intl_LIBRARIES}
 )
 
 if (LIBDW_FOUND)

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -29,6 +29,10 @@ target_link_libraries(librpmbuild PRIVATE
 	MAGIC::MAGIC
 )
 
+if (Iconv_FOUND)
+	target_link_libraries(librpmbuild PRIVATE Iconv::Iconv)
+endif()
+
 if(WITH_CAP)
 	target_link_libraries(librpmbuild PRIVATE PkgConfig::LIBCAP)
 endif()

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -23,11 +23,17 @@ target_link_libraries(librpmbuild PUBLIC librpmio librpm)
 target_link_libraries(librpmbuild PRIVATE
 	libmisc
 	PkgConfig::POPT
-	PkgConfig::LIBELF
-	PkgConfig::LIBDW
 	LUA::LUA
 	MAGIC::MAGIC
 )
+
+if (LIBDW_FOUND)
+	target_link_libraries(librpmbuild PRIVATE PkgConfig::LIBDW)
+endif()
+
+if (LIBELF_FOUND)
+	target_link_libraries(librpmbuild PRIVATE PkgConfig::LIBELF)
+endif()
 
 if (Iconv_FOUND)
 	target_link_libraries(librpmbuild PRIVATE Iconv::Iconv)

--- a/config.h.in
+++ b/config.h.in
@@ -100,6 +100,7 @@
 #cmakedefine HAVE_ZSTD @HAVE_ZSTD@
 #cmakedefine HAVE___PROGNAME @HAVE___PROGNAME@
 #cmakedefine HAVE___SECURE_GETENV @HAVE___SECURE_GETENV@
+#cmakedefine HAVE_GLOB_ONLYDIR @HAVE_GLOB_ONLYDIR@
 #cmakedefine MAJOR_IN_MKDEV @MAJOR_IN_MKDEV@
 #cmakedefine MAJOR_IN_SYSMACROS @MAJOR_IN_SYSMACROS@
 #cmakedefine RUNDIR @rundir@

--- a/include/rpm/rpmbuild.h
+++ b/include/rpm/rpmbuild.h
@@ -6,7 +6,6 @@
  *  This is the *only* module users of librpmbuild should need to include.
  */
 
-#include <rpm/rpmcli.h>
 #include <rpm/rpmds.h>
 #include <rpm/rpmspec.h>
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(librpm PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
 	${CMAKE_CURRENT_BINARY_DIR}
+	${Intl_INCLUDE_DIRS}
 )
 
 target_sources(librpm PRIVATE
@@ -72,6 +73,6 @@ add_custom_command(OUTPUT tagtbl.C
 )
 
 target_link_libraries(librpm PUBLIC librpmio)
-target_link_libraries(librpm PRIVATE PkgConfig::POPT LUA::LUA)
+target_link_libraries(librpm PRIVATE PkgConfig::POPT LUA::LUA ${Intl_LIBRARIES})
 
 install(TARGETS librpm EXPORT rpm-targets)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,6 +18,8 @@ target_include_directories(librpm PRIVATE
 	${CMAKE_CURRENT_BINARY_DIR}
 	${Intl_INCLUDE_DIRS}
 )
+# This is needed for rpmcli.h
+target_include_directories(librpm PUBLIC ${POPT_INCLUDE_DIRS})
 
 target_sources(librpm PRIVATE
 	backend/dbi.c backend/dbi.h backend/dummydb.c

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(libmisc OBJECT fts.c rpmfts.h)
+target_include_directories(libmisc PRIVATE ${Intl_INCLUDE_DIRS})

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -47,7 +47,8 @@ set(RPM_PLUGINDIR ${CMAKE_INSTALL_FULL_LIBDIR}/rpm-plugins
 
 get_property(plugins DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(plugin ${plugins})
-	target_link_libraries(${plugin} PRIVATE librpmio librpm)
+	target_link_libraries(${plugin} PRIVATE librpmio librpm ${Intl_LIBRARIES})
+	target_include_directories(${plugin} PRIVATE ${Intl_INCLUDE_DIRS})
 	install(TARGETS ${plugin} DESTINATION ${RPM_PLUGINDIR})
 	install(FILES macros.transaction_${plugin} DESTINATION ${RPM_MACROSDIR})
 endforeach()

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -24,9 +24,10 @@ set_target_properties(librpmio PROPERTIES
 	SOVERSION ${RPM_SOVERSION}
 )
 target_link_libraries(librpmio PRIVATE
-			PkgConfig::POPT
-			LUA::LUA
-			ZLIB::ZLIB)
+	PkgConfig::POPT
+	LUA::LUA
+	ZLIB::ZLIB
+)
 
 if (ZSTD_FOUND)
 	target_link_libraries(librpmio PRIVATE PkgConfig::ZSTD)

--- a/rpmio/CMakeLists.txt
+++ b/rpmio/CMakeLists.txt
@@ -8,7 +8,10 @@ target_sources(librpmio PRIVATE
 	rpmstrpool.c rpmmacro_internal.h rpmlua.c rpmlua.h lposix.c
 )
 target_compile_definitions(librpmio PRIVATE RPM_CONFIGDIR="${RPM_CONFIGDIR}")
-target_include_directories(librpmio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(librpmio PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}
+	${Intl_INCLUDE_DIRS}
+)
 
 if (WITH_INTERNAL_OPENPGP)
 	add_subdirectory(rpmpgp_legacy)
@@ -27,6 +30,7 @@ target_link_libraries(librpmio PRIVATE
 	PkgConfig::POPT
 	LUA::LUA
 	ZLIB::ZLIB
+	${Intl_LIBRARIES}
 )
 
 if (ZSTD_FOUND)

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -84,8 +84,10 @@ int rpmGlobPath(const char * pattern, rpmglobFlags flags,
     gflags |= GLOB_BRACE;
     if (home != NULL && strlen(home) > 0) 
 	gflags |= GLOB_TILDE;
+#if HAVE_GLOB_ONLYDIR
     if (dir_only)
 	gflags |= GLOB_ONLYDIR;
+#endif
     if (flags & RPMGLOB_NOCHECK)
 	gflags |= GLOB_NOCHECK;
 

--- a/rpmio/rpmpgp_legacy/CMakeLists.txt
+++ b/rpmio/rpmpgp_legacy/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(rpmpgp_legacy PRIVATE
 	rpmpgp_internal.h rpmpgp_internal.c
 )
 target_include_directories(rpmpgp_legacy PRIVATE ..)
+target_include_directories(rpmpgp_legacy PRIVATE ${Intl_INCLUDE_DIRS})
 if (WITH_OPENSSL)
 	find_package(OpenSSL 3.0.0 REQUIRED)
 	target_sources(rpmpgp_legacy PRIVATE digest_openssl.c)

--- a/sign/CMakeLists.txt
+++ b/sign/CMakeLists.txt
@@ -9,10 +9,11 @@ target_include_directories(librpmsign PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_SOURCE_DIR}/rpmio
 	${CMAKE_SOURCE_DIR}/lib
+	${Intl_INCLUDE_DIRS}
 )
 
 target_link_libraries(librpmsign PUBLIC librpmio librpm)
-target_link_libraries(librpmsign PRIVATE PkgConfig::POPT)
+target_link_libraries(librpmsign PRIVATE PkgConfig::POPT ${Intl_LIBRARIES})
 if (WITH_IMAEVM)
 	target_sources(librpmsign PRIVATE rpmsignfiles.c)
 	target_link_libraries(librpmsign PRIVATE IMA::IMA)

--- a/sign/CMakeLists.txt
+++ b/sign/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(librpmsign PRIVATE
 )
 
 target_link_libraries(librpmsign PUBLIC librpmio librpm)
+target_link_libraries(librpmsign PRIVATE PkgConfig::POPT)
 if (WITH_IMAEVM)
 	target_sources(librpmsign PRIVATE rpmsignfiles.c)
 	target_link_libraries(librpmsign PRIVATE IMA::IMA)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,14 +12,18 @@ add_executable(rpmgraph rpmgraph.c)
 add_executable(rpmlua rpmlua.c)
 add_executable(rpmsort rpmsort.c)
 add_executable(rpmuncompress rpmuncompress.c)
-add_executable(elfdeps elfdeps.c)
 
 target_link_libraries(rpmsign PRIVATE librpmsign)
 target_link_libraries(rpmlua PRIVATE LUA::LUA)
-target_link_libraries(elfdeps PRIVATE PkgConfig::LIBELF)
 target_link_libraries(rpmbuild PRIVATE librpmbuild)
 target_link_libraries(rpmspec PRIVATE librpmbuild)
 target_link_libraries(rpmdeps PRIVATE librpmbuild)
+
+if (LIBELF_FOUND)
+	add_executable(elfdeps elfdeps.c)
+	target_link_libraries(elfdeps PRIVATE PkgConfig::LIBELF)
+	install(TARGETS elfdeps DESTINATION ${RPM_CONFIGDIR})
+endif()
 
 target_include_directories(rpmlua PRIVATE ${CMAKE_SOURCE_DIR}/rpmio)
 target_include_directories(rpmgraph PRIVATE ${CMAKE_SOURCE_DIR}/lib)
@@ -58,5 +62,5 @@ install(TARGETS
 	rpm rpmdb rpmkeys rpmsign rpmbuild rpmspec
 	rpmlua rpmgraph rpmsort
 )
-install(TARGETS elfdeps rpmdeps rpmuncompress DESTINATION ${RPM_CONFIGDIR})
+install(TARGETS rpmdeps rpmuncompress DESTINATION ${RPM_CONFIGDIR})
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,7 +10,6 @@ add_executable(rpmspec rpmspec.c cliutils)
 add_executable(rpmdeps rpmdeps.c)
 add_executable(rpmgraph rpmgraph.c)
 add_executable(rpmlua rpmlua.c)
-add_executable(rpmsort rpmsort.c)
 add_executable(rpmuncompress rpmuncompress.c)
 
 target_link_libraries(rpmsign PRIVATE librpmsign)
@@ -18,6 +17,11 @@ target_link_libraries(rpmlua PRIVATE LUA::LUA)
 target_link_libraries(rpmbuild PRIVATE librpmbuild)
 target_link_libraries(rpmspec PRIVATE librpmbuild)
 target_link_libraries(rpmdeps PRIVATE librpmbuild)
+
+if (HAVE_STRCHRNUL)
+	add_executable(rpmsort rpmsort.c)
+	install(TARGETS rpmsort)
+endif()
 
 if (LIBELF_FOUND)
 	add_executable(elfdeps elfdeps.c)
@@ -60,7 +64,7 @@ endif()
 
 install(TARGETS
 	rpm rpmdb rpmkeys rpmsign rpmbuild rpmspec
-	rpmlua rpmgraph rpmsort
+	rpmlua rpmgraph
 )
 install(TARGETS rpmdeps rpmuncompress DESTINATION ${RPM_CONFIGDIR})
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -47,6 +47,8 @@ endif()
 get_property(executables DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(exe ${executables})
 	target_link_libraries(${exe} PRIVATE librpmio librpm PkgConfig::POPT)
+	target_link_libraries(${exe} PRIVATE ${Intl_LIBRARIES})
+	target_include_directories(${exe} PRIVATE ${Intl_INCLUDE_DIRS})
 endforeach()
 
 foreach(cmd rpmverify rpmquery)

--- a/tools/rpm2archive.c
+++ b/tools/rpm2archive.c
@@ -16,6 +16,7 @@
 #include <archive_entry.h>
 #include <unistd.h>
 #include <errno.h>
+#include <libgen.h>
 
 #include "debug.h"
 
@@ -262,7 +263,7 @@ static int process_package(rpmts ts, const char * filename)
     return rc;
 }
 
-int main(int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     int rc = 0;
     poptContext optCon;
@@ -271,7 +272,7 @@ int main(int argc, const char *argv[])
     xsetprogname(argv[0]);	/* Portability call -- see system.h */
     rpmReadConfigFiles(NULL, NULL);
 
-    optCon = poptGetContext(NULL, argc, argv, optionsTable, 0);
+    optCon = poptGetContext(NULL, argc, (const char **)argv, optionsTable, 0);
     poptSetOtherOptionHelp(optCon, "[OPTIONS]* <FILES>");
 
     if (rstreq(basename(argv[0]), "rpm2cpio")) {


### PR DESCRIPTION
Should fix the issues brought up in #2807 - portability rot that inevitably happens when you only build on one target.