### PR TITLE
Introduce an rpm-controlled per-build directory

### DIFF
--- a/build/files.c
+++ b/build/files.c
@@ -1655,7 +1655,7 @@ static rpmRC processMetadataFile(Package pkg, FileList fl,
 	fn = rpmGenPath(fl->buildRoot, NULL, fileName);
 	absolute = 1;
     } else
-	fn = rpmGenPath("%{_builddir}", "%{?buildsubdir}", fileName);
+	fn = rpmGenPath("%{builddir}", "%{?buildsubdir}", fileName);
 
     switch (tag) {
     default:
@@ -2245,7 +2245,7 @@ int readManifest(rpmSpec spec, const char *path, const char *descr, int flags,
     if (*path == '/') {
 	fn = rpmGetPath(path, NULL);
     } else {
-	fn = rpmGenPath("%{_builddir}", "%{?buildsubdir}", path);
+	fn = rpmGenPath("%{builddir}", "%{?buildsubdir}", path);
     }
     fd = fopen(fn, "r");
 
@@ -2389,7 +2389,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     char *mkdocdir = rpmExpand("%{__mkdir_p} $", sdenv, NULL);
     StringBuf docScript = newStringBuf();
     int count = sd->entriesCount;
-    char *basepath = rpmGenPath(spec->rootDir, "%{_builddir}", "%{?buildsubdir}");
+    char *basepath = rpmGenPath(spec->rootDir, "%{builddir}", "%{?buildsubdir}");
     ARGV_t *files = xmalloc(sizeof(*files) * count);
     int i, j;
 

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1267,28 +1267,38 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	}
     }
 
-    /* 
-     * Expand buildroot one more time to get %{version} and the like
-     * from the main package, validate sanity. The spec->buildRoot could
-     * still contain unexpanded macros but it cannot be empty or '/', and it
-     * can't be messed with by anything spec does beyond this point.
-     */
     if (initialPackage) {
 	if (checkForRequiredForBuild(pkg->header)) {
 	    goto exit;
 	}
 
-	char *buildRoot = rpmGetPath(spec->buildRoot, NULL);
-	free(spec->buildRoot);
-	spec->buildRoot = buildRoot;
-	rpmPushMacro(spec->macros, "buildroot", NULL, spec->buildRoot, RMIL_SPEC);
-	if (*buildRoot == '\0') {
-	    rpmlog(RPMLOG_ERR, _("%%{buildroot} couldn't be empty\n"));
-	    goto exit;
-	}
-	if (rstreq(buildRoot, "/")) {
-	    rpmlog(RPMLOG_ERR, _("%%{buildroot} can not be \"/\"\n"));
-	    goto exit;
+	if (!spec->buildDir) {
+	    /* Grab top builddir on first entry as we'll override _builddir */
+	    if (!rpmMacroIsDefined(spec->macros, "_top_builddir")) {
+		char *top_builddir = rpmExpand("%{_builddir}", NULL);
+		rpmPushMacroFlags(spec->macros, "_top_builddir", NULL,
+				top_builddir, RMIL_GLOBAL, RPMMACRO_LITERAL);
+		free(top_builddir);
+	    }
+
+	    /* Using release here causes a buildid no-recompute test to fail */
+	    spec->buildDir = rpmExpand("%{_top_builddir}/%{NAME}-%{VERSION}-%{_arch}", NULL);
+	    /* Override toplevel _builddir for backwards compatibility */
+	    rpmPushMacroFlags(spec->macros, "_builddir", NULL, spec->buildDir,
+				RMIL_SPEC, RPMMACRO_LITERAL);
+
+	    /* A user-oriented, unambiguous name for the thing */
+	    rpmPushMacroFlags(spec->macros, "builddir", NULL, spec->buildDir,
+				RMIL_SPEC, RPMMACRO_LITERAL);
+
+	    spec->buildRoot = rpmGetPath(spec->buildDir, "/BUILDROOT", NULL);
+	    rpmPushMacroFlags(spec->macros, "buildroot", NULL, spec->buildRoot,
+				RMIL_SPEC, RPMMACRO_LITERAL);
+
+	    char *specparts = rpmGetPath(spec->buildDir, "/SPECPARTS", NULL);
+	    rpmPushMacroFlags(spec->macros, "specpartsdir", NULL, specparts,
+				RMIL_SPEC, RPMMACRO_LITERAL);
+	    free(specparts);
 	}
     }
 

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -994,7 +994,7 @@ exit:
 }
 
 static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
