### PR TITLE
Add --list-keys and --delete-key to rpmkeys 

### DIFF
--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -12,14 +12,18 @@ rpmkeys - RPM Keyring
 SYNOPSIS
 ========
 
-**rpmkeys** {**\--import\|\--checksig**}
+**rpmkeys** {**\--list\|\--import\|\--delete\|\--checksig**}
 
 DESCRIPTION
 ===========
 
 The general forms of rpm digital signature commands are
 
+**rpmkeys** **\--list** \[*KEYHASH \...*\]
+
 **rpmkeys** **\--import** *PUBKEY \...*
+
+**rpmkeys** **\--delete** *KEYHASH \...*
 
 **rpmkeys** {**-K\|\--checksig**} *PACKAGE\_FILE \...*
 
@@ -37,13 +41,21 @@ example, all currently imported public keys can be displayed by:
 
 **rpm -q gpg-pubkey**
 
-Details about a specific public key, when imported, can be displayed by
+A more convenient way to display them is
+
+**rpmkeys** **\--list**
+
+More details about a specific public key, when imported, can be displayed by
 querying. Here\'s information about the Red Hat GPG/DSA key:
 
 **rpm -qi gpg-pubkey-db42a60e**
 
 Finally, public keys can be erased after importing just like packages.
-Here\'s how to remove the Red Hat GPG/DSA key
+Here\'s how to remove the Red Hat GPG/DSA key:
+
+**rpmkeys** **\--delete db42a60e**
+
+Or alternatively:
 
 **rpm -e gpg-pubkey-db42a60e**
 

--- a/docs/man/rpmkeys.8.md
+++ b/docs/man/rpmkeys.8.md
@@ -35,7 +35,7 @@ armored public key can be added to the **rpm** database using
 ring management is performed exactly like package management. For
 example, all currently imported public keys can be displayed by:
 
-**rpm -qa gpg-pubkey\***
+**rpm -q gpg-pubkey**
 
 Details about a specific public key, when imported, can be displayed by
 querying. Here\'s information about the Red Hat GPG/DSA key:

--- a/tests/rpmdb.at
+++ b/tests/rpmdb.at
@@ -56,7 +56,7 @@ runroot rpm \
 [ignore])
 RPMTEST_CLEANUP
 
-AT_SETUP([rpm -qa 3])
+AT_SETUP([rpm -qa and rpmkeys])
 AT_KEYWORDS([rpmdb query])
 RPMDB_INIT
 
@@ -80,6 +80,39 @@ runroot rpm -qa | sort
 [foo-1.0-1.noarch
 gpg-pubkey-1964c5fc-58e63918
 hello-2.0-1.x86_64
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --list
+],
+[0],
+[1964c5fc-58e63918: rpm.org RSA testkey <rsa@rpm.org> public key
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --list 1964c5fc
+],
+[0],
+[1964c5fc-58e63918: rpm.org RSA testkey <rsa@rpm.org> public key
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --list XXX
+],
+[1],
+[package gpg-pubkey-XXX is not installed
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmkeys --delete 1964c5fc
+runroot rpmkeys --list
+],
+[1],
+[package gpg-pubkey is not installed
 ],
 [])
 RPMTEST_CLEANUP


### PR DESCRIPTION
This is a  bit of a hack as it manipulates the parsed cli parameters to
to the "right thing" and then calls rpmcliQuery and rpmErase.


