### PR TITLE
don't attempt to install html pages if they're not built

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -18,7 +18,10 @@ if (DOXYGEN_FOUND)
 elseif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/html/index.html)
 	set(doxsrc ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
-install(DIRECTORY ${doxsrc}/html/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/API)
+
+if (doxsrc)
+	install(DIRECTORY ${doxsrc}/html/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/API)
+endif()
 
 install(FILES
 	README.md


### PR DESCRIPTION
On systems without Doxygen, html pages are not built, but the install fails with:

	Install the project...
	-- Install configuration: ""
	CMake Error at docs/cmake_install.cmake:51 (file):
	  file INSTALL cannot find "/html": No such file or directory.
	Call Stack (most recent call first):
	  cmake_install.cmake:47 (include)

Conditionally install html docs only if we build them.