### PR TITLE
Add a build option for enabling undefined behavior sanitizer, use for CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_NDB "Enable ndb rpmdb support" ON)
 option(ENABLE_BDB_RO "Enable read-only Berkeley DB rpmdb support (EXPERIMENTAL)" OFF)
 option(ENABLE_TESTSUITE "Enable test-suite" ON)
 option(ENABLE_ASAN "Enable address-sanitizer" OFF)
+option(ENABLE_UBSAN "Enable undefined behavior-sanitizer" OFF)
 
 option(WITH_CAP "Build with capability support" ON)
 option(WITH_ACL "Build with ACL support" ON)
@@ -376,8 +377,16 @@ endif()
 
 if (ENABLE_ASAN)
 	add_compile_options(-fsanitize=address)
-	add_compile_options(-fno-omit-frame-pointer)
 	add_link_options(-fsanitize=address)
+endif()
+
+if (ENABLE_UBSAN)
+	add_compile_options(-fsanitize=undefined)
+	add_link_options(-fsanitize=undefined)
+endif()
+
+if (ENABLE_ASAN OR ENABLE_UBSAN)
+	add_compile_options(-fno-omit-frame-pointer)
 endif()
 
 # try to ensure some compiler sanity

--- a/rpmio/expression.c
+++ b/rpmio/expression.c
@@ -274,7 +274,7 @@ static const char *prToken(int val)
 }
 #endif	/* DEBUG_PARSER */
 
-#define RPMEXPR_DISCARD		(1 << 31)	/* internal, discard result */
+#define RPMEXPR_DISCARD	((unsigned)1 << 31)	/* internal, discard result */
 
 static char *getValuebuf(ParseState state, const char *p, size_t size)
 {

--- a/tests/Dockerfile.fedora
+++ b/tests/Dockerfile.fedora
@@ -50,6 +50,7 @@ RUN dnf -y install \
   fsverity-utils fsverity-utils-devel \
   pandoc \
   libasan \
+  libubsan \
   && dnf clean all
 RUN echo "%_dbpath $(rpm --eval '%_dbpath')" > /root/.rpmmacros
 
@@ -79,6 +80,7 @@ ENV CFLAGS="-Og -g"
 RUN cmake \
 	-DENABLE_WERROR=ON \
 	-DENABLE_ASAN=ON \
+	-DENABLE_UBSAN=ON \
 	-DENABLE_BDB_RO=ON \
 	-DWITH_FSVERITY=ON \
 	-DWITH_IMAEVM=ON \


### PR DESCRIPTION
Similar to ASAN, now that we can this is a nice and cheap way to keep compiler gremlins at bay.