### PR TITLE
Expose build time to package build scriptlets via $RPM_BUILD_TIME

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -28,6 +28,7 @@ static rpm_time_t getBuildTime(void)
     char *srcdate;
     time_t epoch;
     char *endptr;
+    char *timestr = NULL;
 
     srcdate = getenv("SOURCE_DATE_EPOCH");
     if (srcdate && rpmExpandNumeric("%{?use_source_date_epoch_as_buildtime}")) {
@@ -39,6 +40,10 @@ static rpm_time_t getBuildTime(void)
             buildTime = (uint32_t) epoch;
     } else
         buildTime = (uint32_t) time(NULL);
+
+    rasprintf(&timestr, "%u", buildTime);
+    setenv("RPM_BUILD_TIME", timestr, 1);
+    free(timestr);
 
     return buildTime;
 }

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -476,6 +476,24 @@ If the main section exists, it must come first to avoid ambiguity.
 Otherwise, append and prepend can be used in any order and multiple
 times, even if the corresponding main section does not exist.
 
+During the execution of build scriptlets, (at least) the following
+rpm-specific environment variables are set:
+
+Variable            | Description
+---------------------------------------------------
+RPM_ARCH            | Architecture of the package
+RPM_BUILD_DIR       | The build directory of the package
+RPM_BUILD_NCPUS     | The number of CPUs available for the build
+RPM_BUILD_ROOT      | The buildroot directory of the package
+RPM_DOC_DIR         | The special documentation directory of the package
+RPM_LD_FLAGS        | Linker flags
+RPM_OPT_FLAGS       | Compiler flags
+RPM_OS              | OS of the package
+RPM_PACKAGE_NAME    | Rpm name of the source package
+RPM_PACKAGE_VERSION | Rpm version of the source package
+RPM_PACKAGE_RELEASE | Rpm release of the source package
+RPM_SOURCE_DIR      | The source directory of the package
+
 ### %prep
 
 %prep prepares the sources for building. This is where sources are

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -485,6 +485,7 @@ RPM_ARCH            | Architecture of the package
 RPM_BUILD_DIR       | The build directory of the package
 RPM_BUILD_NCPUS     | The number of CPUs available for the build
 RPM_BUILD_ROOT      | The buildroot directory of the package
+RPM_BUILD_TIME      | The build time of the package (seconds since the epoch)
 RPM_DOC_DIR         | The special documentation directory of the package
 RPM_LD_FLAGS        | Linker flags
 RPM_OPT_FLAGS       | Compiler flags


### PR DESCRIPTION
This is useful for consistently setting timestamps within build scriptlets, in particular when doing reproducable builds.
