### PR TITLE
Proof-of-concept native support for vpath-style builds

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -198,14 +198,7 @@ rpmRC doScript(rpmSpec spec, rpmBuildFlags what, const char *name,
 	fprintf(fp, "cd '%s'\n", buildSubdir);
 
     if (what == RPMBUILD_RMBUILD) {
-	if (rpmMacroIsDefined(spec->macros, "specpartsdir")) {
-	    char * buf = rpmExpand("%{specpartsdir}", NULL);
-	    fprintf(fp, "rm -rf '%s'\n", buf);
-	    free(buf);
-	}
-	if (buildSubdir[0] != '\0')
-	    fprintf(fp, "rm -rf '%s' '%s.gemspec'\n",
-		    buildSubdir, buildSubdir);
+	fprintf(fp, "rm -rf '%s'\n", spec->buildDir);
     } else if (sb != NULL)
 	fprintf(fp, "%s", sb);
 

--- a/build/files.c
+++ b/build/files.c
@@ -2389,7 +2389,7 @@ static void processSpecialDir(rpmSpec spec, Package pkg, FileList fl,
     char *mkdocdir = rpmExpand("%{__mkdir_p} $", sdenv, NULL);
     StringBuf docScript = newStringBuf();
     int count = sd->entriesCount;
-    char *basepath = rpmGenPath(spec->rootDir, "%{_builddir}", "%{?buildsubdir}");
+    char *basepath = rpmGenPath(spec->rootDir, "%{_builddir}", "%{?sourcesubdir}");
     ARGV_t *files = xmalloc(sizeof(*files) * count);
     int i, j;
 

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1267,27 +1267,8 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	}
     }
 
-    /* 
-     * Expand buildroot one more time to get %{version} and the like
-     * from the main package, validate sanity. The spec->buildRoot could
-     * still contain unexpanded macros but it cannot be empty or '/', and it
-     * can't be messed with by anything spec does beyond this point.
-     */
     if (initialPackage) {
 	if (checkForRequiredForBuild(pkg->header)) {
-	    goto exit;
-	}
-
-	char *buildRoot = rpmGetPath(spec->buildRoot, NULL);
-	free(spec->buildRoot);
-	spec->buildRoot = buildRoot;
-	rpmPushMacro(spec->macros, "buildroot", NULL, spec->buildRoot, RMIL_SPEC);
-	if (*buildRoot == '\0') {
-	    rpmlog(RPMLOG_ERR, _("%%{buildroot} couldn't be empty\n"));
-	    goto exit;
-	}
-	if (rstreq(buildRoot, "/")) {
-	    rpmlog(RPMLOG_ERR, _("%%{buildroot} can not be \"/\"\n"));
 	    goto exit;
 	}
 
@@ -1302,6 +1283,10 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	    /* a user-oriented, unambiguous name for the thing */
 	    rpmPushMacro(spec->macros, "pkgbuilddir", NULL, spec->buildDir, RMIL_SPEC);
 	    rpmPushMacro(spec->macros, "_builddir", NULL, spec->buildDir, RMIL_SPEC);
+
+	    spec->buildRoot = rpmGetPath(spec->buildDir, "/%{_target_platform}-root", NULL);
+	    rpmPushMacro(spec->macros, "buildroot", NULL, spec->buildRoot, RMIL_SPEC
+);
 	}
     }
 

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1284,7 +1284,7 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	    rpmPushMacro(spec->macros, "pkgbuilddir", NULL, spec->buildDir, RMIL_SPEC);
 	    rpmPushMacro(spec->macros, "_builddir", NULL, spec->buildDir, RMIL_SPEC);
 
-	    spec->buildRoot = rpmGetPath(spec->buildDir, "/%{_target_platform}-root", NULL);
+	    spec->buildRoot = rpmGetPath(spec->buildDir, "/%{_target_cpu}-%{_target_os}-root", NULL);
 	    rpmPushMacro(spec->macros, "buildroot", NULL, spec->buildRoot, RMIL_SPEC
 );
 	}

--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -1290,6 +1290,19 @@ int parsePreamble(rpmSpec spec, int initialPackage)
 	    rpmlog(RPMLOG_ERR, _("%%{buildroot} can not be \"/\"\n"));
 	    goto exit;
 	}
