### PR TITLE
Allow comments after conditionals

### DIFF
--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -246,7 +246,7 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
     if ((condition) && (!condition->withArgs)) {
 	const char *s = lbuf + condition->textLen;
 	SKIPSPACE(s);
-	if (s[0])
+	if (s[0] && s[0] != '#')
 	    rpmlog(RPMLOG_WARNING,
 		_("extra tokens at the end of %s directive in line %d:  %s\n"),
 		condition->text, spec->lineNum, lbuf);

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -246,10 +246,12 @@ static int expandMacrosInSpecBuf(rpmSpec spec, int strip)
     if ((condition) && (!condition->withArgs)) {
 	const char *s = lbuf + condition->textLen;
 	SKIPSPACE(s);
-	if (s[0] && s[0] != '#')
-	    rpmlog(RPMLOG_WARNING,
+	if (s[0] && s[0] != '#') {
+	    rpmlog(RPMLOG_ERR,
 		_("extra tokens at the end of %s directive in line %d:  %s\n"),
 		condition->text, spec->lineNum, lbuf);
+	    return 1;
+	}
     }
 
     /* Don't expand macros after %elif (resp. %elifarch, %elifos) in a false branch */

--- a/docs/manual/spec.md
+++ b/docs/manual/spec.md
@@ -14,6 +14,10 @@ Comments in spec file have # at the start of the line.
     # this is a comment
 ```
 
+Comments are also allowed after conditionals (see below). Some older
+versions of RPM (4.14 to 4.19) did issue a warning on those, but they
+are fully legal from RPM 4.20 onward.
+
 Macros are expanded even in comment lines. If this is undesireable, escape
 the macro with an extra percent sign (%):
 

--- a/tests/data/SPECS/eliftest.spec
+++ b/tests/data/SPECS/eliftest.spec
@@ -7,13 +7,13 @@ Group: Testing
 BuildArch: noarch
 
 %if  0%{?testif} == 2
-    %if 0%{?rhel} == 6
+    %if 0%{?rhel} == 6 # check for RHEL version
 Requires: pkg1
-    %elif 0%{?rhel} == 7
+    %elif 0%{?rhel} == 7 # RHEL 7 is complicated
 Requires: pkg2
-    %else
+    %else # others
 Requires: pkg3
-    %endif
+    %endif # rhel
 %endif
 
 %description


### PR DESCRIPTION
Still issue an warning for everything else. Now that comments are allowed again may be we should issue an error for those cases.

Resolves: #829