-			 const char *buildRoot, int recursing);
+			 int recursing);
 
 static rpmRC parseSpecSection(rpmSpec *specptr, int secondary)
 {
@@ -1124,7 +1124,7 @@ static rpmRC parseSpecSection(rpmSpec *specptr, int secondary)
 		if (!rpmMachineScore(RPM_MACHTABLE_BUILDARCH, spec->BANames[x]))
 		    continue;
 		rpmPushMacro(NULL, "_target_cpu", NULL, spec->BANames[x], RMIL_RPMRC);
-		spec->BASpecs[index] = parseSpec(spec->specFile, spec->flags, spec->buildRoot, 1);
+		spec->BASpecs[index] = parseSpec(spec->specFile, spec->flags, 1);
 		if (spec->BASpecs[index] == NULL) {
 			spec->BACount = index;
 			goto errxit;
@@ -1190,7 +1190,7 @@ errxit:
 
 
 static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
-			 const char *buildRoot, int recursing)
+			 int recursing)
 {
     rpmSpec spec;
 
@@ -1199,12 +1199,7 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 
     spec->specFile = rpmGetPath(specFile, NULL);
     pushOFI(spec, spec->specFile);
-    /* If buildRoot not specified, use default %{buildroot} */
-    if (buildRoot) {
-	spec->buildRoot = xstrdup(buildRoot);
-    } else {
-	spec->buildRoot = rpmGetPath("%{?buildroot:%{buildroot}}", NULL);
-    }
+
     rpmPushMacro(NULL, "_docdir", NULL, "%{_defaultdocdir}", RMIL_SPEC);
     rpmPushMacro(NULL, "_licensedir", NULL, "%{_defaultlicensedir}", RMIL_SPEC);
     spec->recursing = recursing;
@@ -1292,7 +1287,7 @@ static rpmRC finalizeSpec(rpmSpec spec)
 rpmSpec rpmSpecParse(const char *specFile, rpmSpecFlags flags,
 		     const char *buildRoot)
 {
-    rpmSpec spec = parseSpec(specFile, flags, buildRoot, 0);
+    rpmSpec spec = parseSpec(specFile, flags, 0);
     if (spec && !(flags & RPMSPEC_NOFINALIZE)) {
 	finalizeSpec(spec);
     }

--- a/build/policies.c
+++ b/build/policies.c
@@ -155,7 +155,7 @@ static ModuleRec newModule(const char *path, const char *name,
     ModuleRec mod;
     uint8_t *raw = NULL;
     ssize_t rawlen = 0;
-    const char *buildDir = "%{_builddir}/%{?buildsubdir}/";
+    const char *buildDir = "%{builddir}/%{?buildsubdir}/";
 
     if (!path) {
 	rpmlog(RPMLOG_ERR, _("%%semodule requires a file path\n"));

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -115,6 +115,7 @@ struct rpmSpec_s {
 
     char * specFile;	/*!< Name of the spec file. */
     char * buildRoot;
+    char * buildDir;
     const char * rootDir;
 
     struct OpenFileInfo * fileStack;

--- a/build/spec.c
+++ b/build/spec.c
@@ -234,6 +234,7 @@ rpmSpec newSpec(void)
     spec->sourcePackage = NULL;
     
     spec->buildRoot = NULL;
+    spec->buildDir = NULL;
 
     spec->buildRestrictions = headerNew();
     spec->BANames = NULL;
@@ -260,6 +261,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     freeStringBuf(spec->parsed);
 
     spec->buildRoot = _free(spec->buildRoot);
+    spec->buildDir = _free(spec->buildDir);
     spec->specFile = _free(spec->specFile);
 
     closeSpec(spec);
@@ -298,7 +300,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     spec->pool = rpmstrPoolFree(spec->pool);
 
     spec->buildHost = _free(spec->buildHost);
-    
+
     spec = _free(spec);
 
     return spec;

--- a/docs/manual/buildprocess.md
+++ b/docs/manual/buildprocess.md
@@ -10,6 +10,7 @@ title: rpm.org - Package Build Process
 * Parse the [spec](spec.md)
   * If  buildarch detected parse spec multiple times - once for each arch with `_target_cpu` macro set
   * Build will iterate over all the spec variants and build multiple versions
+* Execute internal `%mkbuilddir` script to create `%builddir`
 * Check static build requires
 * Execute present [build scriptlets](spec.md#build-scriptlets)
   * `%prep`

--- a/docs/manual/dynamic_specs.md
+++ b/docs/manual/dynamic_specs.md
@@ -13,9 +13,8 @@ build results.
 
 The files need to be placed in the **%{specpartsdir}** (also available
 as **$RPM_SPECPARTS_DIR** in the build scripts) and have a
-**.specpart** postfix. The directory is created by **%setup**. Default
-location is **%{_builddir}/%{buildsubdir}-SPECPARTS** which is beside
-the **%{buildsubdir}**. Scripts must not create it themselves but must
+**.specpart** postfix. The directory is created by **%setup**.
+Scripts must not create it themselves but must
 either fail if it is not present or switch to an alternative that does
 not require the feature. They should give an error message that
 dynamic spec generation is not supported on the given RPM version when

--- a/include/rpm/rpmbuild.h
+++ b/include/rpm/rpmbuild.h
@@ -38,6 +38,7 @@ enum rpmBuildFlags_e {
     RPMBUILD_BUILDREQUIRES	= (1 <<  20), /*!< Execute %%buildrequires. */
     RPMBUILD_DUMPBUILDREQUIRES	= (1 <<  21), /*!< Write buildrequires.nosrc.rpm. */
     RPMBUILD_CONF	= (1 << 22),	/*!< Execute %%conf. */
+    RPMBUILD_MKBUILDDIR	= (1 << 23),	/*!< Internal use only */
 
     RPMBUILD_NOBUILD	= (1 << 31)	/*!< Don't execute or package. */
 };
@@ -77,7 +78,7 @@ typedef	struct rpmBuildArguments_s *	BTA_t;
  *
  * @param specFile	path to spec file
  * @param flags		flags to control operation
- * @param buildRoot	buildRoot override or NULL for default
+ * @param buildRoot	unused
  * @return		new spec control structure
  */
 rpmSpec rpmSpecParse(const char *specFile, rpmSpecFlags flags,

--- a/macros.in
+++ b/macros.in
@@ -165,7 +165,7 @@
     %{?_find_debuginfo_dwz_opts} \\\
     %{?_find_debuginfo_opts} \\\
     %{?_debugsource_packages:-S debugsourcefiles.list} \\\
-    "%{_builddir}/%{?buildsubdir}"\
+    "%{builddir}/%{?buildsubdir}"\
 %{nil}
 
 #	Template for debug information sub-package.
@@ -266,15 +266,6 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	The directory where newly built source packages will be written.
 %_srcrpmdir		%{_topdir}/SRPMS
 
-#	The directory where buildroots will be created.
-%_buildrootdir		%{_topdir}/BUILDROOT
-
-#	Build root path, where %install installs the package during build.
-%buildroot		%{_buildrootdir}/%{NAME}-%{VERSION}-%{RELEASE}.%{_arch}
-
-#	Path for spec file snippets generated during build
-%specpartsdir %{_builddir}/%{buildsubdir}-SPECPARTS
-
 #	Directory where temporaray files can be created.
 %_tmppath		%{_var}/tmp
 
@@ -286,7 +277,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	Macros that are initialized as a side effect of rpmrc and/or spec
 #	file parsing.
 #
-#	The sub-directory (relative to %{_builddir}) where sources are compiled.
+#	The sub-directory (relative to %{builddir}) where sources are compiled.
 #	This macro is set after processing %setup, either explicitly from the
 #	value given to -n or the default name-version.
 #
@@ -763,7 +754,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %___build_cmd		%{?_sudo:%{_sudo} }%{?_remsh:%{_remsh} %{_remhost} }%{?_remsudo:%{_remsudo} }%{?_remchroot:%{_remchroot} %{_remroot} }%{___build_shell} %{___build_args}
 %___build_pre_env \
   RPM_SOURCE_DIR=\"%{_sourcedir}\"\
-  RPM_BUILD_DIR=\"%{_builddir}\"\
+  RPM_BUILD_DIR=\"%{builddir}\"\
   RPM_OPT_FLAGS=\"%{optflags}\"\
   RPM_LD_FLAGS=\"%{?build_ldflags}\"\
   RPM_ARCH=\"%{_arch}\"\
@@ -793,7 +784,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
   %{___build_pre_env} \
   %[%{verbose}?"set -x":""]\
   umask 022\
-  cd \"%{_builddir}\"\
+  cd \"%{builddir}\"\
 
 
 #%___build_body		%{nil}
@@ -815,6 +806,14 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # ---- Scriptlet templates.
 #	Macro(s) that expand to a command and script that is executed.
 #
+%__spec_builddir_shell	%{nil}
+%__spec_builddir_args	%{nil}
+%__spec_builddir_cmd	%{nil}
+%__spec_builddir_pre	%{nil}
+%__spec_builddir_body   %{%nil}
+%__spec_builddir_post	%{nil}
+%__spec_builddir_template %{nil}
+
 %__spec_prep_shell	%{___build_shell}
 %__spec_prep_args	%{___build_args}
 %__spec_prep_cmd	%{___build_cmd}

--- a/tests/data/SPECS/simple.spec
+++ b/tests/data/SPECS/simple.spec
@@ -1,3 +1,5 @@
+%bcond setup 0
+
 Name:           simple
 Version:        1.0
 Release:        1
@@ -5,18 +7,26 @@ Summary:        Simple test package
 Group:		Testing
 License:        GPL
 BuildArch:	noarch
+Source:		source-noroot.tar.gz
 
 %description
 %{summary}
 
-%install
-mkdir -p $RPM_BUILD_ROOT/opt/bin
-cat << EOF > $RPM_BUILD_ROOT/opt/bin/simple
+%if %{with setup}
+%prep
+%setup -C
+%endif
+
+%build
+cat << EOF > simple
 #!/bin/sh
 echo yay
 EOF
+chmod a+x simple
 
-chmod a+x $RPM_BUILD_ROOT/opt/bin/simple
+%install
+mkdir -p $RPM_BUILD_ROOT/opt/bin
+cp simple $RPM_BUILD_ROOT/opt/bin/
 
 %post
 touch /var/lib/simple

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -92,7 +92,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bp /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 ],
 [])
 
@@ -108,7 +109,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -br /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 ],
 [])
@@ -117,7 +119,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bd /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 ],
 [])
@@ -126,7 +129,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bf /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 ],
@@ -135,7 +139,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bc /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -146,7 +151,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bi /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -159,7 +165,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bb /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -174,7 +181,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -ba /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%mkbuilddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -209,6 +217,51 @@ CCC
 DDD
 ],
 [])
+RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild dir layout])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+run rpmbuild \
+	-bi --target noarch --quiet \
+	${RPMDATA}/SPECS/simple.spec
+runroot_other find /build/BUILD|sort
+],
+[0],
+[/build/BUILD
+/build/BUILD/simple-1.0-noarch
+/build/BUILD/simple-1.0-noarch/BUILDROOT
+/build/BUILD/simple-1.0-noarch/BUILDROOT/opt
+/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin
+/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-noarch/simple
+],
+[ignore])
+
+RPMTEST_CHECK([
+run rpmbuild \
+	-bi --target noarch --quiet \
+	--with setup \
+	${RPMDATA}/SPECS/simple.spec
+runroot_other find /build/BUILD|sort
+],
+[0],
+[/build/BUILD
+/build/BUILD/simple-1.0-noarch
+/build/BUILD/simple-1.0-noarch/BUILDROOT
+/build/BUILD/simple-1.0-noarch/BUILDROOT/opt
+/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin
+/build/BUILD/simple-1.0-noarch/BUILDROOT/opt/bin/simple
+/build/BUILD/simple-1.0-noarch/SPECPARTS
+/build/BUILD/simple-1.0-noarch/simple-1.0
+/build/BUILD/simple-1.0-noarch/simple-1.0/dir1
+/build/BUILD/simple-1.0-noarch/simple-1.0/dir1/file3
+/build/BUILD/simple-1.0-noarch/simple-1.0/file1
+/build/BUILD/simple-1.0-noarch/simple-1.0/file2
+/build/BUILD/simple-1.0-noarch/simple-1.0/simple
+],
+[ignore])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -ba autosetup])
@@ -2296,17 +2349,17 @@ runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 ],
 [1],
 [],
