### PR TITLE
Get rid of pgpGrab()

### DIFF
--- a/include/rpm/rpmpgp.h
+++ b/include/rpm/rpmpgp.h
@@ -261,22 +261,6 @@ typedef enum pgpValType_e {
 const char * pgpValString(pgpValType type, uint8_t val);
 
 /** \ingroup rpmpgp
- * Return (native-endian) integer from big-endian representation.
- * @param s		pointer to big-endian integer
- * @param nbytes	no. of bytes
- * @return		native-endian integer
- */
-static inline
-unsigned int pgpGrab(const uint8_t *s, size_t nbytes)
-{
-    size_t i = 0;
-    size_t nb = (nbytes <= sizeof(i) ? nbytes : sizeof(i));
-    while (nb--)
-	i = (i << 8) | *s++;
-    return i;
-}
-
-/** \ingroup rpmpgp
  * Calculate OpenPGP public key fingerprint.
  * @param pkt		OpenPGP packet (i.e. PGPTAG_PUBLIC_KEY)
  * @param pktlen	OpenPGP packet length (no. of bytes)

--- a/lib/rpmvs.c
+++ b/lib/rpmvs.c
@@ -195,6 +195,7 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
     if (sinfo->type == RPMSIG_SIGNATURE_TYPE) {
 	char *lints = NULL;
         int ec = pgpPrtParams2(data, dlen, PGPTAG_SIGNATURE, &sinfo->sig, &lints);
+	const uint8_t *signid;
 	if (ec) {
 	    if (lints) {
 		rasprintf(&sinfo->msg,
@@ -212,7 +213,8 @@ static void rpmsinfoInit(const struct vfyinfo_s *vinfo,
 	    free(lints);
 	}
 	sinfo->hashalgo = pgpDigParamsAlgo(sinfo->sig, PGPVAL_HASHALGO);
-	sinfo->keyid = pgpGrab(pgpDigParamsSignID(sinfo->sig)+4, 4);
+	signid = pgpDigParamsSignID(sinfo->sig);	/* 8 bytes key id */
+	sinfo->keyid = signid[4] << 24 | signid[5] << 16 | signid[6] << 8 | signid[7];
     } else if (sinfo->type == RPMSIG_DIGEST_TYPE) {
 	if (td->type == RPM_BIN_TYPE) {
 	    sinfo->dig = rpmhex(data, dlen);


### PR DESCRIPTION
rpmvs.c is the only one using it in the rpm source and it can be trivially rewritten.