### PR TITLE
perl.req: make heredoc block matching more generic

### DIFF
--- a/scripts/perl.req
+++ b/scripts/perl.req
@@ -102,10 +102,10 @@ sub process_file {
 
   while (<FILE>) {
 
-    # skip the "= <<" block
+    # skip the heredoc block
 
-    if (m/^\s*(?:my\s*)?\$(?:.*)\s*=\s*<<\s*(["'`])(.+?)\1/ ||
-        m/^\s*(?:my\s*)?\$(.*)\s*=\s*<<(\w+)\s*;/) {
+    if (m/^[^'"#]+[\s,=(]<<\s*(["'`])(.+?)\1/ ||
+        m/^[^'"#]+[\s,=(](<<)(\w+)\s*;/) {
       $tag = $2;
       while (<FILE>) {
         chomp;


### PR DESCRIPTION
match any <<MARKER providing:

- it is not in comment (not preceded by #)
- it can't be string literal (not preceded by ' or ")
- as a sanity check it must be preceded by either whitespace, comma or equals sign

adds support for

   return <<"EOS";

   fun(arg, <<"EOS");