### PR TITLE
Sqlite backend spring cleaning

### DIFF
--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -547,7 +547,7 @@ static rpmRC sqlite_idxdbByKey(dbiIndex dbi, dbiCursor dbc,
 			    const char *keyp, size_t keylen, int searchType,
 			    dbiIndexSet *set)
 {
-    int rc = RPMRC_NOTFOUND;
+    rpmRC rc = RPMRC_NOTFOUND;
 
     if (searchType == DBC_PREFIX_SEARCH) {
 	rc = dbiCursorPrep(dbc, "SELECT hnum, idx FROM '%q' "
@@ -563,7 +563,8 @@ static rpmRC sqlite_idxdbByKey(dbiIndex dbi, dbiCursor dbc,
 
 
     if (!rc) {
-	while ((rc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {
+	int sqrc;
+	while ((sqrc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {
 	    unsigned int hnum = sqlite3_column_int(dbc->stmt, 0);
 	    unsigned int tnum = sqlite3_column_int(dbc->stmt, 1);
 
@@ -571,12 +572,12 @@ static rpmRC sqlite_idxdbByKey(dbiIndex dbi, dbiCursor dbc,
 		*set = dbiIndexSetNew(5);
 	    dbiIndexSetAppendOne(*set, hnum, tnum, 0);
 	}
-    }
 
-    if (rc == SQLITE_DONE) {
-	rc = (*set) ? RPMRC_OK : RPMRC_NOTFOUND;
-    } else {
-	rc = dbiCursorResult(dbc);
+	if (sqrc == SQLITE_DONE) {
+	    rc = (*set) ? RPMRC_OK : RPMRC_NOTFOUND;
+	} else {
+	    rc = dbiCursorResult(dbc);
+	}
     }
 
     return rc;

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -53,7 +53,7 @@ static int dbiCursorReset(dbiCursor dbc)
     return 0;
 }
 
-static int dbiCursorResult(dbiCursor dbc)
+static rpmRC dbiCursorResult(dbiCursor dbc)
 {
     int rc = sqlite3_errcode(dbc->sdb);
     int err = (rc != SQLITE_OK && rc != SQLITE_DONE && rc != SQLITE_ROW);
@@ -64,7 +64,7 @@ static int dbiCursorResult(dbiCursor dbc)
     return err ? RPMRC_FAIL : RPMRC_OK;
 }
 
-static int dbiCursorPrep(dbiCursor dbc, const char *fmt, ...)
+static rpmRC dbiCursorPrep(dbiCursor dbc, const char *fmt, ...)
 {
     if (dbc->stmt == NULL) {
 	char *cmd = NULL;
@@ -83,7 +83,7 @@ static int dbiCursorPrep(dbiCursor dbc, const char *fmt, ...)
     return dbiCursorResult(dbc);
 }
 
-static int dbiCursorBindPkg(dbiCursor dbc, unsigned int hnum,
+static rpmRC dbiCursorBindPkg(dbiCursor dbc, unsigned int hnum,
 				void *blob, unsigned int bloblen)
 {
     int rc = 0;
@@ -100,7 +100,7 @@ static int dbiCursorBindPkg(dbiCursor dbc, unsigned int hnum,
     return dbiCursorResult(dbc);
 }
 
-static int dbiCursorBindIdx(dbiCursor dbc, const void *key, int keylen,
+static rpmRC dbiCursorBindIdx(dbiCursor dbc, const void *key, int keylen,
 				dbiIndexItem rec)
 {
     int rc;
@@ -530,7 +530,7 @@ static rpmRC sqlite_pkgdbIter(dbiIndex dbi, dbiCursor dbc,
 
 static rpmRC sqlite_pkgdbGet(dbiIndex dbi, dbiCursor dbc, unsigned int hdrNum, unsigned char **hdrBlob, unsigned int *hdrLen)
 {
-    int rc;
+    rpmRC rc;
 
     if (hdrNum) {
 	rc = sqlite_pkgdbByKey(dbi, dbc, hdrNum, hdrBlob, hdrLen);
@@ -623,7 +623,7 @@ static rpmRC sqlite_idxdbIter(dbiIndex dbi, dbiCursor dbc, dbiIndexSet *set)
 
 static rpmRC sqlite_idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexSet *set, int searchType)
 {
-    int rc;
+    rpmRC rc;
     if (keyp) {
 	rc = sqlite_idxdbByKey(dbi, dbc, keyp, keylen, searchType, set);
     } else {

--- a/lib/backend/sqlite.c
+++ b/lib/backend/sqlite.c
@@ -471,14 +471,14 @@ static rpmRC sqlite_pkgdbPut(dbiIndex dbi, dbiCursor dbc,  unsigned int *hdrNum,
 
 static rpmRC sqlite_pkgdbDel(dbiIndex dbi, dbiCursor dbc,  unsigned int hdrNum)
 {
-    int rc = dbiCursorPrep(dbc, "DELETE FROM '%q' WHERE hnum=?;",
+    rpmRC rc = dbiCursorPrep(dbc, "DELETE FROM '%q' WHERE hnum=?;",
 			    dbi->dbi_file);
 
     if (!rc)
 	rc = dbiCursorBindPkg(dbc, hdrNum, NULL, 0);
 
     if (!rc)
-	while ((rc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {};
+	while (sqlite3_step(dbc->stmt) == SQLITE_ROW) {};
 
     return dbiCursorResult(dbc);
 }
@@ -632,14 +632,14 @@ static rpmRC sqlite_idxdbGet(dbiIndex dbi, dbiCursor dbc, const char *keyp, size
 
 static rpmRC sqlite_idxdbPutOne(dbiIndex dbi, dbiCursor dbc, const char *keyp, size_t keylen, dbiIndexItem rec)
 {
-    int rc = dbiCursorPrep(dbc, "INSERT INTO '%q' VALUES(?, ?, ?)",
+    rpmRC rc = dbiCursorPrep(dbc, "INSERT INTO '%q' VALUES(?, ?, ?)",
 			dbi->dbi_file);
 
     if (!rc)
 	rc = dbiCursorBindIdx(dbc, keyp, keylen, rec);
 
     if (!rc)
-	while ((rc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {};
+	while (sqlite3_step(dbc->stmt) == SQLITE_ROW) {};
 
     return dbiCursorResult(dbc);
 }
@@ -652,13 +652,13 @@ static rpmRC sqlite_idxdbPut(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum
 static rpmRC sqlite_idxdbDel(dbiIndex dbi, rpmTagVal rpmtag, unsigned int hdrNum, Header h)
 {
     dbiCursor dbc = dbiCursorInit(dbi, DBC_WRITE);
-    int rc = dbiCursorPrep(dbc, "DELETE FROM '%q' WHERE hnum=?", dbi->dbi_file);
+    rpmRC rc = dbiCursorPrep(dbc, "DELETE FROM '%q' WHERE hnum=?", dbi->dbi_file);
 
     if (!rc)
 	rc = dbiCursorBindPkg(dbc, hdrNum, NULL, 0);
 
     if (!rc)
-	while ((rc = sqlite3_step(dbc->stmt)) == SQLITE_ROW) {};
+	while (sqlite3_step(dbc->stmt) == SQLITE_ROW) {};
 
     rc = dbiCursorResult(dbc);
     dbiCursorFree(dbi, dbc);


### PR DESCRIPTION
This one is a particularly bad case of int/enum abuse. Not so suprisingly, using separate variables for sqlite and rpm side returns makes the stuff much saner. I can kinda remember this even: "Just make it work now, I'll clean it all up later" and this is payback time.