+
+	/* Grab the top builddir on first entry as we'll override _builddir */
+	if (!rpmMacroIsDefined(spec->macros, "_top_builddir")) {
+	    rpmPushMacro(spec->macros, "_top_builddir", NULL, "%{_builddir}",
+			RMIL_GLOBAL);
+	}
+
+	if (!spec->buildDir) {
+	    spec->buildDir = rpmExpand("%{_top_builddir}/%{NAME}-%{VERSION}-PKG", NULL);
+	    /* a user-oriented, unambiguous name for the thing */
+	    rpmPushMacro(spec->macros, "pkgbuilddir", NULL, spec->buildDir, RMIL_SPEC);
+	    rpmPushMacro(spec->macros, "_builddir", NULL, spec->buildDir, RMIL_SPEC);
+	}
     }
 
     /* if we get down here nextPart has been set to non-error */

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -994,7 +994,7 @@ exit:
 }
 
 static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
-			 const char *buildRoot, int recursing);
+			 int recursing);
 
 static rpmRC parseSpecSection(rpmSpec *specptr, int secondary)
 {
@@ -1124,7 +1124,7 @@ static rpmRC parseSpecSection(rpmSpec *specptr, int secondary)
 		if (!rpmMachineScore(RPM_MACHTABLE_BUILDARCH, spec->BANames[x]))
 		    continue;
 		rpmPushMacro(NULL, "_target_cpu", NULL, spec->BANames[x], RMIL_RPMRC);
-		spec->BASpecs[index] = parseSpec(spec->specFile, spec->flags, spec->buildRoot, 1);
+		spec->BASpecs[index] = parseSpec(spec->specFile, spec->flags, 1);
 		if (spec->BASpecs[index] == NULL) {
 			spec->BACount = index;
 			goto errxit;
@@ -1190,7 +1190,7 @@ errxit:
 
 
 static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
-			 const char *buildRoot, int recursing)
+			 int recursing)
 {
     rpmSpec spec;
 
@@ -1199,12 +1199,7 @@ static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 
     spec->specFile = rpmGetPath(specFile, NULL);
     pushOFI(spec, spec->specFile);
-    /* If buildRoot not specified, use default %{buildroot} */
-    if (buildRoot) {
-	spec->buildRoot = xstrdup(buildRoot);
-    } else {
-	spec->buildRoot = rpmGetPath("%{?buildroot:%{buildroot}}", NULL);
-    }
+
     rpmPushMacro(NULL, "_docdir", NULL, "%{_defaultdocdir}", RMIL_SPEC);
     rpmPushMacro(NULL, "_licensedir", NULL, "%{_defaultlicensedir}", RMIL_SPEC);
     spec->recursing = recursing;
@@ -1292,7 +1287,7 @@ static rpmRC finalizeSpec(rpmSpec spec)
 rpmSpec rpmSpecParse(const char *specFile, rpmSpecFlags flags,
 		     const char *buildRoot)
 {
-    rpmSpec spec = parseSpec(specFile, flags, buildRoot, 0);
+    rpmSpec spec = parseSpec(specFile, flags, 0);
     if (spec && !(flags & RPMSPEC_NOFINALIZE)) {
 	finalizeSpec(spec);
     }

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -115,6 +115,7 @@ struct rpmSpec_s {
 
     char * specFile;	/*!< Name of the spec file. */
     char * buildRoot;
+    char * buildDir;
     const char * rootDir;
 
     struct OpenFileInfo * fileStack;

--- a/build/spec.c
+++ b/build/spec.c
@@ -234,6 +234,7 @@ rpmSpec newSpec(void)
     spec->sourcePackage = NULL;
     
     spec->buildRoot = NULL;
+    spec->buildDir = NULL;
 
     spec->buildRestrictions = headerNew();
     spec->BANames = NULL;
@@ -260,6 +261,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     freeStringBuf(spec->parsed);
 
     spec->buildRoot = _free(spec->buildRoot);
+    spec->buildDir = _free(spec->buildDir);
     spec->specFile = _free(spec->specFile);
 
     closeSpec(spec);
@@ -298,7 +300,7 @@ rpmSpec rpmSpecFree(rpmSpec spec)
     spec->pool = rpmstrPoolFree(spec->pool);
 
     spec->buildHost = _free(spec->buildHost);
-    
+
     spec = _free(spec);
 
     return spec;

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -510,6 +510,7 @@ can just create the directory. It accepts a number of options:
 -D          do not delete the build directory prior to unpacking (used
             when more than one source is to be unpacked with `-a` or `-b`)
 -n DIR      set the name of build directory (default is `%{name}-%{version}`)
+-s          use separate source and build directories (aka vpath build)
 -T          skip the default unpacking of the first source (used with
             `-a` or `-b`)
 -q          operate quietly

--- a/include/rpm/rpmbuild.h
+++ b/include/rpm/rpmbuild.h
@@ -78,7 +78,7 @@ typedef	struct rpmBuildArguments_s *	BTA_t;
  *
  * @param specFile	path to spec file
  * @param flags		flags to control operation
- * @param buildRoot	buildRoot override or NULL for default
+ * @param buildRoot	unused
  * @return		new spec control structure
  */
 rpmSpec rpmSpecParse(const char *specFile, rpmSpecFlags flags,

--- a/include/rpm/rpmbuild.h
+++ b/include/rpm/rpmbuild.h
@@ -38,6 +38,7 @@ enum rpmBuildFlags_e {
     RPMBUILD_BUILDREQUIRES	= (1 <<  20), /*!< Execute %%buildrequires. */
     RPMBUILD_DUMPBUILDREQUIRES	= (1 <<  21), /*!< Write buildrequires.nosrc.rpm. */
     RPMBUILD_CONF	= (1 << 22),	/*!< Execute %%conf. */
+    RPMBUILD_BUILDDIR	= (1 << 23),	/*!< Internal use only */
 
     RPMBUILD_NOBUILD	= (1 << 31)	/*!< Don't execute or package. */
 };

--- a/macros.in
+++ b/macros.in
@@ -1034,7 +1034,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # directory structure (--prefix, --libdir etc) and compiler flags
 # such as CFLAGS.
 #
-%_configure ./configure
+%_configure %{_builddir}/%{sourcesubdir}/configure
 %configure \
   %{set_build_flags}; \
   %{_configure} --host=%{_host} --build=%{_build} \\\
@@ -1309,8 +1309,8 @@ end
 #           	usage of git repository and per-patch commits.
 # -N		Disable automatic patch application
 # -p<num>	Use -p<num> for patch application	
-%autosetup(a:b:cCDn:TvNS:p:)\
-%setup %{-a} %{-b} %{-c} %{-C} %{-D} %{-n} %{-T} %{!-v:-q}\
+%autosetup(a:b:cCDn:TvNS:p:s)\
+%setup %{-a} %{-b} %{-c} %{-C} %{-D} %{-n} %{-T} %{!-v:-q} %{-s}\
 %{-S:%global __scm %{-S*}}\
 %{expand:%__scm_setup_%{__scm} %{!-v:-q}}\
 %{!-N:%autopatch %{-v} %{-p:-p%{-p*}}}

--- a/macros.in
+++ b/macros.in
@@ -264,12 +264,6 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #	The directory where newly built source packages will be written.
 %_srcrpmdir		%{_topdir}/SRPMS
 
-#	The directory where buildroots will be created.
-%_buildrootdir		%{_topdir}/BUILDROOT
-
-#	Build root path, where %install installs the package during build.
-%buildroot		%{_buildrootdir}/%{NAME}-%{VERSION}-%{RELEASE}.%{_arch}
-
 #	Path for spec file snippets generated during build
 %specpartsdir %{_builddir}/%{buildsubdir}-SPECPARTS
 

--- a/macros.in
+++ b/macros.in
@@ -813,6 +813,14 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 # ---- Scriptlet templates.
 #	Macro(s) that expand to a command and script that is executed.
 #
+%__spec_builddir_shell	%{nil}
+%__spec_builddir_args	%{nil}
+%__spec_builddir_cmd	%{nil}
+%__spec_builddir_pre	%{nil}
+%__spec_builddir_body   %{%nil}
+%__spec_builddir_post	%{nil}
+%__spec_builddir_template %{nil}
+
 %__spec_prep_shell	%{___build_shell}
 %__spec_prep_args	%{___build_args}
 %__spec_prep_cmd	%{___build_cmd}

--- a/macros.in
+++ b/macros.in
@@ -265,7 +265,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %_srcrpmdir		%{_topdir}/SRPMS
 
 #	Path for spec file snippets generated during build
-%specpartsdir %{_builddir}/%{buildsubdir}-SPECPARTS
+%specpartsdir %{_builddir}/SPECPARTS
 
 #	Directory where temporaray files can be created.
 %_tmppath		%{_var}/tmp

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2252,17 +2252,17 @@ runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 ],
 [1],
 [],
-[error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/doc/filemisstest-1.0/CREDITS
-error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/foo
-error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/bar{a,b}
+[error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/share/doc/filemisstest-1.0/CREDITS
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/foo
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/bar{a,b}
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/INSTALL': No such file or directory
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/README*': No such file or directory
-error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/doc/filemisstest-1.0/INSTALL
-error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/doc/filemisstest-1.0/README*
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/share/doc/filemisstest-1.0/INSTALL
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/share/doc/filemisstest-1.0/README*
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/LICENSE': No such file or directory
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/OTHERLICENSE?': No such file or directory
-error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/licenses/filemisstest-1.0/LICENSE
-error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/share/licenses/filemisstest-1.0/LICENSE
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-linux-root/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
 ],
 )
 RPMTEST_CLEANUP

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -92,7 +92,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bp /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 ],
 [])
 
@@ -108,7 +109,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -br /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 ],
 [])
