### PR TITLE
No build directives in generated spec parts

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -41,47 +41,48 @@ typedef struct OpenFileInfo {
 
 static const struct PartRec {
     int part;
+    int prebuildonly;
     size_t len;
     const char * token;
 } partList[] = {
-    { PART_PREAMBLE,      LEN_AND_STR("%package")},
-    { PART_PREP,          LEN_AND_STR("%prep")},
-    { PART_BUILDREQUIRES, LEN_AND_STR("%generate_buildrequires")},
-    { PART_CONF,        LEN_AND_STR("%conf")},
-    { PART_BUILD,         LEN_AND_STR("%build")},
-    { PART_INSTALL,       LEN_AND_STR("%install")},
-    { PART_CHECK,         LEN_AND_STR("%check")},
-    { PART_CLEAN,         LEN_AND_STR("%clean")},
-    { PART_PREUN,         LEN_AND_STR("%preun")},
-    { PART_POSTUN,        LEN_AND_STR("%postun")},
-    { PART_PRETRANS,      LEN_AND_STR("%pretrans")},
-    { PART_POSTTRANS,     LEN_AND_STR("%posttrans")},
-    { PART_PREUNTRANS,    LEN_AND_STR("%preuntrans")},
-    { PART_POSTUNTRANS,   LEN_AND_STR("%postuntrans")},
-    { PART_PRE,           LEN_AND_STR("%pre")},
-    { PART_POST,          LEN_AND_STR("%post")},
-    { PART_FILES,         LEN_AND_STR("%files")},
-    { PART_CHANGELOG,     LEN_AND_STR("%changelog")},
-    { PART_DESCRIPTION,   LEN_AND_STR("%description")},
-    { PART_TRIGGERPOSTUN, LEN_AND_STR("%triggerpostun")},
-    { PART_TRIGGERPREIN,  LEN_AND_STR("%triggerprein")},
-    { PART_TRIGGERUN,     LEN_AND_STR("%triggerun")},
-    { PART_TRIGGERIN,     LEN_AND_STR("%triggerin")},
-    { PART_TRIGGERIN,     LEN_AND_STR("%trigger")},
-    { PART_VERIFYSCRIPT,  LEN_AND_STR("%verifyscript")},
-    { PART_POLICIES,      LEN_AND_STR("%sepolicy")},
-    { PART_FILETRIGGERIN,	    LEN_AND_STR("%filetriggerin")},
-    { PART_FILETRIGGERIN,	    LEN_AND_STR("%filetrigger")},
-    { PART_FILETRIGGERUN,	    LEN_AND_STR("%filetriggerun")},
-    { PART_FILETRIGGERPOSTUN,	    LEN_AND_STR("%filetriggerpostun")},
-    { PART_TRANSFILETRIGGERIN,	    LEN_AND_STR("%transfiletriggerin")},
-    { PART_TRANSFILETRIGGERIN,	    LEN_AND_STR("%transfiletrigger")},
-    { PART_TRANSFILETRIGGERUN,	    LEN_AND_STR("%transfiletriggerun")},
-    { PART_TRANSFILETRIGGERPOSTUN,  LEN_AND_STR("%transfiletriggerpostun")},
-    { PART_EMPTY,		    LEN_AND_STR("%end")},
-    { PART_PATCHLIST,               LEN_AND_STR("%patchlist")},
-    { PART_SOURCELIST,              LEN_AND_STR("%sourcelist")},
-    {0, 0, 0}
+    { PART_PREAMBLE,      0, LEN_AND_STR("%package")},
+    { PART_PREP,          1, LEN_AND_STR("%prep")},
+    { PART_BUILDREQUIRES, 1, LEN_AND_STR("%generate_buildrequires")},
+    { PART_CONF,          1, LEN_AND_STR("%conf")},
+    { PART_BUILD,         1, LEN_AND_STR("%build")},
+    { PART_INSTALL,       1, LEN_AND_STR("%install")},
+    { PART_CHECK,         1, LEN_AND_STR("%check")},
+    { PART_CLEAN,         1, LEN_AND_STR("%clean")},
+    { PART_PREUN,         0, LEN_AND_STR("%preun")},
+    { PART_POSTUN,        0, LEN_AND_STR("%postun")},
+    { PART_PRETRANS,      0, LEN_AND_STR("%pretrans")},
+    { PART_POSTTRANS,     0, LEN_AND_STR("%posttrans")},
+    { PART_PREUNTRANS,    0, LEN_AND_STR("%preuntrans")},
+    { PART_POSTUNTRANS,   0, LEN_AND_STR("%postuntrans")},
+    { PART_PRE,           0, LEN_AND_STR("%pre")},
+    { PART_POST,          0, LEN_AND_STR("%post")},
+    { PART_FILES,         0, LEN_AND_STR("%files")},
+    { PART_CHANGELOG,     0, LEN_AND_STR("%changelog")},
+    { PART_DESCRIPTION,   0, LEN_AND_STR("%description")},
+    { PART_TRIGGERPOSTUN, 0, LEN_AND_STR("%triggerpostun")},
+    { PART_TRIGGERPREIN,  0, LEN_AND_STR("%triggerprein")},
+    { PART_TRIGGERUN,     0, LEN_AND_STR("%triggerun")},
+    { PART_TRIGGERIN,     0, LEN_AND_STR("%triggerin")},
+    { PART_TRIGGERIN,     0, LEN_AND_STR("%trigger")},
+    { PART_VERIFYSCRIPT,  0, LEN_AND_STR("%verifyscript")},
+    { PART_POLICIES,      0, LEN_AND_STR("%sepolicy")},
+    { PART_FILETRIGGERIN,	    0, LEN_AND_STR("%filetriggerin")},
+    { PART_FILETRIGGERIN,	    0, LEN_AND_STR("%filetrigger")},
+    { PART_FILETRIGGERUN,	    0, LEN_AND_STR("%filetriggerun")},
+    { PART_FILETRIGGERPOSTUN,	    0, LEN_AND_STR("%filetriggerpostun")},
+    { PART_TRANSFILETRIGGERIN,	    0, LEN_AND_STR("%transfiletriggerin")},
+    { PART_TRANSFILETRIGGERIN,	    0, LEN_AND_STR("%transfiletrigger")},
+    { PART_TRANSFILETRIGGERUN,	    0, LEN_AND_STR("%transfiletriggerun")},
+    { PART_TRANSFILETRIGGERPOSTUN,  0, LEN_AND_STR("%transfiletriggerpostun")},
+    { PART_EMPTY,		    0, LEN_AND_STR("%end")},
+    { PART_PATCHLIST,               1, LEN_AND_STR("%patchlist")},
+    { PART_SOURCELIST,              1, LEN_AND_STR("%sourcelist")},
+    {0, 0, 0, 0}
 };
 
 int isPart(const char *line)
@@ -98,6 +99,18 @@ int isPart(const char *line)
     }
 
     return (p->token ? p->part : PART_NONE);
