### PR TITLE
Issue a warning when passing arguments to non-parametric macros

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1720,6 +1720,12 @@ expandMacro(rpmMacroBuf mb, const char *src, size_t slen)
 	}
 
 	if (me->opts == NULL && !(me->flags & ME_FUNC)) {
+	    if (g || (lastc && *lastc == '}')) {
+		/* XXX TODO: Make this an error in a few years */
+		rpmMacroBufErr(mb, 0,
+			_("unexpected argument to non-parametric macro %%%s\n"),
+			me->name);
+	    }
 	    /* Simple non-parametric macro */
 	    doMacro(mb, me, NULL, NULL);
 	    s = se;

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -426,6 +426,27 @@ runroot rpm \
 0
 0
 ])
+
+RPMTEST_CHECK([
+runroot rpm \
+    --define 'zzz xxx' \
+    --eval '%zzz' \
+    --eval '%{zzz}' \
+    --eval '%{zzz:}' \
+    --eval '%{zzz }' \
+    --eval '%{zzz aa}'
+],
+[0],
+[xxx
+xxx
+xxx
+xxx
+xxx
+],
+[warning: unexpected argument to non-parametric macro %zzz
+warning: unexpected argument to non-parametric macro %zzz
+warning: unexpected argument to non-parametric macro %zzz
+])
 RPMTEST_CLEANUP
 
 AT_SETUP([string functions])


### PR DESCRIPTION
Fixes: #2932