### PR TITLE
Run build scriptlets with closed stdin to enforce unattended builds

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -310,9 +310,14 @@ static int getOutputFrom(ARGV_t argv,
     if (child == 0) {
 	close(toProg[1]);
 	close(fromProg[0]);
-	
-	dup2(toProg[0], STDIN_FILENO);   /* Make stdin the in pipe */
-	close(toProg[0]);
+
+	if (writePtr) {
+	    /* Make stdin the in pipe */
+	    dup2(toProg[0], STDIN_FILENO);
+	    close(toProg[0]);
+	} else {
+	    close(STDIN_FILENO);
+	}
 
 	dup2(fromProg[1], STDOUT_FILENO); /* Make stdout the out pipe */
 	close(fromProg[1]);

--- a/tests/data/SPECS/interact.spec
+++ b/tests/data/SPECS/interact.spec
@@ -1,0 +1,12 @@
+Name: interact
+Version: 1.0
+Release: 1
+Summary: test
+License: Public Domain
+
+# This must abort the build
+%prep
+read EHLO
+echo hello $EHLO
+
+%files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2659,3 +2659,15 @@ rpmspec --define "nosuchmacro /bbb" --parse /data/SPECS/badftrigger.spec
 [ignore],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmbuild interactive])
+AT_KEYWORDS([build])
+RPMDB_INIT
+
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bb /data/SPECS/interact.spec
+],
+[1],
+[ignore],
+[ignore])
+RPMTEST_CLEANUP


### PR DESCRIPTION
Even max-rpm philosophy section points out that rpm builds are unattended, but then we do nothing at all to prevent it? I first though maybe this regressed when we switched the build scripts to use rpmfcExec() a few years ago, but there wasn't anything before that either. Weird.