+}
+
+static const struct PartRec * getPart(int part)
+{
+    const struct PartRec *p;
+
+    for (p = partList; p->token != NULL; p++) {
+	if (p->part == part) {
+	    return p;
+	}
+    }
+    return NULL;
 }
 
 /**
@@ -998,6 +1011,18 @@ exit:
 static rpmSpec parseSpec(const char *specFile, rpmSpecFlags flags,
 			 const char *buildRoot, int recursing);
 
+/* is part allowed at this stage */
+static int checkPart(int parsePart, enum parseStages stage) {
+    if (stage == PARSE_GENERATED) {
+	const struct PartRec *p = getPart(parsePart);
+	if (p && p->prebuildonly ) {
+	    rpmlog(RPMLOG_ERR, _("Section %s is not allowed after build is done!\n"), p->token);
+	    return 1;
+	}
+    }
+    return 0;
+}
+
 static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 {
     rpmSpec spec = *specptr;
@@ -1022,7 +1047,7 @@ static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 	    parsePart = parseEmpty(spec, prevParsePart);
 	    break;
 	case PART_PREAMBLE:
-	    parsePart = parsePreamble(spec, initialPackage);
+	    parsePart = parsePreamble(spec, initialPackage, stage);
 	    initialPackage = 0;
 	    break;
 	case PART_PATCHLIST:
@@ -1111,6 +1136,9 @@ static rpmRC parseSpecSection(rpmSpec *specptr, enum parseStages stage)
 	    goto errxit;
 	}
 
