### PR TITLE
Default to automatic build directory path on declarative builds

### DIFF
--- a/macros.in
+++ b/macros.in
@@ -1348,7 +1348,7 @@ end
 }
 
 # Global buildsystem defaults
-%buildsystem_default_prep() %autosetup -p1 %*
+%buildsystem_default_prep() %autosetup -C -p1 %*
 %buildsystem_default_clean() %{__rm} -rf %{buildroot}
 
 # \endverbatim

--- a/tests/data/SPECS/amhello.spec
+++ b/tests/data/SPECS/amhello.spec
@@ -1,10 +1,11 @@
 %bcond_with alt
 
 %{!?buildsys:%global buildsys autotools}
+%{!?srcname:%global srcname amhello-1.0.tar.gz}
 
 Name: amhello
 Version: 1.0
-Source: amhello-%{version}.tar.gz
+Source: %{srcname}
 License: GPLv2
 Summary: Autotools example
 BuildSystem: %{buildsys}

--- a/tests/rpmbuild.at
+++ b/tests/rpmbuild.at
@@ -67,6 +67,28 @@ runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1.*.rpm
 [ignore])
 
 RPMTEST_CHECK([
+# re-tar the source to a different name
+tar xf /data/SOURCES/amhello-1.0.tar.gz
+mv amhello-1.0 amhello-1.0-prerelease
+tar czf "${RPMTEST}"/tmp/amhello-pre.tgz amhello-1.0-prerelease/
+runroot rpmbuild -bb \
+	--define "_prefix /usr" \
+	--define "_docdir_fmt %%{NAME}" \
+	--define "_sourcedir /tmp" \
+	--define "srcname amhello-pre.tgz" \
+	--quiet /data/SPECS/amhello.spec
+
+runroot rpm -qpl --noartifact /build/RPMS/*/amhello-1.0-1.*.rpm
+],
+[0],
+[/usr/bin/hello
+/usr/share/doc/amhello
+/usr/share/doc/amhello/README
+/usr/share/doc/amhello/README.distro
+],
+[ignore])
+
+RPMTEST_CHECK([
 runroot rpmbuild -bb \
 	--define "_prefix /usr" \
 	--define "_docdir_fmt %%{NAME}" \
@@ -91,7 +113,7 @@ runroot rpmbuild -bb \
 ],
 [1],
 [],
-[error: line 10: Unknown buildsystem: bogons
+[error: line 11: Unknown buildsystem: bogons
 ])
 
 RPMTEST_CLEANUP


### PR DESCRIPTION
The new %(auto)setup -C option complements the declarative buildsystem very nicely: this is a trivial detail, don't bother the packager. While we can't default to it everywhere, Buildsystem is a great opportunity to do so.

Suggested-by: Miro Hrončok <miro@hroncok.cz>

Fixes: #2998