### PR TITLE
Remove cycles from CMake dependency graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,17 +434,17 @@ function(add_tarball targetname namever treeish)
 	set(distname ${tarname}.bz2)
 	set(docname ${namever}-doc.${distfmt})
 
-	add_custom_target(${docname}
-		DEPENDS man apidoc
+	file(GLOB man_pages docs/man/*.[1-8])
+	add_custom_command(OUTPUT ${docname}
+		DEPENDS man apidoc docs/html/ ${man_pages}
 		COMMAND tar
 			-C ${CMAKE_BINARY_DIR}
 			--transform 's:^:${namever}/:'
 			-cf ${docname} docs/man/*.[1-8] docs/html/
 	)
 
-	add_custom_target(${distname}
+	add_custom_command(OUTPUT ${distname}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		BYPRODUCTS ${distname} ${docname}
 		VERBATIM
 		DEPENDS ChangeLog ${docname} po/rpm.pot
 		COMMAND git archive

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,15 +42,17 @@ foreach(exe ${executables})
 endforeach()
 
 foreach(cmd rpmverify rpmquery)
-	add_custom_target(${cmd} ALL COMMAND
+	add_custom_command(OUTPUT ${cmd} COMMAND
 			${CMAKE_COMMAND} -E create_symlink rpm ${cmd}
-			BYPRODUCTS ${cmd})
+			)
+	add_custom_target(${cmd}_link ALL DEPENDS ${cmd})
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${cmd} TYPE BIN)
 endforeach()
 if (WITH_ARCHIVE)
-	add_custom_target(rpm2cpio ALL COMMAND
+	add_custom_command(OUTPUT rpm2cpio COMMAND
 			${CMAKE_COMMAND} -E create_symlink rpm2archive rpm2cpio
-			BYPRODUCTS rpm2cpio)
+			)
+	add_custom_target(rpm2cpio_link ALL DEPENDS rpm2cpio)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rpm2cpio TYPE BIN)
 endif()
 


### PR DESCRIPTION
Attempts to generate a Ninja build from the existing CMake structure failed complaining about phony cycles related to the use of `add_custom_target` and placing the primary output file in the `DEPENDS` option.