### PR TITLE
Add missing include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 set(CMAKE_SHARED_MODULE_PREFIX "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(GNUInstallDirs)
+include(CheckSymbolExists)
 add_compile_definitions(_GNU_SOURCE)
 add_definitions(-D_FILE_OFFSET_BITS=64)
 


### PR DESCRIPTION
The build fails because of a missing include in cmake:

    CMake Error at CMakeLists.txt:353 (check_symbol_exists):
      Unknown CMake command "check_symbol_exists".

Include the needed file to fix the issue.