### PR TITLE
Drop erroneous BYPRODUCTS uses from the cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,6 @@ function(add_tarball targetname namever treeish)
 
 	add_custom_target(${distname}
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		BYPRODUCTS ${distname} ${docname}
 		VERBATIM
 		DEPENDS ChangeLog ${docname} po/rpm.pot
 		COMMAND git archive

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -56,13 +56,13 @@ endforeach()
 foreach(cmd rpmverify rpmquery)
 	add_custom_target(${cmd} ALL COMMAND
 			${CMAKE_COMMAND} -E create_symlink rpm ${cmd}
-			BYPRODUCTS ${cmd})
+			)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${cmd} TYPE BIN)
 endforeach()
 if (WITH_ARCHIVE)
 	add_custom_target(rpm2cpio ALL COMMAND
 			${CMAKE_COMMAND} -E create_symlink rpm2archive rpm2cpio
-			BYPRODUCTS rpm2cpio)
+			)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rpm2cpio TYPE BIN)
 endif()
 


### PR DESCRIPTION
BYPRODUCTS is only relevant for Ninja generator which we officially don't even support, but on which these usages cause Ninja to error out with "phony target names itself as an input" messages.

I don't remember why exactly I put these BYPRODUCTS in there, but I know it was NOT to support Ninja explicitly. Probably it seemed somehow relevant to this cmake newbie and since it didn't harm anything ... on the make generator. Taking them out makes Ninja happy except for the test-suite. The make generator is still the only officially supported one though.

Reported-by: Timothy Brackett <brackett.tc@gmail.com>