### PR TITLE
Fix dependency generators sometimes dying with SIGPIPE

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -295,6 +295,8 @@ static int getOutputFrom(ARGV_t argv,
 	return -1;
     }
     
+    void *oldhandler = signal(SIGPIPE, SIG_IGN);
+
     child = fork();
     if (child < 0) {
 	rpmlog(RPMLOG_ERR, _("Couldn't fork %s: %s\n"),
@@ -305,9 +307,12 @@ static int getOutputFrom(ARGV_t argv,
 	    close(fromProg[0]);
 	    close(fromProg[1]);
 	}
-	return -1;
+	ret = -1;
+	goto exit;
     }
     if (child == 0) {
+	signal(SIGPIPE, SIG_DFL);
+
 	close(toProg[1]);
 	close(fromProg[0]);
 
@@ -441,6 +446,7 @@ reap:
     ret = 0;
 
 exit:
+    signal(SIGPIPE, oldhandler);
     return ret;
 }
 


### PR DESCRIPTION
If a dependency generator dies while we're still writing to its stdin, it causes us to die rather randomly. Typically happens with fake dependency generators that don't actually bother reading their input and/or write anything back. This is almost certainly the ghost failure we've occasionally seen in the test-suite too (#2470).

Resurrect the explicit SIG_IGN that got removed apparently in commit 375a6b5630b8e37e1d3f0c7ecbe10fe460c4d420. The matter was further confused by NSPR (which we once relied on) always setting SIGPIPE to SIG_IGN.

Suggested-by: Michael Schroeder <mls@suse.de>

Fixes: #2949