### PR TITLE
Return false when comparing different python objects holding the same version tag

### DIFF
--- a/python/rpmver-py.c
+++ b/python/rpmver-py.c
@@ -80,6 +80,9 @@ static PyObject *ver_richcmp(rpmverObject *s, rpmverObject *o, int op)
     case Py_EQ:
 	v = rpmverCmp(s->ver, o->ver) == 0;
 	break;
+    case Py_NE:
+	v = rpmverCmp(s->ver, o->ver) != 0;
+	break;
     case Py_GE:
 	v = rpmverCmp(s->ver, o->ver) >= 0;
 	break;

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -705,11 +705,13 @@ RPMPY_TEST([version objects 1],[
 pv = None
 for vs in [ '1.0', '1.0', '4:1.0', '1.5-1', '3:2.0-1']:
     v = rpm.ver(vs)
+    v_eq = rpm.ver(vs)
     myprint('(%s, %s, %s)' % (v.e, v.v, v.r))
     if pv:
         myprint('%s < %s: %s' % (pv.evr, v.evr, pv < v))
         myprint('%s > %s: %s' % (pv.evr, v.evr, pv > v))
         myprint('%s == %s: %s' % (pv.evr, v.evr, pv == v))
+        myprint('%s != %s: %s' % (v.evr, v_eq.evr, v != v_eq))
     pv = v
 ],
 [(None, 1.0, None)
@@ -717,18 +719,22 @@ for vs in [ '1.0', '1.0', '4:1.0', '1.5-1', '3:2.0-1']:
 1.0 < 1.0: False
 1.0 > 1.0: False
 1.0 == 1.0: True
+1.0 != 1.0: False
 (4, 1.0, None)
 1.0 < 4:1.0: True
 1.0 > 4:1.0: False
 1.0 == 4:1.0: False
+4:1.0 != 4:1.0: False
 (None, 1.5, 1)
 4:1.0 < 1.5-1: False
 4:1.0 > 1.5-1: True
 4:1.0 == 1.5-1: False
+1.5-1 != 1.5-1: False
 (3, 2.0, 1)
 1.5-1 < 3:2.0-1: True
 1.5-1 > 3:2.0-1: False
 1.5-1 == 3:2.0-1: False
+3:2.0-1 != 3:2.0-1: False
 ],
 [])
 


### PR DESCRIPTION
Hello!

While I was working on another issue, I found that the inequality operator of python `rpm.ver` objects would not work as I was expecting to. `!=` would always return `True` if the compared objects were not the actual same python object. That was leading to situations as

```python
    (v := rpm.ver('1.0')) != v        # False, we are comparing the object with itself
    rpm.ver('1.0') != rpm.ver('1.0')  # True, although they hold the same version tag string
```
I'm not sure whether that was the intended behavior or not. It was not quite what I expected when I tried applying the operator. I didn't research the topic really exhaustively, but I couldn't find related issues at least in the PRs of this repo.

Anyway, this patch adds the `PY_NE` case to the `tp_richcompare` slot function and adds some extra checks to a related existing test.

Thanks for the attention! :smile: 

cc: @luckyh