### PR TITLE
Add ability to specify extra command after %setup

### DIFF
--- a/build/parsePrep.c
+++ b/build/parsePrep.c
@@ -297,6 +297,14 @@ void doSetupMacro(rpmMacroBuf mb, rpmMacroEntry me, ARGV_t margs, size_t *parsed
 	free(fix);
     }
 
+    /* Allow custom action after setup */
+    {	char *post = rpmExpand("%{_setup_post}", NULL);
+	if (post && *post != '%') {
+	    appendMb(mb, post, 1);
+	}
+	free(post);
+    }
+
 exit:
     freeStringBuf(before);
     freeStringBuf(after);

--- a/macros.in
+++ b/macros.in
@@ -717,7 +717,7 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 %__os_install_post	%{___build_post}
 
 # Macro to fix broken permissions in sources
-%_fixperms      %{__chmod} -Rf a+rX,u+w,g-w,o-w
+%_fixperms		%{__chmod} -Rf a+rX,u+w,g-w,o-w
 
 %__smp_use_ncpus() %([ -z "$RPM_BUILD_NCPUS" ] \\\
 	&& RPM_BUILD_NCPUS="%{getncpus %{?1}}"; \\\
@@ -1180,6 +1180,9 @@ Supplements:   (%{name} = %{version}-%{release} and langpacks-%{1})\
 
 #------------------------------------------------------------------------------
 # Macros for further automated spec %setup and patch application
+
+# Allow post-setup customization when setup is finished
+%_setup_post %{nil}
 
 # default to plain patch
 %__scm patch


### PR DESCRIPTION
Allow custom action done after %_fixperms is done. Creates %_setup_post macro, which will be expanded after %setup. Consequently also always done in autosetup.