+	if (checkPart(parsePart, stage)) {
+	    goto errxit;
+	}
 	if (parsePart == PART_BUILDARCHITECTURES) {
 	    int index;
 	    int x;

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -21,6 +21,11 @@
 #define ALLOWED_CHARS_EVR ALLOWED_CHARS_VERREL "-:"
 #define LEN_AND_STR(_tag) (sizeof(_tag)-1), (_tag)
 
+enum parseStages {
+    PARSE_SPECFILE,
+    PARSE_BUILDSYS,
+    PARSE_GENERATED,
+};
 
 enum sections_e {
     SECT_PREP		= 0,
@@ -359,10 +364,11 @@ int parsePolicies(rpmSpec spec);
  * Parse tags from preamble of a spec file.
  * @param spec		spec file control structure
  * @param initialPackage
+ * @param stage
  * @return		>= 0 next rpmParseState, < 0 on error
  */
 RPM_GNUC_INTERNAL
-int parsePreamble(rpmSpec spec, int initialPackage);
+int parsePreamble(rpmSpec spec, int initialPackage, enum parseStages stage);
 
 /** \ingroup rpmbuild
  * Parse %%pre et al scriptlets from a spec file.

--- a/docs/manual/dynamic_specs.md
+++ b/docs/manual/dynamic_specs.md
@@ -34,3 +34,14 @@ interpreted right away.
 
 [Example](https://github.com/rpm-software-management/rpm/blob/master/tests/data/SPECS/dynamic.spec)
 from our tests set.
+
+As dynamic spec parts are generate during build they cannot include
+directives that are needed for or influence building. This includes
+all build scripts, sources and patches, Build dependencies, tags
+regarding the build environment (**ExcludeArch**, **ExclusiveArch**,
+**ExcludeOS**, **ExclusiveOS**), **BuildArch** except for declaring
+sub packages **noarch** and **BuildSystem**. These will create an
+error if encountered in a dynamically generated spec part.
+
+While declaring macros used in the build scripts are not an error they
+won't have an influence on the build for obvious reasons.

--- a/tests/data/SPECS/dynamic.spec
+++ b/tests/data/SPECS/dynamic.spec
@@ -41,6 +41,8 @@ echo "LicenseToKill: True" >> %{specpartsdir}/mainpkg.specpart
 echo "%package docs" >> %{specpartsdir}/docs.specpart
 %{?!FAIL:echo "Summary: Documentation for dynamic spec" >> %{specpartsdir}/docs.specpart}
 echo "BuildArch: noarch" >> %{specpartsdir}/docs.specpart
+%{?FORBIDDENTAG:echo "BuildRequires: python3" >> %{specpartsdir}/docs.specpart}
+%{?FORBIDDENSECTION:echo "%check" >> %{specpartsdir}/docs.specpart}
 echo "%description docs" >> %{specpartsdir}/docs.specpart
 echo "Test for dynamically generated spec files" >> %{specpartsdir}/docs.specpart
 echo "%files docs" >> $RPM_SPECPARTS_DIR/docs.specpart

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2764,6 +2764,40 @@ error: parsing failed
 
 RPMTEST_CLEANUP
 
+# ------------------------------
+# Check failing dynamic spec generation
+AT_SETUP([rpmbuild with dynamic spec generation fail])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "FORBIDDENSECTION 1" -ba /data/SPECS/dynamic.spec
+],
+[1],
+[],
+[error: Section %check is not allowed after build is done!
+error: parsing failed
+])
+
+RPMTEST_CLEANUP
+
+# ------------------------------
+# Check failing dynamic spec generation
+AT_SETUP([rpmbuild with dynamic spec generation fail])
+AT_KEYWORDS([build])
+RPMDB_INIT
+RPMTEST_CHECK([
+
+runroot rpmbuild --quiet -D "FULLDYNAMIC 1" -D "FORBIDDENTAG 1" -ba /data/SPECS/dynamic.spec
+],
+[1],
+[],
+[error: line 4: Tag not allowed after build is done: BuildRequires: python3
+error: parsing failed
+])
+
+RPMTEST_CLEANUP
+
 
 # ------------------------------
 # Check source name with space


### PR DESCRIPTION
Many things need to be known before the build can be started. Make
declaring these sections or directives an error when encountered parsing
the generated Spec parts.
    
Resolves: #2693
    