### PR TITLE
Use Ninja-compatible syntax for passing TESTOPTS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,7 @@ if (MKTREE_BACKEND STREQUAL oci)
 		configure_file(${DOCKERFILE} Dockerfile COPYONLY)
 		add_custom_target(ci
 			COMMAND ./mktree.oci build
-			COMMAND ./mktree.oci check ${JOBS} $(TESTOPTS)
+			COMMAND ./mktree.oci check ${JOBS} $ENV{TESTOPTS}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		)
 	else()
@@ -143,7 +143,7 @@ add_custom_target(shell
 )
 
 add_custom_target(check
-	COMMAND ./mktree check ${JOBS} $(TESTOPTS)
+	COMMAND ./mktree check ${JOBS} $ENV{TESTOPTS}
 	DEPENDS tree
 )
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,6 +59,11 @@ For all available options, see the output of the command:
 By default, tests are executed in parallel using all available cores, pass a
 specific `-jN` value to limit.
 
+Note that when building with Ninja, TESTOPTS must be passed via the
+environment (also works with make):
+
+    TESTOPTS="..." ninja check
+
 ## Interactive testing
 
 To drop into an interactive GNU Autotest shell, run:


### PR DESCRIPTION
Ninja doesn't support passing environment as command line arguments like make does, access TESTOPTS through environment instead of the make syntax to make it work for both generators.