### PR TITLE
Use a less intrusive unattended enforcement in rpmbuild

### DIFF
--- a/build/rpmfc.c
+++ b/build/rpmfc.c
@@ -316,12 +316,16 @@ static int getOutputFrom(ARGV_t argv,
 	close(toProg[1]);
 	close(fromProg[0]);
 
+	/*
+	 * When expecting input, make stdin the in pipe as you'd normally do.
+	 * Otherwise pass stdout(!) as the in pipe to cause reads to error
+	 * out. Just closing the fd breaks some software (eg libtool).
+	 */
 	if (writePtr) {
-	    /* Make stdin the in pipe */
 	    dup2(toProg[0], STDIN_FILENO);
 	    close(toProg[0]);
 	} else {
-	    close(STDIN_FILENO);
+	    dup2(fromProg[1], STDIN_FILENO);
 	}
 
 	dup2(fromProg[1], STDOUT_FILENO); /* Make stdout the out pipe */

--- a/tests/data/SPECS/stdin.spec
+++ b/tests/data/SPECS/stdin.spec
@@ -1,0 +1,13 @@
+Name: stdin
+Version: 1.0
+Release: 1
+Summary: libtool weirdness test-case
+License: Public Domain
+
+%prep
+# func_lalib_unsafe_p in libtool does this
+echo Fo > bar
+exec 5<&0 < bar
+exec 0<&2 2<&-
+
+%files

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -2917,6 +2917,13 @@ runroot rpmbuild --quiet -bb /data/SPECS/interact.spec
 [1],
 [ignore],
 [ignore])
+
+RPMTEST_CHECK([
+runroot rpmbuild --quiet -bp /data/SPECS/stdin.spec
+],
+[0],
+[ignore],
+[ignore])
 RPMTEST_CLEANUP
 
 AT_SETUP([rpmbuild bpf file])


### PR DESCRIPTION
Commit e5d7a823c99b84d65ecbf3810b68aab372ef5d14 broke builds relying on libtool (and no doubt some others as well) because libtool redirects stdin in some of its tests and this fails if stdin is closed. Instead of closing, pass the write-only end of the pipe as the stdin to build scriptlets. This way the descriptor is there and can be further redirected, but any attempt to read from the (unredirected) stdin will error out. Add a test-case too.