### PR TITLE
Ignore non-scriptlet weak dependencies in ordering

### DIFF
--- a/lib/order.c
+++ b/lib/order.c
@@ -94,9 +94,21 @@ static inline int addSingleRelation(rpmte p,
 	    RPMSENSE_SCRIPT_PRE : RPMSENSE_SCRIPT_PREUN;
     }
 
-    /* Avoid loop-breaker inflation from weak dependencies for now */
-    if (rpmdsIsWeak(dep))
-	flags = 0;
+    /*
+     * Avoid dependency loop tangles from weak dependencies: demote scriptlet
+     * dependencies to regular ones to avoid loop-breaker inflation, and
+     * and ignore non-scriptlet ones entirely (like "meta" would do).
+     */
+    if (rpmdsIsWeak(dep)) {
+	/* ...but demoting ordering hints would be tragicomic */
+	if (rpmdsTagN(dep) != RPMTAG_ORDERNAME) {
+	    if (flags) {
+		flags = 0;
+	    } else {
+		return 0;
+	    }
+	}
+    }
 
     if (reversed) {
 	rpmte r = p;

--- a/tests/rpmorder.at
+++ b/tests/rpmorder.at
@@ -46,14 +46,14 @@ deptest-three-1.0-1.noarch
 [])
 RPMTEST_CLEANUP
 
-# same as above but with weak dependencies
+# same as above but with mixed weak dependencies
 AT_SETUP([basic install/erase order 2])
 AT_KEYWORDS([install erase order])
 RPMDB_INIT
 
 runroot rpmbuild --quiet -bb \
 	--define "pkg one" \
-	--define "recs deptest-two" \
+	--define "reqs deptest-two" \
 	/data/SPECS/deptest.spec
 runroot rpmbuild --quiet -bb \
 	--define "pkg two" \
@@ -72,17 +72,17 @@ runroot rpm -Uv --justdb \
 [0],
 [Verifying packages...
 Preparing packages...
-deptest-three-1.0-1.noarch
 deptest-two-1.0-1.noarch
 deptest-one-1.0-1.noarch
+deptest-three-1.0-1.noarch
 ],
 [])
 
 RPMTEST_CHECK([
 runroot rpm -ev --justdb \
+	deptest-two \
         deptest-three \
-	deptest-one \
-	deptest-two
+	deptest-one
 ],
 [0],
 [Preparing packages...
@@ -93,7 +93,9 @@ deptest-three-1.0-1.noarch
 [])
 RPMTEST_CLEANUP
 
-# same as above but with weak reverse dependencies
+# same as above but with all weak reverse dependencies
+# these are all considered meta by ordering, so order is simply reverse
+# of the cli
 AT_SETUP([basic install/erase order 3])
 AT_KEYWORDS([install erase order])
 RPMDB_INIT
@@ -119,9 +121,9 @@ runroot rpm -Uv --justdb \
 [0],
 [Verifying packages...
 Preparing packages...
+deptest-one-1.0-1.noarch
 deptest-three-1.0-1.noarch
 deptest-two-1.0-1.noarch
-deptest-one-1.0-1.noarch
 ],
 [])
 
@@ -133,8 +135,8 @@ runroot rpm -ev --justdb \
 ],
 [0],
 [Preparing packages...
-deptest-one-1.0-1.noarch
 deptest-two-1.0-1.noarch
+deptest-one-1.0-1.noarch
 deptest-three-1.0-1.noarch
 ],
 [])


### PR DESCRIPTION
Taking weak dependencies into account during ordering has caused a noticeable wave of dependency loop caused install failure bug reports at least in Fedora. This is counter-productive: weak dependencies are commonly used to introduce more exotic / heavier dependencies to packages without causing impossible loops, but now we're doing that to ourselves.

Commit d6353c96fed98a8d30d9ebadf4d6a19a5149edee demoted scriptlet dependencies to regular ones, but this had precisely zero effect because there were no such dependencies in the wild because due to a bug that made it impossible to create such dependencies manually. That bug is now fixed, but in addition, demote non-scriptlet dependencies to meta for ordering purposes (as in, just ignore them). This helps concretely helps bringing down the number (and density) of install ordering dependency loops in the wild.

It's worth mentioning that sysusers dependencies are flagged as scriptlet dependencies, so it's important that these don't get ignored even if %_use_weak_usergroup_deps is enabled.

Adjust ordering tests accordingly, in particular turn the first weak dependency test into a mixed set that demonstrates the effect of this change.

Fixes: #1346