### PR TITLE
Ensure binary and source headers are identified as such after parse

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -418,6 +418,7 @@ static int buildSpec(rpmts ts, BTA_t buildArgs, rpmSpec spec, int what)
 		!(spec->flags & RPMSPEC_FORCE)) {
 		/* Create buildreqs package */
 		char *nvr = headerGetAsString(spec->packages->header, RPMTAG_NVR);
+		free(spec->sourceRpmName);
 		rasprintf(&spec->sourceRpmName, "%s.buildreqs.nosrc.rpm", nvr);
 		free(nvr);
 		/* free sources to not include them in the buildreqs package */

--- a/build/files.c
+++ b/build/files.c
@@ -2661,16 +2661,6 @@ exit:
     return fl.processingFailed ? RPMRC_FAIL : RPMRC_OK;
 }
 
-static void genSourceRpmName(rpmSpec spec)
-{
-    if (spec->sourceRpmName == NULL) {
-	char *nvr = headerGetAsString(spec->packages->header, RPMTAG_NVR);
-	rasprintf(&spec->sourceRpmName, "%s.%ssrc.rpm", nvr,
-	    	  spec->noSource ? "no" : "");
-	free(nvr);
-    }
-}
-
 rpmRC processSourceFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags)
 {
     struct Source *srcPtr;
@@ -2688,7 +2678,6 @@ rpmRC processSourceFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags)
 	oneshot = 1;
     }
 
-    genSourceRpmName(spec);
     /* Construct the file list and source entries */
     argvAdd(&files, spec->specFile);
     for (srcPtr = spec->sources; srcPtr != NULL; srcPtr = srcPtr->next) {
@@ -3130,7 +3119,6 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
     elf_version (EV_CURRENT);
 #endif
     check_fileList = newStringBuf();
-    genSourceRpmName(spec);
     buildroot = rpmGenPath(spec->rootDir, spec->buildRoot, NULL);
     
     if (rpmExpandNumeric("%{?_debuginfo_subpackages}")) {
@@ -3185,8 +3173,6 @@ rpmRC processBinaryFiles(rpmSpec spec, rpmBuildPkgFlags pkgFlags,
 
 	if (pkg->fileList == NULL)
 	    continue;
-
-	headerPutString(pkg->header, RPMTAG_SOURCERPM, spec->sourceRpmName);
 
 	nvr = headerGetAsString(pkg->header, RPMTAG_NVRA);
 	rpmlog(RPMLOG_NOTICE, _("Processing files: %s\n"), nvr);

--- a/build/pack.c
+++ b/build/pack.c
@@ -796,13 +796,11 @@ rpmRC packageSources(rpmSpec spec, char **cookie)
 {
     Package sourcePkg = spec->sourcePackage;
     rpmRC rc;
-    uint32_t one = 1;
 
     /* Add some cruft */
     headerPutString(sourcePkg->header, RPMTAG_RPMVERSION, VERSION);
     headerPutString(sourcePkg->header, RPMTAG_BUILDHOST, spec->buildHost);
     headerPutUint32(sourcePkg->header, RPMTAG_BUILDTIME, &(spec->buildTime), 1);
-    headerPutUint32(sourcePkg->header, RPMTAG_SOURCEPACKAGE, &one, 1);
 
     /* Include spec in parsed and expanded form */
     headerPutString(sourcePkg->header, RPMTAG_SPEC,

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -735,7 +735,10 @@ static void initSourceHeader(rpmSpec spec)
 
 static void finalizeSourceHeader(rpmSpec spec)
 {
+    uint32_t one = 1;
+
     /* Only specific tags are added to the source package header */
+    headerPutUint32(spec->sourcePackage->header, RPMTAG_SOURCEPACKAGE, &one, 1);
     headerCopyTags(spec->packages->header, spec->sourcePackage->header, sourceTags);
 
     /* Provide all package NEVRs that would be built */

--- a/build/parseSpec.c
+++ b/build/parseSpec.c
@@ -731,6 +731,12 @@ static void initSourceHeader(rpmSpec spec)
 	    }
 	}
     }
+    if (spec->sourceRpmName == NULL) {
+	char *nvr = headerGetAsString(spec->packages->header, RPMTAG_NVR);
+	rasprintf(&spec->sourceRpmName, "%s.%ssrc.rpm", nvr,
+		spec->noSource ? "no" : "");
+	free(nvr);
+    }
 }
 
 static void finalizeSourceHeader(rpmSpec spec)
@@ -1309,6 +1315,8 @@ static rpmRC finalizeSpec(rpmSpec spec)
 	headerPutString(pkg->header, RPMTAG_OS, os);
 	headerPutString(pkg->header, RPMTAG_PLATFORM, platform);
 	headerPutString(pkg->header, RPMTAG_OPTFLAGS, optflags);
+	headerPutString(pkg->header, RPMTAG_SOURCERPM, spec->sourceRpmName);
+
 
 	if (pkg != spec->packages) {
 	    copyInheritedTags(pkg->header, spec->packages->header);

--- a/lib/headerutil.c
+++ b/lib/headerutil.c
@@ -14,7 +14,14 @@
 
 int headerIsSource(Header h)
 {
-    return (!headerIsEntry(h, RPMTAG_SOURCERPM));
+    /* Positive identification of a source package */
+    if (headerIsEntry(h, RPMTAG_SOURCEPACKAGE))
+	return 1;
+    /* Positive identification of a binary package */
+    if (headerIsEntry(h, RPMTAG_SOURCERPM))
+	return 0;
+    /* Dunno, guess so (as per traditional behavior) */
+    return 1;
 }
 
 Header headerCopy(Header h)

--- a/tests/rpmquery.at
+++ b/tests/rpmquery.at
@@ -1317,6 +1317,7 @@ runroot rpmspec -q --qf "[[%{*:tagnum}\n]]" --srpm /data/SPECS/mini.spec
 1016
 1021
 1022
+1106
 ],
 [])
 
@@ -1334,6 +1335,7 @@ License
 Group
 Os
 Arch
+Sourcepackage
 ],
 [])
 RPMTEST_CLEANUP

--- a/tests/rpmspec.at
+++ b/tests/rpmspec.at
@@ -361,3 +361,24 @@ make DESTDIR=$RPM_BUILD_ROOT install
 ]],
 [])
 RPMTEST_CLEANUP
+
+AT_SETUP([rpmspec -q --rpms and --srpm])
+AT_KEYWORDS([rpmspec query])
+RPMTEST_CHECK([
+runroot rpmspec -q --rpms --target s390x \
+	/data/SPECS/hello.spec
+],
+[0],
+[hello-1.0-1.s390x
+],
+[])
+
+RPMTEST_CHECK([
+runroot rpmspec -q --srpm \
+	/data/SPECS/hello.spec
+],
+[0],
+[hello-1.0-1.src
+],
+[])
+RPMTEST_CLEANUP


### PR DESCRIPTION
The two commits improve source and binary package header detection right after spec parse, fixing #2819 in the process. Details in commits.