### PR TITLE
Validate Buildsystem definitions, error out on unknown

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -837,11 +837,8 @@ static rpmRC handlePreambleTag(rpmSpec spec, enum parseStages stage,
     switch (tag) {
     case RPMTAG_BUILDSYSTEM:
 	SINGLE_TOKEN_ONLY;
-	if (rpmCharCheck(spec, field,
-			ALLOWED_CHARS_NAME, ALLOWED_FIRSTCHARS_NAME))
-	{
+	if (checkBuildsystem(spec, field))
 	    goto exit;
-	}
 	break;
     case RPMTAG_BUILDOPTION:
 	if (addBuildOption(spec, lang, field))

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -975,7 +975,7 @@ static rpmRC parseBuildsysSect(rpmSpec spec, const char *prefix,
 		argvAdd(&av, "--");
 		argvAppend(&av, spec->buildopts[sc->section]);
 		args = argvJoin(av, " ");
-		free(av);
+		argvFree(av);
 	    }
 	    char *buf = rstrscat(NULL, "%", sc->name, "\n",
 				       "%", mn, " ",

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -952,6 +952,10 @@ int checkBuildsystem(rpmSpec spec, const char *name)
 	    continue;
 	char *mn = rstrscat(NULL, "buildsystem_", name, "_", sc->name, NULL);
 	if (!rpmMacroIsParametric(NULL, mn)) {
+	    rpmlog(RPMLOG_DEBUG,
+		"required parametric macro %%%s not defined buildsystem %s\n",
+		mn, name);
+
 	    rpmlog(RPMLOG_ERR, _("line %d: Unknown buildsystem: %s\n"),
 		    spec->lineNum, name);
 	    rc = -1;

--- a/build/rpmbuild_internal.h
+++ b/build/rpmbuild_internal.h
@@ -638,6 +638,9 @@ RPM_GNUC_INTERNAL
 int checkForDuplicates(Header h);
 
 RPM_GNUC_INTERNAL
+int checkBuildsystem(rpmSpec spec, const char *buildsys);
+
+RPM_GNUC_INTERNAL
 void fillOutMainPackage(Header h);
 
 RPM_GNUC_INTERNAL

--- a/build/spec.c
+++ b/build/spec.c
@@ -280,6 +280,10 @@ rpmSpec rpmSpecFree(rpmSpec spec)
 
     spec->buildRestrictions = headerFree(spec->buildRestrictions);
 
+    for (int i = 0; i < NR_SECT; i++) {
+	argvFree(spec->buildopts[i]);
+    }
+
     if (!spec->recursing) {
 	if (spec->BASpecs != NULL)
 	while (spec->BACount--) {

--- a/docs/manual/buildsystem.md
+++ b/docs/manual/buildsystem.md
@@ -50,15 +50,6 @@ BuildOption(conf): --enable-fu
 Passing these per-section options to the actual buildsystem of the
 package is the responsibility of the buildsystem specific macros.
 
-3) Complex packages can have things like multiple build systems, in
-which case you might want to invoke the macros manually, eg.
-
-```
-%buildsystem_autotools_build
-cd python
-%buildsystem_python_build
-```
-
 ## Supporting new build systems
 
 Supporting new build system types is just a matter of declaring a few

--- a/tests/data/SPECS/amhello.spec
+++ b/tests/data/SPECS/amhello.spec
@@ -1,11 +1,13 @@
 %bcond_with alt
 
+%{!?buildsys:%global buildsys autotools}
+
 Name: amhello
 Version: 1.0
 Source: amhello-%{version}.tar.gz
 License: GPLv2
 Summary: Autotools example
-BuildSystem: autotools
+BuildSystem: %{buildsys}
 
 %if %{with alt}
 BuildOption: --program-prefix=alt-

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -83,6 +83,17 @@ runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1alt.*.rpm
 /usr/share/doc/amhello/README.distro
 ],
 [ignore])
+
+RPMTEST_CHECK([
+runroot rpmbuild -bb \
+	--define "buildsys bogons" \
+	--quiet /data/SPECS/amhello.spec
+],
+[1],
+[],
+[error: line 10: Unknown buildsystem: bogons
+])
+
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild -b steps])


### PR DESCRIPTION
Verify all required sections (%conf, %build and %install) are covered by the requested buildsystem, error out with a proper error message if not.