### PR TITLE
Don't warn about missing user/group on skipped files

### DIFF
--- a/lib/fsm.c
+++ b/lib/fsm.c
@@ -903,7 +903,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
 	fp->fpath = fsmFsPath(fi, fp->suffix);
 
 	/* Remap file perms, owner, and group. */
-	rc = rpmfiStat(fi, 1, &fp->sb);
+	rc = rpmfiStat(fi, (fp->skip == 0), &fp->sb);
 
 	/* Hardlinks are tricky and handled elsewhere for install */
 	fp->setmeta = (fp->skip == 0) &&


### PR DESCRIPTION
There's no reason to complain about missing user/group for entities we don't create at all. It's cosmetical only, but "regressed" in the 4.17 fsm robustness rewrite.

Reported in https://issues.redhat.com/browse/RHEL-18037