-[error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/CREDITS
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/foo
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/bar{a,b}
-cp: cannot stat '/build/BUILD/INSTALL': No such file or directory
-cp: cannot stat '/build/BUILD/README*': No such file or directory
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/INSTALL
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/README*
-cp: cannot stat '/build/BUILD/LICENSE': No such file or directory
-cp: cannot stat '/build/BUILD/OTHERLICENSE?': No such file or directory
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/LICENSE
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
+[error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/doc/filemisstest-1.0/CREDITS
+error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/foo
+error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/bar{a,b}
+cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/INSTALL': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/README*': No such file or directory
+error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/doc/filemisstest-1.0/INSTALL
+error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/doc/filemisstest-1.0/README*
+cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/LICENSE': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-x86_64/OTHERLICENSE?': No such file or directory
+error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/licenses/filemisstest-1.0/LICENSE
+error: File not found: /build/BUILD/filemisstest-1.0-x86_64/BUILDROOT/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
 ],
 )
 RPMTEST_CLEANUP

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -299,6 +299,7 @@ runroot rpmspec --parse \
 	--define "__patch /usr/bin/patch" \
 	--define "__chmod /usr/bin/chmod" \
 	--define "debug_package %{nil}" \
+	--target x86_64 \
 	/data/SPECS/hello.spec
 ],
 [0],