@@ -117,7 +119,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bd /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 ],
 [])
@@ -126,7 +129,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bf /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 ],
@@ -135,7 +139,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bc /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -146,7 +151,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bi /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -159,7 +165,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -bb /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -174,7 +181,8 @@ RPMTEST_CHECK([
 runroot rpmbuild -ba /data/SPECS/specstep.spec 2>&1|grep ^Executing|cut -d: -f1
 ],
 [0],
-[Executing(%prep)
+[Executing(%builddir)
+Executing(%prep)
 Executing(%generate_buildrequires)
 Executing(%conf)
 Executing(%build)
@@ -2247,12 +2255,12 @@ runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 [error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/CREDITS
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/foo
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/bar{a,b}
-cp: cannot stat '/build/BUILD/INSTALL': No such file or directory
-cp: cannot stat '/build/BUILD/README*': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/INSTALL': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/README*': No such file or directory
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/INSTALL
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/README*
-cp: cannot stat '/build/BUILD/LICENSE': No such file or directory
-cp: cannot stat '/build/BUILD/OTHERLICENSE?': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/LICENSE': No such file or directory
+cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/OTHERLICENSE?': No such file or directory
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/LICENSE
 error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
 ],

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2252,17 +2252,17 @@ runroot rpmbuild -bb --quiet /data/SPECS/filemiss.spec
 ],
 [1],
 [],
-[error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/CREDITS
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/foo
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/bar{a,b}
+[error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/doc/filemisstest-1.0/CREDITS
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/foo
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/bar{a,b}
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/INSTALL': No such file or directory
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/README*': No such file or directory
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/INSTALL
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/doc/filemisstest-1.0/README*
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/doc/filemisstest-1.0/INSTALL
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/doc/filemisstest-1.0/README*
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/LICENSE': No such file or directory
 cp: cannot stat '/build/BUILD/filemisstest-1.0-PKG/OTHERLICENSE?': No such file or directory
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/LICENSE
-error: File not found: /build/BUILDROOT/filemisstest-1.0-1.x86_64/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/licenses/filemisstest-1.0/LICENSE
+error: File not found: /build/BUILD/filemisstest-1.0-PKG/noarch-redhat-linux-root/opt/share/licenses/filemisstest-1.0/OTHERLICENSE?
 ],
 )
 RPMTEST_CLEANUP

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -333,8 +333,8 @@ if [ $STATUS -ne 0 ]; then
   exit $STATUS
 fi
 cd 'hello-1.0'
-rm -rf '/build/BUILD/hello-1.0-PKG/hello-1.0-SPECPARTS'
-/usr/bin/mkdir -p '/build/BUILD/hello-1.0-PKG/hello-1.0-SPECPARTS'
+rm -rf '/build/BUILD/hello-1.0-PKG/SPECPARTS'
+/usr/bin/mkdir -p '/build/BUILD/hello-1.0-PKG/SPECPARTS'
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 
 echo "Patch #0 (hello-1.0-modernize.patch):"

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -325,7 +325,7 @@ Prefix: /usr
 Simple rpm demonstration.
 
 %prep
-cd '/build/BUILD'
+cd '/build/BUILD/hello-1.0-PKG'
 rm -rf 'hello-1.0'
 /usr/lib/rpm/rpmuncompress -x '/build/SOURCES/hello-1.0.tar.gz'
 STATUS=$?
@@ -333,8 +333,8 @@ if [ $STATUS -ne 0 ]; then
   exit $STATUS
 fi
 cd 'hello-1.0'
-rm -rf '/build/BUILD/hello-1.0-SPECPARTS'
-/usr/bin/mkdir -p '/build/BUILD/hello-1.0-SPECPARTS'
+rm -rf '/build/BUILD/hello-1.0-PKG/hello-1.0-SPECPARTS'
+/usr/bin/mkdir -p '/build/BUILD/hello-1.0-PKG/hello-1.0-SPECPARTS'
 /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
 
 echo "Patch #0 (hello-1.0-modernize.patch):"

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -335,7 +335,7 @@ fi
 cd 'hello-1.0'
 rm -rf '/build/BUILD/hello-1.0-PKG/SPECPARTS'
 /usr/bin/mkdir -p '/build/BUILD/hello-1.0-PKG/SPECPARTS'
-/usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+/usr/bin/chmod -Rf a+rX,u+w,g-w,o-w /build/BUILD/hello-1.0-PKG/hello-1.0
 
 echo "Patch #0 (hello-1.0-modernize.patch):"
 /usr/bin/patch --no-backup-if-mismatch -f -p1 -b --suffix .modernize --fuzz=0 < /build/SOURCES/hello-1.0-modernize.patch

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -21,7 +21,6 @@ static struct rpmBuildArguments_s rpmBTArgs;
 #define	POPT_NOLANG		-1012
 #define	POPT_RMSOURCE		-1013
 #define	POPT_RMBUILD		-1014
-#define	POPT_BUILDROOT		-1015
 #define	POPT_TARGETPLATFORM	-1016
 #define	POPT_NOBUILD		-1017
 #define	POPT_RMSPEC		-1019
@@ -126,13 +125,6 @@ static void buildArgCallback( poptContext con,
     case POPT_RMSOURCE: rba->buildAmount |= RPMBUILD_RMSOURCE; break;
     case POPT_RMSPEC: rba->buildAmount |= RPMBUILD_RMSPEC; break;
     case POPT_RMBUILD: rba->buildAmount |= RPMBUILD_RMBUILD; break;
-    case POPT_BUILDROOT:
-	if (rba->buildRootOverride) {
-	    rpmlog(RPMLOG_ERR, _("buildroot already specified, ignoring %s\n"), arg);
-	    break;
-	}
-	rba->buildRootOverride = xstrdup(arg);
-	break;
     case POPT_TARGETPLATFORM:
 	argvSplit(&build_targets, arg, ",");
 	break;
@@ -251,8 +243,6 @@ static struct poptOption rpmBuildPoptTable[] = {
 	N_("build through %install (%prep, %build, then install) from <source package>"),
 	N_("<source package>") },
 
- { "buildroot", '\0', POPT_ARG_STRING, 0,  POPT_BUILDROOT,
-	N_("override build root"), "DIRECTORY" },
  { "build-in-place", '\0', 0, 0, POPT_BUILDINPLACE,
 	N_("run build in current directory"), NULL },
  { "clean", '\0', 0, 0, POPT_RMBUILD,
@@ -523,7 +513,7 @@ static int buildForTarget(rpmts ts, const char * arg, BTA_t ba)
     }
 
     /* Create build tree if necessary */
-    if (rpmMkdirs(root, "%{_topdir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}:%{_buildrootdir}"))
+    if (rpmMkdirs(root, "%{_topdir}:%{_builddir}:%{_rpmdir}:%{_srcrpmdir}"))
 	goto exit;
 
     if ((rc = rpmSpecBuild(ts, spec, ba))) {

--- a/tools/rpmbuild.c
+++ b/tools/rpmbuild.c
@@ -676,6 +676,8 @@ int main(int argc, char *argv[])
 	if (!noDeps) {
 	    ba->buildAmount |= RPMBUILD_CHECKBUILDREQUIRES;
 	}
+	if (!shortCircuit)
+	    ba->buildAmount |= RPMBUILD_BUILDDIR;
 	break;
     case 'l':
 	ba->buildAmount |= RPMBUILD_FILECHECK;
@@ -683,8 +685,10 @@ int main(int argc, char *argv[])
     case 'r':
 	/* fallthrough */
     case 'd':
-	if (!shortCircuit)
+	if (!shortCircuit) {
 	    ba->buildAmount |= RPMBUILD_PREP;
+	    ba->buildAmount |= RPMBUILD_BUILDDIR;
+	}
 	ba->buildAmount |= RPMBUILD_BUILDREQUIRES;
 	ba->buildAmount |= RPMBUILD_DUMPBUILDREQUIRES;
 	if (!noDeps)


### PR DESCRIPTION
Add a new %setup switch -s to indicate building in a directory outside the source directory, known as vpath build in some circles. Add a new %{sourcesubdir} macro which by default equals %{buildsubdir}, but when -s is used, we create and switch to a separate directory after unpacking.

A one gotcha here is that special %doc and %license has traditionally worked for both built and pre-existing content. With build and source trees separated, both cannot work. As special %doc/%license is mostly used for things like README's and COPYING which come as part of the source, we define %doc on vpath builds to mean source directory, and assume built content has its own means of installing (eg make install-doc).

Another potential issue is that we redefine %_configure to an absolute path in the sourcesubdir, this would break some unusual cases where %configure is used to invoke a configure-script outside the project top directory. It's mainly redefined here to make testing -s on an autotools project easy, a final implementation might do something else.