### PR TITLE
Support rpmver-py comparison operator inheritance

### DIFF
--- a/python/rpmver-py.h
+++ b/python/rpmver-py.h
@@ -8,7 +8,7 @@ typedef struct rpmverObject_s rpmverObject;
 extern PyTypeObject* rpmver_Type;
 extern PyType_Spec rpmver_Type_Spec;
 
-#define verObject_Check(v)	(((PyObject*)v)->ob_type == rpmver_Type)
+#define verObject_Check(v)	PyObject_TypeCheck(v, rpmver_Type)
 
 int verFromPyObject(PyObject *item, rpmver *ver);
 PyObject * rpmver_Wrap(PyTypeObject *subtype, rpmver ver);

--- a/tests/rpmpython.at
+++ b/tests/rpmpython.at
@@ -748,3 +748,30 @@ for vt in [ (None, "1.0", None), (None, "1.0", "2"), ("1", "1.0", "3") ]:
 1:1.0-3
 ],
 [])
+
+RPMPY_TEST([version objects 3],[
+class Foo(rpm.ver):
+    pass
+f1 = Foo('v1.0')
+v1 = rpm.ver('v1.0')
+f2 = Foo('v2.0')
+myprint('%s > %s: %s' % (f1, f2, f1 > f2))
+myprint('%s < %s: %s' % (f1, f2, f1 < f2))
+myprint('%s < %s: %s' % (f1, v1, f1 < v1))
+myprint('%s > %s: %s' % (f2, v1, f2 > v1))
+myprint('%s > %s: %s' % (v1, f1, v1 > f1))
+myprint('%s < %s: %s' % (v1, f2, v1 < f2))
+myprint('%s == %s: %s' % (v1, f1, v1 == f1))
+myprint('%s == %s: %s' % (f1, f2, f1 == f2))
+myprint('%s != %s: %s' % (f1, f2, f1 != f2))
+],
+[v1.0 > v2.0: False
+v1.0 < v2.0: True
+v1.0 < v1.0: False
+v2.0 > v1.0: True
+v1.0 > v1.0: False
+v1.0 < v2.0: True
+v1.0 == v1.0: True
+v1.0 == v2.0: False
+v1.0 != v2.0: True
+])


### PR DESCRIPTION
Hi again,

I'm opening this PR due to the main issue I found when writing a `rpm.ver` subclass in python: Trying to compare different subclass instances would raise a `NotImplementedError` while it was supported on base class instances.

The reason behind that was that the `verObject_Check` macro checked for operand types to be the same as `rpm.ver`. A way to overcome that, is checking their types are subclasses of `rpm.ver`, or simply calling `PyObject_TypeCheck`.

I'm proposing this patch only targeting the `rpm.ver` type as I'm not sure if such behavior was intended in the first place. In fact, most of the python bindings seem to follow the same type check pattern. Moreover, although not directly related to `rpm.ver` (but `rpm.ts`), I found a similar proposal was made but not merged in #1600. In case you consider this to be valid proposal and that it could be helpful for other python bindings, I could try to provide a more general patch as well.

Thank you for the attention once again!