### PR TITLE
Add --patches and --sources aliases to rpmspec

### DIFF
--- a/rpmpopt.in
+++ b/rpmpopt.in
@@ -247,6 +247,10 @@ rpmspec	alias --buildconflicts	--srpm --conflicts \
 	--POPTdesc=$"list capabilities conflicting with build of this package"
 rpmspec	alias --buildrequires	--srpm --requires \
 	--POPTdesc=$"list capabilities required to build this package"
+rpmspec alias --patches		--srpm --qf "[%{PATCH}\n]" \
+	--POPTdesc=$"list patches in this spec"
+rpmspec alias --sources		--srpm --qf "[%{SOURCE}\n]" \
+	--POPTdesc=$"list sources in this spec"
 rpmspec alias --httpport	--define '_httpport !#:+'
 rpmspec alias --httpproxy	--define '_httpproxy !#:+'
 rpmspec alias --with		--define "_with_!#:+     --with-!#:+" \

--- a/tests/data/SPECS/poltest.spec
+++ b/tests/data/SPECS/poltest.spec
@@ -32,7 +32,6 @@ make DESTDIR=%{buildroot} prefix=%{_prefix} install
 %package policy
 Summary: Policy for the poltest package
 Group: System/Policy
-Collections: sepolicy
 %description policy
 Policy for the poltest package
 

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -361,3 +361,23 @@ make DESTDIR=$RPM_BUILD_ROOT install
 ]],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmspec --patches and --sources])
+AT_KEYWORDS([rpmspec])
+RPMTEST_CHECK([
+rpmspec -q --patches /data/SPECS/hello-autopatch.spec
+],
+[0],
+[hello-1.0-install.patch
+hello-1.0-modernize.patch
+],
+[])
+RPMTEST_CHECK([
+rpmspec -q --sources /data/SPECS/poltest.spec
+],
+[0],
+[poltest-policy-1.0.tar.bz2
+poltest-1.0.tar.bz2
+],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
These are common needs and the query is not exactly obvious, so why not.

Hijack the otherwise unused poltest.spec for the sources test, it's the only multi-source spec we have. Only, it hasn't been parseable in about ten years because of the Collections: tag, so remove that...