### PR TITLE
Work around ASAN incompatibility with GH runner image >= 20240310.1.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Build the Fedora testing environment
         run: ./mktree.oci build
         working-directory: ./tests
+      - name: Fix kernel mmap rnd bits
+        # High entropy setting in GH runner images >= 20240310.1.0
+        # causes ASAN blowing up here and there:
+        # https://github.com/actions/runner-images/issues/9491
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Run the test suite
         run: ./mktree.oci check --interactive=false -j$(nproc)
         working-directory: ./tests


### PR DESCRIPTION
Some of our Python tests started suddenly failing semi-consistently, this turned out to be an issue in the most recent GH runner image kernel where ADSL runs with more entropy than before, and this clashes with ASAN. Revert the runner VM to the former values to fix for now.

Oh and don't think I figured this out by myself, this workaround was suggested by @igsilya in
https://github.com/actions/runner-images/issues/9491, cheers!