### PR TITLE
Allow whitespace before directives in the Preamble

### DIFF
--- a/build/parsePreamble.c
+++ b/build/parsePreamble.c
@@ -293,7 +293,9 @@ int addSource(rpmSpec spec, int specline, const char *srcname, rpmTagVal tag)
     }
 
     if (specline) {
-	nonum = parseTagNumber(spec->line + strlen(name), &num);
+	char * s = spec->line;
+	SKIPSPACE(s);
+	nonum = parseTagNumber(s + strlen(name), &num);
 	if (nonum < 0) {
 	    rpmlog(RPMLOG_ERR, _("line %d: Bad %s number: %s\n"),
 		     spec->lineNum, name, spec->line);
@@ -1133,10 +1135,11 @@ static struct PreambleRec_s const preambleList[] = {
 static int findPreambleTag(rpmSpec spec, PreambleRec * pr, const char ** macro, char * lang)
 {
     PreambleRec p;
-    char *s;
+    char *s = spec->line;
+    SKIPSPACE(s);
 
     for (p = preambleList; p->token != NULL; p++) {
-	if (!(p->token && !rstrncasecmp(spec->line, p->token, p->len)))
+	if (!(p->token && !rstrncasecmp(s, p->token, p->len)))
 	    continue;
 	if (p->deprecated) {
 	    rpmlog(RPMLOG_WARNING, _("line %d: %s is deprecated: %s\n"),
@@ -1147,7 +1150,7 @@ static int findPreambleTag(rpmSpec spec, PreambleRec * pr, const char ** macro, 
     if (p == NULL || p->token == NULL)
 	return 1;
 
-    s = spec->line + p->len;
+    s = s + p->len;
     SKIPSPACE(s);
 
     switch (p->type) {

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -75,6 +75,10 @@ if used in them.
 
 ### Preamble tags
 
+Since RPM 4.20 preamble tags can be indented with white space. Older
+versions require the Tags to be at the beginning of a line. Comments
+and empty lines are allowed.
+
 #### Name
 
 The Name tag contains the proper name of the package. Names must not

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -71,6 +71,22 @@ other conditionals.
 %if-conditionals are not macros, and are unlikely to yield expected results
 if used in them.
 
+### Sections ###
+
+The spec file is divided in several sections. Except of the preamble
+of the main package right at the start spec file (and spec parts)
+sections begin with a percent sign and the name of the section. They
+need to be at the start of a new line. Most section types allow
+passing options in this first line. These section markers looks like
+macros (with parameters) but are not.
+
+Each section type has its own rules and syntax. Conditionals are
+evaluated first and then macros expanded. Only then are the sections
+parsed by the rules of the section types. The content of build and
+runtime scripts is then passed on the the interpreter - possible being
+stored in a header tag inbetween. The syntax of the other sections is
+described below.
+
 ## Preamble
 
 ### Preamble tags

--- a/tests/data/SPECS/hello.spec
+++ b/tests/data/SPECS/hello.spec
@@ -5,16 +5,16 @@
 # package which can be built under runroot in the test-suite.
 
 Summary: hello -- hello, world rpm
-Name: hello
+ Name: hello
 Version: 1.0
-Release: 1
-Group: Utilities
+	Release: 1
+ Group: Utilities
 License: GPL
 SourceLicense: GPL, ASL 1.0
 Distribution: RPM test suite.
 URL: http://rpm.org
-Source0: hello-1.0.tar.gz
-Patch0: hello-1.0-modernize.patch
+	Source0: hello-1.0.tar.gz
+ Patch0: hello-1.0-modernize.patch
 Prefix: /usr
 
 %description

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -310,16 +310,16 @@ runroot rpmspec --parse \
 
 
 Summary: hello -- hello, world rpm
-Name: hello
+ Name: hello
 Version: 1.0
-Release: 1
-Group: Utilities
+	Release: 1
+ Group: Utilities
 License: GPL
 SourceLicense: GPL, ASL 1.0
 Distribution: RPM test suite.
 URL: http://rpm.org
-Source0: hello-1.0.tar.gz
-Patch0: hello-1.0-modernize.patch
+	Source0: hello-1.0.tar.gz
+ Patch0: hello-1.0-modernize.patch
 Prefix: /usr
 
 %description


### PR DESCRIPTION
Update to the documentation is still needed

Resolves: #2927