@@ -325,7 +326,7 @@ Prefix: /usr
 Simple rpm demonstration.
 
 %prep
-cd '/build/BUILD'
+cd '/build/BUILD/hello-1.0-x86_64'
 rm -rf 'hello-1.0'
 /usr/lib/rpm/rpmuncompress -x '/build/SOURCES/hello-1.0.tar.gz'
 STATUS=$?
@@ -333,8 +334,8 @@ if [ $STATUS -ne 0 ]; then
   exit $STATUS
 fi
 cd 'hello-1.0'
-rm -rf '/build/BUILD/hello-1.0-SPECPARTS'
-/usr/bin/mkdir -p '/build/BUILD/hello-1.0-SPECPARTS'
+rm -rf '/build/BUILD/hello-1.0-x86_64/SPECPARTS'
+/usr/bin/mkdir -p '/build/BUILD/hello-1.0-x86_64/SPECPARTS'
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 
 echo "Patch #0 (hello-1.0-modernize.patch):"

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -560,7 +560,7 @@ static int build(rpmts ts, const char * arg, BTA_t ba, const char * rcfile)
 
     /* parse up the build operators */
 
-    printf(_("Building target platforms: %s\n"), targets);
+    fprintf(stderr, _("Building target platforms: %s\n"), targets);
 
     ba->buildAmount &= ~buildCleanMask;
     for (ARGV_const_t target = build_targets; target && *target; target++) {
@@ -568,7 +568,7 @@ static int build(rpmts ts, const char * arg, BTA_t ba, const char * rcfile)
 	if (*(target + 1) == NULL)
 	    ba->buildAmount |= cleanFlags;
 
-	printf(_("Building for target %s\n"), *target);
+	fprintf(stderr, _("Building for target %s\n"), *target);
 
 	/* Read in configuration for target. */
 	rpmFreeMacros(NULL);

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -21,7 +21,6 @@ static struct rpmBuildArguments_s rpmBTArgs;
 #define	POPT_NOLANG		-1012
 #define	POPT_RMSOURCE		-1013
 #define	POPT_RMBUILD		-1014
-#define	POPT_BUILDROOT		-1015
 #define	POPT_TARGETPLATFORM	-1016
 #define	POPT_NOBUILD		-1017
 #define	POPT_RMSPEC		-1019
@@ -126,13 +125,6 @@ static void buildArgCallback( poptContext con,
     case POPT_RMSOURCE: rba->buildAmount |= RPMBUILD_RMSOURCE; break;
     case POPT_RMSPEC: rba->buildAmount |= RPMBUILD_RMSPEC; break;
     case POPT_RMBUILD: rba->buildAmount |= RPMBUILD_RMBUILD; break;
-    case POPT_BUILDROOT:
-	if (rba->buildRootOverride) {
-	    rpmlog(RPMLOG_ERR, _("buildroot already specified, ignoring %s\n"), arg);
-	    break;
-	}
-	rba->buildRootOverride = xstrdup(arg);
-	break;
     case POPT_TARGETPLATFORM:
 	argvSplit(&build_targets, arg, ",");
 	break;
@@ -251,8 +243,6 @@ static struct poptOption rpmBuildPoptTable[] = {
 	N_("build through %install (%prep, %build, then install) from <source package>"),
 	N_("<source package>") },
 
- { "buildroot", '\0', POPT_ARG_STRING, 0,  POPT_BUILDROOT,
-	N_("override build root"), "DIRECTORY" },
  { "build-in-place", '\0', 0, 0, POPT_BUILDINPLACE,
 	N_("run build in current directory"), NULL },
  { "clean", '\0', 0, 0, POPT_RMBUILD,
@@ -523,7 +513,7 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba)
     }
 
     /* Create build tree if necessary */
-    if (rpmMkdirs(root, "%{_topdir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}:%{_buildrootdir}"))
+    if (rpmMkdirs(root, "%{_topdir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}"))
 	goto exit;
 
     if ((rc = rpmSpecBuild(ts, spec, ba))) {
@@ -676,6 +666,8 @@ int main(int argc, char *argv[])
 	if (!noDeps) {
 	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
 	}
+	if (!shortCircuit)
+	    ba->buildAmount |= RPMBUILD_MKBUILDDIR;
 	break;
     case 'l':
 	ba->buildAmount |= RPMBUILD_FILECHECK;
@@ -683,8 +675,10 @@ int main(int argc, char *argv[])
     case 'r':
 	/* fallthrough */
     case 'd':
-	if (!shortCircuit)
+	if (!shortCircuit) {
 	    ba->buildAmount |= RPMBUILD_PREP;
+	    ba->buildAmount |= RPMBUILD_MKBUILDDIR;
+	}
 	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
 	ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
 	if (!noDeps)


### PR DESCRIPTION
In our ancient wacko setup, %_builddir is shared by all your packages, under which a package may create %buildsubdir - if it uses %setup that is. In other words, there's no safe and sane place for rpm to place per-build material. Introduce a new intermediate directory between the two, created in a newly added (internal) %builddir build step, to give rpm that place. This opens up all manner of opportunities, to be explored in later commits.

A new build-time macro %pkgbuilddir is added for the absolute path of this new directory, but in addition we override %_builddir to the same value for maximum compatibility with existing specs - a LOT of packages reference %{_builddir} for all sorts of (mostly bad) reasons and we don't want to deal with the carnage that would follow from breaking it. A further complication here is that defining %_builddir (along with sources etc) to current working directory is a common configuration (used eg by fedpkg and its variants) that we don't want to break either. So upon entry, we grab the pre-existing %_builddir and define %_top_builddir from it, which we can then base the %pkgbuilddir on, while preserving compatibility with both of the above scenarios.

Fixes: #2078