### PR TITLE
Make user/group lookup caching thread-safe

### DIFF
--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -36,6 +36,7 @@
 #include "rpmio_internal.h"	/* XXX for rpmioSlurp */
 #include "misc.h"
 #include "backend/dbi.h"
+#include "rpmug.h"
 
 #include "debug.h"
 
@@ -1872,6 +1873,7 @@ void rpmFreeRpmrc(void)
     rpmFreeCrypto();
     rpmlua lua = rpmluaGetGlobalState();
     rpmluaFree(lua);
+    rpmugFree();
 
     rpmrcCtxRelease(ctx);
     return;

--- a/lib/rpmug.c
+++ b/lib/rpmug.c
@@ -18,7 +18,7 @@ struct rpmug_s {
     gid_t lastGid;
 };
 
-static struct rpmug_s *rpmug = NULL;
+static __thread struct rpmug_s *rpmug = NULL;
 
 static const char *getpath(const char *bn, const char *dfl, char **dest)
 {

--- a/lib/rpmug.c
+++ b/lib/rpmug.c
@@ -194,9 +194,7 @@ const char * rpmugUname(uid_t uid)
 
     rpmugInit();
 
-    if (uid == rpmug->lastUid) {
-	return rpmug->lastUname;
-    } else {
+    if (uid != rpmug->lastUid) {
 	char *uname = NULL;
 
 	if (lookup_str(pwfile(), uid, 2, 0, &uname))
@@ -205,9 +203,8 @@ const char * rpmugUname(uid_t uid)
 	rpmug->lastUid = uid;
 	free(rpmug->lastUname);
 	rpmug->lastUname = uname;
-
-	return rpmug->lastUname;
     }
+    return rpmug->lastUname;
 }
 
 const char * rpmugGname(gid_t gid)
@@ -217,9 +214,7 @@ const char * rpmugGname(gid_t gid)
 
     rpmugInit();
 
-    if (gid == rpmug->lastGid) {
-	return rpmug->lastGname;
-    } else {
+    if (gid != rpmug->lastGid) {
 	char *gname = NULL;
 
 	if (lookup_str(grpfile(), gid, 2, 0, &gname))
@@ -228,9 +223,8 @@ const char * rpmugGname(gid_t gid)
 	rpmug->lastGid = gid;
 	free(rpmug->lastGname);
 	rpmug->lastGname = gname;
-
-	return rpmug->lastGname;
     }
+    return rpmug->lastGname;
 }
 
 void rpmugFree(void)


### PR DESCRIPTION
This seems like a huge overkill when in 4.19.1 there's exactly one rpmfiStat() call that unnecessarily invokes an rpmug lookup in a threaded scenario, but then rpmfiStat() and rpmfilesStat() are public APIs that people expect to be safe for use within the originating thread.

Collect all the caching data into a struct and allocate on per-thread basis, this seems like the path of least trouble in this case and git diff --stat agrees.

It's worth noting that this also simplifies the caching, we no longer keep separate name to id and id to name, totaling caches totaling four. We simply cache one id/name for for user and another for group data. Also, reset ids to 0 rather than -1, this is far more obviously a safe value as we have special cases to handle id 0.

rpmugUname() and rpmugGname() are have no users in the current codebase, so this was developed wrt commit c576d96930bfaf8f4328170de4c2915e76c1f715 where they still are used, to avoid nasty surprises later on if somebody finds a new case for these.

Fixes: #2826