### PR TITLE
Kick out an "experimental" %_query_selector_match from 2001

### DIFF
--- a/lib/rpmdb.c
+++ b/lib/rpmdb.c
@@ -1167,7 +1167,6 @@ static char * mireDup(rpmTagVal tag, rpmMireMode *modep,
 int rpmdbSetIteratorRE(rpmdbMatchIterator mi, rpmTagVal tag,
 		rpmMireMode mode, const char * pattern)
 {
-    static rpmMireMode defmode = (rpmMireMode)-1;
     miRE mire = NULL;
     char * allpat = NULL;
     int notmatch = 0;
@@ -1176,22 +1175,6 @@ int rpmdbSetIteratorRE(rpmdbMatchIterator mi, rpmTagVal tag,
     int eflags = 0;
     int fnflags = 0;
     int rc = 0;
-
-    if (defmode == (rpmMireMode)-1) {
-	char *t = rpmExpand("%{?_query_selector_match}", NULL);
-
-	if (*t == '\0' || rstreq(t, "default"))
-	    defmode = RPMMIRE_DEFAULT;
-	else if (rstreq(t, "strcmp"))
-	    defmode = RPMMIRE_STRCMP;
-	else if (rstreq(t, "regex"))
-	    defmode = RPMMIRE_REGEX;
-	else if (rstreq(t, "glob"))
-	    defmode = RPMMIRE_GLOB;
-	else
-	    defmode = RPMMIRE_DEFAULT;
-	free(t);
-     }
 
     /* Handle missing epoch, see mireSkip() */
     if (tag == RPMTAG_EPOCH && pattern == NULL)
@@ -1207,9 +1190,6 @@ int rpmdbSetIteratorRE(rpmdbMatchIterator mi, rpmTagVal tag,
     }
 
     allpat = mireDup(tag, &mode, pattern);
-
-    if (mode == RPMMIRE_DEFAULT)
-	mode = defmode;
 
     switch (mode) {
     case RPMMIRE_DEFAULT:

--- a/macros.in
+++ b/macros.in
@@ -352,17 +352,6 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 #
 #%_netsharedpath
 
-#	(experimental)
-#	The type of pattern match used on rpmdb iterator selectors:
-#	"default"	simple glob-like regex, periods will be escaped,
-#			splats will have period prepended, full "^...$" match
-#			required. Also, file path tags will use glob(7).
-#	"strcmp"	compare strings
-#	"regex"		regex(7) patterns using regcomp(3)/regexec(3)
-#	"glob"		glob(7) patterns using fnmatch(3)
-#
-%_query_selector_match	default
-
 #	Configurable packager information, same as Packager: in a specfile.
 #
 #%packager


### PR DESCRIPTION
Something like this can't really be a macro configurable between such wildly differing purposes, especially when callers almost certainly expect the traditional default behavior anyway. I can't see anybody missing this.

Besides nuking an apparently unnecessary feature and weird logic (how many levels of default do you want?), it eliminates an unwanted static initializer relying on a non-enum value of an enum variable.