### PR TITLE
Create Issue templates for Bug reports and RFEs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Start condition e.g. installed packages
+2. Command (line) executed
+3. Error encountered
+
+Please link or attach the packages or spec files involved.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Output**
+If applicable, add copy of the output on the command line or a screenshots to help explain your problem.
+
+**Environment**
+ - OS / Distribution: [e.g. Fedora 42]
+ - Version [e.g. rpm-4.19.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: RFE
+assignees: ''
+
+---
+
+Generally requests for new features should be opened as a [Discussion](https://github.com/rpm-software-management/rpm/discussions) first. There feedback from the community can be collected and possible solutions can be discussed. Consider maintaining a design outline in the top post and update it as the discussion progresses. After a plan of action has solidified an issue for actually implementing it can be created.
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is or what you are trying to do and can't (easily).
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Have a bit of structure for the bug reports to tell people what information is expected/necessary.

Point people to discussions for RFEs and have RFE tickets only be created after a course of action has been decided on.

Resolves: #2752