### PR TITLE
Revert doxygen as a default build requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ option(WITH_ZSTD "Build with zstd support" ON)
 option(WITH_LIBDW "Build with libdw support" ON)
 option(WITH_LIBELF "Build with libelf support" ON)
 option(WITH_LIBLZMA "Build with liblzma support" ON)
-option(WITH_DOXYGEN "Build with doxygen support" ON)
+option(WITH_DOXYGEN "Build API docs with doxygen" OFF)
 
 set(RPM_CONFIGDIR "${CMAKE_INSTALL_PREFIX}/lib/rpm" CACHE PATH "rpm home")
 set(RPM_MACROSDIR "${RPM_CONFIGDIR}/macros.d")


### PR DESCRIPTION
Doxygen is absolutely not required for building rpm, it's only required for building dist tarballs which come with the documentation pre-built.

Fixes: 26a1ccf2819ab148aef3cd354e1cbdb70a9fe5b7