### PR TITLE
Support per-user macro configuration in XDG_CONFIG_HOME

### DIFF
--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -369,8 +369,12 @@ you wish to see the expansion of a macro defined in a spec file.
 Most rpm configuration is done via macros. There are numerous places from
 which macros are read, in recent rpm versions the macro path can be seen
 with `rpm --showrc|grep "^Macro path"`. If there are multiple definitions
-of the same macro, the last one wins. User-level configuration goes
-to ~/.rpmmacros which is always the last one in the path.
+of the same macro, the last one wins.
+
+Per-user macros are always the last in the path. As of rpm >= 4.20, rpm
+primarily looks for per-user configuration inside `~/.config/rpm` directory
+(as per `XDG_CONFIG_HOME` specification), but falls back to the traditional
+`~/.rpmmacros` location if necessary.
 
 The macro file syntax is simply:
 

--- a/include/rpm/rpmfileutil.h
+++ b/include/rpm/rpmfileutil.h
@@ -120,7 +120,8 @@ char * rpmGetPath (const char * path, ...) RPM_GNUC_NULL_TERMINATED;
 
 /** \ingroup rpmfileutil
  * Expand a glob pattern into matching paths.
- * A pattern that is not a glob is returned as is.
+ * When RPMGLOB_NOCHECK is specified, non-matching and non-glob patterns
+ * are returned as is.
  * @param pattern	glob pattern
  * @param flags		bit(s) to control glob operation
  * @param[out] *argcPtr	no. of paths
@@ -132,7 +133,6 @@ int rpmGlobPath(const char * pattern, rpmglobFlags flags,
 
 /** \ingroup rpmfileutil
  * Expand a glob pattern into matching paths, fail if nothing matches.
- * A pattern that is not a glob is returned as is.
  * @param pattern	glob pattern
  * @param[out] *argcPtr	no. of paths
  * @param[out] *argvPtr	ARGV_t array of paths

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -463,7 +463,6 @@ static void setDefaults(void)
 			  	"~/.rpmrc", NULL);
     }
 
-#ifndef MACROFILES
     if (!macrofiles) {
 	macrofiles = rstrscat(NULL, confdir, "/macros", ":",
 				confdir, "/macros.d/macros.*", ":",
@@ -475,9 +474,6 @@ static void setDefaults(void)
 				SYSCONFDIR "/rpm/%{_target}/macros", ":",
 				"~/.rpmmacros", NULL);
     }
-#else
-    macrofiles = MACROFILES;
-#endif
 }
 
 /* FIX: se usage inconsistent, W2DO? */

--- a/lib/rpmrc.c
+++ b/lib/rpmrc.c
@@ -1731,7 +1731,7 @@ static rpmRC rpmReadRC(rpmrcCtx ctx, const char * rcfiles)
     argvSplit(&globs, rcfiles, ":");
     for (p = globs; *p; p++) {
 	ARGV_t av = NULL;
-	if (rpmGlob(*p, NULL, &av) == 0) {
+	if (rpmGlobPath(*p, RPMGLOB_NOCHECK, NULL, &av) == 0) {
 	    argvAppend(&files, av);
 	    argvFree(av);
 	}

--- a/rpmio/rpmglob.c
+++ b/rpmio/rpmglob.c
@@ -76,7 +76,7 @@ int rpmGlobPath(const char * pattern, rpmglobFlags flags,
 	/* We still want to count matches so use a scratch list */
 	argvPtr = &argv;
 
-    if (!local || !ismagic(pattern)) {
+    if ((flags & RPMGLOB_NOCHECK) && (!local || !ismagic(pattern))) {
 	argvAdd(argvPtr, pattern);
 	goto exit;
     }

--- a/tests/rpmmacro.at
+++ b/tests/rpmmacro.at
@@ -2,6 +2,42 @@
 #
 AT_BANNER([RPM macros])
 
+AT_SETUP([macro path])
+AT_KEYWORDS([macros])
+RPMDB_INIT
+
+# .rpmmacros exists, new directory not
+RPMTEST_CHECK([[
+rm -f ~/.config/rpm
+touch ~/.rpmmacros
+runroot rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+]],
+[0],
+[~/.rpmmacros
+],
+[])
+
+# prefer new style if it exists
+RPMTEST_CHECK([[
+mkdir -p ~/.config/rpm
+runroot rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+]],
+[0],
+[~/.config/rpm/macros
+],
+[])
+
+# prefer new style if no config exists
+RPMTEST_CHECK([[
+rm -f ~/.config/rpm/macros ~/.rpmmacros
+runroot --setenv  XDG_CONFIG_HOME "~/.zzz" rpm --showrc | awk '/^Macro path/{print(a[split($0,a,":")])}'
+]],
+[0],
+[~/.zzz/rpm/macros
+],
+[])
+RPMTEST_CLEANUP
+
 # ------------------------------
 AT_SETUP([simple rpm --eval])
 AT_KEYWORDS([macros])


### PR DESCRIPTION
Look for per-user macros primarily in ${XDG_CONFIG_HOME}/rpmmacros but fall back to traditional ~/.rpmmacros iff it exists and there's no config in the XDG location. As per the XDG spec, if ${XDG_CONFIG_HOME} is not set, it defaults to ~/.config

Fixes: #2153