### PR TITLE
Make %dirname behave like dirname (3)

### DIFF
--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -6,6 +6,7 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <errno.h>
+#include <libgen.h>
 #ifdef HAVE_SCHED_GETAFFINITY
 #include <sched.h>
 #endif
@@ -1306,9 +1307,7 @@ static void doFoo(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 	    b++;
     } else if (rstreq("dirname", me->name)) {
 	buf = xstrdup(argv[1]);
-	if ((b = strrchr(buf, '/')) != NULL)
-	    *b = '\0';
-	b = buf;
+	b = dirname(buf);
     } else if (rstreq("shrink", me->name)) {
 	/*
 	 * shrink body by removing all leading and trailing whitespaces and

--- a/rpmio/macro.c
+++ b/rpmio/macro.c
@@ -1301,10 +1301,7 @@ static void doFoo(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t argv, size_t *parsed)
 
     if (rstreq("basename", me->name)) {
 	buf = xstrdup(argv[1]);
-	if ((b = strrchr(buf, '/')) == NULL)
-	    b = buf;
-	else
-	    b++;
+	b = basename(buf);
     } else if (rstreq("dirname", me->name)) {
 	buf = xstrdup(argv[1]);
 	b = dirname(buf);

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -364,6 +364,15 @@ runroot rpm --eval "%{dirname:dir}"
 runroot rpm --eval "%{dirname dir}"
 runroot rpm --eval "%dirname"
 runroot rpm --eval "%dirname dir"
+runroot rpm --eval "%dirname /"
+runroot rpm --eval "%dirname ./"
+runroot rpm --eval "%dirname .."
+runroot rpm --eval "%dirname ../"
+runroot rpm --eval "%dirname ../foo"
+runroot rpm --eval "%dirname /foo"
+runroot rpm --eval "%dirname /foo/"
+runroot rpm --eval "%dirname /foo/foobar"
+runroot rpm --eval "%dirname /foo/foobar/"
 runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
@@ -381,10 +390,19 @@ runroot rpm --eval "%shrink %%%%"
 runroot rpm --eval "%verbose foo"
 ],
 [0],
-[
-dir
-dir
-dir
+[.
+.
+.
+.
+/
+.
+.
+.
+..
+/
+/
+/foo
+/foo
 /hello/%%
 
 bar

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -373,6 +373,11 @@ runroot rpm --eval "%dirname /foo"
 runroot rpm --eval "%dirname /foo/"
 runroot rpm --eval "%dirname /foo/foobar"
 runroot rpm --eval "%dirname /foo/foobar/"
+runroot rpm --eval "%basename /foo/foobar"
+runroot rpm --eval "%basename /foo/foobar/"
+runroot rpm --eval "%basename /"
+runroot rpm --eval "%basename foobar/"
+runroot rpm --eval "%basename foobar"
 runroot rpm --define '%xxx /hello/%%%%/world' --eval '%{dirname:%xxx}'
 runroot rpm --eval "%{uncompress}"
 runroot rpm --eval "%{uncompress:}"
@@ -403,6 +408,11 @@ runroot rpm --eval "%verbose foo"
 /
 /foo
 /foo
+foobar
+foobar
+/
+foobar
+foobar
 /hello/%%
 
 bar


### PR DESCRIPTION
Strip trailing "/"
Keep "." and ".." untouched
Keep root dir for files in the root dir
Return "." for files without directory and empty strings

See man 3 dirname

Resolves: 2928