### PR TITLE
rpm2archive: fix hardlink handling in cpio output

### DIFF
--- a/tools/rpm2archive.c
+++ b/tools/rpm2archive.c
@@ -58,9 +58,9 @@ static void fill_archive_entry(struct archive_entry * entry, rpmfi fi,
 	archive_entry_set_symlink(entry, rpmfiFLink(fi));
 
     if (sb.st_nlink > 1) {
-	/* hardlink sizes are special, see rpmfiStat() */
-	archive_entry_set_size(entry, rpmfiFSize(fi));
 	if (rpmfiArchiveHasContent(fi)) {
+	    /* hardlink sizes are special, see rpmfiStat() */
+	    archive_entry_set_size(entry, rpmfiFSize(fi));
 	    _free(*hardlink);
 	    *hardlink = xstrdup(archive_entry_pathname(entry));
 	} else {
@@ -153,9 +153,6 @@ static int process_package(rpmts ts, const char * filename)
 	exit(EXIT_FAILURE);
     }
 
-    rpmfiles files = rpmfilesNew(NULL, h, 0, RPMFI_KEEPHEADER);
-    rpmfi fi = rpmfiNewArchiveReader(gzdi, files, RPMFI_ITER_READ_ARCHIVE_CONTENT_FIRST);
-
     /* create archive */
     a = archive_write_new();
     if (compress) {
@@ -213,6 +210,9 @@ static int process_package(rpmts ts, const char * filename)
 
     char * buf = xmalloc(BUFSIZE);
     char * hardlink = NULL;
+
+    rpmfiles files = rpmfilesNew(NULL, h, 0, RPMFI_KEEPHEADER);
+    rpmfi fi = rpmfiNewArchiveReader(gzdi, files, format_code == ARCHIVE_FORMAT_CPIO_SVR4_NOCRC ? RPMFI_ITER_READ_ARCHIVE : RPMFI_ITER_READ_ARCHIVE_CONTENT_FIRST);
 
     rc = 0;
     while (rc >= 0) {


### PR DESCRIPTION
In the "newc" cpio format the content of hardlinked files is supposted to be stored with the last hardlink and not the first.

Fixes issue #2974